### PR TITLE
docs(image): add SD card size recommendation

### DIFF
--- a/tools/README-image-builder.md
+++ b/tools/README-image-builder.md
@@ -95,6 +95,10 @@ gunzip -c digits-pi-*.img.gz | sudo dd of=/dev/sdX bs=4M status=progress
 11. **Enables services** -- first-boot, AP check, mixer restore, digitsd
 12. **Shrinks and compresses** the final image
 
+## SD Card Requirements
+
+The final image is ~7 GB uncompressed. An **8 GB microSD card** is the minimum recommended size. Larger cards work fine but the extra space goes unused.
+
 ## Partition Layout
 
 | Partition | Mount Point | Filesystem | Mode | Size |


### PR DESCRIPTION
## What

Adds an "SD Card Requirements" section to the image builder README noting that 8 GB microSD is sufficient.

## Why

The image is ~7 GB (512 MB boot + 4 GB root + 2 GB data). We had no documented size recommendation, and 16 GB cards are overkill. 8 GB fits with room to spare.

## Test plan

- Verified partition sizes in `build-image.sh` and `partition-setup.sh` total ~6.5 GB
- Documentation-only change