### PR TITLE
fix(image): remove stray fi that broke image build

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -159,7 +159,6 @@ while [[ "${1:-}" == --* ]]; do
     esac
     shift
 done
-fi
 
 require_cmd() {
     for cmd in "$@"; do


### PR DESCRIPTION
## Summary
- Removes an orphaned `fi` on line 162 of `tools/build-image.sh` that caused a syntax error when running `make image-dev` or `make image`
- The `while`/`case`/`done` block for parsing `--dev` and `--pcb` flags had a leftover `fi` from a previous refactor

## Test plan
- [x] `make image-dev` completes successfully