### PR TITLE
fix(digitsd): resolve updater binary path from running executable

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -648,7 +648,7 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 			return
 		}
 		reportStatus("rebooting", "Installing digitsd "+result.PiVersion+" -- restarting...")
-		if err := up.ApplyPiUpdate(path); err != nil {
+		if err := up.ApplyPiUpdate(path, result.PiVersion); err != nil {
 			log.Printf("updater: pi update failed: %v", err)
 			reportStatus("failed", fmt.Sprintf("Install failed: %v", err))
 			return

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -32,7 +33,7 @@ type Config struct {
 	CurrentFWVersion string
 	StagingDir       string // default: /data/digits/staging
 	FlashScript      string // default: /usr/local/bin/flash-pico.sh
-	BinaryPath       string // default: /usr/local/bin/digitsd
+	BinaryPath       string // default: os.Executable() result
 	FirmwarePath     string // default: /data/digits/firmware.elf
 }
 
@@ -49,8 +50,14 @@ func New(cfg Config) *Updater {
 		cfg.FlashScript = "/usr/local/bin/flash-pico.sh"
 	}
 	if cfg.BinaryPath == "" {
-		cfg.BinaryPath = "/usr/local/bin/digitsd"
+		exe, err := os.Executable()
+		if err != nil {
+			cfg.BinaryPath = "/usr/local/bin/digitsd"
+		} else {
+			cfg.BinaryPath = exe
+		}
 	}
+	log.Printf("updater: BinaryPath=%s", cfg.BinaryPath)
 	if cfg.FirmwarePath == "" {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
 	}
@@ -188,7 +195,7 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 
 // ApplyPiUpdate replaces the digitsd binary on the read-only rootfs and exits
 // (systemd restarts). Temporarily remounts / as rw for the copy, then restores ro.
-func (u *Updater) ApplyPiUpdate(stagedBinary string) error {
+func (u *Updater) ApplyPiUpdate(stagedBinary, expectedVersion string) error {
 	if err := os.Chmod(stagedBinary, 0755); err != nil {
 		return fmt.Errorf("chmod: %w", err)
 	}
@@ -217,6 +224,18 @@ func (u *Updater) ApplyPiUpdate(stagedBinary string) error {
 		return fmt.Errorf("rename binary: %w", err)
 	}
 	os.Remove(stagedBinary)
+
+	// Verify the installed binary reports the expected version.
+	if expectedVersion != "" {
+		out, err := exec.Command(u.cfg.BinaryPath, "-version").CombinedOutput()
+		if err != nil {
+			log.Printf("updater: WARNING: version check failed: %v", err)
+		} else if !strings.Contains(string(out), expectedVersion) {
+			log.Printf("updater: WARNING: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion)
+		} else {
+			log.Printf("updater: verified installed version: %s", strings.TrimSpace(string(out)))
+		}
+	}
 
 	// Restore read-only rootfs.
 	if err := exec.Command("sudo", "mount", "-o", "remount,ro", "/").Run(); err != nil {


### PR DESCRIPTION
## What

Re-applies the changes from #58 that were lost during a history rewrite. The updater now uses `os.Executable()` to resolve BinaryPath instead of hardcoding `/usr/local/bin/digitsd`, and verifies the installed version after copying.

## Why

Older Pi images run digitsd from `/data/digits/digitsd/digitsd`, not `/usr/local/bin/digitsd`. The hardcoded path caused the updater to copy the new binary to the wrong location, so updates silently failed to take effect. Post-install version verification catches this class of problem going forward.

## Test plan

- `go vet ./...` passes
- `make test` passes (including updater package tests)
- Verified the changes match the original #58 PR scope (no SWD path changes, no unrelated files)