### PR TITLE
fix(digitsd): move audio test from *#*8 to *#8378# (*#TEST#)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Hidden codes entered on the keypad during an active call.
 | Code | Action | Details |
 |------|--------|---------|
 | `*#*0` -- `*#*9` | Volume | Sets earpiece volume (0 = quiet, 9 = max). Persists across reboots. |
-| `*#*8` | Audio test | Records 5 s from mic, plays it back through earpiece. |
+| `*#8378#` | Audio test | Records 5 s from mic, plays it back through earpiece. (`*#TEST#` on keypad.) |
 | `*#*#` | Shutdown | Graceful power-off. Safe to unplug after LED goes dark. |
 | `*##*` | Reboot | Immediate reboot. |
 | `*#0*` | Force re-pair | Clears device token, reboots into pairing mode. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,12 +159,12 @@ Dial `*#*` followed by any digit `0`–`9` to set the volume level. The setting 
 
 | Code | Also written as | What it does |
 |------|----------------|-------------|
-| `*#*8` | -- | **Audio test** -- records a 3-second clip and plays it back. Useful for checking mic/speaker. |
+| `*#8378#` | `*#TEST#` | **Audio test** -- records a 3-second clip and plays it back. Useful for checking mic/speaker. |
 | `*#73887#` | `*#SETUP#` | **Re-enter Wi-Fi setup mode.** Use this if you change your Wi-Fi network or password. The phone reboots into setup mode. |
 | `*#*#` | -- | **Safe shutdown.** Powers off the phone gracefully. Unplug after the LED goes dark. |
 | `*##*` | -- | **Reboot.** Restarts the phone's software. Takes about 60 seconds. |
 
-> **Tip:** The `*#SETUP#` label is a mnemonic -- `SETUP` = `73887` on a phone keypad. The shutdown (`*#*#`) and reboot (`*##*`) codes use `*` and `#` keys only.
+> **Tip:** The `*#SETUP#` and `*#TEST#` labels are mnemonics -- `SETUP` = `73887` and `TEST` = `8378` on a phone keypad. The shutdown (`*#*#`) and reboot (`*##*`) codes use `*` and `#` keys only.
 
 ---
 
@@ -241,7 +241,7 @@ There's nothing to tap, no account to log into, no data to harvest. The phone do
 ### The call sounds bad / echoey
 
 - Try adjusting the volume with `*#*5` or `*#*6` (a lower volume can reduce echo)
-- Run the audio test: dial `*#*8` while off-hook, speak into the handset, and listen to the playback. If it sounds distorted, the volume may be too high.
+- Run the audio test: dial `*#8378#` (`*#TEST#`) while off-hook, speak into the handset, and listen to the playback. If it sounds distorted, the volume may be too high.
 - Move the phone away from the Wi-Fi router if they're right next to each other
 
 ### The phone isn't ringing for incoming calls
@@ -266,7 +266,7 @@ Dial `*#73887#` (or `*#SETUP#`) while off-hook. The phone will reboot into setup
 │  HANG UP        Place handset on cradle         │
 ├─────────────────────────────────────────────────┤
 │  VOLUME         *#*0 (mute) ... *#*9 (max)      │
