### PR TITLE
feat(server): add household timezone setting

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -199,6 +199,8 @@ func (d *Database) migrate() error {
 		DROP TABLE IF EXISTS phones`,
 		// v7: allow devices to exist before pairing (line_id NULL until paired)
 		`ALTER TABLE devices ALTER COLUMN line_id DROP NOT NULL`,
+		// v8: household timezone
+		`ALTER TABLE households ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'UTC'`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -11,6 +11,7 @@ type Household struct {
 	ID                 string
 	Name               string
 	CallHistoryEnabled bool
+	Timezone           string
 	CreatedAt          time.Time
 }
 
@@ -42,9 +43,9 @@ func (s *Store) Create(name, ownerUserID string) (*Household, error) {
 
 	h := &Household{}
 	err = tx.QueryRow(
-		`INSERT INTO households (name) VALUES ($1) RETURNING id, name, created_at`,
+		`INSERT INTO households (name) VALUES ($1) RETURNING id, name, timezone, created_at`,
 		name,
-	).Scan(&h.ID, &h.Name, &h.CreatedAt)
+	).Scan(&h.ID, &h.Name, &h.Timezone, &h.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("insert household: %w", err)
 	}
@@ -67,9 +68,9 @@ func (s *Store) Create(name, ownerUserID string) (*Household, error) {
 func (s *Store) GetByID(id string) (*Household, error) {
 	h := &Household{}
 	err := s.db.QueryRow(
-		`SELECT id, name, call_history_enabled, created_at FROM households WHERE id = $1`,
+		`SELECT id, name, call_history_enabled, timezone, created_at FROM households WHERE id = $1`,
 		id,
-	).Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.CreatedAt)
+	).Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.Timezone, &h.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("household not found")
 	}
@@ -82,7 +83,7 @@ func (s *Store) GetByID(id string) (*Household, error) {
 // GetForUser returns all households the given user belongs to.
 func (s *Store) GetForUser(userID string) ([]*Household, error) {
 	rows, err := s.db.Query(
-		`SELECT h.id, h.name, h.call_history_enabled, h.created_at
+		`SELECT h.id, h.name, h.call_history_enabled, h.timezone, h.created_at
 		 FROM households h
 		 JOIN household_members m ON m.household_id = h.id
 		 WHERE m.user_id = $1
@@ -97,7 +98,7 @@ func (s *Store) GetForUser(userID string) ([]*Household, error) {
 	var households []*Household
 	for rows.Next() {
 		h := &Household{}
-		if err := rows.Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.CreatedAt); err != nil {
+		if err := rows.Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.Timezone, &h.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan household: %w", err)
 		}
 		households = append(households, h)

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -177,6 +177,16 @@ func (s *Store) UpdateName(householdID, name string) error {
 	return nil
 }
 
+// Location returns the parsed *time.Location for this household's timezone.
+// Falls back to time.UTC if the timezone string is invalid.
+func (h *Household) Location() *time.Location {
+	loc, err := time.LoadLocation(h.Timezone)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
 // SetCallHistoryEnabled toggles call history for a household.
 func (s *Store) SetCallHistoryEnabled(householdID string, enabled bool) error {
 	_, err := s.db.Exec(
@@ -185,6 +195,21 @@ func (s *Store) SetCallHistoryEnabled(householdID string, enabled bool) error {
 	)
 	if err != nil {
 		return fmt.Errorf("set call history: %w", err)
+	}
+	return nil
+}
+
+// SetTimezone updates the IANA timezone for a household.
+func (s *Store) SetTimezone(householdID, tz string) error {
+	if _, err := time.LoadLocation(tz); err != nil {
+		return fmt.Errorf("invalid timezone %q: %w", tz, err)
+	}
+	_, err := s.db.Exec(
+		`UPDATE households SET timezone = $1 WHERE id = $2`,
+		tz, householdID,
+	)
+	if err != nil {
+		return fmt.Errorf("set timezone: %w", err)
 	}
 	return nil
 }

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -3,6 +3,7 @@ package household
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/justinlindh/digits/server/internal/db"
 )
@@ -179,6 +180,72 @@ func TestAddMember(t *testing.T) {
 	}
 	if role != "admin" {
 		t.Errorf("updated role = %q, want admin", role)
+	}
+}
+
+func TestSetTimezone(t *testing.T) {
+	s, database := testStore(t)
+	userID := createTestUser(t, database, "tz@example.com")
+
+	h, err := s.Create("TZ Family", userID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Default should be UTC
+	got, err := s.GetByID(h.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Timezone != "UTC" {
+		t.Errorf("default timezone = %q, want UTC", got.Timezone)
+	}
+
+	// Set valid timezone
+	if err := s.SetTimezone(h.ID, "America/Denver"); err != nil {
+		t.Fatalf("SetTimezone: %v", err)
+	}
+	got, err = s.GetByID(h.ID)
+	if err != nil {
+		t.Fatalf("GetByID after set: %v", err)
+	}
+	if got.Timezone != "America/Denver" {
+		t.Errorf("timezone = %q, want America/Denver", got.Timezone)
+	}
+}
+
+func TestSetTimezone_Invalid(t *testing.T) {
+	s, database := testStore(t)
+	userID := createTestUser(t, database, "badtz@example.com")
+
+	h, err := s.Create("Bad TZ Family", userID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	err = s.SetTimezone(h.ID, "Not/A/Timezone")
+	if err == nil {
+		t.Error("expected error for invalid timezone, got nil")
+	}
+}
+
+func TestHouseholdLocation(t *testing.T) {
+	h := &Household{Timezone: "America/New_York"}
+	loc := h.Location()
+	if loc.String() != "America/New_York" {
+		t.Errorf("Location() = %q, want America/New_York", loc.String())
+	}
+
+	h2 := &Household{Timezone: ""}
+	loc2 := h2.Location()
+	if loc2 != time.UTC {
+		t.Errorf("Location() for empty timezone = %q, want UTC", loc2.String())
+	}
+
+	h3 := &Household{Timezone: "Fake/Zone"}
+	loc3 := h3.Location()
+	if loc3 != time.UTC {
+		t.Errorf("Location() for invalid timezone = %q, want UTC", loc3.String())
 	}
 }
 

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -71,6 +71,9 @@ func TestCreate(t *testing.T) {
 	if got.Name != h.Name {
 		t.Errorf("name mismatch: got %q, want %q", got.Name, h.Name)
 	}
+	if got.Timezone != "UTC" {
+		t.Errorf("default timezone = %q, want UTC", got.Timezone)
+	}
 }
 
 func TestGetForUser(t *testing.T) {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -201,6 +201,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)
 	protected.HandleFunc("POST /settings/call-history", h.handleSettingsCallHistory)
+	protected.HandleFunc("POST /settings/timezone", h.handleSettingsTimezone)
 	protected.HandleFunc("GET /links", h.handleLinksGet)
 	protected.HandleFunc("POST /links/invite", h.handleLinksInvitePost)
 	protected.HandleFunc("POST /links/accept", h.handleLinksAcceptPost)
@@ -1254,6 +1255,31 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 	enabled := r.FormValue("enabled") == "true"
 	if err := h.householdStore.SetCallHistoryEnabled(households[0].ID, enabled); err != nil {
 		slog.Error("set call history failed", "err", err)
+	}
+	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
+}
+
+func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request) {
+	if h.householdStore == nil {
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	households, _ := h.householdStore.GetForUser(user.ID)
+	if len(households) == 0 {
+		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+		return
+	}
+	r.ParseForm()
+	tz := strings.TrimSpace(r.FormValue("timezone"))
+	if tz != "" {
+		if err := h.householdStore.SetTimezone(households[0].ID, tz); err != nil {
+			slog.Warn("set timezone failed", "err", err)
+		}
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -596,17 +596,18 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	hhName, callHistory, loc := h.householdContext(r)
+
 	devInfo := h.hub.DeviceInfo(number)
 	if devInfo != nil {
-		loc := h.householdTimezone(r)
 		devInfo.LastSeen = devInfo.LastSeen.In(loc)
 	}
 
 	renderWith(w, h.tmplPhoneDetail, "layout.html", lineDetailData{
 		Page:                  "phones",
 		Version:               version.Version,
-		CallHistoryEnabled:    h.callHistoryEnabled(r),
-		HouseholdName:         h.householdNameFromContext(r),
+		CallHistoryEnabled:    callHistory,
+		HouseholdName:         hhName,
 		Line:                  *ln,
 		Online:                online,
 		Devices:               devices,
@@ -725,7 +726,8 @@ type callsData struct {
 }
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
-	if !h.callHistoryEnabled(r) {
+	hhName, callHistory, loc := h.householdContext(r)
+	if !callHistory {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -733,7 +735,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 
 	// Scope call log to the user's household lines
 	user := auth.UserFromContext(r.Context())
-	if user != nil && h.lineStore != nil {
+	if user != nil && h.lineStore != nil && h.householdStore != nil {
 		households, err := h.householdStore.GetForUser(user.ID)
 		if err != nil {
 			slog.Error("get households for user failed", "user_id", user.ID, "err", err)
@@ -766,12 +768,11 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		recent = []calls.Call{}
 	}
 
-	loc := h.householdTimezone(r)
 	for i := range recent {
 		recent[i].StartedAt = recent[i].StartedAt.In(loc)
 	}
 
-	renderWith(w, h.tmplCalls, "layout.html", callsData{Page: "calls", Version: version.Version, CallHistoryEnabled: h.callHistoryEnabled(r), HouseholdName: h.householdNameFromContext(r), Calls: recent})
+	renderWith(w, h.tmplCalls, "layout.html", callsData{Page: "calls", Version: version.Version, CallHistoryEnabled: callHistory, HouseholdName: hhName, Calls: recent})
 }
 
 // ---- Settings ----
@@ -1279,6 +1280,8 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 	if tz != "" {
 		if err := h.householdStore.SetTimezone(households[0].ID, tz); err != nil {
 			slog.Warn("set timezone failed", "err", err)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			return
 		}
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -789,7 +789,7 @@ type settingsData struct {
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	var hh *household.Household
-	if user != nil {
+	if user != nil && h.householdStore != nil {
 		households, _ := h.householdStore.GetForUser(user.ID)
 		if len(households) > 0 {
 			hh = households[0]

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -595,6 +595,12 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	devInfo := h.hub.DeviceInfo(number)
+	if devInfo != nil {
+		loc := h.householdTimezone(r)
+		devInfo.LastSeen = devInfo.LastSeen.In(loc)
+	}
+
 	renderWith(w, h.tmplPhoneDetail, "layout.html", lineDetailData{
 		Page:                  "phones",
 		Version:               version.Version,
@@ -603,7 +609,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		Line:                  *ln,
 		Online:                online,
 		Devices:               devices,
-		DeviceInfo:            h.hub.DeviceInfo(number),
+		DeviceInfo:            devInfo,
 		LatestPiVersion:       latestPi,
 		LatestFirmwareVersion: latestFw,
 		PiReleases:            piReleases,
@@ -757,6 +763,11 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 	}
 	if recent == nil {
 		recent = []calls.Call{}
+	}
+
+	loc := h.householdTimezone(r)
+	for i := range recent {
+		recent[i].StartedAt = recent[i].StartedAt.In(loc)
 	}
 
 	renderWith(w, h.tmplCalls, "layout.html", callsData{Page: "calls", Version: version.Version, CallHistoryEnabled: h.callHistoryEnabled(r), HouseholdName: h.householdNameFromContext(r), Calls: recent})
@@ -1247,30 +1258,35 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
 
-// householdContext returns the household name and call-history flag for the current user.
-func (h *Handler) householdContext(r *http.Request) (name string, callHistory bool) {
+// householdContext returns the household name, call-history flag, and timezone location for the current user.
+func (h *Handler) householdContext(r *http.Request) (name string, callHistory bool, loc *time.Location) {
 	if h.householdStore == nil {
-		return "", false
+		return "", false, time.UTC
 	}
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		return "", false
+		return "", false, time.UTC
 	}
 	households, err := h.householdStore.GetForUser(user.ID)
 	if err != nil || len(households) == 0 {
-		return "", false
+		return "", false, time.UTC
 	}
-	return households[0].Name, households[0].CallHistoryEnabled
+	return households[0].Name, households[0].CallHistoryEnabled, households[0].Location()
 }
 
 func (h *Handler) callHistoryEnabled(r *http.Request) bool {
-	_, ch := h.householdContext(r)
+	_, ch, _ := h.householdContext(r)
 	return ch
 }
 
 func (h *Handler) householdNameFromContext(r *http.Request) string {
-	name, _ := h.householdContext(r)
+	name, _, _ := h.householdContext(r)
 	return name
+}
+
+func (h *Handler) householdTimezone(r *http.Request) *time.Location {
+	_, _, loc := h.householdContext(r)
+	return loc
 }
 
 func (h *Handler) handleAPIVersion(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/email"
+	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
+	"github.com/justinlindh/digits/server/internal/pairing"
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
@@ -201,6 +203,119 @@ func TestAPIStatusReturnsJSON(t *testing.T) {
 	}
 	if !strings.Contains(w.Header().Get("Content-Type"), "application/json") {
 		t.Errorf("expected JSON content type")
+	}
+}
+
+// setupHandlerWithHousehold is like setupHandler but wires in a real householdStore.
+func setupHandlerWithHousehold(t *testing.T) (*Handler, *db.Database, *auth.Store) {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	database, err := db.Open(dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	lineStore := line.NewStore(database)
+	deviceStore := device.NewStore(database)
+	hub := signaling.NewHub()
+	tracker := calls.New(database)
+	relay := signaling.NewRelay(hub, tracker, nil)
+
+	authStore := auth.NewStoreFromDB(database.DB)
+	householdStore := household.NewStore(database.DB)
+	pairingStore := pairing.NewStore(database.DB)
+
+	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)
+	emailSender := email.NewNoopSender()
+	loginTmpl, err := template.New("").ParseFS(TemplateFS(), "templates/layout.html", "templates/login.html")
+	if err != nil {
+		t.Fatalf("parse login template: %v", err)
+	}
+	authHandlers := auth.NewHandlers(authStore, googleAuth, emailSender, "http://localhost", "", loginTmpl, false)
+
+	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
+		Addr:        ":8443",
+	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, nil, emailSender, "", "")
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+	return h, database, authStore
+}
+
+func TestSettingsTimezonePost(t *testing.T) {
+	h, database, authStore := setupHandlerWithHousehold(t)
+	cookie := addSessionCookie(t, authStore)
+
+	user, _ := authStore.GetUserByEmail("test@example.com")
+	householdStore := h.householdStore
+	hh, err := householdStore.Create("TZ Test Family", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+
+	form := url.Values{"timezone": {"America/Chicago"}}
+	req := httptest.NewRequest(http.MethodPost, "/settings/timezone", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303 redirect, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/settings?saved=1" {
+		t.Errorf("redirect location = %q, want /settings?saved=1", loc)
+	}
+
+	got, err := householdStore.GetByID(hh.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Timezone != "America/Chicago" {
+		t.Errorf("timezone = %q, want America/Chicago", got.Timezone)
+	}
+}
+
+func TestSettingsTimezonePost_Invalid(t *testing.T) {
+	h, database, authStore := setupHandlerWithHousehold(t)
+	cookie := addSessionCookie(t, authStore)
+
+	user, _ := authStore.GetUserByEmail("test@example.com")
+	householdStore := h.householdStore
+	hh, err := householdStore.Create("TZ Invalid Family", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+
+	form := url.Values{"timezone": {"Fake/Zone"}}
+	req := httptest.NewRequest(http.MethodPost, "/settings/timezone", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303 redirect, got %d", w.Code)
+	}
+
+	got, err := householdStore.GetByID(hh.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Timezone != "UTC" {
+		t.Errorf("timezone = %q, want UTC (invalid should be rejected)", got.Timezone)
 	}
 }
 

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -39,6 +39,8 @@ func setupHandler(t *testing.T) (*Handler, *db.Database, *auth.Store) {
 	relay := signaling.NewRelay(hub, tracker, nil)
 
 	authStore := auth.NewStoreFromDB(database.DB)
+	householdStore := household.NewStore(database.DB)
+	pairingStore := pairing.NewStore(database.DB)
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)
 	emailSender := email.NewNoopSender()
 	loginTmpl, err := template.New("").ParseFS(TemplateFS(), "templates/layout.html", "templates/login.html")
@@ -49,7 +51,7 @@ func setupHandler(t *testing.T) (*Handler, *db.Database, *auth.Store) {
 
 	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
 		Addr:        ":8443",
-	}, authStore, authHandlers, googleAuth, nil, nil, nil, nil, "", "")
+	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, nil, emailSender, "", "")
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -206,48 +208,8 @@ func TestAPIStatusReturnsJSON(t *testing.T) {
 	}
 }
 
-// setupHandlerWithHousehold is like setupHandler but wires in a real householdStore.
-func setupHandlerWithHousehold(t *testing.T) (*Handler, *db.Database, *auth.Store) {
-	t.Helper()
-	dsn := os.Getenv("TEST_DATABASE_URL")
-	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set")
-	}
-	database, err := db.Open(dsn)
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	t.Cleanup(func() { database.Close() })
-
-	lineStore := line.NewStore(database)
-	deviceStore := device.NewStore(database)
-	hub := signaling.NewHub()
-	tracker := calls.New(database)
-	relay := signaling.NewRelay(hub, tracker, nil)
-
-	authStore := auth.NewStoreFromDB(database.DB)
-	householdStore := household.NewStore(database.DB)
-	pairingStore := pairing.NewStore(database.DB)
-
-	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)
-	emailSender := email.NewNoopSender()
-	loginTmpl, err := template.New("").ParseFS(TemplateFS(), "templates/layout.html", "templates/login.html")
-	if err != nil {
-		t.Fatalf("parse login template: %v", err)
-	}
-	authHandlers := auth.NewHandlers(authStore, googleAuth, emailSender, "http://localhost", "", loginTmpl, false)
-
-	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
-		Addr:        ":8443",
-	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, nil, emailSender, "", "")
-	if err != nil {
-		t.Fatalf("NewHandler: %v", err)
-	}
-	return h, database, authStore
-}
-
 func TestSettingsTimezonePost(t *testing.T) {
-	h, database, authStore := setupHandlerWithHousehold(t)
+	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)
 
 	user, _ := authStore.GetUserByEmail("test@example.com")
@@ -285,7 +247,7 @@ func TestSettingsTimezonePost(t *testing.T) {
 }
 
 func TestSettingsTimezonePost_Invalid(t *testing.T) {
-	h, database, authStore := setupHandlerWithHousehold(t)
+	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)
 
 	user, _ := authStore.GetUserByEmail("test@example.com")

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -62,6 +62,108 @@
   </div>
   {{end}}
 
+  <!-- Timezone -->
+  {{if .Household}}
+  <div class="bg-[#161b22] border border-[#21262d] rounded-lg">
+    <div class="px-4 py-3 border-b border-[#21262d]">
+      <h2 class="text-sm font-medium text-[#e6edf3]">Timezone</h2>
+    </div>
+    <div class="p-4">
+      <form action="/settings/timezone" method="POST" class="flex flex-col md:flex-row gap-3 md:items-end">
+        <div class="flex-1">
+          <label for="timezone" class="block text-xs text-[#8b949e] mb-1">Display timezone</label>
+          <select id="timezone" name="timezone"
+            class="w-full px-3 py-2 rounded-md bg-[#0d1117] border border-[#21262d] text-[#e6edf3] text-sm focus:outline-none focus:ring-2 focus:ring-[#58a6ff]/50 focus:border-[#58a6ff]">
+            <optgroup label="Americas">
+              <option value="Pacific/Honolulu">Honolulu (HST)</option>
+              <option value="America/Anchorage">Anchorage (AKST)</option>
+              <option value="America/Los_Angeles">Los Angeles (PST)</option>
+              <option value="America/Phoenix">Phoenix (MST)</option>
+              <option value="America/Denver">Denver (MST)</option>
+              <option value="America/Chicago">Chicago (CST)</option>
+              <option value="America/New_York">New York (EST)</option>
+              <option value="America/Toronto">Toronto (EST)</option>
+              <option value="America/Vancouver">Vancouver (PST)</option>
+              <option value="America/Mexico_City">Mexico City (CST)</option>
+              <option value="America/Sao_Paulo">Sao Paulo (BRT)</option>
+              <option value="America/Argentina/Buenos_Aires">Buenos Aires (ART)</option>
+            </optgroup>
+            <optgroup label="Europe">
+              <option value="Europe/London">London (GMT)</option>
+              <option value="Europe/Paris">Paris (CET)</option>
+              <option value="Europe/Berlin">Berlin (CET)</option>
+              <option value="Europe/Amsterdam">Amsterdam (CET)</option>
+              <option value="Europe/Rome">Rome (CET)</option>
+              <option value="Europe/Madrid">Madrid (CET)</option>
+              <option value="Europe/Stockholm">Stockholm (CET)</option>
+              <option value="Europe/Helsinki">Helsinki (EET)</option>
+              <option value="Europe/Moscow">Moscow (MSK)</option>
+              <option value="Europe/Istanbul">Istanbul (TRT)</option>
+            </optgroup>
+            <optgroup label="Asia">
+              <option value="Asia/Dubai">Dubai (GST)</option>
+              <option value="Asia/Kolkata">Kolkata (IST)</option>
+              <option value="Asia/Bangkok">Bangkok (ICT)</option>
+              <option value="Asia/Singapore">Singapore (SGT)</option>
+              <option value="Asia/Shanghai">Shanghai (CST)</option>
+              <option value="Asia/Hong_Kong">Hong Kong (HKT)</option>
+              <option value="Asia/Tokyo">Tokyo (JST)</option>
+              <option value="Asia/Seoul">Seoul (KST)</option>
+            </optgroup>
+            <optgroup label="Oceania">
+              <option value="Australia/Perth">Perth (AWST)</option>
+              <option value="Australia/Brisbane">Brisbane (AEST)</option>
+              <option value="Australia/Sydney">Sydney (AEST)</option>
+              <option value="Australia/Melbourne">Melbourne (AEST)</option>
+              <option value="Pacific/Auckland">Auckland (NZST)</option>
+            </optgroup>
+            <optgroup label="Africa">
+              <option value="Africa/Cairo">Cairo (EET)</option>
+              <option value="Africa/Lagos">Lagos (WAT)</option>
+              <option value="Africa/Johannesburg">Johannesburg (SAST)</option>
+            </optgroup>
+            <optgroup label="Other">
+              <option value="UTC">UTC</option>
+            </optgroup>
+          </select>
+        </div>
+        <button type="submit"
+          class="w-full md:w-auto px-4 py-2 rounded-md bg-[#238636] text-white text-sm font-medium hover:bg-[#2ea043] transition-colors">
+          Save
+        </button>
+      </form>
+      <p class="text-xs text-[#8b949e] mt-2">
+        Timestamps in the app will display in this timezone.
+      </p>
+    </div>
+    <script>
+    (function() {
+      var select = document.getElementById('timezone');
+      var current = '{{.Household.Timezone}}';
+      // Set current value
+      for (var i = 0; i < select.options.length; i++) {
+        if (select.options[i].value === current) {
+          select.selectedIndex = i;
+          break;
+        }
+      }
+      // Auto-detect: if still UTC, suggest browser timezone
+      if (current === 'UTC') {
+        try {
+          var detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+          for (var j = 0; j < select.options.length; j++) {
+            if (select.options[j].value === detected) {
+              select.selectedIndex = j;
+              break;
+            }
+          }
+        } catch(e) {}
+      }
+    })();
+    </script>
+  </div>
+  {{end}}
+
   <!-- Privacy -->
   {{if .Household}}
   <div class="bg-[#161b22] border border-[#21262d] rounded-lg">


### PR DESCRIPTION
## What

Adds a household-level timezone setting so timestamps in the web UI display in the user's local time instead of UTC.

## Why

The "Last Check-in" timestamp on phone detail and call history times were displaying in server time (UTC), which was confusing -- showing 8:21 PM when it was actually 1:21 PM local time.

## Test plan

- [x] `go vet ./...` clean
- [x] `make test` passes (all packages)
- [ ] Manual: open Settings, verify Timezone dropdown appears with browser auto-detect
- [ ] Manual: set timezone, verify "Last Check-in" on phone detail shows local time
- [ ] Manual: verify call history timestamps show local time

### Changes

- v8 migration: `timezone TEXT NOT NULL DEFAULT 'UTC'` on households table
- `Household.Location()` helper with UTC fallback
- `SetTimezone` store method with IANA validation via `time.LoadLocation`
- `householdContext` returns `*time.Location`; handlers convert `LastSeen` and `StartedAt` before rendering
- Settings page: curated dropdown of ~40 IANA zones grouped by region, with browser auto-detect JS
- Reduced redundant `GetForUser` DB calls per request in `handlePhoneDetail` and `handleCalls`