### PR TITLE
fix(ci): work around libssl3 arm64 conflict in pi-release

### DIFF
--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -48,7 +48,21 @@ jobs:
           printf 'Types: deb\nURIs: http://ports.ubuntu.com/\nSuites: %s %s-updates\nComponents: main restricted universe\nArchitectures: arm64\n' \
             "$(lsb_release -cs)" "$(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/arm64.sources
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu libasound2-dev:arm64 libopus-dev:arm64 libopusfile-dev:arm64 pkg-config
+          # libopusfile-dev:arm64 can't be installed via apt (libssl3t64 conflict),
+          # so install other deps normally, then extract opusfile from downloaded debs
+          sudo apt-get install -y gcc-aarch64-linux-gnu libasound2-dev:arm64 libopus-dev:arm64 libogg-dev:arm64 pkg-config
+          # Create opusfile pkg-config entry
+          sudo bash -c 'printf "prefix=/usr\nexec_prefix=\${prefix}\nlibdir=\${prefix}/lib/aarch64-linux-gnu\nincludedir=\${prefix}/include\n\nName: opusfile\nDescription: opusfile for cross-compilation\nVersion: 0.12\nRequires: opus\nLibs: -L\${libdir} -lopusfile\nCflags: -I\${includedir}/opus\n" \
+            > /usr/lib/aarch64-linux-gnu/pkgconfig/opusfile.pc'
+          # Extract opusfile headers and libs from downloaded debs
+          apt-get download libopusfile-dev libopusfile0:arm64
+          dpkg-deb -x libopusfile-dev*.deb /tmp/opusfile-dev
+          dpkg-deb -x libopusfile0*.deb /tmp/opusfile-lib
+          sudo cp /tmp/opusfile-dev/usr/include/opus/opusfile.h /usr/include/opus/
+          sudo cp /tmp/opusfile-lib/usr/lib/aarch64-linux-gnu/libopusfile.so* /usr/lib/aarch64-linux-gnu/
+          sudo ln -sf libopusfile.so.0 /usr/lib/aarch64-linux-gnu/libopusfile.so
+          sudo ldconfig
+          rm -rf /tmp/opusfile-dev /tmp/opusfile-lib *.deb
 
       - name: Install semantic-release
         run: |


### PR DESCRIPTION
## What

Replaces the broken `apt-get install libopusfile-dev:arm64` with a manual deb extraction approach for the pi-release CI workflow.

## Why

`libopusfile-dev:arm64` depends on `libssl3t64:arm64`, which conflicts with the held amd64 `libssl3` on GitHub Actions runners. This is the same fix from PR #60, which showed as "MERGED" on GitHub but whose merge commit (`de33e52`) never actually reached main due to a branch divergence.

The deb extraction approach matches what `pi/image/Dockerfile` already does for the same dependency.

## Test plan

- Verified the approach matches the working Dockerfile (lines 40-57)
- The previous version of this fix (commit `7748f87`) was tested in CI on the `fix/pi-release-libssl-conflict` branch