### PR TITLE
fix(digitsd): correct SWD flash detection paths

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -561,8 +561,8 @@ func (d *daemonCallbacks) HandleSocketCommand(cmd string) string {
 // Default paths for SWD flash infrastructure on the Pi.
 const (
 	defaultFirmwarePath = "/data/digits/firmware.elf"
-	defaultSWDConfig    = "/data/digits/swd/digits-swd.cfg"
-	defaultOpenOCD      = "/usr/local/bin/openocd"
+	defaultSWDConfig    = "/usr/local/share/digits/swd/digits-swd.cfg"
+	defaultOpenOCD      = "/usr/bin/openocd"
 )
 
 // statusFunc is a callback to report update progress back to the server.


### PR DESCRIPTION
## What

Fixes the two hardcoded SWD paths in digitsd so the flash capability probe actually runs on device.

## Why

The web UI reports firmware flashing as unavailable on devices that have SWD wired up. The root cause is two wrong path constants:

- `defaultOpenOCD` pointed to `/usr/local/bin/openocd` but `apt install openocd` puts it at `/usr/bin/openocd`
- `defaultSWDConfig` pointed to `/data/digits/swd/digits-swd.cfg` but the image overlay installs it to `/usr/local/share/digits/swd/digits-swd.cfg`

Because the first `os.Stat` check failed, `swdFilesPresent` was always false, the async SWD probe goroutine never launched, and `flash_capable` stayed false.

## Test plan

- SSH'd into Digits 2 (`192.168.2.228`) and confirmed:
  - `/usr/bin/openocd` exists (installed via apt), `/usr/local/bin/openocd` does not
  - `/usr/local/share/digits/swd/digits-swd.cfg` exists, `/data/digits/swd/` does not
  - Manual SWD probe (`sudo openocd -f ... -c "init; shutdown"`) succeeds and detects both RP2040 cores
- Verified the image builder (`tools/build-image.sh`) installs openocd via apt (lands in `/usr/bin/`)
- Verified `flash-pico.sh` and sudoers config both reference `/usr/bin/openocd`
- `go vet ./...` and `make test` pass