### PR TITLE
fix(digitsd): guard against nil conn in signal client Send

### DIFF
--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -121,6 +121,9 @@ func (c *Client) Send(msg *Message) error {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.conn == nil {
+		return fmt.Errorf("signal: not connected")
+	}
 	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
 		return fmt.Errorf("signal: write: %w", err)
 	}


### PR DESCRIPTION
## What

Adds a nil check for the websocket connection in `signal.Client.Send()` to prevent a panic when sending before the connection is established.

## Why

The SWD probe goroutine calls `sendDeviceInfo` as soon as the probe completes, which can race ahead of `sig.Connect()`. When the probe finishes first, `c.conn` is nil and `WriteMessage` panics with a nil pointer dereference. This was causing digitsd to crash-loop on every boot (observed restart counter at 65 on Digits 2).

The send at line 1086 (after `Connect()`) ensures device info still reaches the server, so the early failed send is harmless.

## Test plan

- `make test` passes in `pi/digitsd/`
- Verified crash-loop in journal logs on Digits 2 device (192.168.2.228) -- panic trace points to `Client.Send` with nil `conn`