### PR TITLE
fix(ci): use ADMIN_PAT for release index pushes to main

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_PAT }}
 
       - uses: actions/setup-node@v6
         with:
@@ -92,6 +93,4 @@ jobs:
           git add artifacts/releases.json
           git commit -m "ci: update releases.json for fw/v${VERSION} [skip ci]" || true
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_PAT }}
 
       - uses: actions/setup-node@v6
         with:
@@ -86,5 +87,3 @@ jobs:
           git add artifacts/releases.json
           git commit -m "ci: update releases.json for pi/v${VERSION} [skip ci]" || true
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Use `ADMIN_PAT` instead of `GITHUB_TOKEN` in pi-release and fw-release workflows when pushing releases.json updates to main.

## Why

Branch protection (now a ruleset) requires PRs for pushes to main. `GITHUB_TOKEN` can't bypass this, but a PAT from an admin can. The `ADMIN_PAT` secret is passed via `actions/checkout` so git push inherits the credential.

## Test plan

- Trigger a pi or fw release and verify the releases.json commit pushes successfully to main.