### PR TITLE
feat(server): show last seen timestamp for offline devices

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -201,6 +201,8 @@ func (d *Database) migrate() error {
 		`ALTER TABLE devices ALTER COLUMN line_id DROP NOT NULL`,
 		// v8: household timezone
 		`ALTER TABLE households ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'UTC'`,
+		// v9: device last-seen timestamp
+		`ALTER TABLE devices ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -23,6 +23,7 @@ type Device struct {
 	PairingCodeExpiresAt *time.Time
 	PairedAt             *time.Time
 	CreatedAt            time.Time
+	LastSeenAt           *time.Time
 }
 
 // Store provides CRUD operations for devices.
@@ -42,10 +43,10 @@ func (s *Store) Create(lineID int64, hardwareID string) (*Device, error) {
 		INSERT INTO devices (line_id, hardware_id)
 		VALUES ($1, $2)
 		RETURNING id, line_id, hardware_id, device_id, device_token,
-		          pairing_code, pairing_code_expires_at, paired_at, created_at
+		          pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 	`, lineID, hardwareID).Scan(
 		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt,
+		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create device: %w", err)
@@ -58,12 +59,12 @@ func (s *Store) GetByID(id int64) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRow(`
 		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at
+		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 		FROM devices
 		WHERE id = $1
 	`, id).Scan(
 		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt,
+		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -79,12 +80,12 @@ func (s *Store) GetByHardwareID(hwID string) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRow(`
 		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at
+		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 		FROM devices
 		WHERE hardware_id = $1
 	`, hwID).Scan(
 		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt,
+		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -99,7 +100,7 @@ func (s *Store) GetByHardwareID(hwID string) (*Device, error) {
 func (s *Store) ListByLine(lineID int64) ([]Device, error) {
 	rows, err := s.db.Query(`
 		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at
+		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 		FROM devices
 		WHERE line_id = $1
 		ORDER BY created_at
@@ -114,7 +115,7 @@ func (s *Store) ListByLine(lineID int64) ([]Device, error) {
 		var d Device
 		if err := rows.Scan(
 			&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-			&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt,
+			&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan device: %w", err)
 		}
@@ -186,13 +187,13 @@ func (s *Store) GetByPairingCode(code string) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRow(`
 		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at
+		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 		FROM devices
 		WHERE pairing_code = $1
 		  AND pairing_code_expires_at > NOW()
 	`, code).Scan(
 		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt,
+		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -181,6 +181,18 @@ func (s *Store) CompletePairing(id int64) error {
 	return nil
 }
 
+// TouchLastSeen updates last_seen_at to NOW() for the device with the given hardware ID.
+func (s *Store) TouchLastSeen(hardwareID string) error {
+	_, err := s.db.Exec(
+		`UPDATE devices SET last_seen_at = NOW() WHERE hardware_id = $1`,
+		hardwareID,
+	)
+	if err != nil {
+		return fmt.Errorf("touch last seen: %w", err)
+	}
+	return nil
+}
+
 // GetByPairingCode returns the device with the given pairing code, provided
 // the code has not yet expired. Returns ErrNotFound if no matching device exists.
 func (s *Store) GetByPairingCode(code string) (*Device, error) {

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -175,6 +175,47 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestTouchLastSeen(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "LastSeen Household")
+	lineID := createTestLine(t, database, "5558880001", hhID)
+
+	dev, err := s.Create(lineID, "hw-lastseen-001")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Initially nil
+	if dev.LastSeenAt != nil {
+		t.Errorf("expected LastSeenAt to be nil initially, got %v", dev.LastSeenAt)
+	}
+
+	// Touch it
+	if err := s.TouchLastSeen("hw-lastseen-001"); err != nil {
+		t.Fatalf("TouchLastSeen: %v", err)
+	}
+
+	got, err := s.GetByID(dev.ID)
+	if err != nil {
+		t.Fatalf("GetByID after touch: %v", err)
+	}
+	if got.LastSeenAt == nil {
+		t.Fatal("expected LastSeenAt to be set after TouchLastSeen")
+	}
+	if time.Since(*got.LastSeenAt) > 5*time.Second {
+		t.Errorf("LastSeenAt too old: %v", got.LastSeenAt)
+	}
+}
+
+func TestTouchLastSeen_UnknownHardware(t *testing.T) {
+	s, _ := testStore(t)
+
+	// Should not error for unknown hardware ID (just no rows affected)
+	if err := s.TouchLastSeen("does-not-exist"); err != nil {
+		t.Errorf("TouchLastSeen for unknown hardware: %v", err)
+	}
+}
+
 func TestPairingCode(t *testing.T) {
 	s, database := testStore(t)
 	hhID := createTestHousehold(t, database, "Pairing Household")

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -21,7 +21,6 @@ type Conn struct {
 	FirmwareVersion string
 	FirmwareCommit  string
 	FlashCapable    bool
-	LastSeen        time.Time
 }
 
 type Hub struct {
@@ -133,7 +132,6 @@ type DeviceInfoSnapshot struct {
 	FirmwareVersion string
 	FirmwareCommit  string
 	FlashCapable    bool
-	LastSeen        time.Time
 }
 
 // DeviceInfo returns version info for a connected phone. Returns nil if offline.
@@ -150,7 +148,6 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 		FirmwareVersion: conn.FirmwareVersion,
 		FirmwareCommit:  conn.FirmwareCommit,
 		FlashCapable:    conn.FlashCapable,
-		LastSeen:        conn.LastSeen,
 	}
 }
 
@@ -200,7 +197,6 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string, 
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
 	conn.FlashCapable = flashCapable
-	conn.LastSeen = time.Now()
 	return true
 }
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1180,11 +1180,21 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	h.hub.Register(msg.Number, conn)
 	number := msg.Number
+	if msg.HardwareID != "" && h.deviceStore != nil {
+		if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
+			slog.Warn("touch last seen on connect failed", "hardware_id", msg.HardwareID, "err", err)
+		}
+	}
 
 	// Configure pong handler to extend read deadline on each pong
 	ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
 	ws.SetPongHandler(func(string) error {
 		ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
+		if msg.HardwareID != "" && h.deviceStore != nil {
+			if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
+				slog.Warn("touch last seen on pong failed", "hardware_id", msg.HardwareID, "err", err)
+			}
+		}
 		return nil
 	})
 
@@ -1219,6 +1229,13 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read pump (blocks until disconnect)
 	defer h.hub.Unregister(number, conn)
+	defer func() {
+		if msg.HardwareID != "" && h.deviceStore != nil {
+			if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
+				slog.Warn("touch last seen on disconnect failed", "hardware_id", msg.HardwareID, "err", err)
+			}
+		}
+	}()
 	for {
 		_, data, err := ws.ReadMessage()
 		if err != nil {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -565,6 +565,7 @@ type lineDetailData struct {
 	Online                bool
 	Devices               []device.Device
 	DeviceInfo            *signaling.DeviceInfoSnapshot
+	LastSeenAt            *time.Time
 	LatestPiVersion       string
 	LatestFirmwareVersion string
 	PiReleases            []updates.Release
@@ -585,6 +586,13 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		devices, _ = h.deviceStore.ListByLine(ln.ID)
 	}
 
+	var lastSeenAt *time.Time
+	for _, d := range devices {
+		if d.LastSeenAt != nil && (lastSeenAt == nil || d.LastSeenAt.After(*lastSeenAt)) {
+			lastSeenAt = d.LastSeenAt
+		}
+	}
+
 	var latestPi, latestFw string
 	var piReleases, fwReleases []updates.Release
 	if h.Releases != nil {
@@ -598,10 +606,12 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 
 	hhName, callHistory, loc := h.householdContext(r)
 
-	devInfo := h.hub.DeviceInfo(number)
-	if devInfo != nil {
-		devInfo.LastSeen = devInfo.LastSeen.In(loc)
+	if lastSeenAt != nil {
+		t := lastSeenAt.In(loc)
+		lastSeenAt = &t
 	}
+
+	devInfo := h.hub.DeviceInfo(number)
 
 	renderWith(w, h.tmplPhoneDetail, "layout.html", lineDetailData{
 		Page:                  "phones",
@@ -612,6 +622,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		Online:                online,
 		Devices:               devices,
 		DeviceInfo:            devInfo,
+		LastSeenAt:            lastSeenAt,
 		LatestPiVersion:       latestPi,
 		LatestFirmwareVersion: latestFw,
 		PiReleases:            piReleases,

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -133,10 +133,12 @@
             {{end}}
           </div>
         </div>
+        {{if $.LastSeenAt}}
         <div>
           <label class="block text-xs text-[#8b949e] mb-1">Last Check-in</label>
-          <span class="text-sm text-[#c9d1d9]">{{.DeviceInfo.LastSeen.Format "Jan 2, 2006 3:04 PM"}}</span>
+          <span class="text-sm text-[#c9d1d9]">{{$.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}</span>
         </div>
+        {{end}}
         {{if .Online}}
         <!-- Per-component update sections -->
         <div class="pt-3 border-t border-[#21262d] space-y-3">
@@ -386,7 +388,13 @@
           </div>
           {{else}}
           <p class="text-sm text-[#8b949e]">Device is offline</p>
-          <p class="text-xs text-[#484f58]">Version info is available when the device is connected.</p>
+          {{if $.LastSeenAt}}
+          <div class="mt-2">
+            <label class="block text-xs text-[#8b949e] mb-1">Last seen</label>
+            <span class="text-sm text-[#c9d1d9]">{{$.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}</span>
+          </div>
+          {{end}}
+          <p class="text-xs text-[#484f58] mt-2">Version info is available when the device is connected.</p>
           {{end}}
         {{end}}
       </div>


### PR DESCRIPTION
## What

Persists device last-seen timestamps to the database and displays them on the phone detail page for both online ("Last Check-in") and offline ("Last seen") devices.

## Why

Previously, "Last Check-in" only showed when a device was online (sourced from in-memory hub state). When the device went offline or the server restarted, the timestamp was lost. This makes it impossible to tell when an offline device was last connected.

## Test plan

- [x] `go vet ./...` clean
- [x] `make test` passes
- [ ] Manual: connect a device, verify "Last Check-in" shows in Hardware & Software
- [ ] Manual: disconnect device, verify "Last seen" appears with disconnect time
- [ ] Manual: restart server, verify "Last seen" persists for offline devices
- [ ] Manual: verify timestamps display in household timezone

### Changes

- v9 migration: `last_seen_at TIMESTAMPTZ` on devices table (nullable)
- `TouchLastSeen(hardwareID)` store method
- WebSocket handler calls TouchLastSeen on connect, every pong (~30s), and disconnect
- Removed in-memory `LastSeen` from hub `Conn` and `DeviceInfoSnapshot` (DB is source of truth)
- Template shows "Last Check-in" (online) and "Last seen" (offline) from persisted field