### PR TITLE
docs(docs): add prerequisites section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,19 +15,27 @@ scripts/        Firmware build/flash helpers
 docs/           Hardware notes, protocol specs, architecture
 ```
 
+## Prerequisites
+
+- **Go 1.26+**
+- **PostgreSQL** -- the server reads `DATABASE_URL` to connect. Migrations run automatically on startup (inline in `internal/db/db.go`).
+- **Cross-compile toolchain** (for digitsd): `sudo apt install gcc-aarch64-linux-gnu libasound2-dev:arm64 libopus-dev:arm64 libopusfile-dev:arm64 pkg-config`
+- **Pico SDK** (for firmware): set `PICO_SDK_PATH` to your checkout
+
 ## Build and test
 
 Server (from `server/`):
 ```
 make build          # builds bin/signald
+make run            # build + run the server
 make test           # go test ./...
-make e2e            # Playwright tests (needs running server)
+make e2e            # Playwright tests (needs running server via make run)
 go vet ./...
 ```
 
 digitsd (from `pi/digitsd/`):
 ```
-make build          # cross-compiles to linux/arm64 (needs aarch64-linux-gnu-gcc)
+make build          # cross-compiles to linux/arm64 (needs cross-compile toolchain above)
 make build-local    # native build
 make test
 ```


### PR DESCRIPTION
## What

Adds a Prerequisites section to CLAUDE.md covering Go version, PostgreSQL setup, cross-compile toolchain install, and Pico SDK. Also clarifies how to start the dev server (`make run`) and references the cross-compile toolchain from the digitsd build instructions.

## Why

The existing CLAUDE.md mentioned needing `aarch64-linux-gnu-gcc` and a "running server" for e2e tests but didn't explain how to set those up. These additions reduce onboarding friction.

## Test plan

- Read the file, verify accuracy against go.mod, Makefiles, and CI workflows.