### PR TITLE
docs: remove system overview diagram from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="docs/diagrams/img/03-system-overview.png" alt="Digits system overview" width="600">
-</p>
-
 <h1 align="center">Digits</h1>
 
 <p align="center">


### PR DESCRIPTION
Removes the system overview diagram image from the top of the README.