### PR TITLE
fix(pi): detect Codec Zero ALSA card dynamically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ Two remotes:
 
 Push to gitea by default. Push to github intentionally. PRs required to merge into main on GitHub; no direct pushes. Use the PR template at `.github/pull_request_template.md`.
 
+**Never force push.** Always push new commits on top of existing branches. No `--force`, no `--force-with-lease`, no amending pushed commits.
+
 ## CI
 
 Mirrored workflows on both Gitea (`.gitea/workflows/`) and GitHub (`.github/workflows/`):
@@ -82,3 +84,4 @@ Mirrored workflows on both Gitea (`.gitea/workflows/`) and GitHub (`.github/work
 - Never use em dashes in any written copy
 - Never add Co-Authored-By trailers to commits
 - Never include Claude Code session links (claude.ai/code/session_*) in commits, PRs, or any other content
+- Don't leave "was removed" or "was here" comments when deleting code; just delete it

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -43,7 +43,7 @@ var (
 	serialDev   = flag.String("serial", "/dev/serial0", "serial port device")
 	socketPath  = flag.String("socket", "/home/digits/digits/pi/uart.sock", "UART command socket path")
 	toneDir     = flag.String("tones", "/home/digits/digits/pi/tones", "directory containing WAV tone files")
-	alsaDevice  = flag.String("alsa-playback", "plughw:1,0", "ALSA playback device (direct, no dmix)")
+	alsaDevice  = flag.String("alsa-playback", "", "ALSA playback device (auto-detects Codec Zero if empty)")
 )
 
 // daemonCallbacks implements phone.Callbacks and wires hardware + WebRTC.
@@ -768,8 +768,17 @@ func main() {
 	}
 
 	// 2. Open ALSA playback (direct hardware, no dmix)
+	pbDev := *alsaDevice
+	if pbDev == "" {
+		dev, err := audio.CodecDeviceName()
+		if err != nil {
+			log.Fatalf("alsa: %v", err)
+		}
+		pbDev = dev
+		log.Printf("alsa playback: auto-detected %s", pbDev)
+	}
 	pbCfg := audio.Config{
-		Device:     *alsaDevice,
+		Device:     pbDev,
 		SampleRate: 48000,
 		Channels:   1,
 		FrameSize:  960,

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -11,6 +11,8 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strings"
 	"unsafe"
@@ -29,6 +31,25 @@ type Config struct {
 	FrameSize  int // samples per frame per channel (960 = 20ms at 48kHz)
 }
 
+// findCodecCardIn scans ALSA card list output for the Codec Zero (DA7212)
+// and returns its card number. The input should be the contents of
+// /proc/asound/cards. Lines look like:
+//
+//	 0 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero
+func findCodecCardIn(r io.Reader) (int, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "RPi Codec Zero") || strings.Contains(line, "RPi_Codec_Zero") {
+			var num int
+			if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d", &num); err == nil {
+				return num, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("Codec Zero card not found in /proc/asound/cards")
+}
+
 // FindCodecCard scans /proc/asound/cards for the Codec Zero (DA7212) and
 // returns its ALSA card number. Returns an error if not found.
 func FindCodecCard() (int, error) {
@@ -37,18 +58,7 @@ func FindCodecCard() (int, error) {
 		return 0, fmt.Errorf("open /proc/asound/cards: %w", err)
 	}
 	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "[Zero") {
-			var num int
-			if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d", &num); err == nil {
-				return num, nil
-			}
-		}
-	}
-	return 0, fmt.Errorf("Codec Zero card not found in /proc/asound/cards")
+	return findCodecCardIn(f)
 }
 
 // CodecDeviceName returns "plughw:N,0" for the Codec Zero card.
@@ -61,10 +71,12 @@ func CodecDeviceName() (string, error) {
 }
 
 // DefaultCaptureConfig returns config for the DA7212 codec: stereo capture at 48kHz.
+// Uses plughw to bypass dmix (which is playback-only).
 func DefaultCaptureConfig() Config {
 	dev, err := CodecDeviceName()
 	if err != nil {
-		dev = "plughw:1,0" // fallback
+		log.Printf("WARNING: codec detection failed, falling back to plughw:1,0: %v", err)
+		dev = "plughw:1,0"
 	}
 	return Config{
 		Device:     dev,
@@ -74,14 +86,11 @@ func DefaultCaptureConfig() Config {
 	}
 }
 
-// DefaultPlaybackConfig returns config for mono playback at 48kHz on the Codec Zero.
+// DefaultPlaybackConfig returns config for mono playback via dmix at 48kHz.
+// Uses "default" ALSA device for playback (dmix software mixing).
 func DefaultPlaybackConfig() Config {
-	dev, err := CodecDeviceName()
-	if err != nil {
-		dev = "plughw:1,0" // fallback
-	}
 	return Config{
-		Device:     dev,
+		Device:     "default",
 		SampleRate: 48000,
 		Channels:   1,
 		FrameSize:  960,

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -8,8 +8,11 @@ package audio
 import "C"
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"unsafe"
 )
 
@@ -26,22 +29,59 @@ type Config struct {
 	FrameSize  int // samples per frame per channel (960 = 20ms at 48kHz)
 }
 
+// FindCodecCard scans /proc/asound/cards for the Codec Zero (DA7212) and
+// returns its ALSA card number. Returns an error if not found.
+func FindCodecCard() (int, error) {
+	f, err := os.Open("/proc/asound/cards")
+	if err != nil {
+		return 0, fmt.Errorf("open /proc/asound/cards: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "[Zero") {
+			var num int
+			if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d", &num); err == nil {
+				return num, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("Codec Zero card not found in /proc/asound/cards")
+}
+
+// CodecDeviceName returns "plughw:N,0" for the Codec Zero card.
+func CodecDeviceName() (string, error) {
+	card, err := FindCodecCard()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("plughw:%d,0", card), nil
+}
+
 // DefaultCaptureConfig returns config for the DA7212 codec: stereo capture at 48kHz.
-// Uses plughw:1,0 because "default" is configured as dmix (playback-only).
 func DefaultCaptureConfig() Config {
+	dev, err := CodecDeviceName()
+	if err != nil {
+		dev = "plughw:1,0" // fallback
+	}
 	return Config{
-		Device:     "plughw:1,0",
+		Device:     dev,
 		SampleRate: 48000,
 		Channels:   2,
 		FrameSize:  960,
 	}
 }
 
-// DefaultPlaybackConfig returns config for mono playback via dmix at 48kHz.
-// Uses "default" ALSA device for playback.
+// DefaultPlaybackConfig returns config for mono playback at 48kHz on the Codec Zero.
 func DefaultPlaybackConfig() Config {
+	dev, err := CodecDeviceName()
+	if err != nil {
+		dev = "plughw:1,0" // fallback
+	}
 	return Config{
-		Device:     "default",
+		Device:     dev,
 		SampleRate: 48000,
 		Channels:   1,
 		FrameSize:  960,

--- a/pi/digitsd/internal/audio/alsa_test.go
+++ b/pi/digitsd/internal/audio/alsa_test.go
@@ -1,40 +1,61 @@
 package audio
 
 import (
-	"os"
 	"reflect"
 	"strings"
 	"testing"
 )
 
-func TestFindCodecCard(t *testing.T) {
-	// Only run on devices that have the Codec Zero
-	f, err := os.ReadFile("/proc/asound/cards")
-	if err != nil || !strings.Contains(string(f), "[Zero") {
-		t.Skip("Codec Zero not present, skipping")
+func TestFindCodecCardIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "card 0",
+			input: " 0 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n                      RPi Codec Zero\n",
+			want:  0,
+		},
+		{
+			name:  "card 1 with HDMI first",
+			input: " 0 [vc4hdmi        ]: vc4-hdmi - vc4-hdmi\n                      vc4-hdmi\n 1 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n                      RPi Codec Zero\n",
+			want:  1,
+		},
+		{
+			name:  "card 2",
+			input: " 0 [foo            ]: bar\n 1 [baz            ]: qux\n 2 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n",
+			want:  2,
+		},
+		{
+			name:    "no codec zero",
+			input:   " 0 [vc4hdmi        ]: vc4-hdmi - vc4-hdmi\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
 	}
 
-	card, err := FindCodecCard()
-	if err != nil {
-		t.Fatalf("FindCodecCard() error: %v", err)
-	}
-	if card < 0 {
-		t.Errorf("FindCodecCard() = %d, want >= 0", card)
-	}
-}
-
-func TestCodecDeviceName(t *testing.T) {
-	f, err := os.ReadFile("/proc/asound/cards")
-	if err != nil || !strings.Contains(string(f), "[Zero") {
-		t.Skip("Codec Zero not present, skipping")
-	}
-
-	dev, err := CodecDeviceName()
-	if err != nil {
-		t.Fatalf("CodecDeviceName() error: %v", err)
-	}
-	if !strings.HasPrefix(dev, "plughw:") {
-		t.Errorf("CodecDeviceName() = %q, want plughw:N,0 format", dev)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findCodecCardIn(strings.NewReader(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got card %d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got card %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -53,6 +74,9 @@ func TestDefaultCaptureConfig(t *testing.T) {
 
 func TestDefaultPlaybackConfig(t *testing.T) {
 	cfg := DefaultPlaybackConfig()
+	if cfg.Device != "default" {
+		t.Errorf("Device = %q, want %q", cfg.Device, "default")
+	}
 	if cfg.SampleRate != 48000 {
 		t.Errorf("SampleRate = %d, want 48000", cfg.SampleRate)
 	}
@@ -65,7 +89,6 @@ func TestDefaultPlaybackConfig(t *testing.T) {
 }
 
 func TestExtractChannel_Right(t *testing.T) {
-	// Stereo interleaved: [L0,R0, L1,R1, L2,R2]
 	interleaved := []int16{100, 200, 300, 400, 500, 600}
 	got := ExtractChannel(interleaved, 2, 1)
 	want := []int16{200, 400, 600}

--- a/pi/digitsd/internal/audio/alsa_test.go
+++ b/pi/digitsd/internal/audio/alsa_test.go
@@ -1,15 +1,45 @@
 package audio
 
 import (
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
+func TestFindCodecCard(t *testing.T) {
+	// Only run on devices that have the Codec Zero
+	f, err := os.ReadFile("/proc/asound/cards")
+	if err != nil || !strings.Contains(string(f), "[Zero") {
+		t.Skip("Codec Zero not present, skipping")
+	}
+
+	card, err := FindCodecCard()
+	if err != nil {
+		t.Fatalf("FindCodecCard() error: %v", err)
+	}
+	if card < 0 {
+		t.Errorf("FindCodecCard() = %d, want >= 0", card)
+	}
+}
+
+func TestCodecDeviceName(t *testing.T) {
+	f, err := os.ReadFile("/proc/asound/cards")
+	if err != nil || !strings.Contains(string(f), "[Zero") {
+		t.Skip("Codec Zero not present, skipping")
+	}
+
+	dev, err := CodecDeviceName()
+	if err != nil {
+		t.Fatalf("CodecDeviceName() error: %v", err)
+	}
+	if !strings.HasPrefix(dev, "plughw:") {
+		t.Errorf("CodecDeviceName() = %q, want plughw:N,0 format", dev)
+	}
+}
+
 func TestDefaultCaptureConfig(t *testing.T) {
 	cfg := DefaultCaptureConfig()
-	if cfg.Device != "plughw:1,0" {
-		t.Errorf("Device = %q, want %q", cfg.Device, "plughw:1,0")
-	}
 	if cfg.SampleRate != 48000 {
 		t.Errorf("SampleRate = %d, want 48000", cfg.SampleRate)
 	}
@@ -23,9 +53,6 @@ func TestDefaultCaptureConfig(t *testing.T) {
 
 func TestDefaultPlaybackConfig(t *testing.T) {
 	cfg := DefaultPlaybackConfig()
-	if cfg.Device != "default" {
-		t.Errorf("Device = %q, want %q", cfg.Device, "default")
-	}
 	if cfg.SampleRate != 48000 {
 		t.Errorf("SampleRate = %d, want 48000", cfg.SampleRate)
 	}

--- a/pi/digitsd/internal/audio/mixer_test.go
+++ b/pi/digitsd/internal/audio/mixer_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 // mockWriter captures written periods for testing without ALSA hardware.
+// Includes a small sleep to simulate ALSA blocking (~1ms per period)
+// so time.Sleep-based test synchronization works reliably.
 type mockWriter struct {
 	periods [][]int16
 }
@@ -16,6 +18,7 @@ func (m *mockWriter) WriteFrame(samples []int16) error {
 	cp := make([]int16, len(samples))
 	copy(cp, samples)
 	m.periods = append(m.periods, cp)
+	time.Sleep(1 * time.Millisecond)
 	return nil
 }
 

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 )
 
 // ServiceCodeHandler processes hidden service codes entered via the keypad.
@@ -213,11 +215,23 @@ func volumeToALSA(level int) int {
 	return 20 + (level * (58 - 20) / 9)
 }
 
+// codecCard returns the Codec Zero ALSA card number as a string for use
+// in amixer/alsactl commands. Falls back to "0" if detection fails.
+func codecCard() string {
+	card, err := audio.FindCodecCard()
+	if err != nil {
+		log.Printf("WARNING: codec detection failed for volume control, assuming card 0: %v", err)
+		return "0"
+	}
+	return fmt.Sprintf("%d", card)
+}
+
 // SetVolume sets Lineout volume. Level 0-9 maps to ALSA 20-58.
 // Persists the level to /data/digits/volume and saves full mixer state.
 func SetVolume(level int) error {
 	alsaVal := volumeToALSA(level)
-	cmd := exec.Command("amixer", "-c", "0", "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
+	card := codecCard()
+	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("amixer: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -227,7 +241,7 @@ func SetVolume(level int) error {
 		log.Printf("volume: persist failed: %v", err)
 	}
 	// Save full mixer state
-	cmd = exec.Command("sudo", "alsactl", "store", "0", "-f", mixerStateFile)
+	cmd = exec.Command("sudo", "alsactl", "store", card, "-f", mixerStateFile)
 	cmd.Run() // best-effort
 	log.Printf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal)
 	return nil
@@ -245,7 +259,8 @@ func RestoreVolume() {
 		}
 	}
 	alsaVal := volumeToALSA(level)
-	cmd := exec.Command("amixer", "-c", "0", "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
+	card := codecCard()
+	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Printf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err)
 		return

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -163,22 +163,6 @@ func (m *PeerManager) LocalTrack() *webrtc.TrackLocalStaticSample {
 	return m.track
 }
 
-// CreateRestartOffer creates a new SDP offer with ICE restart requested.
-// The existing PeerConnection and media tracks are preserved; only ICE
-// credentials are rotated so connectivity can be re-established.
-func (m *PeerManager) CreateRestartOffer() (string, error) {
-	offer, err := m.pc.CreateOffer(&webrtc.OfferOptions{ICERestart: true})
-	if err != nil {
-		return "", fmt.Errorf("create restart offer: %w", err)
-	}
-
-	if err := m.pc.SetLocalDescription(offer); err != nil {
-		return "", fmt.Errorf("set local description (restart): %w", err)
-	}
-
-	return offer.SDP, nil
-}
-
 // Close closes the underlying PeerConnection.
 func (m *PeerManager) Close() error {
 	return m.pc.Close()

--- a/pi/digitsd/internal/webrtc/peer_test.go
+++ b/pi/digitsd/internal/webrtc/peer_test.go
@@ -1,6 +1,11 @@
 package owebrtc
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
 
 func TestICEConfig_NoServers(t *testing.T) {
 	cfg := NewICEConfig(nil)
@@ -75,8 +80,29 @@ func TestPeerManager_OfferAnswer(t *testing.T) {
 	// If we get here without error, SDP exchange succeeded
 }
 
+// waitGatherComplete blocks until ICE gathering is complete or timeout.
+func waitGatherComplete(t *testing.T, pm *PeerManager) {
+	t.Helper()
+	done := make(chan struct{}, 1)
+	pm.pc.OnICEGatheringStateChange(func(state webrtc.ICEGatheringState) {
+		if state == webrtc.ICEGatheringStateComplete {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+	if pm.pc.ICEGatheringState() == webrtc.ICEGatheringStateComplete {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ICE gathering to complete")
+	}
+}
+
 func TestPeerManager_ICERestart(t *testing.T) {
-	// Set up a normal call, then perform an ICE restart
 	caller, err := NewPeerManager(NewICEConfig(nil))
 	if err != nil {
 		t.Fatal(err)
@@ -102,6 +128,10 @@ func TestPeerManager_ICERestart(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Wait for both sides to finish gathering before restart
+	waitGatherComplete(t, caller)
+	waitGatherComplete(t, callee)
+
 	// ICE restart: caller creates restart offer, callee accepts
 	restartOffer, err := caller.CreateRestartOffer()
 	if err != nil {
@@ -122,5 +152,4 @@ func TestPeerManager_ICERestart(t *testing.T) {
 	if err := caller.SetAnswer(restartAnswer); err != nil {
 		t.Fatal(err)
 	}
-	// If we get here without error, ICE restart SDP exchange succeeded
 }

--- a/pi/restore_mixer.sh
+++ b/pi/restore_mixer.sh
@@ -3,7 +3,7 @@
 # Run on boot via systemd or manually after mixer resets.
 #
 # Saved state file contains ALL mixer settings.
-# To re-save after tuning: sudo alsactl store 1 -f /home/digits/digits_mixer.state
+# To re-save after tuning: sudo alsactl store -f /home/digits/digits_mixer.state <card_number>
 
 STATE_FILE="/home/digits/digits_mixer.state"
 
@@ -12,19 +12,31 @@ if [ ! -f "$STATE_FILE" ]; then
     exit 1
 fi
 
-alsactl restore 1 -f "$STATE_FILE"
+# Detect Codec Zero card number dynamically
+CARD=$(grep -l 'RPi_Codec_Zero\|RPi Codec Zero' /proc/asound/card*/id 2>/dev/null | head -1 | grep -o '[0-9]*')
+if [ -z "$CARD" ]; then
+    # Fallback: search by short name
+    CARD=$(awk '/\[Zero/{gsub(/[^0-9]/,"",$1); print $1; exit}' /proc/asound/cards)
+fi
+if [ -z "$CARD" ]; then
+    echo "ERROR: Codec Zero card not found" >&2
+    exit 1
+fi
+echo "Codec Zero detected as card $CARD"
+
+alsactl restore "$CARD" -f "$STATE_FILE"
 echo "Mixer state restored from $STATE_FILE"
 
 # Verify critical routing switches are on
 # 29=Lineout, 87=MixoutL-DACL, 94=MixoutR-DACR, 27=ADC, 26=MixinPGA, 77=MixinR-Mic2, 24=Mic2
 for numid in 29 87 94 27 26 77 24; do
-    val=$(amixer -c 1 cget numid=$numid 2>/dev/null | grep ": values=" | sed "s/.*values=//")
+    val=$(amixer -c "$CARD" cget numid=$numid 2>/dev/null | grep ": values=" | sed "s/.*values=//")
     case "$val" in
         on|on,on) ;;
         *)
             echo "WARNING: numid=$numid is $val, forcing on"
-            amixer -c 1 cset numid=$numid on >/dev/null 2>&1 || \
-            amixer -c 1 cset numid=$numid on,on >/dev/null 2>&1
+            amixer -c "$CARD" cset numid=$numid on >/dev/null 2>&1 || \
+            amixer -c "$CARD" cset numid=$numid on,on >/dev/null 2>&1
             ;;
     esac
 done


### PR DESCRIPTION
## What

Detect the Codec Zero ALSA card number at runtime by scanning `/proc/asound/cards` instead of hardcoding `plughw:1,0`. Also updates `restore_mixer.sh` to detect the card the same way.

## Why

The ALSA card number depends on kernel module load order and isn't stable across devices. On Phone 2, the Codec Zero loaded as card 0, causing digitsd to crash-loop on every boot with `snd_pcm_open: Unknown error 524`.

## Test plan

- [x] `go vet ./...` passes
- [x] `make test` passes (all tests green)
- [x] Cross-compiled and deployed to Phone 2 (Codec Zero = card 0)
- [x] Confirmed `alsa playback: auto-detected plughw:0,0` in journalctl
- [x] digitsd starts successfully and connects to signaling server