### PR TITLE
fix(image): strip Raspbian firstboot init from cmdline.txt

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -649,6 +649,15 @@ info "Configuring read-only root filesystem..."
 
 CMDLINE="${BOOT_MNT}/cmdline.txt"
 if [[ -f "$CMDLINE" ]]; then
+    # Remove Raspbian firstboot init — its initramfs resize script matches
+    # "firstboot" in cmdline and expands p2 to fill the disk, destroying p3.
+    # Our digits-first-boot.service handles identity/SSH setup instead.
+    sed -i 's| init=/usr/lib/raspberrypi-sys-mods/firstboot||' "$CMDLINE"
+    # Remove quiet (no splash screen, want to see boot messages)
+    sed -i 's/ quiet//g' "$CMDLINE"
+    # Remove splash
+    sed -i 's/ splash//g' "$CMDLINE"
+    sed -i 's/ plymouth.ignore-serial-consoles//g' "$CMDLINE"
     # Remove fsck.repair=yes (incompatible with ro root)
     sed -i 's/fsck\.repair=yes //g' "$CMDLINE"
     # Remove serial console (conflicts with disable-bt UART for Pico)


### PR DESCRIPTION
## What

Strip `init=/usr/lib/raspberrypi-sys-mods/firstboot` (and `quiet`/`splash`/`plymouth` flags) from cmdline.txt during the image build.

## Why

The stock Raspberry Pi OS cmdline.txt includes an `init=` that triggers the Raspbian firstboot script. The initramfs script at `local-premount/firstboot` greps `/proc/cmdline` for the string "firstboot" -- which matches the `init=` path -- and runs `parted resizepart 2` to expand root (p2) to fill the disk. On our 3-partition image, this overwrites p3 (data), corrupting the root filesystem and destroying `/data`. dnsmasq then crash-loops on boot because the binary itself is damaged, causing AP mode DHCP to fail ("IP configuration failure" when connecting to the setup AP).

Our `digits-first-boot.service` already handles device identity and SSH key generation, so the Raspbian firstboot is not needed.

## Test plan

- Built image with fix via `build-docker.sh --dev`
- Flashed to SD card, booted Pi Zero 2 W
- AP mode worked: phone connected, received IP via DHCP, captive portal loaded
- After Wi-Fi setup, Pi rebooted and connected to network as expected