### PR TITLE
fix(server,digitsd,firmware): minor cleanups across all components

### DIFF
--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -210,7 +210,7 @@ static void process_pi_command(const char *cmd) {
         printf("%s\n", buf);
         // Now drive each row LOW and read columns
         for (int row = 0; row < 4; ++row) {
-            uint8_t rpin = (row < 2) ? (2 + row) : (2 + row);  // GP2-GP5
+            uint8_t rpin = 2 + row;  // GP2-GP5
             gpio_put(rpin, 0);
             sleep_us(50);  // generous settle
             snprintf(buf, sizeof(buf), "SCAN R%d/GP%d=LOW: C0=%d C1=%d C2=%d C3=%d",

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -44,8 +44,8 @@ var (
 	serialDev   = flag.String("serial", "/dev/serial0", "serial port device")
 	socketPath  = flag.String("socket", "/home/digits/digits/pi/uart.sock", "UART command socket path")
 	toneDir     = flag.String("tones", "/home/digits/digits/pi/tones", "directory containing WAV tone files")
-	alsaDevice   = flag.String("alsa-playback", "", "ALSA playback device (auto-detects Codec Zero if empty)")
-	showVersion  = flag.Bool("version", false, "print version and exit")
+	alsaDevice  = flag.String("alsa-playback", "", "ALSA playback device (auto-detects Codec Zero if empty)")
+	showVersion = flag.Bool("version", false, "print version and exit")
 )
 
 // daemonCallbacks implements phone.Callbacks and wires hardware + WebRTC.

--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -77,7 +77,11 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "failed to read user info", http.StatusInternalServerError)
+		return
+	}
 
 	var info struct {
 		ID    string `json:"id"`


### PR DESCRIPTION
## What

Small cleanups touching all three components to trigger release CI for each after the tag reset.

## Why

Old release tags pointed to orphaned commits after a history rewrite. Tags were deleted and reset to v1.0.0 on current main. This PR exercises the release pipelines to verify they work with the new tags.

## Test plan

- server: `make test` and `go vet` pass
- digitsd: `go vet` passes
- firmware: change is a trivially correct simplification (redundant ternary where both branches are identical)
- All three release workflows should trigger on merge and produce v1.0.1 releases