### PR TITLE
fix(server): deny calls when CanCall returns an error

### DIFF
--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -88,6 +88,9 @@ func (r *Relay) handleCall(from string, msg *Message) {
 	if r.CallAuthorizer != nil {
 		allowed, err := r.CallAuthorizer.CanCall(from, msg.To)
 		if err != nil || !allowed {
+			if err != nil {
+				slog.Error("call authorization failed", "from", from, "to", msg.To, "err", err)
+			}
 			r.Hub.SendTo(from, &Message{Type: TypeError, Error: "not_authorized"})
 			return
 		}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -87,7 +87,7 @@ func (r *Relay) handleCall(from string, msg *Message) {
 	// Enforce call authorization
 	if r.CallAuthorizer != nil {
 		allowed, err := r.CallAuthorizer.CanCall(from, msg.To)
-		if err == nil && !allowed {
+		if err != nil || !allowed {
 			r.Hub.SendTo(from, &Message{Type: TypeError, Error: "not_authorized"})
 			return
 		}

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1,6 +1,7 @@
 package signaling
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -40,6 +41,14 @@ type mockCallAuthorizer struct {
 
 func (m *mockCallAuthorizer) CanCall(fromNumber, toNumber string) (bool, error) {
 	return m.allowed[[2]string{fromNumber, toNumber}], nil
+}
+
+type errorCallAuthorizer struct {
+	err error
+}
+
+func (m *errorCallAuthorizer) CanCall(fromNumber, toNumber string) (bool, error) {
+	return false, m.err
 }
 
 func TestRelayCallFlow(t *testing.T) {
@@ -180,6 +189,43 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 		t.Fatalf("phone 3 should not have received anything, got: %+v", msg)
 	default:
 		// correct: nothing delivered to phone 3
+	}
+}
+
+func TestRelayCallDeniedOnAuthorizerError(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+
+	authorizer := &errorCallAuthorizer{err: errors.New("db connection failed")}
+	relay := NewRelay(hub, tracker, authorizer)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140002"})
+
+	select {
+	case data := <-conn1.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if msg.Type != TypeError || msg.Error != "not_authorized" {
+			t.Fatalf("expected not_authorized error, got: %+v", msg)
+		}
+	default:
+		t.Fatal("caller did not receive error when authorizer fails")
+	}
+
+	// Callee should not receive a ring
+	select {
+	case data := <-conn2.Send:
+		msg, _ := ParseMessage(data)
+		t.Fatalf("callee should not have received anything, got: %+v", msg)
+	default:
+		// correct
 	}
 }
 


### PR DESCRIPTION
## What

Change the call authorization check in the relay to deny on error instead of allowing.

## Why

The previous check (`err == nil && !allowed`) silently allowed calls through when `CanCall` returned a database error. This is a security issue: any DB failure in the authorization path would bypass call restrictions. Flagged in code review on #71.

## Test plan

- [x] New test `TestRelayCallDeniedOnAuthorizerError` verifies calls are denied when the authorizer returns an error
- [x] All existing relay tests pass
- [x] Full `make test` passes