### PR TITLE
fix(pi): run digitsd from read-only rootfs to prevent corruption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help server server-test pi-build pi-test firmware image image-dev clean
+.PHONY: help server server-test pi-build pi-test firmware image image-dev flash clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -34,6 +34,16 @@ image: ## Build flashable Pi SD card image (Docker)
 
 image-dev: ## Build Pi image with SSH enabled (Docker)
 	./pi/image/build-docker.sh --dev
+
+flash: ## Flash the most recent image to SD card (SD=<device>, e.g. make flash SD=/dev/sdd)
+	@if [ -z "$(SD)" ]; then echo "Usage: make flash SD=/dev/sdX"; exit 1; fi
+	@IMAGE=$$(ls -t digits-pi-*.img.gz 2>/dev/null | head -1); \
+	if [ -z "$$IMAGE" ]; then echo "No image found -- run 'make image-dev' first"; exit 1; fi; \
+	echo "Flashing $$IMAGE → $(SD)"; \
+	echo "WARNING: This will overwrite all data on $(SD). Press Ctrl-C to cancel."; \
+	read -r -p "Continue? [y/N] " ans; \
+	if [ "$$ans" != "y" ] && [ "$$ans" != "Y" ]; then echo "Aborted."; exit 1; fi; \
+	gunzip -c "$$IMAGE" | sudo dd of=$(SD) bs=4M status=progress conv=fsync
 
 # ── Utilities ────────────────────────────────────────────────────────────────
 

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -32,7 +32,7 @@ type Config struct {
 	CurrentFWVersion string
 	StagingDir       string // default: /data/digits/staging
 	FlashScript      string // default: /usr/local/bin/flash-pico.sh
-	BinaryPath       string // default: /data/digits/digitsd/digitsd
+	BinaryPath       string // default: /usr/local/bin/digitsd
 	FirmwarePath     string // default: /data/digits/firmware.elf
 }
 
@@ -49,7 +49,7 @@ func New(cfg Config) *Updater {
 		cfg.FlashScript = "/usr/local/bin/flash-pico.sh"
 	}
 	if cfg.BinaryPath == "" {
-		cfg.BinaryPath = "/data/digits/digitsd/digitsd"
+		cfg.BinaryPath = "/usr/local/bin/digitsd"
 	}
 	if cfg.FirmwarePath == "" {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
@@ -183,19 +183,66 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 	return destPath, nil
 }
 
-// ApplyPiUpdate replaces the digitsd binary and exits (systemd restarts).
-// Staging dir and binary path are on the same filesystem (/data), so rename is atomic.
+// ApplyPiUpdate replaces the digitsd binary on the read-only rootfs and exits
+// (systemd restarts). Temporarily remounts / as rw for the copy, then restores ro.
 func (u *Updater) ApplyPiUpdate(stagedBinary string) error {
 	if err := os.Chmod(stagedBinary, 0755); err != nil {
 		return fmt.Errorf("chmod: %w", err)
 	}
-	if err := os.Rename(stagedBinary, u.cfg.BinaryPath); err != nil {
-		return fmt.Errorf("rename: %w", err)
+
+	// Remount rootfs read-write so we can replace the binary.
+	if err := exec.Command("mount", "-o", "remount,rw", "/").Run(); err != nil {
+		return fmt.Errorf("remount rw: %w", err)
+	}
+
+	// Copy staged binary to destination (cross-filesystem, can't use rename).
+	if err := copyFile(stagedBinary, u.cfg.BinaryPath); err != nil {
+		// Best-effort restore ro before returning.
+		exec.Command("mount", "-o", "remount,ro", "/").Run()
+		return fmt.Errorf("copy binary: %w", err)
+	}
+	os.Remove(stagedBinary)
+
+	// Restore read-only rootfs.
+	if err := exec.Command("mount", "-o", "remount,ro", "/").Run(); err != nil {
+		log.Printf("updater: WARNING: failed to remount ro: %v", err)
 	}
 
 	log.Println("updater: Pi binary updated -- exiting for restart")
 	os.Exit(0)
 	return nil // unreachable
+}
+
+// copyFile copies src to dst atomically using a temp file + rename.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".tmp"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := os.Chmod(tmp, 0755); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return os.Rename(tmp, dst)
 }
 
 // ApplyFirmwareUpdate moves the ELF to the flash path and runs the flash script.

--- a/pi/image/init-data.sh
+++ b/pi/image/init-data.sh
@@ -60,7 +60,7 @@ trap cleanup EXIT
 
 info "Creating /data directory structure at $MOUNT_POINT..."
 
-# digits/ — digitsd binary, config, tones, updater staging
+# digits/ — config, tones, updater staging
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits"
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits/tones"
 

--- a/pi/image/init-data.sh
+++ b/pi/image/init-data.sh
@@ -11,7 +11,7 @@
 #
 # Creates:
 #   /data/
-#   ├── digits/           # digitsd binary, config, tones
+#   ├── digits/           # config and tones (binary lives on read-only rootfs)
 #   │   ├── config.json   # placeholder — filled by captive portal
 #   │   └── tones/        # audio tone files
 #   ├── wifi/             # wpa_supplicant.conf (written by setup portal)
@@ -62,7 +62,6 @@ info "Creating /data directory structure at $MOUNT_POINT..."
 
 # digits/ — digitsd binary, config, tones, updater staging
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits"
-install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits/digitsd"
 install -d -m 755 -o 999 -g 992 "${MOUNT_POINT}/digits/tones"
 
 # wifi/ — wpa_supplicant.conf written by setup portal

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -578,9 +578,6 @@ info "Copying Digits binaries..."
 install -m 755 "${BUILD_DIR}/digitsd" "${ROOTFS_MNT}/usr/local/bin/digitsd"
 install -m 755 "${BUILD_DIR}/digits-setup" "${ROOTFS_MNT}/usr/local/bin/digits-setup"
 
-# Also copy digitsd to /data for the OTA updater (replaces binary in-place)
-mkdir -p "${DATA_MNT}/digits/digitsd"
-install -m 755 "${BUILD_DIR}/digitsd" "${DATA_MNT}/digits/digitsd/digitsd"
 
 # ── step 13: copy rootfs overlay (host-side) ────────────────────────────────
 


### PR DESCRIPTION
## What

Moves digitsd to run exclusively from `/usr/local/bin/digitsd` on the read-only rootfs instead of a copy on the writable `/data` partition.

## Why

The digitsd binary on `/data/digits/digitsd/digitsd` was deleted or corrupted on digits-1c09, leaving the service crash-looping (exit 203/EXEC) with no recovery path. The read-only rootfs is already designed to prevent this class of failure -- the binary should live there, not on the writable partition.

Same principle as #44 (wifi config corruption), but simpler: the ro filesystem is the protection, no boot-time validation needed.

## Test plan

- `go vet ./internal/updater/` and `go test ./internal/updater/` pass
- Verified no remaining references to `/data/digits/digitsd` in the codebase
- OTA updater correctly remounts rw, copies the binary (cross-filesystem), and restores ro