### PR TITLE
feat(pi): add interactive UART terminal script

### DIFF
--- a/scripts/uart-term.sh
+++ b/scripts/uart-term.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Interactive UART terminal to a Pico via the digitsd Unix socket.
+# Usage: uart-term.sh <ip>
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: uart-term.sh <ip>" >&2
+    exit 1
+fi
+HOST="dev@$1"
+SOCK="/data/digits/uart.sock"
+
+SCRIPT=$(cat <<'PYEOF'
+import socket, sys, readline
+
+sock_path = sys.argv[1]
+print(f"Connected to {sock_path}")
+print("Type UART commands (PING, STATE?, LED:ON, etc). Ctrl-C to quit.\n")
+
+while True:
+    try:
+        cmd = input("uart> ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        break
+    if not cmd:
+        continue
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(sock_path)
+        s.settimeout(2)
+        s.sendall((cmd + "\n").encode())
+        resp = s.recv(4096).decode().strip()
+        s.close()
+        print(resp)
+    except socket.timeout:
+        print("(no response)")
+    except Exception as e:
+        print(f"error: {e}")
+PYEOF
+)
+
+sshpass -p digits scp -q <(echo "$SCRIPT") "$HOST:/tmp/uart-term.py" 2>/dev/null \
+    || sshpass -p digits ssh "$HOST" "cat > /tmp/uart-term.py" <<< "$SCRIPT"
+sshpass -p digits ssh -t "$HOST" sudo python3 -u /tmp/uart-term.py "$SOCK"

--- a/scripts/uart-term.sh
+++ b/scripts/uart-term.sh
@@ -25,21 +25,21 @@ while True:
         break
     if not cmd:
         continue
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
-        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.connect(sock_path)
         s.settimeout(2)
         s.sendall((cmd + "\n").encode())
         resp = s.recv(4096).decode().strip()
-        s.close()
         print(resp)
     except socket.timeout:
         print("(no response)")
     except Exception as e:
         print(f"error: {e}")
+    finally:
+        s.close()
 PYEOF
 )
 
-sshpass -p digits scp -q <(echo "$SCRIPT") "$HOST:/tmp/uart-term.py" 2>/dev/null \
-    || sshpass -p digits ssh "$HOST" "cat > /tmp/uart-term.py" <<< "$SCRIPT"
+sshpass -p digits ssh "$HOST" "cat > /tmp/uart-term.py" <<< "$SCRIPT"
 sshpass -p digits ssh -t "$HOST" sudo python3 -u /tmp/uart-term.py "$SOCK"


### PR DESCRIPTION
## What

Adds `scripts/uart-term.sh` -- an interactive UART command prompt for Pi phones over SSH.

## Why

Debugging Pico firmware (keypad testing, GPIO dumps, LED/ringer control) currently requires either a USB console connection or manually crafting Python one-liners over SSH. This script gives a simple `uart>` prompt that sends commands through the digitsd Unix socket without stopping the service.

## Test plan

- Ran `./scripts/uart-term.sh 192.168.2.228` and verified PING, STATE?, LED:BLINK, LED:OFF, KEYTEST, and KEYDUMP commands all return correct responses