### PR TITLE
feat(digitsd): ICE restart on transient connection drops

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -122,7 +122,8 @@ Bandwidth per active TURN-relayed call: ~40kbps per direction. Negligible at sma
 - Bidirectional Opus/WebRTC audio across NAT (STUN/TURN)
 - End-to-end encrypted calls (DTLS-SRTP)
 - ICE server credential fetch from signald with periodic refresh
-- Connection failure detection (auto-hangup on ICE failure)
+- ICE restart on transient connection drops (caller-initiated, single attempt with 15s timeout)
+- Connection failure detection (hangup after failed ICE restart)
 - Mechanical bell, dial tone, ringback, and busy tone
 - Household linking via invite codes
 - Device pairing via one-time codes
@@ -131,5 +132,3 @@ Bandwidth per active TURN-relayed call: ~40kbps per direction. Negligible at sma
 - RNNoise background noise suppression
 
 ### Next
-
-- ICE restart on transient connection drops (currently hangs up; could attempt renegotiation)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -63,6 +63,10 @@ type daemonCallbacks struct {
 	debugMode        bool     // read from DIGITS_DEBUG env at startup
 	paired           atomic.Bool
 	pairingCode      string   // current pairing code from server
+	callPeer         string   // number of the remote party during an active call
+	isCaller         bool     // true if we initiated the current call
+	isRestartingICE  bool     // true while an ICE restart is in progress
+	restartTimer     *time.Timer // timeout for ICE restart attempt
 }
 
 // --- phone.Callbacks implementation ---
@@ -119,11 +123,12 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 		return
 	}
 
+	d.callPeer = targetNumber
+	d.isCaller = true
+	d.isRestartingICE = false
+
 	d.peerMgr.OnConnectionState = func(state webrtc.PeerConnectionState) {
-		if state == webrtc.PeerConnectionStateFailed {
-			log.Println("webrtc: connection failed, hanging up")
-			d.ctrl.HandleSignal("hangup")
-		}
+		d.handleConnectionStateChange(state)
 	}
 
 	// Handle remote audio track
@@ -220,6 +225,10 @@ func (d *daemonCallbacks) AnswerCall() {
 	d.pendingOffer = ""
 	d.pendingCaller = ""
 
+	d.callPeer = caller
+	d.isCaller = false
+	d.isRestartingICE = false
+
 	iceCfg := owebrtc.NewICEConfig(d.iceServers)
 	var err error
 	d.peerMgr, err = owebrtc.NewPeerManager(iceCfg)
@@ -229,10 +238,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	}
 
 	d.peerMgr.OnConnectionState = func(state webrtc.PeerConnectionState) {
-		if state == webrtc.PeerConnectionStateFailed {
-			log.Println("webrtc: connection failed, hanging up")
-			d.ctrl.HandleSignal("hangup")
-		}
+		d.handleConnectionStateChange(state)
 	}
 
 	// Handle remote audio track — decode and feed into mixer.
@@ -387,6 +393,13 @@ func (d *daemonCallbacks) HangupCall() {
 	d.pendingOffer = ""
 	d.pendingCaller = ""
 	d.pendingICE = nil
+	d.callPeer = ""
+	d.isCaller = false
+	d.isRestartingICE = false
+	if d.restartTimer != nil {
+		d.restartTimer.Stop()
+		d.restartTimer = nil
+	}
 
 	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup}) //nolint:errcheck
 
@@ -400,6 +413,102 @@ func (d *daemonCallbacks) HangupCall() {
 	}
 
 	log.Println("call ended")
