### PR TITLE
fix(image): remove userconf-pi SSH banner from built images

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -481,6 +481,7 @@ chroot "$ROOTFS_MNT" /bin/bash -c "
     DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove ${PURGE_LIST} 2>/dev/null || true
     DEBIAN_FRONTEND=noninteractive apt-get autoremove -y 2>/dev/null || true
     apt-get clean
+    rm -f /etc/ssh/sshd_config.d/rename_user.conf
 "
 
 # ── step 6: install required packages (chroot — apt-get only) ───────────────


### PR DESCRIPTION
## What

Deletes the leftover `rename_user.conf` sshd config fragment during image build so the "SSH may not work until a valid user has been set up" banner no longer appears on every SSH connection.

## Why

The `userconf-pi` package is purged during image build, but its conffile at `/etc/ssh/sshd_config.d/rename_user.conf` survives the purge. That file sets `Banner /usr/share/userconf-pi/sshd_banner`, which prints a misleading warning on every SSH login even though the `dev` user is fully configured.

## Test plan

- Verified the banner source on a running device (`cat /etc/ssh/sshd_config.d/rename_user.conf` shows the Banner directive)
- Confirmed the file is not removed by `apt-get purge userconf-pi`
- Next image build will include the `rm -f` and should produce banner-free SSH sessions