### PR TITLE
fix(server,digitsd): WebSocket keepalive and Makefile version ldflags

### DIFF
--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -4,14 +4,19 @@ PI_DIR   = ~/digits/digitsd
 GOOS     = linux
 GOARCH   = arm64
 
+VERSION ?= dev
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS  = -X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$(VERSION) \
+           -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$(COMMIT)
+
 .PHONY: build build-local deploy run test clean
 
 build:
 	CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOOS=$(GOOS) GOARCH=$(GOARCH) \
-		go build -o bin/$(BINARY) ./cmd/digitsd
+		go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) ./cmd/digitsd
 
 build-local:
-	go build -o bin/$(BINARY) ./cmd/digitsd
+	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) ./cmd/digitsd
 
 deploy: build
 	ssh $(PI_HOST) "mkdir -p $(PI_DIR)"

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	// pongTimeout is how long the client waits for a pong (or any read)
+	// pingTimeout is how long the client waits between server pings
 	// before considering the connection dead. Must be greater than the
 	// server's ping interval (30s).
-	pongTimeout = 45 * time.Second
+	pingTimeout = 45 * time.Second
 )
 
 // Client connects to a signald WebSocket server and manages message I/O.
@@ -78,10 +78,10 @@ func (c *Client) Connect() error {
 
 	// Reset read deadline on each server ping so Cloudflare/proxy
 	// idle timeouts don't kill the connection.
-	c.conn.SetReadDeadline(time.Now().Add(pongTimeout))
-	c.conn.SetPongHandler(func(string) error {
-		c.conn.SetReadDeadline(time.Now().Add(pongTimeout))
-		return nil
+	c.conn.SetReadDeadline(time.Now().Add(pingTimeout))
+	c.conn.SetPingHandler(func(appData string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pingTimeout))
+		return c.conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
 	})
 
 	go c.readPump()

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -6,8 +6,16 @@ import (
 	"log"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
+)
+
+const (
+	// pongTimeout is how long the client waits for a pong (or any read)
+	// before considering the connection dead. Must be greater than the
+	// server's ping interval (30s).
+	pongTimeout = 45 * time.Second
 )
 
 // Client connects to a signald WebSocket server and manages message I/O.
@@ -67,6 +75,14 @@ func (c *Client) Connect() error {
 		conn.Close()
 		return fmt.Errorf("signal: send register: %w", err)
 	}
+
+	// Reset read deadline on each server ping so Cloudflare/proxy
+	// idle timeouts don't kill the connection.
+	c.conn.SetReadDeadline(time.Now().Add(pongTimeout))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongTimeout))
+		return nil
+	})
 
 	go c.readPump()
 	return nil

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1154,6 +1154,12 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	const (
+		wsPingInterval = 30 * time.Second
+		wsPongTimeout  = 45 * time.Second
+		wsWriteTimeout = 10 * time.Second
+	)
+
 	conn := &signaling.Conn{
 		WS:         ws,
 		HardwareID: msg.HardwareID,
@@ -1162,16 +1168,38 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	h.hub.Register(msg.Number, conn)
 	number := msg.Number
 
-	// Write pump
+	// Configure pong handler to extend read deadline on each pong
+	ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
+	ws.SetPongHandler(func(string) error {
+		ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
+		return nil
+	})
+
+	// Write pump with periodic pings
 	go func() {
+		ticker := time.NewTicker(wsPingInterval)
+		defer ticker.Stop()
 		defer ws.Close()
-		for data := range conn.Send {
-			if err := ws.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
-				return
-			}
-			if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-				slog.Error("websocket write failed", "number", number, "err", err)
-				return
+		for {
+			select {
+			case data, ok := <-conn.Send:
+				if !ok {
+					return
+				}
+				if err := ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
+					return
+				}
+				if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
+					slog.Error("websocket write failed", "number", number, "err", err)
+					return
+				}
+			case <-ticker.C:
+				if err := ws.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
+					return
+				}
+				if err := ws.WriteMessage(websocket.PingMessage, nil); err != nil {
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## What

Adds WebSocket ping/pong keepalive between the signaling server and digitsd clients, and injects version/commit info via ldflags in the digitsd Makefile.

## Why

WebSocket connections through Cloudflare drop every ~90s due to idle timeouts, causing constant reconnect cycles on phones. Dev builds of digitsd report `pi=dev(unknown)` because the Makefile didn't pass ldflags, making it impossible to identify which version a device is running.

## Test plan

- [ ] Deploy signald with keepalive changes, verify digitsd connections stay up beyond 90s
- [ ] Build digitsd with `make build-local`, verify `device_info` logs the git commit instead of "unknown"
- [ ] Build with `make build-local VERSION=1.2.3`, verify version is "1.2.3"
- [ ] Server tests pass (`make test` in server/)
- [ ] digitsd tests pass (`make test` in pi/digitsd/)