### PR TITLE
feat: per-component OTA update UI with flash capability detection

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -809,7 +809,11 @@ func main() {
 	phone.RestoreVolume()
 	log.Println("digitsd ready")
 
-	sendDeviceInfo(sig, fwVersion, fwCommit)
+	_, err1 := os.Stat("/usr/local/bin/openocd")
+	_, err2 := os.Stat("/usr/local/bin/flash-pico.sh")
+	flashCapable := err1 == nil && err2 == nil
+
+	sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable)
 	requestICEServers(sig)
 
 	// Refresh ICE credentials periodically (TURN creds are time-limited)
@@ -1072,7 +1076,7 @@ func main() {
 					continue
 				}
 				log.Println("signal: reconnected")
-				sendDeviceInfo(sig, fwVersion, fwCommit)
+				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable)
 				requestICEServers(sig)
 				break
 			}
@@ -1087,17 +1091,18 @@ func requestICEServers(sig *sigclient.Client) {
 	}
 }
 
-func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string) {
+func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapable bool) {
 	if err := sig.Send(&sigclient.Message{
 		Type:            sigclient.TypeDeviceInfo,
 		PiVersion:       version.Version,
 		PiCommit:        version.Commit,
 		FirmwareVersion: fwVersion,
 		FirmwareCommit:  fwCommit,
+		FlashCapable:    flashCapable,
 	}); err != nil {
 		log.Printf("device_info: send failed: %v", err)
 	} else {
-		log.Printf("device_info: pi=%s(%s) fw=%s(%s)", version.Version, version.Commit, fwVersion, fwCommit)
+		log.Printf("device_info: pi=%s(%s) fw=%s(%s) flash_capable=%v", version.Version, version.Commit, fwVersion, fwCommit, flashCapable)
 	}
 }
 

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -79,6 +79,9 @@ type Message struct {
 	// Update status fields (update_status messages)
 	UpdateStatus string `json:"update_status,omitempty"` // downloading, applying, rebooting, success, failed
 	UpdateDetail string `json:"update_detail,omitempty"` // human-readable detail
+
+	// Flash capability (device_info messages)
+	FlashCapable bool `json:"flash_capable,omitempty"`
 }
 
 // ParseMessage deserializes a JSON-encoded signaling message.

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -20,6 +20,7 @@ type Conn struct {
 	PiCommit        string
 	FirmwareVersion string
 	FirmwareCommit  string
+	FlashCapable    bool
 	LastSeen        time.Time
 }
 
@@ -131,6 +132,7 @@ type DeviceInfoSnapshot struct {
 	PiCommit        string
 	FirmwareVersion string
 	FirmwareCommit  string
+	FlashCapable    bool
 	LastSeen        time.Time
 }
 
@@ -147,6 +149,7 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 		PiCommit:        conn.PiCommit,
 		FirmwareVersion: conn.FirmwareVersion,
 		FirmwareCommit:  conn.FirmwareCommit,
+		FlashCapable:    conn.FlashCapable,
 		LastSeen:        conn.LastSeen,
 	}
 }
@@ -185,7 +188,7 @@ func (h *Hub) ClearUpdateStatus(number string) {
 }
 
 // UpdateDeviceInfo sets version info for a connected phone under the write lock.
