### PR TITLE
fix: make devices.line_id nullable for unpaired devices

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['pi', 'firmware', 'server', 'image', 'docs', 'ci'],
+      ['pi', 'digitsd', 'firmware', 'server', 'image', 'docs', 'ci'],
     ],
     'scope-empty': [1, 'never'],
   },

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
           cache-dependency-path: server/go.sum
 
       - name: Build

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -862,14 +862,18 @@ func main() {
 				// Check easter eggs, then service codes
 				if !easterEggs.AddKey(key) {
 					if svcCodes.AddKey(key) {
-						// Service code fired — double beep + reset to idle
-						mixer.StopAll()
-						mixer.PlayOnce("dtmf_star")
-						time.Sleep(120 * time.Millisecond)
-						mixer.PlayOnce("dtmf_star")
-						time.Sleep(120 * time.Millisecond)
-						ctrl.Reset()
-						log.Printf("phone: service code %q handled, reset to idle", key)
+						// Service code fired — pause, double beep, then back to dial tone
+						go func() {
+							mixer.StopAll()
+							time.Sleep(250 * time.Millisecond)
+							mixer.PlayOnce("dtmf_star")
+							time.Sleep(150 * time.Millisecond)
+							mixer.PlayOnce("dtmf_star")
+							time.Sleep(300 * time.Millisecond)
+							ctrl.Reset()
+							mixer.PlayLoop("tone_dial")
+							log.Printf("phone: service code handled, reset to dial tone")
+						}()
 					}
 				}
 			}

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -197,6 +197,8 @@ func (d *Database) migrate() error {
 		DROP TABLE IF EXISTS contact_invites;
 		DROP TABLE IF EXISTS contacts;
 		DROP TABLE IF EXISTS phones`,
+		// v7: allow devices to exist before pairing (line_id NULL until paired)
+		`ALTER TABLE devices ALTER COLUMN line_id DROP NOT NULL`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -15,7 +15,7 @@ var ErrNotFound = errors.New("device not found")
 // Device represents a physical handset paired to a line.
 type Device struct {
 	ID                   int64
-	LineID               int64
+	LineID               *int64
 	HardwareID           string
 	DeviceID             string
 	DeviceToken          *string

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -70,8 +70,8 @@ func TestCreateAndGetByID(t *testing.T) {
 	if dev.ID == 0 {
 		t.Error("expected non-zero device ID")
 	}
-	if dev.LineID != lineID {
-		t.Errorf("LineID = %d, want %d", dev.LineID, lineID)
+	if dev.LineID == nil || *dev.LineID != lineID {
+		t.Errorf("LineID = %v, want %d", dev.LineID, lineID)
 	}
 	if dev.HardwareID != "hw-abc-123" {
 		t.Errorf("HardwareID = %q, want hw-abc-123", dev.HardwareID)

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -59,10 +59,10 @@ func (s *Store) GenerateCode(hardwareID string) (string, error) {
 	expiresAt := time.Now().Add(CodeTTL)
 
 	// Upsert: insert device row if it doesn't exist, or update the pairing code.
-	// New devices get line_id=0 as a placeholder until pairing completes.
+	// New devices get line_id=NULL until pairing completes and a line is created.
 	_, err = s.db.Exec(`
 		INSERT INTO devices (line_id, hardware_id, pairing_code, pairing_code_expires_at)
-		VALUES (0, $1, $2, $3)
+		VALUES (NULL, $1, $2, $3)
 		ON CONFLICT (hardware_id) DO UPDATE
 		SET pairing_code = $2, pairing_code_expires_at = $3
 	`, hardwareID, newCode, expiresAt)


### PR DESCRIPTION
## Summary
- Makes `devices.line_id` nullable so devices can exist before pairing completes (NULL instead of placeholder `0`)
- Adds DB migration (v7) to drop the NOT NULL constraint
- Updates `Device.LineID` to `*int64` and fixes pairing to insert NULL instead of `0`
- Also includes: digitsd double-beep confirmation, CI artifact naming fixes, and docs reorganization

## Test plan
- [ ] Verify `server-ci` workflow passes
- [ ] Test device pairing flow end-to-end with a fresh database