### PR TITLE
feat(digitsd): dockerize cross-compile build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ docs/           Hardware notes, protocol specs, architecture
 
 - **Go 1.26+**
 - **PostgreSQL** -- the server reads `DATABASE_URL` to connect. Migrations run automatically on startup (inline in `internal/db/db.go`).
-- **Cross-compile toolchain** (for digitsd): `sudo apt install gcc-aarch64-linux-gnu libasound2-dev:arm64 libopus-dev:arm64 libopusfile-dev:arm64 pkg-config`
+- **Docker** (for digitsd cross-compile): `make build` uses a Docker container, no host cross-compile toolchain needed
 - **Pico SDK** (for firmware): set `PICO_SDK_PATH` to your checkout
 
 ## Build and test
@@ -35,8 +35,8 @@ go vet ./...
 
 digitsd (from `pi/digitsd/`):
 ```
-make build          # cross-compiles to linux/arm64 (needs cross-compile toolchain above)
-make build-local    # native build
+make build          # cross-compiles to linux/arm64 via Docker
+make build-local    # native build (requires local cross-compile libs)
 make test
 ```
 

--- a/pi/digitsd/Dockerfile.builder
+++ b/pi/digitsd/Dockerfile.builder
@@ -1,0 +1,19 @@
+FROM golang:1.26
+
+RUN dpkg --add-architecture arm64 \
+    && apt-get update -qq \
+    && apt-get install -y -qq \
+       gcc-aarch64-linux-gnu \
+       libasound2-dev:arm64 \
+       libopus-dev:arm64 \
+       libopusfile-dev:arm64 \
+       pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global --add safe.directory /src
+
+ENV CGO_ENABLED=1 \
+    CC=aarch64-linux-gnu-gcc \
+    GOOS=linux \
+    GOARCH=arm64 \
+    PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig

--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -1,18 +1,25 @@
-BINARY   = digitsd
-PI_HOST ?= digits@<pi-ip>
-PI_DIR   = ~/digits/digitsd
-GOOS     = linux
-GOARCH   = arm64
+BINARY      = digitsd
+PI_HOST    ?= digits@<pi-ip>
+PI_DIR      = ~/digits/digitsd
+BUILDER_IMG = digitsd-builder
 
 VERSION ?= dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LDFLAGS  = -X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$(VERSION) \
            -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$(COMMIT)
+REPO_ROOT   = $(shell git rev-parse --show-toplevel)
 
-.PHONY: build build-local deploy run test clean
+.PHONY: build build-local builder deploy run test clean
 
-build:
-	CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOOS=$(GOOS) GOARCH=$(GOARCH) \
+builder:
+	@docker build -q -t $(BUILDER_IMG) -f Dockerfile.builder .
+
+build: builder
+	@mkdir -p bin
+	docker run --rm \
+		-v $(REPO_ROOT):/src -w /src/pi/digitsd \
+		-v digitsd-gomodcache:/go/pkg/mod \
+		$(BUILDER_IMG) \
 		go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) ./cmd/digitsd
 
 build-local:


### PR DESCRIPTION
## Summary
- Replace host cross-compile toolchain with Docker-based builder (`Dockerfile.builder`)
- `make build` builds a reusable Docker image, then runs the Go cross-compile inside it
- Named volume (`digitsd-gomodcache`) caches Go modules across builds
- No host dependencies needed beyond Docker

## Test plan
- [x] `make build` produces a valid aarch64 binary
- [x] Second build skips module downloads (cache works)
- [ ] `make build-local` still works for native builds