-func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string) bool {
+func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string, flashCapable bool) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	conn, ok := h.conns[number]
@@ -196,6 +199,7 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string) 
 	conn.PiCommit = piCommit
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
+	conn.FlashCapable = flashCapable
 	conn.LastSeen = time.Now()
 	return true
 }

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -55,6 +55,9 @@ type Message struct {
 	// Update status fields (update_status messages)
 	UpdateStatus string `json:"update_status,omitempty"` // downloading, applying, rebooting, success, failed
 	UpdateDetail string `json:"update_detail,omitempty"` // human-readable detail
+
+	// Flash capability (device_info messages)
+	FlashCapable bool `json:"flash_capable,omitempty"`
 }
 
 func ParseMessage(data []byte) (*Message, error) {

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -52,7 +52,7 @@ func (r *Relay) HandleMessage(from string, msg *Message) {
 	case TypeRequestICE:
 		r.handleRequestICE(from, msg)
 	case TypeDeviceInfo:
-		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit) {
+		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.FlashCapable) {
 			slog.Info("device_info", "number", from,
 				"pi_version", msg.PiVersion,
 				"fw_version", msg.FirmwareVersion)

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -104,7 +104,14 @@
             {{end}}
           </div>
           <div>
-            <label class="block text-xs text-[#8b949e] mb-1">Firmware</label>
+            <label class="block text-xs text-[#8b949e] mb-1 flex items-center gap-1.5">
+              Firmware
+              {{if .DeviceInfo.FlashCapable}}
+              <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a3a25] text-[#3fb950] border border-[#3fb950]/30">SWD</span>
+              {{else}}
+              <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1c2128] text-[#484f58] border border-[#30363d]">No SWD</span>
+              {{end}}
+            </label>
             <span class="text-sm font-mono text-[#e6edf3]">{{if .DeviceInfo.FirmwareVersion}}{{.DeviceInfo.FirmwareVersion}}{{else}}<span class="text-[#484f58] italic">unknown</span>{{end}}</span>
             {{if .DeviceInfo.FirmwareCommit}}
             <span class="text-xs font-mono text-[#484f58] ml-1">({{.DeviceInfo.FirmwareCommit}})</span>
@@ -131,98 +138,119 @@
           <span class="text-sm text-[#c9d1d9]">{{.DeviceInfo.LastSeen.Format "Jan 2, 2006 3:04 PM"}}</span>
         </div>
         {{if .Online}}
-        <!-- Version picker -->
-        <div class="pt-3 border-t border-[#21262d]" id="version-picker">
-          <button onclick="document.getElementById('version-panel').classList.toggle('hidden'); this.querySelector('svg').classList.toggle('rotate-180')" type="button"
-                  class="w-full flex items-center justify-between px-4 py-2 bg-[#1f6feb] hover:bg-[#388bfd] text-white text-sm rounded transition-colors">
-            <span>Update Device</span>
-            <svg class="w-4 h-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-            </svg>
-          </button>
+        <!-- Per-component update sections -->
+        <div class="pt-3 border-t border-[#21262d] space-y-3">
 
-          <div id="version-panel" class="hidden mt-3 space-y-4">
-            {{if or .PiReleases .FWReleases}}
-            <div id="update-form">
-              <!-- Pi Software versions -->
-              {{if .PiReleases}}
-              <div class="mb-4">
-                <label class="block text-xs font-medium text-[#8b949e] mb-2">Pi Software Version</label>
-                <div class="space-y-1 max-h-48 overflow-y-auto">
-                  {{range .PiReleases}}
-                  <label class="version-option flex items-center gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border border-transparent">
-                    <input type="radio" name="target_pi_version" value="{{.Version}}"
-                           {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}checked{{end}}{{end}}
-                           onchange="highlightVersion(this)" class="accent-[#1f6feb]">
-                    <div class="flex-1 flex items-center gap-2">
-                      <span class="text-sm font-mono text-[#e6edf3]">{{.Version}}</span>
-                      {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1f6feb]/20 text-[#58a6ff] border border-[#1f6feb]/30">latest</span>
-                      {{end}}{{end}}
-                      {{if $.DeviceInfo.PiVersion}}{{if eq .Version $.DeviceInfo.PiVersion}}
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a3a25] text-[#3fb950] border border-[#3fb950]/30">installed</span>
-                      {{end}}{{end}}
-                    </div>
-                    {{if .Date}}
-                    <span class="text-xs text-[#484f58]">{{.Date}}</span>
-                    {{end}}
-                  </label>
-                  {{end}}
-                </div>
-              </div>
-              {{end}}
-
-              <!-- Firmware versions -->
-              {{if .FWReleases}}
-              <div class="mb-4">
-                <label class="block text-xs font-medium text-[#8b949e] mb-2">Firmware Version</label>
-                <div class="space-y-1 max-h-48 overflow-y-auto">
-                  {{range .FWReleases}}
-                  <label class="version-option flex items-center gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border border-transparent">
-                    <input type="radio" name="target_fw_version" value="{{.Version}}"
-                           {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}checked{{end}}{{end}}
-                           onchange="highlightVersion(this)" class="accent-[#1f6feb]">
-                    <div class="flex-1 flex items-center gap-2">
-                      <span class="text-sm font-mono text-[#e6edf3]">{{.Version}}</span>
-                      {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1f6feb]/20 text-[#58a6ff] border border-[#1f6feb]/30">latest</span>
-                      {{end}}{{end}}
-                      {{if $.DeviceInfo.FirmwareVersion}}{{if eq .Version $.DeviceInfo.FirmwareVersion}}
-                      <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a3a25] text-[#3fb950] border border-[#3fb950]/30">installed</span>
-                      {{end}}{{end}}
-                    </div>
-                    {{if .Date}}
-                    <span class="text-xs text-[#484f58]">{{.Date}}</span>
-                    {{end}}
-                  </label>
-                  {{end}}
-                </div>
-              </div>
-              {{end}}
-
-              <button type="button" id="install-btn" onclick="triggerUpdate()"
-                      class="w-full px-4 py-2.5 bg-[#238636] hover:bg-[#2ea043] text-white text-sm font-medium rounded transition-colors">
-                Install Selected Versions
-              </button>
-              <!-- Update progress indicator -->
-              <div id="update-progress" class="hidden mt-3">
-                <div class="flex items-center gap-2 px-3 py-2 rounded bg-[#0d1117] border border-[#21262d]">
-                  <div id="progress-spinner" class="w-4 h-4 border-2 border-[#58a6ff] border-t-transparent rounded-full animate-spin"></div>
-                  <span id="progress-text" class="text-sm text-[#c9d1d9]">Sending update command...</span>
-                </div>
-              </div>
-            </div>
-            {{else}}
-            <p class="text-sm text-[#8b949e]">No releases available in the release index.</p>
-            <button type="button" onclick="triggerUpdate()" class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
-              Check for Updates
+          <!-- Pi Software update -->
+          <div>
+            <button onclick="togglePanel('pi-panel', this)" type="button"
+                    class="w-full flex items-center justify-between px-4 py-2 bg-[#1f6feb] hover:bg-[#388bfd] text-white text-sm rounded transition-colors">
+              <span>Update Pi Software</span>
+              <svg class="w-4 h-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+              </svg>
             </button>
-            {{end}}
+            <div id="pi-panel" class="hidden mt-3 space-y-3">
+              {{if .PiReleases}}
+              <div class="space-y-1 max-h-48 overflow-y-auto">
+                {{range .PiReleases}}
+                <label class="version-option flex items-center gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border border-transparent">
+                  <input type="radio" name="target_pi_version" value="{{.Version}}"
+                         {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}checked{{end}}{{end}}
+                         onchange="highlightVersion(this)" class="accent-[#1f6feb]">
+                  <div class="flex-1 flex items-center gap-2">
+                    <span class="text-sm font-mono text-[#e6edf3]">{{.Version}}</span>
+                    {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1f6feb]/20 text-[#58a6ff] border border-[#1f6feb]/30">latest</span>
+                    {{end}}{{end}}
+                    {{if $.DeviceInfo.PiVersion}}{{if eq .Version $.DeviceInfo.PiVersion}}
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a3a25] text-[#3fb950] border border-[#3fb950]/30">installed</span>
+                    {{end}}{{end}}
+                  </div>
+                  {{if .Date}}
+                  <span class="text-xs text-[#484f58]">{{.Date}}</span>
+                  {{end}}
+                </label>
+                {{end}}
+              </div>
+              <button type="button" id="pi-install-btn" onclick="triggerPiUpdate()"
+                      class="w-full px-4 py-2.5 bg-[#238636] hover:bg-[#2ea043] text-white text-sm font-medium rounded transition-colors">
+                Install Pi Software
+              </button>
+              <div id="pi-update-progress" class="hidden mt-2">
+                <div class="flex items-center gap-2 px-3 py-2 rounded bg-[#0d1117] border border-[#21262d]">
+                  <div id="pi-progress-spinner" class="w-4 h-4 border-2 border-[#58a6ff] border-t-transparent rounded-full animate-spin"></div>
+                  <span id="pi-progress-text" class="text-sm text-[#c9d1d9]">Sending update command...</span>
+                </div>
+              </div>
+              {{else}}
+              <p class="text-sm text-[#8b949e]">No Pi releases available.</p>
+              {{end}}
+            </div>
           </div>
+
+          <!-- Firmware update -->
+          {{if .DeviceInfo.FlashCapable}}
+          <div>
+            <button onclick="togglePanel('fw-panel', this)" type="button"
+                    class="w-full flex items-center justify-between px-4 py-2 bg-[#1f6feb] hover:bg-[#388bfd] text-white text-sm rounded transition-colors">
+              <span>Update Firmware</span>
+              <svg class="w-4 h-4 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+              </svg>
+            </button>
+            <div id="fw-panel" class="hidden mt-3 space-y-3">
+              {{if .FWReleases}}
+              <div class="space-y-1 max-h-48 overflow-y-auto">
+                {{range .FWReleases}}
+                <label class="version-option flex items-center gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border border-transparent">
+                  <input type="radio" name="target_fw_version" value="{{.Version}}"
+                         {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}checked{{end}}{{end}}
+                         onchange="highlightVersion(this)" class="accent-[#1f6feb]">
+                  <div class="flex-1 flex items-center gap-2">
+                    <span class="text-sm font-mono text-[#e6edf3]">{{.Version}}</span>
+                    {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1f6feb]/20 text-[#58a6ff] border border-[#1f6feb]/30">latest</span>
+                    {{end}}{{end}}
+                    {{if $.DeviceInfo.FirmwareVersion}}{{if eq .Version $.DeviceInfo.FirmwareVersion}}
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#1a3a25] text-[#3fb950] border border-[#3fb950]/30">installed</span>
+                    {{end}}{{end}}
+                  </div>
+                  {{if .Date}}
+                  <span class="text-xs text-[#484f58]">{{.Date}}</span>
+                  {{end}}
+                </label>
+                {{end}}
+              </div>
+              <button type="button" id="fw-install-btn" onclick="triggerFwUpdate()"
+                      class="w-full px-4 py-2.5 bg-[#238636] hover:bg-[#2ea043] text-white text-sm font-medium rounded transition-colors">
+                Install Firmware
+              </button>
+              <div id="fw-update-progress" class="hidden mt-2">
+                <div class="flex items-center gap-2 px-3 py-2 rounded bg-[#0d1117] border border-[#21262d]">
+                  <div id="fw-progress-spinner" class="w-4 h-4 border-2 border-[#58a6ff] border-t-transparent rounded-full animate-spin"></div>
+                  <span id="fw-progress-text" class="text-sm text-[#c9d1d9]">Sending update command...</span>
+                </div>
+              </div>
+              {{else}}
+              <p class="text-sm text-[#8b949e]">No firmware releases available.</p>
+              {{end}}
+            </div>
+          </div>
+          {{else}}
+          <p class="text-sm text-[#484f58]">Firmware updates require SWD wiring — flash via USB</p>
+          {{end}}
+
         </div>
         <script>
         var phoneNumber = '{{$.Line.Number}}';
-        var pollTimer = null;
+        var piPollTimer = null;
+        var fwPollTimer = null;
+
+        function togglePanel(id, btn) {
+          document.getElementById(id).classList.toggle('hidden');
+          btn.querySelector('svg').classList.toggle('rotate-180');
+        }
 
         function highlightVersion(radio) {
           var name = radio.name;
@@ -239,21 +267,29 @@
         }
         document.querySelectorAll('.version-option input:checked').forEach(highlightVersion);
 
-        function triggerUpdate() {
-          var btn = document.getElementById('install-btn');
-          var progress = document.getElementById('update-progress');
-          var progressText = document.getElementById('progress-text');
-          var spinner = document.getElementById('progress-spinner');
+        function triggerPiUpdate() {
+          var btn = document.getElementById('pi-install-btn');
+          var piRadio = document.querySelector('input[name="target_pi_version"]:checked');
+          var body = new URLSearchParams();
+          if (piRadio) body.append('target_pi_version', piRadio.value);
+          startUpdate('pi', btn, body);
+        }
+
+        function triggerFwUpdate() {
+          var btn = document.getElementById('fw-install-btn');
+          var fwRadio = document.querySelector('input[name="target_fw_version"]:checked');
+          var body = new URLSearchParams();
+          if (fwRadio) body.append('target_fw_version', fwRadio.value);
+          startUpdate('fw', btn, body);
+        }
+
+        function startUpdate(prefix, btn, body) {
+          var progress = document.getElementById(prefix + '-update-progress');
+          var progressText = document.getElementById(prefix + '-progress-text');
           if (btn) btn.disabled = true;
           if (btn) btn.classList.add('opacity-50', 'cursor-not-allowed');
           if (progress) progress.classList.remove('hidden');
           if (progressText) progressText.textContent = 'Sending update command...';
-
-          var piRadio = document.querySelector('input[name="target_pi_version"]:checked');
-          var fwRadio = document.querySelector('input[name="target_fw_version"]:checked');
-          var body = new URLSearchParams();
-          if (piRadio) body.append('target_pi_version', piRadio.value);
-          if (fwRadio) body.append('target_fw_version', fwRadio.value);
 
           fetch('/phones/' + phoneNumber + '/update', {
             method: 'POST',
@@ -263,33 +299,33 @@
           .then(function(r) { return r.json(); })
           .then(function(data) {
             if (data.error) {
-              showResult('failed', 'Failed to send: ' + data.error);
+              showResult(prefix, 'failed', 'Failed to send: ' + data.error);
               return;
             }
             if (progressText) progressText.textContent = 'Update triggered — waiting for device...';
-            startPolling();
+            startPolling(prefix);
           })
           .catch(function(err) {
-            showResult('failed', 'Network error: ' + err.message);
+            showResult(prefix, 'failed', 'Network error: ' + err.message);
           });
         }
 
-        function startPolling() {
-          if (pollTimer) clearInterval(pollTimer);
+        function startPolling(prefix) {
+          var timerVar = prefix === 'pi' ? 'piPollTimer' : 'fwPollTimer';
+          if (window[timerVar]) clearInterval(window[timerVar]);
           var attempts = 0;
-          pollTimer = setInterval(function() {
+          window[timerVar] = setInterval(function() {
             attempts++;
-            if (attempts > 120) { // 2 minutes max
-              clearInterval(pollTimer);
-              showResult('failed', 'Timed out waiting for update status');
+            if (attempts > 120) {
+              clearInterval(window[timerVar]);
+              showResult(prefix, 'failed', 'Timed out waiting for update status');
               return;
             }
             fetch('/phones/' + phoneNumber + '/update-status')
             .then(function(r) { return r.json(); })
             .then(function(data) {
-              if (!data.status) return; // no status yet
-              var progressText = document.getElementById('progress-text');
-              var spinner = document.getElementById('progress-spinner');
+              if (!data.status) return;
+              var progressText = document.getElementById(prefix + '-progress-text');
               switch (data.status) {
                 case 'downloading':
                   if (progressText) progressText.textContent = 'Downloading update... ' + (data.detail || '');
@@ -301,30 +337,29 @@
                   if (progressText) progressText.textContent = 'Rebooting device...';
                   break;
                 case 'success':
-                  clearInterval(pollTimer);
-                  showResult('success', data.detail || 'Update installed successfully');
-                  // Reload page after a moment to show new version info
+                  clearInterval(window[timerVar]);
+                  showResult(prefix, 'success', data.detail || 'Update installed successfully');
                   setTimeout(function() { location.reload(); }, 2000);
                   break;
                 case 'up_to_date':
-                  clearInterval(pollTimer);
-                  showResult('success', data.detail || 'Already up to date');
+                  clearInterval(window[timerVar]);
+                  showResult(prefix, 'success', data.detail || 'Already up to date');
                   break;
                 case 'failed':
-                  clearInterval(pollTimer);
-                  showResult('failed', data.detail || 'Update failed');
+                  clearInterval(window[timerVar]);
+                  showResult(prefix, 'failed', data.detail || 'Update failed');
                   break;
               }
             })
-            .catch(function() {}); // ignore poll errors
+            .catch(function() {});
           }, 1000);
         }
 
-        function showResult(type, message) {
-          var progress = document.getElementById('update-progress');
-          var spinner = document.getElementById('progress-spinner');
-          var progressText = document.getElementById('progress-text');
-          var btn = document.getElementById('install-btn');
+        function showResult(prefix, type, message) {
+          var progress = document.getElementById(prefix + '-update-progress');
+          var spinner = document.getElementById(prefix + '-progress-spinner');
+          var progressText = document.getElementById(prefix + '-progress-text');
+          var btn = document.getElementById(prefix + '-install-btn');
           if (spinner) spinner.classList.add('hidden');
           if (progress) progress.classList.remove('hidden');
           if (type === 'success') {
@@ -339,7 +374,6 @@
               progressText.className = 'text-sm text-[#f85149]';
             }
             if (progress) progress.querySelector('div').classList.add('border-[#f85149]/30');
-            // Re-enable button on failure
             if (btn) btn.disabled = false;
             if (btn) btn.classList.remove('opacity-50', 'cursor-not-allowed');
           }

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -173,7 +173,7 @@
                 </label>
                 {{end}}
               </div>
-              <button type="button" id="pi-install-btn" onclick="triggerPiUpdate()"
+              <button type="button" id="pi-install-btn" onclick="triggerComponentUpdate('pi', 'target_pi_version')"
                       class="w-full px-4 py-2.5 bg-[#238636] hover:bg-[#2ea043] text-white text-sm font-medium rounded transition-colors">
                 Install Pi Software
               </button>
@@ -222,7 +222,7 @@
                 </label>
                 {{end}}
               </div>
-              <button type="button" id="fw-install-btn" onclick="triggerFwUpdate()"
+              <button type="button" id="fw-install-btn" onclick="triggerComponentUpdate('fw', 'target_fw_version')"
                       class="w-full px-4 py-2.5 bg-[#238636] hover:bg-[#2ea043] text-white text-sm font-medium rounded transition-colors">
                 Install Firmware
               </button>
@@ -267,20 +267,12 @@
         }
         document.querySelectorAll('.version-option input:checked').forEach(highlightVersion);
 
-        function triggerPiUpdate() {
-          var btn = document.getElementById('pi-install-btn');
-          var piRadio = document.querySelector('input[name="target_pi_version"]:checked');
+        function triggerComponentUpdate(prefix, paramName) {
+          var btn = document.getElementById(prefix + '-install-btn');
+          var radio = document.querySelector('input[name="' + paramName + '"]:checked');
           var body = new URLSearchParams();
-          if (piRadio) body.append('target_pi_version', piRadio.value);
-          startUpdate('pi', btn, body);
-        }
-
-        function triggerFwUpdate() {
-          var btn = document.getElementById('fw-install-btn');
-          var fwRadio = document.querySelector('input[name="target_fw_version"]:checked');
-          var body = new URLSearchParams();
-          if (fwRadio) body.append('target_fw_version', fwRadio.value);
-          startUpdate('fw', btn, body);
+          if (radio) body.append(paramName, radio.value);
+          startUpdate(prefix, btn, body);
         }
 
         function startUpdate(prefix, btn, body) {


### PR DESCRIPTION
## Changes

### Pi side
- Detects SWD flash capability at startup (checks for openocd + flash-pico.sh)
- Reports `flash_capable` bool in `device_info` messages to the server

### Server side  
- Stores and exposes `flash_capable` in device info snapshots
- Reworked phone detail page with separate Pi Software and Firmware update sections
- Pi: always shows version picker and update button
- Firmware: shows update button only when device has SWD capability
- Devices without SWD show "Firmware updates require SWD wiring" message
- Green "SWD" / gray "No SWD" badge on firmware label

### Backward compatible
Old Pi binaries that don't send `flash_capable` default to false (no SWD), which is the safe/correct behavior.