+}
+
+// handleConnectionStateChange is called (without d.mu held) when the WebRTC
+// peer connection state changes.  On transient failures the original caller
+// attempts a single ICE restart before giving up.
+func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectionState) {
+	switch state {
+	case webrtc.PeerConnectionStateConnected:
+		d.mu.Lock()
+		wasRestarting := d.isRestartingICE
+		d.isRestartingICE = false
+		if d.restartTimer != nil {
+			d.restartTimer.Stop()
+			d.restartTimer = nil
+		}
+		d.mu.Unlock()
+		if wasRestarting {
+			log.Println("webrtc: ICE restart succeeded — connection recovered")
+		}
+
+	case webrtc.PeerConnectionStateFailed:
+		d.mu.Lock()
+		alreadyRestarting := d.isRestartingICE
+		isCaller := d.isCaller
+		d.mu.Unlock()
+
+		if alreadyRestarting {
+			// Restart already attempted and still failed — give up.
+			log.Println("webrtc: ICE restart failed, hanging up")
+			d.ctrl.HandleSignal("hangup")
+			return
+		}
+
+		if isCaller {
+			// Original caller initiates the ICE restart.
+			log.Println("webrtc: connection failed, attempting ICE restart")
+			d.attemptICERestart()
+		} else {
+			// Callee waits for the caller's restart offer with a timeout.
+			log.Println("webrtc: connection failed, waiting for ICE restart from caller")
+			d.mu.Lock()
+			d.isRestartingICE = true
+			d.restartTimer = time.AfterFunc(15*time.Second, func() {
+				d.mu.Lock()
+				restarting := d.isRestartingICE
+				d.mu.Unlock()
+				if restarting {
+					log.Println("webrtc: timed out waiting for ICE restart, hanging up")
+					d.ctrl.HandleSignal("hangup")
+				}
+			})
+			d.mu.Unlock()
+		}
+	}
+}
+
+// attemptICERestart creates a new SDP offer with rotated ICE credentials
+// and sends it to the remote peer.  A timeout fires if the connection
+// does not recover within 15 seconds.
+func (d *daemonCallbacks) attemptICERestart() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.peerMgr == nil {
+		log.Println("ice-restart: no peer manager, hanging up")
+		go d.ctrl.HandleSignal("hangup")
+		return
+	}
+
+	d.isRestartingICE = true
+
+	offer, err := d.peerMgr.CreateRestartOffer()
+	if err != nil {
+		log.Printf("ice-restart: create offer failed: %v", err)
+		d.isRestartingICE = false
+		go d.ctrl.HandleSignal("hangup")
+		return
+	}
+
+	peer := d.callPeer
+	d.restartTimer = time.AfterFunc(15*time.Second, func() {
+		d.mu.Lock()
+		restarting := d.isRestartingICE
+		d.mu.Unlock()
+		if restarting {
+			log.Println("webrtc: ICE restart timed out, hanging up")
+			d.ctrl.HandleSignal("hangup")
+		}
+	})
+
+	log.Printf("ice-restart: sending restart offer to %s (%d bytes)", peer, len(offer))
+	d.sig.Send(&sigclient.Message{ //nolint:errcheck
+		Type: sigclient.TypeICERestart,
+		To:   peer,
+		SDP:  offer,
+	})
 }
 
 // --- phone.SocketHandler implementation ---
@@ -1021,6 +1130,46 @@ func main() {
 				}
 				go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion,
 					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable, statusReporter)
+
+			case sigclient.TypeICERestart:
+				cb.mu.Lock()
+				pm := cb.peerMgr
+				peer := cb.callPeer
+				cb.mu.Unlock()
+				if pm == nil {
+					log.Println("ice-restart: no active peer connection, ignoring")
+					break
+				}
+				log.Printf("ice-restart: received restart offer from %s (%d bytes)", msg.From, len(msg.SDP))
+				answerSDP, err := pm.AcceptRestartOffer(msg.SDP)
+				if err != nil {
+					log.Printf("ice-restart: accept offer failed: %v", err)
+					break
+				}
+				cb.mu.Lock()
+				cb.isRestartingICE = true
+				if cb.restartTimer != nil {
+					cb.restartTimer.Stop()
+				}
+				cb.restartTimer = time.AfterFunc(15*time.Second, func() {
+					cb.mu.Lock()
+					restarting := cb.isRestartingICE
+					cb.mu.Unlock()
+					if restarting {
+						log.Println("webrtc: ICE restart timed out after accepting offer, hanging up")
+						ctrl.HandleSignal("hangup")
+					}
+				})
+				cb.mu.Unlock()
+				if peer == "" {
+					peer = msg.From
+				}
+				log.Printf("ice-restart: sending restart answer to %s (%d bytes)", peer, len(answerSDP))
+				sig.Send(&sigclient.Message{ //nolint:errcheck
+					Type: sigclient.TypeSDP,
+					To:   peer,
+					SDP:  answerSDP,
+				})
 
 			case sigclient.TypeICEServers:
 				cb.mu.Lock()

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -28,6 +28,10 @@ import (
 	"github.com/pion/webrtc/v4/pkg/media"
 )
 
