### PR TITLE
fix(ci): configure Claude Code action with project rules and permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,14 +19,14 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -36,15 +36,23 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          prompt: |
+            You are working on Digits, a private encrypted phone network built from vintage desk phones.
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+            Key rules:
+            - Use conventional commits. Valid scopes: pi, digitsd, firmware, server, image, docs, ci
+            - Never use em dashes in any written copy
+            - Never add Co-Authored-By trailers to commits
+            - Go style: raw SQL with database/sql (no ORM), errors returned not panicked
+            - Server web UI uses htmx + Tailwind, templates in internal/web/templates/
+            - Firmware is C with Pico SDK conventions
+            - PRs target main and should use the PR template at .github/pull_request_template.md
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+          allowed_tools: |
+            Bash(make build)
+            Bash(make test)
+            Bash(make build-local)
+            Bash(go vet ./...)
+            Bash(go test ./...)
+            Bash(npm run lint)
+            mcp__github


### PR DESCRIPTION
## What

Configures the Claude Code GitHub Action with proper permissions, project-specific rules, and allowed tools.

## Why

The default workflow had read-only permissions (Claude couldn't comment, commit, or push) and no project context. This adds:

- **Write permissions** for contents, PRs, and issues so Claude can actually act
- **Root prompt** with project conventions: conventional commits with valid scopes, no em dashes, Go style rules, PR template usage
- **Allowed tools**: `make build`, `make test`, `go vet`, `go test` so Claude can verify changes
- **GitHub MCP** (`mcp__github`) so Claude can reply to comments and interact with PRs/issues
- **Checkout bumped to v6** to match the rest of the repo's workflows

## Test plan

- Merge and mention `@claude` on a PR or issue to verify it responds and can push changes.