### PR TITLE
fix(ci): update Go version to 1.26 in all workflows

### DIFF
--- a/.gitea/workflows/pi-release.yml
+++ b/.gitea/workflows/pi-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.26"
 
       - name: Validate release prerequisites
         run: |

--- a/.gitea/workflows/server-ci.yml
+++ b/.gitea/workflows/server-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
           cache-dependency-path: server/go.sum
 
       - name: Build

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Why
+
+<!-- Why is this change needed? Link issues if relevant. -->
+
+## Test plan
+
+<!-- How did you verify this works? -->

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version: "1.26"
           cache-dependency-path: pi/digitsd/go.sum
 
       - name: Install aarch64 cross-compiler and libraries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# Digits
+
+Private encrypted phone network built from gutted vintage desk phones. Three components talk to each other: firmware on an RP2040, a Go daemon on a Pi Zero 2 W, and a Go signaling server.
+
+## Repo layout
+
+```
+firmware/       RP2040 Pico firmware (C, CMake, Pico SDK)
+pi/digitsd/     Pi-side daemon (Go, cross-compiled to arm64)
+pi/digits-setup/ First-boot setup tool (Go)
+pi/image/       Pi OS image builder
+server/         Signaling server + web UI (Go, htmx, Tailwind)
+tools/          Build scripts for firmware, Pi binaries, and OS images
+scripts/        Firmware build/flash helpers
+docs/           Hardware notes, protocol specs, architecture
+```
+
+## Build and test
+
+Server (from `server/`):
+```
+make build          # builds bin/signald
+make test           # go test ./...
+make e2e            # Playwright tests (needs running server)
+go vet ./...
+```
+
+digitsd (from `pi/digitsd/`):
+```
+make build          # cross-compiles to linux/arm64 (needs aarch64-linux-gnu-gcc)
+make build-local    # native build
+make test
+```
+
+Firmware (from repo root):
+```
+PICO_SDK_PATH=/path/to/pico-sdk ./scripts/build.sh
+./scripts/flash.sh  # copies UF2 to mounted Pico
+```
+
+## Commit conventions
+
+Conventional commits enforced by commitlint. Scope is required (warning if empty, error if invalid).
+
+Valid scopes: `pi`, `digitsd`, `firmware`, `server`, `image`, `docs`, `ci`
+
+Examples:
+```
+fix(server): handle NULL line_id in device lookup
+feat(digitsd): add volume service code
+docs: update wiring notes
+```
+
+## Git workflow
+
+Two remotes:
+- **gitea** -- primary development remote (ssh://git@192.168.1.199:2222/dumbot/digits.git)
+- **github** -- public mirror (git@github.com:justinlindh/digits.git)
+
+Push to gitea by default. Push to github intentionally. PRs required to merge into main on GitHub; no direct pushes. Use the PR template at `.github/pull_request_template.md`.
+
+## CI
+
+Mirrored workflows on both Gitea (`.gitea/workflows/`) and GitHub (`.github/workflows/`):
+- **commitlint** -- validates commit messages on PRs
+- **server-ci** -- build, test, vet (triggers on `server/` changes)
+- **fw-release / pi-release / server-release** -- tag-triggered release pipelines
+
+## Style
+
+- Go: standard project layout, raw SQL with `database/sql` (no ORM), errors returned not panicked
+- Server web UI: htmx + Tailwind, templates in `internal/web/templates/`
+- Firmware: C with Pico SDK conventions
+- Never use em dashes in any written copy
+- Never add Co-Authored-By trailers to commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,7 @@ docs: update wiring notes
 
 ## Git workflow
 
-Two remotes:
-- **gitea** -- primary development remote (ssh://git@192.168.1.199:2222/dumbot/digits.git)
-- **github** -- public mirror (git@github.com:justinlindh/digits.git)
-
-Push to gitea by default. Push to github intentionally. PRs required to merge into main on GitHub; no direct pushes. Use the PR template at `.github/pull_request_template.md`.
+PRs required to merge into main on GitHub; no direct pushes. Use the PR template at `.github/pull_request_template.md`.
 
 ## CI
 


### PR DESCRIPTION
## What

Updates Go from 1.22 to 1.26 in all CI workflows that were still pinned to the old version. Also adds CLAUDE.md and a lightweight PR template.

## Why

go.mod requires >= 1.26.1 but pi-release (both Gitea and GitHub) and Gitea server-ci were still on 1.22, causing build failures.

## Test plan

- [ ] Verify commitlint and server-ci pass on this PR
- [ ] Trigger a pi-release dry run after merge to confirm the build succeeds