### PR TITLE
chore: gitignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules/
 
 # Claude Code
 .claude/
+CLAUDE.local.md
 
 # Misc
 __pycache__/


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.local.md` to `.gitignore` to prevent local infrastructure notes (IPs, SSH credentials, deployment targets) from being committed.

## Test plan
- [x] Verify `CLAUDE.local.md` is no longer tracked by git
- [x] Verify the file still exists locally for agent use