### PR TITLE
docs(hardware): add LCSC part numbers to v2 KiCad schematic

### DIFF
--- a/kicad/digits-pcb-v2/digits-pcb-v2.kicad_sch
+++ b/kicad/digits-pcb-v2/digits-pcb-v2.kicad_sch
@@ -6978,6 +6978,17 @@
 				)
 			)
 		)
+		(property "LCSC Part #" "C347421"
+			(at 0 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "2"
 			(uuid "3e71e401-f6e2-4c73-ae11-530a8258092c")
 		)
@@ -7067,6 +7078,17 @@
 				)
 			)
 		)
+		(property "LCSC Part #" "C22452"
+			(at 0 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "a4f63ad7-34d4-4276-bf33-681090e52369")
 		)
@@ -7140,6 +7162,17 @@
 		)
 		(property "Description" "Unpolarized capacitor"
 			(at 104.14 30.48 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC Part #" "C49678"
+			(at 0 0 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -7551,6 +7584,17 @@
 				)
 			)
 		)
+		(property "LCSC Part #" "C17557"
+			(at 34.29 121.92 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "1"
 			(uuid "12b957af-101d-4105-8030-8927413aa58a")
 		)
@@ -7624,6 +7668,17 @@
 		)
 		(property "Description" "Polarized capacitor"
 			(at 92.71 143.51 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC Part #" "C976031"
+			(at 0 0 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)
@@ -8662,6 +8717,17 @@
 				)
 			)
 		)
+		(property "LCSC Part #" "C9400"
+			(at 0 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
 		(pin "2"
 			(uuid "4d74a526-b34d-4049-92d8-65e14eb40202")
 		)
@@ -8735,6 +8801,17 @@
 		)
 		(property "Description" "Polarized capacitor"
 			(at 129.54 157.48 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "LCSC Part #" "C2895286"
+			(at 0 0 0)
 			(hide yes)
 			(show_name no)
 			(do_not_autoplace no)


### PR DESCRIPTION
Add `LCSC Part #` field to all SMT components in the v2 KiCad schematic for JLCPCB Fabrication Toolkit compatibility.

| Ref | Part | LCSC # |
|-----|------|--------|
| U1 | LM2596S-5.0 | C347421 |
| D1 | SS54 | C22452 |
| L1 | CDRH127 33µH | C9400 |
| C1 | 680µF 25V | C976031 |
| C2 | 220µF 25V | C2895286 |
| C3 | 100nF 0805 | C49678 |
| R1 | 220Ω 0805 | C17557 |

All part numbers verified against JLCPCB live inventory.

View in KiCad: Schematic Editor → Tools → Edit Symbol Fields