### PR TITLE
fix(digitsd): check file close error in download

### DIFF
--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -167,7 +167,10 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 		os.Remove(destPath + ".tmp")
 		return "", fmt.Errorf("download write: %w", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		os.Remove(destPath + ".tmp")
+		return "", fmt.Errorf("flush download: %w", err)
+	}
 
 	gotSHA := hex.EncodeToString(h.Sum(nil))
 	if expectedSHA != "" && gotSHA != expectedSHA {


### PR DESCRIPTION
## Summary
- Check the error from `f.Close()` in `Download()` to catch flush failures on the Pi's SD card
- Also serves as a test that `fix(digitsd)` commits trigger a pi patch release after #48

## Test plan
- [ ] Merge and verify a new `pi/v*` release is created by semantic-release