+// iceRestartTimeout is how long to wait for an ICE restart to succeed
+// before giving up and hanging up the call.
+const iceRestartTimeout = 15 * time.Second
+
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 }
@@ -415,9 +419,9 @@ func (d *daemonCallbacks) HangupCall() {
 	log.Println("call ended")
 }
 
-// handleConnectionStateChange is called (without d.mu held) when the WebRTC
-// peer connection state changes.  On transient failures the original caller
-// attempts a single ICE restart before giving up.
+// handleConnectionStateChange is called (without d.mu held) from a pion
+// goroutine when the WebRTC peer connection state changes.  On transient
+// failures the original caller attempts a single ICE restart before giving up.
 func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectionState) {
 	switch state {
 	case webrtc.PeerConnectionStateConnected:
@@ -430,7 +434,7 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 		}
 		d.mu.Unlock()
 		if wasRestarting {
-			log.Println("webrtc: ICE restart succeeded — connection recovered")
+			log.Println("webrtc: ICE restart succeeded -- connection recovered")
 		}
 
 	case webrtc.PeerConnectionStateFailed:
@@ -440,38 +444,26 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 		d.mu.Unlock()
 
 		if alreadyRestarting {
-			// Restart already attempted and still failed — give up.
 			log.Println("webrtc: ICE restart failed, hanging up")
-			d.ctrl.HandleSignal("hangup")
+			go d.ctrl.HandleSignal("hangup")
 			return
 		}
 
 		if isCaller {
-			// Original caller initiates the ICE restart.
 			log.Println("webrtc: connection failed, attempting ICE restart")
 			d.attemptICERestart()
 		} else {
-			// Callee waits for the caller's restart offer with a timeout.
 			log.Println("webrtc: connection failed, waiting for ICE restart from caller")
 			d.mu.Lock()
 			d.isRestartingICE = true
-			d.restartTimer = time.AfterFunc(15*time.Second, func() {
-				d.mu.Lock()
-				restarting := d.isRestartingICE
-				d.mu.Unlock()
-				if restarting {
-					log.Println("webrtc: timed out waiting for ICE restart, hanging up")
-					d.ctrl.HandleSignal("hangup")
-				}
-			})
+			d.startRestartTimeout()
 			d.mu.Unlock()
 		}
 	}
 }
 
 // attemptICERestart creates a new SDP offer with rotated ICE credentials
-// and sends it to the remote peer.  A timeout fires if the connection
-// does not recover within 15 seconds.
+// and sends it to the remote peer.  Must NOT be called with d.mu held.
 func (d *daemonCallbacks) attemptICERestart() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -493,7 +485,20 @@ func (d *daemonCallbacks) attemptICERestart() {
 	}
 
 	peer := d.callPeer
