### PR TITLE
fix(ci): include digitsd scope in pi release rules

### DIFF
--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -9,7 +9,10 @@ module.exports = {
         { scope: 'pi', type: 'fix', release: 'patch' },
         { scope: 'pi', type: 'perf', release: 'patch' },
         { scope: 'pi', breaking: true, release: 'major' },
-        { scope: '!pi', release: false },
+        { scope: 'digitsd', type: 'feat', release: 'minor' },
+        { scope: 'digitsd', type: 'fix', release: 'patch' },
+        { scope: 'digitsd', type: 'perf', release: 'patch' },
+        { scope: 'digitsd', breaking: true, release: 'major' },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],


### PR DESCRIPTION
## Summary
- Adds `digitsd` scope to pi `.releaserc.cjs` release rules so `fix(digitsd)` and `feat(digitsd)` commits trigger pi patch/minor releases
- Previously only `pi`-scoped commits triggered releases, meaning digitsd bug fixes never produced a new version

## Test plan
- [ ] Merge PR #47 (which has `fix(digitsd)` commits) after this and verify a new `pi/v*` release is created