### PR TITLE
fix(server): validate active call before forwarding ICE restart

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -93,6 +93,14 @@ func (t *Tracker) OnCallEnded(caller, callee string) error {
 	return err
 }
 
+func (t *Tracker) InCall(a, b string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, fwd := t.active[callKey(a, b)]
+	_, rev := t.active[callKey(b, a)]
+	return fwd || rev
+}
+
 func (t *Tracker) Active() []activeCall {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -11,6 +11,7 @@ type CallTracker interface {
 	OnCallInitiated(from, to string) error
 	OnCallAnswered(caller, callee string) error
 	OnCallEnded(caller, callee string) error
+	InCall(a, b string) bool
 }
 
 // CallAuthorizer determines whether a call from one number to another is permitted.
@@ -46,7 +47,7 @@ func (r *Relay) HandleMessage(from string, msg *Message) {
 	case TypeICE:
 		r.forward(msg)
 	case TypeICERestart:
-		r.forward(msg)
+		r.handleICERestart(from, msg)
 	case TypeAnswer:
 		r.handleAnswer(from, msg)
 	case TypeHangup:
@@ -100,6 +101,15 @@ func (r *Relay) handleCall(from string, msg *Message) {
 		Type: TypeRing,
 		From: from,
 	})
+}
+
+func (r *Relay) handleICERestart(from string, msg *Message) {
+	if r.Tracker != nil && !r.Tracker.InCall(from, msg.To) {
+		slog.Warn("ice_restart without active call", "from", from, "to", msg.To)
+		r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
+		return
+	}
+	r.forward(msg)
 }
 
 func (r *Relay) handleAnswer(from string, msg *Message) {

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -8,10 +8,16 @@ type mockTracker struct {
 	initiated []string
 	answered  []string
 	ended     []string
+	calls     map[string]bool // "a→b" keys for active calls
+}
+
+func newMockTracker() *mockTracker {
+	return &mockTracker{calls: make(map[string]bool)}
 }
 
 func (m *mockTracker) OnCallInitiated(from, to string) error {
 	m.initiated = append(m.initiated, from+"→"+to)
+	m.calls[from+"→"+to] = true
 	return nil
 }
 func (m *mockTracker) OnCallAnswered(caller, callee string) error {
@@ -20,7 +26,12 @@ func (m *mockTracker) OnCallAnswered(caller, callee string) error {
 }
 func (m *mockTracker) OnCallEnded(caller, callee string) error {
 	m.ended = append(m.ended, caller+"→"+callee)
+	delete(m.calls, caller+"→"+callee)
+	delete(m.calls, callee+"→"+caller)
 	return nil
+}
+func (m *mockTracker) InCall(a, b string) bool {
+	return m.calls[a+"→"+b] || m.calls[b+"→"+a]
 }
 
 type mockCallAuthorizer struct {
@@ -33,7 +44,7 @@ func (m *mockCallAuthorizer) CanCall(fromNumber, toNumber string) (bool, error) 
 
 func TestRelayCallFlow(t *testing.T) {
 	hub := NewHub()
-	tracker := &mockTracker{}
+	tracker := newMockTracker()
 	relay := NewRelay(hub, tracker, nil)
 
 	// Register two mock connections
@@ -85,7 +96,7 @@ func TestRelayCallToOfflinePhone(t *testing.T) {
 
 func TestRelayCallAuthorizationIntegration(t *testing.T) {
 	hub := NewHub()
-	tracker := &mockTracker{}
+	tracker := newMockTracker()
 
 	// 3140001 and 3140002 are authorized; 3140003 is NOT authorized to be called by 3140001
 	authorizer := &mockCallAuthorizer{
@@ -174,12 +185,17 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 
 func TestRelayICERestartForwarded(t *testing.T) {
 	hub := NewHub()
-	relay := NewRelay(hub, nil, nil)
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
 	hub.Register("3140001", conn1)
 	hub.Register("3140002", conn2)
+
+	// Establish an active call first
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140002"})
+	<-conn2.Send // drain ring
 
 	// Phone 1 sends ICE restart to Phone 2
 	relay.HandleMessage("3140001", &Message{
@@ -205,6 +221,50 @@ func TestRelayICERestartForwarded(t *testing.T) {
 		}
 	default:
 		t.Fatal("phone 2 did not receive ice_restart")
+	}
+}
+
+func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+
+	// Phone 1 sends ICE restart without an active call
+	relay.HandleMessage("3140001", &Message{
+		Type: TypeICERestart,
+		To:   "3140002",
+		SDP:  "v=0\r\nrestart-offer\r\n",
+	})
+
+	// Sender should get an error
+	select {
+	case data := <-conn1.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeError {
+			t.Fatalf("expected error, got %s", msg.Type)
+		}
+		if msg.Error != "no active call" {
+			t.Fatalf("expected 'no active call', got %q", msg.Error)
+		}
+	default:
+		t.Fatal("sender did not receive error for ice_restart without active call")
+	}
+
+	// Target should not have received anything
+	select {
+	case data := <-conn2.Send:
+		msg, _ := ParseMessage(data)
+		t.Fatalf("target should not receive anything, got: %+v", msg)
+	default:
+		// correct
 	}
 }
 


### PR DESCRIPTION
## What

Gate `TypeICERestart` messages in the relay on an active-call check, preventing forwarding between peers that are not in a call.

## Why

ICE restart messages were forwarded unconditionally via `r.forward()`, unlike other call-state-dependent message types. This allowed any connected device to relay ICE restart messages to any other device without an established call.

## Test plan

- `go test ./...` -- all server tests pass
- `TestRelayICERestartForwarded` -- verifies ICE restart is forwarded when an active call exists
- `TestRelayICERestartRejectedWithoutCall` -- verifies ICE restart returns "no active call" error and is not forwarded when no call is active