### PR TITLE
fix(ci): remove redundant prompt and enable sticky status comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,3 +37,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model claude-opus-4-6 --allowedTools "Bash(make build)" --allowedTools "Bash(make test)" --allowedTools "Bash(make build-local)" --allowedTools "Bash(go vet ./...)" --allowedTools "Bash(go test ./...)" --allowedTools "Bash(npm run lint)" --allowedTools "mcp__github"'
           use_sticky_comment: "true"
+
+          prompt: |
+            If the user's comment is just "@claude" with no other instructions, review the PR:
+            - Read the full diff
+            - Post inline comments on anything incorrect, risky, or improvable
+            - Use GitHub suggestion blocks for concrete fixes
+            - Comment on the PR with a short summary of your findings
+
+            If the user gives specific instructions, follow those instead.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,15 +36,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model claude-opus-4-6 --allowedTools "Bash(make build)" --allowedTools "Bash(make test)" --allowedTools "Bash(make build-local)" --allowedTools "Bash(go vet ./...)" --allowedTools "Bash(go test ./...)" --allowedTools "Bash(npm run lint)" --allowedTools "mcp__github"'
-
-          prompt: |
-            You are working on Digits, a private encrypted phone network built from vintage desk phones.
-
-            Key rules:
-            - Use conventional commits. Valid scopes: pi, digitsd, firmware, server, image, docs, ci
-            - Never use em dashes in any written copy
-            - Never add Co-Authored-By trailers to commits
-            - Go style: raw SQL with database/sql (no ORM), errors returned not panicked
-            - Server web UI uses htmx + Tailwind, templates in internal/web/templates/
-            - Firmware is C with Pico SDK conventions
-            - PRs target main and should use the PR template at .github/pull_request_template.md
+          use_sticky_comment: "true"


### PR DESCRIPTION
## What

- Remove the `prompt` input from the Claude Code workflow -- the action reads CLAUDE.md automatically in tag mode, so it was redundant.
- Enable `use_sticky_comment` so Claude posts an initial status comment on the PR while it works, then updates it with results.

## Why

The `prompt` was duplicating rules already in CLAUDE.md and may have been interfering with the default tag-mode behavior (which injects PR context, comments, and diffs automatically). The sticky comment gives visibility that Claude is working before it finishes.

## Test plan

- Merge and `@claude review this PR` on any PR -- verify it posts a status comment immediately and replies with a review.