### PR TITLE
fix(server): exclude .sha256 assets from binary URL classification

### DIFF
--- a/pi/image/init-data.sh
+++ b/pi/image/init-data.sh
@@ -60,8 +60,9 @@ trap cleanup EXIT
 
 info "Creating /data directory structure at $MOUNT_POINT..."
 
-# digits/ — digitsd binary, config, tones
+# digits/ — digitsd binary, config, tones, updater staging
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits"
+install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits/digitsd"
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits/tones"
 
 # wifi/ — wpa_supplicant.conf written by setup portal

--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -247,6 +247,9 @@ func classifyAssets(assets []ghAsset) (binaryURL, sha256URL string) {
 		if a.BrowserDownloadURL == "" {
 			continue
 		}
+		if strings.HasSuffix(a.Name, ".sha256") {
+			continue
+		}
 		if strings.HasSuffix(a.Name, ".elf") || strings.Contains(a.Name, "aarch64") {
 			binaryURL = a.BrowserDownloadURL
 			binaryName = a.Name

--- a/server/internal/updates/github_test.go
+++ b/server/internal/updates/github_test.go
@@ -159,6 +159,35 @@ func TestGitHubReleases_APIError(t *testing.T) {
 	}
 }
 
+func TestClassifyAssets_SHA256NotPickedAsBinary(t *testing.T) {
+	// GitHub doesn't guarantee asset order — .sha256 might come last and
+	// its name also contains "aarch64", so it must be explicitly skipped.
+	assets := []ghAsset{
+		{Name: "digitsd-1.0.0-aarch64.sha256", BrowserDownloadURL: "https://example.com/digitsd.sha256"},
+		{Name: "digitsd-1.0.0-aarch64", BrowserDownloadURL: "https://example.com/digitsd"},
+	}
+	binaryURL, sha256URL := classifyAssets(assets)
+	if binaryURL != "https://example.com/digitsd" {
+		t.Errorf("binaryURL = %q, want the binary not the checksum", binaryURL)
+	}
+	if sha256URL != "https://example.com/digitsd.sha256" {
+		t.Errorf("sha256URL = %q, want the .sha256 URL", sha256URL)
+	}
+
+	// Also test reversed order (sha256 after binary)
+	assets2 := []ghAsset{
+		{Name: "digitsd-1.0.0-aarch64", BrowserDownloadURL: "https://example.com/digitsd"},
+		{Name: "digitsd-1.0.0-aarch64.sha256", BrowserDownloadURL: "https://example.com/digitsd.sha256"},
+	}
+	binaryURL2, sha256URL2 := classifyAssets(assets2)
+	if binaryURL2 != "https://example.com/digitsd" {
+		t.Errorf("reversed: binaryURL = %q, want the binary", binaryURL2)
+	}
+	if sha256URL2 != "https://example.com/digitsd.sha256" {
+		t.Errorf("reversed: sha256URL = %q, want the .sha256 URL", sha256URL2)
+	}
+}
+
 func TestParseTag(t *testing.T) {
 	cases := []struct {
 		tag           string

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -578,6 +578,10 @@ info "Copying Digits binaries..."
 install -m 755 "${BUILD_DIR}/digitsd" "${ROOTFS_MNT}/usr/local/bin/digitsd"
 install -m 755 "${BUILD_DIR}/digits-setup" "${ROOTFS_MNT}/usr/local/bin/digits-setup"
 
+# Also copy digitsd to /data for the OTA updater (replaces binary in-place)
+mkdir -p "${DATA_MNT}/digits/digitsd"
+install -m 755 "${BUILD_DIR}/digitsd" "${DATA_MNT}/digits/digitsd/digitsd"
+
 # ── step 13: copy rootfs overlay (host-side) ────────────────────────────────
 
 info "Copying rootfs overlay..."


### PR DESCRIPTION
## What

Fix OTA updater downloading the SHA256 checksum file instead of the actual digitsd binary. Also create the `/data/digits/digitsd/` directory in the image build.

## Why

`classifyAssets` matched `.sha256` files as binary downloads because their names also contain "aarch64". When GitHub returned assets in an order where the checksum file came after the binary, it overwrote the binary URL. The updater then downloaded a 65-byte hash, replaced the real binary with it, and reported "updated to dev" because the hash file isn't executable.

Separately, the OTA updater's `rename` to `/data/digits/digitsd/digitsd` failed on fresh images because `init-data.sh` never created that directory.

## Test plan

- Added `TestClassifyAssets_SHA256NotPickedAsBinary` covering both asset orderings
- All server tests pass
- Created missing directory on both phones, verified updater rename path works