### PR TITLE
fix(digitsd): play busy tone when dialing own number

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -921,7 +921,7 @@ func main() {
 	}
 
 	// 8. Create phone Controller
-	ctrl := phone.NewController(cb)
+	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
 
 	// 9. Start socket server (backward compat for debugging + latclient auto-answer)

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -41,14 +41,17 @@ type Controller struct {
 	state          State
 	cb             Callbacks
 	digits         string
+	ownNumber      string
 	contactChecker ContactChecker
 }
 
 // NewController creates a new Controller starting in StateIDLE.
-func NewController(cb Callbacks) *Controller {
+// ownNumber is this phone's number; dialing it will produce a busy tone.
+func NewController(cb Callbacks, ownNumber string) *Controller {
 	return &Controller{
-		state: StateIDLE,
-		cb:    cb,
+		state:     StateIDLE,
+		cb:        cb,
+		ownNumber: ownNumber,
 	}
 }
 
@@ -192,6 +195,15 @@ func (c *Controller) onKey(digit string) {
 func (c *Controller) onDial(number string) {
 	if c.state != StateDIALING {
 		log.Printf("phone: DIAL event ignored in state %s", c.state)
+		return
+	}
+
+	// Self-call: dialing your own number gets an immediate busy tone,
+	// just like a real POTS line.
+	if c.ownNumber != "" && number == c.ownNumber {
+		log.Printf("phone: self-call detected — busy tone")
+		c.state = StateCALLING
+		c.cb.SendTone("BUSY")
 		return
 	}
 

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -47,7 +47,7 @@ func waitForTone(cb *mockCallbacks, tone string) {
 
 func TestController_OutgoingCallFlow(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	// Pick up handset
 	c.HandleEvent("HOOK:OFF")
@@ -121,7 +121,7 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 // 2. Full incoming call flow: ring signal → HOOK:OFF → hangup signal
 func TestController_IncomingCallFlow(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	// Incoming ring
 	c.HandleSignal("ring")
@@ -173,7 +173,7 @@ func TestController_IncomingCallFlow(t *testing.T) {
 // 3. KEY in IDLE is ignored — no state change, no callbacks
 func TestController_IgnoreKeyInIdle(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	c.HandleEvent("KEY:5")
 
@@ -188,7 +188,7 @@ func TestController_IgnoreKeyInIdle(t *testing.T) {
 // 4. Hang up during DIALING → IDLE, no HangupCall
 func TestController_HangupDuringDialing(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	c.HandleEvent("HOOK:OFF") // → DIAL_TONE
 	c.HandleEvent("KEY:5")    // → DIALING
@@ -205,7 +205,7 @@ func TestController_HangupDuringDialing(t *testing.T) {
 // 5. Hang up during CALLING → IDLE, HangupCall IS called
 func TestController_HangupDuringCalling(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	c.HandleEvent("HOOK:OFF")    // → DIAL_TONE
 	c.HandleEvent("KEY:5")       // → DIALING
@@ -223,7 +223,7 @@ func TestController_HangupDuringCalling(t *testing.T) {
 // 6. Busy signal during CALLING → SendTone("STOP"), stays in CALLING or logs
 func TestController_BusySignal(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	c.HandleEvent("HOOK:OFF")
 	c.HandleEvent("KEY:5")
@@ -262,7 +262,7 @@ func (m *mockContactChecker) IsContact(number string) bool {
 // Test: dialing an allowed contact proceeds normally
 func TestController_DialAllowedContact(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 	c.SetContactChecker(&mockContactChecker{allowed: map[string]bool{"5551234": true}})
 
 	c.HandleEvent("HOOK:OFF")
@@ -281,7 +281,7 @@ func TestController_DialAllowedContact(t *testing.T) {
 // Test: dialing a blocked number gets rejection tones, not a call
 func TestController_DialBlockedContact(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 	c.SetContactChecker(&mockContactChecker{allowed: map[string]bool{"5559999": true}})
 
 	c.HandleEvent("HOOK:OFF")
@@ -310,7 +310,7 @@ func TestController_DialBlockedContact(t *testing.T) {
 // Test: no ContactChecker set = all calls allowed (backward compat)
 func TestController_NoContactChecker_AllowsAll(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 	// No SetContactChecker call
 
 	c.HandleEvent("HOOK:OFF")
@@ -326,10 +326,31 @@ func TestController_NoContactChecker_AllowsAll(t *testing.T) {
 	}
 }
 
-// 7. Incoming ring signal while CONNECTED → stays CONNECTED, ignored
+// 7. Self-dial → immediate busy tone, no call initiated
+func TestController_SelfDial(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "5551234")
+
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:5")
+	c.HandleEvent("DIAL:5551234") // own number
+
+	if c.State() != StateCALLING {
+		t.Fatalf("expected CALLING, got %s", c.State())
+	}
+	if len(cb.calls) != 0 {
+		t.Errorf("expected no InitiateCall for self-dial, got %v", cb.calls)
+	}
+	lastTone := cb.tones[len(cb.tones)-1]
+	if lastTone != "BUSY" {
+		t.Errorf("expected BUSY tone for self-dial, got %s", lastTone)
+	}
+}
+
+// 8. Incoming ring signal while CONNECTED → stays CONNECTED, ignored
 func TestController_IncomingWhileBusy(t *testing.T) {
 	cb := &mockCallbacks{}
-	c := NewController(cb)
+	c := NewController(cb, "")
 
 	// Set up CONNECTED state via outgoing call flow
 	c.HandleEvent("HOOK:OFF")


### PR DESCRIPTION
## What

Play an immediate busy tone when a phone dials its own number, matching real POTS behavior.

## Why

Previously, dialing your own number would silently hang with no audio feedback. Real phone lines return a busy signal in this case.

## Test plan

- [x] `go test ./internal/phone/` passes (11 tests including new `TestController_SelfDial`)
- [ ] Deploy to a phone and dial its own number -- verify busy tone plays immediately
- [ ] Dial a different number -- verify normal call flow is unaffected