### PR TITLE
fix(pi): validate wifi config at boot, fall back to AP mode if corrupt

### DIFF
--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -24,6 +24,7 @@ type Configurator interface {
 type FileSystem interface {
 	MkdirAll(path string, perm os.FileMode) error
 	WriteFile(name string, data []byte, perm os.FileMode) error
+	ReadFile(name string) ([]byte, error)
 }
 
 // Rebooter abstracts the system reboot.
@@ -40,6 +41,10 @@ func (OSFileSystem) MkdirAll(path string, perm os.FileMode) error {
 
 func (OSFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return os.WriteFile(name, data, perm)
+}
+
+func (OSFileSystem) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
 }
 
 // SystemRebooter calls `systemctl reboot`.
@@ -105,6 +110,15 @@ method=auto
 	nmPath := filepath.Join(wpaDir, "digits-wifi.nmconnection")
 	if err := fs.WriteFile(nmPath, []byte(nmConn), 0600); err != nil {
 		return fmt.Errorf("write nmconnection: %w", err)
+	}
+
+	// Read back and verify the file was written correctly
+	readBack, err := fs.ReadFile(nmPath)
+	if err != nil {
+		return fmt.Errorf("verify nmconnection: read-back failed: %w", err)
+	}
+	if string(readBack) != nmConn {
+		return fmt.Errorf("verify nmconnection: read-back mismatch (wrote %d bytes, read %d bytes)", len(nmConn), len(readBack))
 	}
 
 	// Set wifi-configured flag

--- a/pi/digits-setup/internal/wifi/configure_test.go
+++ b/pi/digits-setup/internal/wifi/configure_test.go
@@ -35,6 +35,14 @@ func (m *mockFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
+func (m *mockFS) ReadFile(name string) ([]byte, error) {
+	f, ok := m.files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return f.data, nil
+}
+
 // mockRebooter records if reboot was scheduled.
 type mockRebooter struct {
 	called bool
@@ -155,6 +163,38 @@ func TestConfigureVisibleNetworkNoScanSSID(t *testing.T) {
 	nmStr := string(nm.data)
 	if strings.Contains(nmStr, "hidden=") {
 		t.Errorf("visible network should not have hidden=, got: %s", nmStr)
+	}
+}
+
+// corruptingFS writes null bytes instead of actual data, simulating filesystem corruption.
+type corruptingFS struct {
+	mockFS
+}
+
+func (c *corruptingFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	corrupt := make([]byte, len(data))
+	c.files[name] = mockFile{data: corrupt, perm: perm}
+	return nil
+}
+
+func TestConfigureCorruptWrite(t *testing.T) {
+	fs := &corruptingFS{mockFS: *newMockFS()}
+	rebooter := &mockRebooter{}
+
+	req := ConfigRequest{
+		SSID:     "MyNetwork",
+		Password: "secret123",
+	}
+
+	err := ConfigureWithDeps(req, fs, rebooter)
+	if err == nil {
+		t.Fatal("expected error for corrupt write")
+	}
+	if !strings.Contains(err.Error(), "read-back mismatch") {
+		t.Errorf("error = %q, want read-back mismatch", err.Error())
+	}
+	if rebooter.called {
+		t.Error("reboot should not be scheduled on corrupt write")
 	}
 }
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -28,9 +28,10 @@ validate_nmconnection() {
         log "VALIDATE: file empty: $file"
         return 1
     fi
-    # Check for null bytes (sign of filesystem corruption)
-    if tr -d '\0' < "$file" | wc -c | grep -q '^0$'; then
-        log "VALIDATE: file is all null bytes: $file"
+    # Check for null bytes (sign of filesystem corruption).
+    # A valid nmconnection file is plain text and should never contain nulls.
+    if grep -Pq '\x00' "$file"; then
+        log "VALIDATE: file contains null bytes: $file"
         return 1
     fi
     # Must contain key NM connection sections

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -16,6 +16,47 @@ log() {
     logger -t "$LOG_TAG" "$*" 2>/dev/null || true
 }
 
+# Validate that an nmconnection file is not corrupt.
+# Returns 0 if valid, 1 if missing/corrupt.
+validate_nmconnection() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        log "VALIDATE: file missing: $file"
+        return 1
+    fi
+    if [ ! -s "$file" ]; then
+        log "VALIDATE: file empty: $file"
+        return 1
+    fi
+    # Check for null bytes (sign of filesystem corruption)
+    if tr -d '\0' < "$file" | wc -c | grep -q '^0$'; then
+        log "VALIDATE: file is all null bytes: $file"
+        return 1
+    fi
+    # Must contain key NM connection sections
+    if ! grep -q '^\[connection\]' "$file" || ! grep -q '^\[wifi\]' "$file"; then
+        log "VALIDATE: file missing required [connection] or [wifi] sections: $file"
+        return 1
+    fi
+    return 0
+}
+
+# Clear wifi-configured state so the device falls back to AP mode.
+reset_wifi_config() {
+    log "Resetting wifi config -- will enter AP mode"
+    rm -f "$WIFI_CONFIGURED_FLAG"
+    rm -f "$NM_CONN_SRC"
+}
+
+if [ -f "$WIFI_CONFIGURED_FLAG" ]; then
+    # Validate the config file before trusting it
+    if ! validate_nmconnection "$NM_CONN_SRC"; then
+        log "WARNING: Wi-Fi config is corrupt or missing -- falling back to AP mode"
+        reset_wifi_config
+        # Fall through to the AP mode block below
+    fi
+fi
+
 if [ -f "$WIFI_CONFIGURED_FLAG" ]; then
     log "Wi-Fi configured — starting normal boot"
 


### PR DESCRIPTION
## What

Validates the wifi nmconnection file at boot and catches corrupt writes at setup time. If the config is corrupt, the device falls back to AP mode for reconfiguration instead of booting into a broken state with no network.

## Why

Digits 2 (digits-b8e0) had its `/data/wifi/digits-wifi.nmconnection` file corrupted to all null bytes, likely from a failed write or power loss. The `wifi-configured` flag was still set, so the device skipped AP mode and tried to connect with a garbage config. This left it with no network and no recovery path short of pulling the SD card.

## Test plan

- `go test ./internal/wifi/...` passes, including new `TestConfigureCorruptWrite` case
- Verified the null-byte detection logic matches the corruption observed on the actual SD card (257 bytes of `\0`)
- Boot script changes are shell-only and testable by placing corrupt/valid files in `/data/wifi/` on a test image