-│  AUDIO TEST     *#*8                            │
+│  AUDIO TEST     *#8378#  (*#TEST#)              │
 │  WI-FI SETUP    *#73887#  (*#SETUP#)            │
 │  REBOOT         *##*                            │
 │  SHUTDOWN       *#*#                            │

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -18,11 +18,10 @@ import (
 //
 //	*#*#     → shutdown
 //	*##*     → reboot
+//	*#8378#  → *#TEST# — audio test (records clip, plays back)
 //	*#73887# → *#SETUP# — Wi-Fi re-provisioning (removes /data/wifi-configured, reboots)
 //
 // Volume codes: *#*N where N=0-9
-//
-//	*#*8 → audio test (special)
 type ServiceCodeHandler struct {
 	buffer      string
 	onVolume    func(level int)
@@ -49,7 +48,7 @@ func (h *ServiceCodeHandler) SetVolumeCallback(fn func(level int)) {
 	h.onVolume = fn
 }
 
-// SetAudioTestCallback sets the function called for *#*8.
+// SetAudioTestCallback sets the function called for *#8378# (*#TEST#).
 func (h *ServiceCodeHandler) SetAudioTestCallback(fn func()) {
 	h.onAudioTest = fn
 }
@@ -142,6 +141,20 @@ func (h *ServiceCodeHandler) check() bool {
 	}
 
 
+	// --- 7-character codes ---
+
+	if len(h.buffer) >= 7 {
+		last7 := h.buffer[len(h.buffer)-7:]
+		if last7 == "*#8378#" {
+			log.Println("service code: *#8378# (*#TEST#) → audio test")
+			if h.onAudioTest != nil {
+				go h.onAudioTest()
+			}
+			h.buffer = ""
+			return true
+		}
+	}
+
 	// --- 4-character codes ---
 
 	if len(h.buffer) < 4 {
@@ -178,12 +191,6 @@ func (h *ServiceCodeHandler) check() bool {
 		ch := last4[3]
 		if ch >= '0' && ch <= '9' {
 			level := int(ch - '0')
-			if level == 8 && h.onAudioTest != nil {
-				log.Println("service code: *#*8 → audio test")
-				go h.onAudioTest()
-				h.buffer = ""
-				return true
-			}
 			if h.onVolume != nil {
 				log.Printf("service code: *#*%d → volume %d", level, level)
 				h.onVolume(level)

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -44,18 +44,38 @@ func TestServiceCodeVolume(t *testing.T) {
 }
 
 func TestServiceCodeAudioTest(t *testing.T) {
-	called := false
 	h := NewServiceCodeHandler()
-	h.SetAudioTestCallback(func() { called = true })
+	h.SetAudioTestCallback(func() {})
 
-	for _, k := range "*#*8" {
+	code := "*#8378#"
+	var triggered bool
+	for i, k := range code {
+		result := h.AddKey(string(k))
+		if result && i < len(code)-1 {
+			t.Fatalf("triggered too early at index %d", i)
+		}
+		if result {
+			triggered = true
+		}
+	}
+	if !triggered {
+		t.Error("*#8378# (*#TEST#) should trigger audio test")
+	}
+}
+
+func TestServiceCodeVolume8Works(t *testing.T) {
+	var gotLevel int
+	h := NewServiceCodeHandler()
+	h.SetVolumeCallback(func(level int) { gotLevel = level })
+
+	for _, k := range "*#*" {
 		h.AddKey(string(k))
 	}
-	// Audio test callback is called in a goroutine, so give it a moment
-	// Actually, check returns true synchronously
-	if !called {
-		// The callback is called in a goroutine, so it may not have run yet
-		// For testing purposes, just check the return value
+	if !h.AddKey("8") {
+		t.Error("*#*8 should trigger volume")
+	}
+	if gotLevel != 8 {
+		t.Errorf("expected level 8, got %d", gotLevel)
 	}
 }
 


### PR DESCRIPTION
## What

Moves the audio test service code from `*#*8` to `*#8378#` (`*#TEST#`), freeing volume level 8 for actual volume control.

## Why

`*#*8` sat inside the volume range (`*#*0`-`*#*9`), which meant volume 8 was unreachable. The new code follows the mnemonic pattern already used by `*#SETUP#` and `*#UPDATE#`.

## Test plan

- [x] `go test ./internal/phone/ -run ServiceCode -v` -- all 16 tests pass
- [x] New `TestServiceCodeVolume8Works` confirms `*#*8` now triggers volume 8
- [x] Updated `TestServiceCodeAudioTest` confirms `*#8378#` triggers audio test
- [ ] Manual test on phone: dial `*#*8` and verify volume changes, dial `*#8378#` and verify mic/speaker test