### PR TITLE
fix(server): fix broken JOIN in CanCall cross-household query

### DIFF
--- a/server/internal/line/authorizer.go
+++ b/server/internal/line/authorizer.go
@@ -20,7 +20,8 @@ func (a *Authorizer) CanCall(fromNumber, toNumber string) (bool, error) {
         SELECT EXISTS (
             SELECT 1 FROM caller, callee WHERE caller.household_id = callee.household_id
             UNION ALL
-            SELECT 1 FROM caller, callee
+            SELECT 1 FROM caller
+            JOIN callee ON true
             JOIN household_links hl ON hl.status = 'active'
               AND (
                 (hl.household_a_id = caller.household_id AND hl.household_b_id = callee.household_id)


### PR DESCRIPTION
## What

Fix SQL syntax error in the `CanCall` authorizer that broke cross-household call authorization.

## Why

`FROM caller, callee JOIN household_links` is parsed by Postgres as `FROM caller, (callee JOIN household_links)`, making the `caller` CTE inaccessible in the ON clause. Every cross-household authorization check errored, silently falling through to allow-by-default in the relay.

## Test plan

- [ ] Verify linked-household calls succeed without Postgres errors in the DB logs
- [ ] Verify unlinked-household calls are rejected with `not_authorized`