### PR TITLE
fix(pi): trigger release for GitHub Releases updater refactor

### DIFF
--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -81,7 +81,8 @@ type Release struct {
 	Date    string `json:"date,omitempty"`
 }
 
-// CheckVersion queries the release index and builds a result.
+// CheckVersion queries the release index from /api/updates/releases and
+// compares available versions against the currently running versions.
 // If targetPi/targetFW are empty, the latest version is used.
 // If the resolved version matches the current version, that component is skipped.
 func (u *Updater) CheckVersion(targetPi, targetFW string) (*CheckResult, error) {


### PR DESCRIPTION
Devices running pi/v1.1.1 or earlier have the old updater code that hits `/api/updates/latest` (removed in PR #12) and fails with a parse error. The updater refactor landed in #12 but the merge commit wasn't scoped to `(pi)`, so semantic-release didn't cut a new pi release. This triggers one.