### PR TITLE
feat(server): return busy signal when callee is in active call

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -93,6 +93,17 @@ func (t *Tracker) OnCallEnded(caller, callee string) error {
 	return err
 }
 
+func (t *Tracker) Busy(number string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, c := range t.active {
+		if c.Caller == number || c.Callee == number {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *Tracker) InCall(a, b string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -95,7 +95,7 @@ func (r *Relay) handleCall(from string, msg *Message) {
 	}
 
 	if r.Tracker != nil {
-		if r.Tracker.Busy(msg.To) {
+		if r.Tracker.Busy(from) || r.Tracker.Busy(msg.To) {
 			r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -12,6 +12,7 @@ type CallTracker interface {
 	OnCallAnswered(caller, callee string) error
 	OnCallEnded(caller, callee string) error
 	InCall(a, b string) bool
+	Busy(number string) bool
 }
 
 // CallAuthorizer determines whether a call from one number to another is permitted.
@@ -94,6 +95,10 @@ func (r *Relay) handleCall(from string, msg *Message) {
 	}
 
 	if r.Tracker != nil {
+		if r.Tracker.Busy(msg.To) {
+			r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
+			return
+		}
 		r.Tracker.OnCallInitiated(from, msg.To)
 	}
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1,6 +1,7 @@
 package signaling
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -30,6 +31,16 @@ func (m *mockTracker) OnCallEnded(caller, callee string) error {
 	delete(m.calls, callee+"→"+caller)
 	return nil
 }
+func (m *mockTracker) Busy(number string) bool {
+	for k := range m.calls {
+		a, b, _ := strings.Cut(k, "→")
+		if a == number || b == number {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *mockTracker) InCall(a, b string) bool {
 	return m.calls[a+"→"+b] || m.calls[b+"→"+a]
 }

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -194,6 +194,64 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 	}
 }
 
+func TestRelayBusySignal(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	conn3 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+	hub.Register("3140003", conn3)
+
+	// Phone 1 calls Phone 2 (establishes active call)
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140002"})
+	<-conn2.Send // drain ring
+
+	// Phone 3 calls Phone 2 (busy) -- should get busy signal
+	relay.HandleMessage("3140003", &Message{Type: TypeCall, To: "3140002"})
+
+	select {
+	case data := <-conn3.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if msg.Type != TypeBusy {
+			t.Fatalf("expected busy, got: %+v", msg)
+		}
+	default:
+		t.Fatal("phone 3 did not receive busy signal")
+	}
+
+	// Phone 1 tries to call Phone 3 while already on a call -- should also get busy
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140003"})
+
+	select {
+	case data := <-conn1.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if msg.Type != TypeBusy {
+			t.Fatalf("expected busy for caller already in call, got: %+v", msg)
+		}
+	default:
+		t.Fatal("phone 1 did not receive busy signal when already in a call")
+	}
+
+	// Phone 3 should not have received anything from the second call attempt
+	select {
+	case data := <-conn3.Send:
+		msg, _ := ParseMessage(data)
+		t.Fatalf("phone 3 should not have received anything, got: %+v", msg)
+	default:
+		// correct
+	}
+}
+
 func TestRelayICERestartForwarded(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()


### PR DESCRIPTION
## What

Send a busy signal to the caller when the target phone is already in an active call or off-hook.

## Why

Calling a phone that was off-hook or on another call would send a ring to the target with no response, leaving the caller on dead air with no feedback.

## Test plan

- [ ] Call a phone that is already on a call -- caller should hear busy tone
- [ ] Call a phone that is off-hook -- caller should hear busy tone
- [ ] Call an idle phone -- should ring normally