-	d.restartTimer = time.AfterFunc(15*time.Second, func() {
+	d.startRestartTimeout()
+
+	log.Printf("ice-restart: sending restart offer to %s (%d bytes)", peer, len(offer))
+	d.sig.Send(&sigclient.Message{ //nolint:errcheck
+		Type: sigclient.TypeICERestart,
+		To:   peer,
+		SDP:  offer,
+	})
+}
+
+// startRestartTimeout sets a timer that hangs up the call if the ICE restart
+// does not complete within iceRestartTimeout.  Must be called with d.mu held.
+func (d *daemonCallbacks) startRestartTimeout() {
+	d.restartTimer = time.AfterFunc(iceRestartTimeout, func() {
 		d.mu.Lock()
 		restarting := d.isRestartingICE
 		d.mu.Unlock()
@@ -501,13 +506,6 @@ func (d *daemonCallbacks) attemptICERestart() {
 			log.Println("webrtc: ICE restart timed out, hanging up")
 			d.ctrl.HandleSignal("hangup")
 		}
-	})
-
-	log.Printf("ice-restart: sending restart offer to %s (%d bytes)", peer, len(offer))
-	d.sig.Send(&sigclient.Message{ //nolint:errcheck
-		Type: sigclient.TypeICERestart,
-		To:   peer,
-		SDP:  offer,
 	})
 }
 
@@ -1141,7 +1139,7 @@ func main() {
 					break
 				}
 				log.Printf("ice-restart: received restart offer from %s (%d bytes)", msg.From, len(msg.SDP))
-				answerSDP, err := pm.AcceptRestartOffer(msg.SDP)
+				answerSDP, err := pm.AcceptOffer(msg.SDP)
 				if err != nil {
 					log.Printf("ice-restart: accept offer failed: %v", err)
 					break
@@ -1151,15 +1149,7 @@ func main() {
 				if cb.restartTimer != nil {
 					cb.restartTimer.Stop()
 				}
-				cb.restartTimer = time.AfterFunc(15*time.Second, func() {
-					cb.mu.Lock()
-					restarting := cb.isRestartingICE
-					cb.mu.Unlock()
-					if restarting {
-						log.Println("webrtc: ICE restart timed out after accepting offer, hanging up")
-						ctrl.HandleSignal("hangup")
-					}
-				})
+				cb.startRestartTimeout()
 				cb.mu.Unlock()
 				if peer == "" {
 					peer = msg.From

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -36,6 +36,10 @@ const (
 
 	// TypeUpdateStatus is sent to the server to report update progress.
 	TypeUpdateStatus = "update_status"
+
+	// TypeICERestart is sent by either peer to initiate an ICE restart.
+	// Carries a new SDP offer with rotated ICE credentials.
+	TypeICERestart = "ice_restart"
 )
 
 // ContactEntry represents a single contact in a sync payload.

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -139,6 +139,23 @@ func TestParseContactsUpdatedNudge(t *testing.T) {
 	}
 }
 
+func TestParseICERestartMessage(t *testing.T) {
+	raw := `{"type":"ice_restart","from":"3140001","to":"3140002","sdp":"v=0\r\n"}`
+	msg, err := ParseMessage([]byte(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if msg.Type != TypeICERestart {
+		t.Errorf("expected type %q, got %q", TypeICERestart, msg.Type)
+	}
+	if msg.From != "3140001" {
+		t.Errorf("expected from %q, got %q", "3140001", msg.From)
+	}
+	if msg.SDP != "v=0\r\n" {
+		t.Errorf("expected SDP %q, got %q", "v=0\r\n", msg.SDP)
+	}
+}
+
 func TestParseSyncRequest(t *testing.T) {
 	msg := &Message{Type: TypeSync}
 	data, err := msg.Marshal()

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -91,7 +91,18 @@ func NewPeerManager(iceCfg *ICEConfig) (*PeerManager, error) {
 // ICE candidates are NOT gathered inline — they trickle via OnICECandidate.
 // The caller MUST send the returned SDP before ICE candidates reach the remote peer.
 func (m *PeerManager) CreateOffer() (string, error) {
-	offer, err := m.pc.CreateOffer(nil)
+	return m.createOffer(nil)
+}
+
+// CreateRestartOffer creates a new SDP offer with ICE restart requested.
+// The existing PeerConnection and media tracks are preserved; only ICE
+// credentials are rotated so connectivity can be re-established.
+func (m *PeerManager) CreateRestartOffer() (string, error) {
+	return m.createOffer(&webrtc.OfferOptions{ICERestart: true})
+}
+
+func (m *PeerManager) createOffer(opts *webrtc.OfferOptions) (string, error) {
+	offer, err := m.pc.CreateOffer(opts)
 	if err != nil {
 		return "", fmt.Errorf("create offer: %w", err)
 	}
@@ -106,6 +117,7 @@ func (m *PeerManager) CreateOffer() (string, error) {
 // AcceptOffer sets the remote description from an incoming offer SDP, creates an
 // answer, and sets the local description. ICE candidates trickle via OnICECandidate.
 // The caller MUST send the returned answer SDP before forwarding ICE candidates.
+// Also used to accept ICE restart offers on an existing PeerConnection.
 func (m *PeerManager) AcceptOffer(offerSDP string) (string, error) {
 	if err := m.pc.SetRemoteDescription(webrtc.SessionDescription{
 		Type: webrtc.SDPTypeOffer,
@@ -165,29 +177,6 @@ func (m *PeerManager) CreateRestartOffer() (string, error) {
 	}
 
 	return offer.SDP, nil
-}
-
-// AcceptRestartOffer processes an incoming ICE restart offer on an existing
-// PeerConnection. It sets the remote description, creates an answer, and
-// sets the local description. ICE candidates trickle via OnICECandidate.
-func (m *PeerManager) AcceptRestartOffer(offerSDP string) (string, error) {
-	if err := m.pc.SetRemoteDescription(webrtc.SessionDescription{
-		Type: webrtc.SDPTypeOffer,
-		SDP:  offerSDP,
-	}); err != nil {
-		return "", fmt.Errorf("set remote description (restart offer): %w", err)
-	}
-
-	answer, err := m.pc.CreateAnswer(nil)
-	if err != nil {
-		return "", fmt.Errorf("create restart answer: %w", err)
-	}
-
-	if err := m.pc.SetLocalDescription(answer); err != nil {
-		return "", fmt.Errorf("set local description (restart answer): %w", err)
-	}
-
-	return answer.SDP, nil
 }
 
 // Close closes the underlying PeerConnection.

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -151,6 +151,45 @@ func (m *PeerManager) LocalTrack() *webrtc.TrackLocalStaticSample {
 	return m.track
 }
 
+// CreateRestartOffer creates a new SDP offer with ICE restart requested.
+// The existing PeerConnection and media tracks are preserved; only ICE
+// credentials are rotated so connectivity can be re-established.
+func (m *PeerManager) CreateRestartOffer() (string, error) {
+	offer, err := m.pc.CreateOffer(&webrtc.OfferOptions{ICERestart: true})
+	if err != nil {
+		return "", fmt.Errorf("create restart offer: %w", err)
+	}
+
+	if err := m.pc.SetLocalDescription(offer); err != nil {
+		return "", fmt.Errorf("set local description (restart): %w", err)
+	}
+
+	return offer.SDP, nil
+}
+
+// AcceptRestartOffer processes an incoming ICE restart offer on an existing
+// PeerConnection. It sets the remote description, creates an answer, and
+// sets the local description. ICE candidates trickle via OnICECandidate.
+func (m *PeerManager) AcceptRestartOffer(offerSDP string) (string, error) {
+	if err := m.pc.SetRemoteDescription(webrtc.SessionDescription{
+		Type: webrtc.SDPTypeOffer,
+		SDP:  offerSDP,
+	}); err != nil {
+		return "", fmt.Errorf("set remote description (restart offer): %w", err)
+	}
+
+	answer, err := m.pc.CreateAnswer(nil)
+	if err != nil {
+		return "", fmt.Errorf("create restart answer: %w", err)
+	}
+
+	if err := m.pc.SetLocalDescription(answer); err != nil {
+		return "", fmt.Errorf("set local description (restart answer): %w", err)
+	}
+
+	return answer.SDP, nil
+}
+
 // Close closes the underlying PeerConnection.
 func (m *PeerManager) Close() error {
 	return m.pc.Close()

--- a/pi/digitsd/internal/webrtc/peer_test.go
+++ b/pi/digitsd/internal/webrtc/peer_test.go
@@ -74,3 +74,53 @@ func TestPeerManager_OfferAnswer(t *testing.T) {
 	}
 	// If we get here without error, SDP exchange succeeded
 }
+
+func TestPeerManager_ICERestart(t *testing.T) {
+	// Set up a normal call, then perform an ICE restart
+	caller, err := NewPeerManager(NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer caller.Close()
+
+	callee, err := NewPeerManager(NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer callee.Close()
+
+	// Initial SDP exchange
+	offer, err := caller.CreateOffer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer, err := callee.AcceptOffer(offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := caller.SetAnswer(answer); err != nil {
+		t.Fatal(err)
+	}
+
+	// ICE restart: caller creates restart offer, callee accepts
+	restartOffer, err := caller.CreateRestartOffer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restartOffer == "" {
+		t.Fatal("empty restart offer")
+	}
+
+	restartAnswer, err := callee.AcceptRestartOffer(restartOffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restartAnswer == "" {
+		t.Fatal("empty restart answer")
+	}
+
+	if err := caller.SetAnswer(restartAnswer); err != nil {
+		t.Fatal(err)
+	}
+	// If we get here without error, ICE restart SDP exchange succeeded
+}

--- a/pi/digitsd/internal/webrtc/peer_test.go
+++ b/pi/digitsd/internal/webrtc/peer_test.go
@@ -111,7 +111,7 @@ func TestPeerManager_ICERestart(t *testing.T) {
 		t.Fatal("empty restart offer")
 	}
 
-	restartAnswer, err := callee.AcceptRestartOffer(restartOffer)
+	restartAnswer, err := callee.AcceptOffer(restartOffer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/README.md
+++ b/server/README.md
@@ -199,6 +199,7 @@ After SDP/ICE exchange, audio flows peer-to-peer via WebRTC DTLS-SRTP.
 | `paired`          | Server -> Phone | `device_token`                       | Device successfully paired           |
 | `update_trigger`  | Server -> Phone | `target_pi_version`, `target_fw_version` | Trigger OTA update on device     |
 | `update_status`   | Phone -> Server | `update_status`, `update_detail`     | Report update progress               |
+| `ice_restart`     | Bidirectional  | `to`, `from`, `sdp`                  | ICE restart offer with new credentials |
 
 ## Architecture
 

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -20,6 +20,7 @@ const (
 	TypeDeviceInfo  = "device_info" // Phone → Server: version info on connect
 	TypeUpdateTrigger   = "update_trigger"    // Server → Phone: check and apply updates
 	TypeUpdateStatus    = "update_status"     // Phone → Server: update progress report
+	TypeICERestart      = "ice_restart"       // Bidirectional: ICE restart offer with new credentials
 )
 
 // ICEServer represents a STUN or TURN server configuration.

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -45,6 +45,8 @@ func (r *Relay) HandleMessage(from string, msg *Message) {
 		r.forward(msg)
 	case TypeICE:
 		r.forward(msg)
+	case TypeICERestart:
+		r.forward(msg)
 	case TypeAnswer:
 		r.handleAnswer(from, msg)
 	case TypeHangup:

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -172,6 +172,42 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 	}
 }
 
+func TestRelayICERestartForwarded(t *testing.T) {
+	hub := NewHub()
+	relay := NewRelay(hub, nil, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+
+	// Phone 1 sends ICE restart to Phone 2
+	relay.HandleMessage("3140001", &Message{
+		Type: TypeICERestart,
+		To:   "3140002",
+		SDP:  "v=0\r\nrestart-offer\r\n",
+	})
+
+	select {
+	case data := <-conn2.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeICERestart {
+			t.Fatalf("expected ice_restart, got %s", msg.Type)
+		}
+		if msg.From != "3140001" {
+			t.Fatalf("expected from 3140001, got %s", msg.From)
+		}
+		if msg.SDP != "v=0\r\nrestart-offer\r\n" {
+			t.Fatalf("unexpected SDP: %q", msg.SDP)
+		}
+	default:
+		t.Fatal("phone 2 did not receive ice_restart")
+	}
+}
+
 func TestHubOnlineNumbers(t *testing.T) {
 	hub := NewHub()
 	conn1 := &Conn{Send: make(chan []byte, 1)}


### PR DESCRIPTION
## What

Attempts a single ICE restart when a WebRTC peer connection fails, instead of immediately hanging up. If the restart doesn't recover the connection within 15 seconds, the call is torn down as before.

## Why

A brief Wi-Fi hiccup or momentary packet loss currently kills the entire call. ICE restart lets the existing peer connection renegotiate its transport layer without tearing down media tracks, so audio resumes seamlessly on recovery.

Closes #25

## How it works

- **Caller initiates**: the original caller creates a new SDP offer with `ICERestart: true` and sends it via a new `ice_restart` signaling message
- **Callee responds**: accepts the restart offer, generates an answer with new ICE credentials, sends it back as a regular `sdp` message
- **Role-based**: only the caller initiates to avoid glare (both sides sending offers simultaneously). The callee waits up to 15s for the restart offer
- **Single attempt**: if the restart itself fails or times out, the call hangs up

## Changes

- `pi/digitsd/internal/webrtc/peer.go` -- `CreateRestartOffer()` via shared `createOffer()` helper
- `pi/digitsd/cmd/digitsd/main.go` -- connection state handler with restart logic, role tracking (`isCaller`/`callPeer`), `startRestartTimeout()` helper
- `pi/digitsd/internal/signal/protocol.go` -- `ice_restart` message type
- `server/internal/signaling/protocol.go` + `relay.go` -- server forwards `ice_restart` like `sdp`/`ice`
- `docs/architecture/overview.md` -- moved from "Next" to "Working"
- `server/README.md` -- added `ice_restart` to protocol table

## Test plan

- [ ] Unit tests added for `CreateRestartOffer` SDP exchange (`peer_test.go`)
- [ ] Unit test for `ice_restart` message parsing (`protocol_test.go`)
- [ ] Unit test for server relay forwarding `ice_restart` (`relay_test.go`)
- [ ] Manual test: establish call between two phones, briefly disconnect one phone's Wi-Fi, verify call recovers
- [ ] Manual test: establish call, disconnect Wi-Fi for >15s, verify call hangs up after timeout