### PR TITLE
feat(server,digitsd): authenticate devices on WebSocket connect

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -863,7 +863,7 @@ func main() {
 	}
 
 	// 4. Create signaling client
-	sig := sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID)
+	sig := sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken)
 
 	// 5. Create Opus encoder and decoder
 	enc, err := codec.NewEncoder(48000, 1, 24000)
@@ -1367,7 +1367,7 @@ func main() {
 			for {
 				log.Printf("signal: connection lost, reconnecting in %s...", backoff)
 				time.Sleep(backoff)
-				sig = sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID)
+				sig = sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken)
 				cb.mu.Lock()
 				cb.sig = sig
 				cb.mu.Unlock()

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	url             string
 	number          string
 	hardwareID      string
+	deviceToken     string
 	conn            *websocket.Conn
 	inbox           chan *Message
 	done            chan struct{}
@@ -31,13 +32,14 @@ type Client struct {
 }
 
 // NewClient creates a new Client. Call Connect() to establish the connection.
-func NewClient(url, number, hardwareID string) *Client {
+func NewClient(url, number, hardwareID, deviceToken string) *Client {
 	return &Client{
-		url:        url,
-		number:     number,
-		hardwareID: hardwareID,
-		inbox:      make(chan *Message, 32),
-		done:       make(chan struct{}),
+		url:         url,
+		number:      number,
+		hardwareID:  hardwareID,
+		deviceToken: deviceToken,
+		inbox:       make(chan *Message, 32),
+		done:        make(chan struct{}),
 	}
 }
 
@@ -62,7 +64,7 @@ func (c *Client) Connect() error {
 	c.conn = conn
 
 	// Send registration
-	reg := &Message{Type: TypeRegister, Number: c.number, HardwareID: c.hardwareID}
+	reg := &Message{Type: TypeRegister, Number: c.number, HardwareID: c.hardwareID, DeviceToken: c.deviceToken}
 	data, err := reg.Marshal()
 	if err != nil {
 		conn.Close()

--- a/pi/digitsd/internal/signal/client_test.go
+++ b/pi/digitsd/internal/signal/client_test.go
@@ -47,7 +47,7 @@ func TestClient_ConnectAndRegister(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id")
+	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id", "")
 	if err := c.Connect(); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestClient_ReceiveMessages(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id")
+	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id", "")
 	if err := c.Connect(); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestClient_SendMessage(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id")
+	c := NewClient(wsURL(ts), "+15550001111", "test-hw-id", "")
 	if err := c.Connect(); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/server/internal/admin/auth.go
+++ b/server/internal/admin/auth.go
@@ -2,12 +2,12 @@ package admin
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/justinlindh/digits/server/internal/device"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -60,7 +60,7 @@ func (s *AuthStore) CreateSession(adminID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("generate token: %w", err)
 	}
-	tokenHash := hashToken(token)
+	tokenHash := device.HashToken(token)
 	expires := time.Now().Add(24 * time.Hour)
 
 	_, err = s.db.DB.Exec(
@@ -74,7 +74,7 @@ func (s *AuthStore) CreateSession(adminID string) (string, error) {
 }
 
 func (s *AuthStore) ValidateSession(token string) (string, error) {
-	tokenHash := hashToken(token)
+	tokenHash := device.HashToken(token)
 	var adminID string
 	err := s.db.DB.QueryRow(
 		"SELECT admin_id FROM admin_sessions WHERE token_hash = $1 AND expires_at > NOW()",
@@ -99,7 +99,3 @@ func generateToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-func hashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
-}

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -2,12 +2,12 @@ package auth
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
 	"time"
 
+	"github.com/justinlindh/digits/server/internal/device"
 	_ "github.com/lib/pq"
 )
 
@@ -134,7 +134,7 @@ func (s *Store) CreateSession(userID string, ttl time.Duration) (string, *Sessio
 	if err != nil {
 		return "", nil, err
 	}
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	sess := &Session{}
 	err = s.db.QueryRow(
 		`INSERT INTO sessions (user_id, token_hash, expires_at)
@@ -150,7 +150,7 @@ func (s *Store) CreateSession(userID string, ttl time.Duration) (string, *Sessio
 
 // ValidateSession looks up a session by its raw token and checks it hasn't expired.
 func (s *Store) ValidateSession(token string) (*Session, error) {
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	sess := &Session{}
 	err := s.db.QueryRow(
 		`SELECT id, user_id, expires_at, created_at FROM sessions
@@ -168,14 +168,14 @@ func (s *Store) ValidateSession(token string) (*Session, error) {
 
 // DeleteSession removes a session by its raw token (used for logout).
 func (s *Store) DeleteSession(token string) error {
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	_, err := s.db.Exec(`DELETE FROM sessions WHERE token_hash = $1`, hash)
 	return err
 }
 
 // RefreshSession extends the expiry of an active session.
 func (s *Store) RefreshSession(token string, ttl time.Duration) error {
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	_, err := s.db.Exec(
 		`UPDATE sessions SET expires_at = $1 WHERE token_hash = $2 AND expires_at > NOW()`,
 		time.Now().Add(ttl), hash,
@@ -190,7 +190,7 @@ func (s *Store) CreateMagicLink(email string, ttl time.Duration) (string, error)
 	if err != nil {
 		return "", err
 	}
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	_, err = s.db.Exec(
 		`INSERT INTO magic_links (email, token_hash, expires_at) VALUES ($1, $2, $3)`,
 		email, hash, time.Now().Add(ttl),
@@ -205,7 +205,7 @@ func (s *Store) CreateMagicLink(email string, ttl time.Duration) (string, error)
 // Returns the associated email on success. Returns an error if the token
 // is invalid, expired, or has already been used.
 func (s *Store) ValidateMagicLink(token string) (string, error) {
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	var email string
 	err := s.db.QueryRow(
 		`UPDATE magic_links SET used = TRUE
@@ -247,8 +247,3 @@ func randomToken(bytes int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// hashToken returns the hex-encoded SHA-256 hash of the token.
-func hashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
-}

--- a/server/internal/auth/store_test.go
+++ b/server/internal/auth/store_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/db"
+	"github.com/justinlindh/digits/server/internal/device"
 )
 
 // testDB creates a Store connected to the test database, running migrations first.
@@ -274,7 +275,7 @@ func TestCleanupExpired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	hash := hashToken(token)
+	hash := device.HashToken(token)
 	s.db.Exec(`UPDATE sessions SET expires_at = NOW() - interval '1 second' WHERE token_hash = $1`, hash)
 
 	// Create a magic link and force-expire it
@@ -282,7 +283,7 @@ func TestCleanupExpired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}
-	mlHash := hashToken(mlToken)
+	mlHash := device.HashToken(mlToken)
 	s.db.Exec(`UPDATE magic_links SET expires_at = NOW() - interval '1 second' WHERE token_hash = $1`, mlHash)
 
 	if err := s.CleanupExpired(); err != nil {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -204,7 +204,14 @@ func (d *Database) migrate() error {
 		// v9: device last-seen timestamp
 		`ALTER TABLE devices ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ`,
 		// v10: hash existing plaintext device tokens with SHA-256
-		`UPDATE devices SET device_token = encode(sha256(device_token::bytea), 'hex') WHERE device_token IS NOT NULL AND length(device_token) = 64`,
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 10) THEN
+        UPDATE devices SET device_token = encode(sha256(device_token::bytea), 'hex')
+        WHERE device_token IS NOT NULL;
+        INSERT INTO schema_version (version) VALUES (10);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -203,6 +203,8 @@ func (d *Database) migrate() error {
 		`ALTER TABLE households ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'UTC'`,
 		// v9: device last-seen timestamp
 		`ALTER TABLE devices ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ`,
+		// v10: hash existing plaintext device tokens with SHA-256
+		`UPDATE devices SET device_token = encode(sha256(device_token::bytea), 'hex') WHERE device_token IS NOT NULL AND length(device_token) = 64`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -219,6 +219,12 @@ func (s *Store) GetByPairingCode(code string) (*Device, error) {
 	return d, nil
 }
 
+// HashToken returns the SHA-256 hex hash of a plaintext device token.
+func HashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
+
 // ValidateToken checks if the given plaintext token matches the stored hash
 // for the device with the given hardware ID. Uses constant-time comparison.
 func (s *Store) ValidateToken(hardwareID, token string) (bool, error) {
@@ -236,7 +242,6 @@ func (s *Store) ValidateToken(hardwareID, token string) (bool, error) {
 	if !storedHash.Valid {
 		return false, nil
 	}
-	h := sha256.Sum256([]byte(token))
-	candidate := hex.EncodeToString(h[:])
+	candidate := HashToken(token)
 	return subtle.ConstantTimeCompare([]byte(candidate), []byte(storedHash.String)) == 1, nil
 }

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -1,7 +1,10 @@
 package device
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -214,4 +217,26 @@ func (s *Store) GetByPairingCode(code string) (*Device, error) {
 		return nil, fmt.Errorf("get device by pairing code: %w", err)
 	}
 	return d, nil
+}
+
+// ValidateToken checks if the given plaintext token matches the stored hash
+// for the device with the given hardware ID. Uses constant-time comparison.
+func (s *Store) ValidateToken(hardwareID, token string) (bool, error) {
+	var storedHash sql.NullString
+	err := s.db.QueryRow(
+		`SELECT device_token FROM devices WHERE hardware_id = $1 AND paired_at IS NOT NULL`,
+		hardwareID,
+	).Scan(&storedHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("validate token: %w", err)
+	}
+	if !storedHash.Valid {
+		return false, nil
+	}
+	h := sha256.Sum256([]byte(token))
+	candidate := hex.EncodeToString(h[:])
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(storedHash.String)) == 1, nil
 }

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -225,6 +225,34 @@ func HashToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// AuthStatus returns the pairing and token status for a device.
+// Returns (paired, tokenValid, error).
+// If the device doesn't exist, returns (false, false, nil).
+// If paired and token is provided, validates it against the stored hash.
+func (s *Store) AuthStatus(hardwareID, token string) (paired bool, tokenValid bool, err error) {
+	var pairedAt sql.NullTime
+	var storedHash sql.NullString
+	err = s.db.QueryRow(
+		`SELECT paired_at, device_token FROM devices WHERE hardware_id = $1`,
+		hardwareID,
+	).Scan(&pairedAt, &storedHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("auth status: %w", err)
+	}
+	if !pairedAt.Valid {
+		return false, false, nil
+	}
+	if token == "" || !storedHash.Valid {
+		return true, false, nil
+	}
+	candidate := HashToken(token)
+	valid := subtle.ConstantTimeCompare([]byte(candidate), []byte(storedHash.String)) == 1
+	return true, valid, nil
+}
+
 // ValidateToken checks if the given plaintext token matches the stored hash
 // for the device with the given hardware ID. Uses constant-time comparison.
 func (s *Store) ValidateToken(hardwareID, token string) (bool, error) {

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -1,6 +1,8 @@
 package device
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"testing"
 	"time"
@@ -266,5 +268,82 @@ func TestPairingCode(t *testing.T) {
 	}
 	if completed.PairedAt == nil {
 		t.Error("expected PairedAt to be set after CompletePairing")
+	}
+}
+
+// hashToken hashes a plaintext token with SHA-256, matching the server's storage format.
+func hashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
+
+func TestValidateToken_Correct(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Token Household")
+	lineID := createTestLine(t, database, "5551110001", hhID)
+
+	dev, err := s.Create(lineID, "hw-token-001")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Simulate what pairing does: store hashed token, mark as paired
+	plaintext := "deadbeef01234567890abcdef01234567890abcdef01234567890abcdef012345"
+	hashed := hashToken(plaintext)
+	_, err = database.DB.Exec(
+		`UPDATE devices SET device_token = $1, paired_at = NOW() WHERE id = $2`,
+		hashed, dev.ID,
+	)
+	if err != nil {
+		t.Fatalf("set hashed token: %v", err)
+	}
+
+	valid, err := s.ValidateToken("hw-token-001", plaintext)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if !valid {
+		t.Error("expected ValidateToken to return true for correct token")
+	}
+}
+
+func TestValidateToken_Wrong(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Token Wrong Household")
+	lineID := createTestLine(t, database, "5551110002", hhID)
+
+	dev, err := s.Create(lineID, "hw-token-002")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	plaintext := "deadbeef01234567890abcdef01234567890abcdef01234567890abcdef012345"
+	hashed := hashToken(plaintext)
+	_, err = database.DB.Exec(
+		`UPDATE devices SET device_token = $1, paired_at = NOW() WHERE id = $2`,
+		hashed, dev.ID,
+	)
+	if err != nil {
+		t.Fatalf("set hashed token: %v", err)
+	}
+
+	valid, err := s.ValidateToken("hw-token-002", "wrong-token")
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if valid {
+		t.Error("expected ValidateToken to return false for wrong token")
+	}
+}
+
+func TestValidateToken_NonExistent(t *testing.T) {
+	s, _ := testStore(t)
+
+	valid, err := s.ValidateToken("hw-does-not-exist", "any-token")
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if valid {
+		t.Error("expected ValidateToken to return false for non-existent hardware ID")
 	}
 }

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -1,8 +1,6 @@
 package device
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"os"
 	"testing"
 	"time"
@@ -271,12 +269,6 @@ func TestPairingCode(t *testing.T) {
 	}
 }
 
-// hashToken hashes a plaintext token with SHA-256, matching the server's storage format.
-func hashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
-}
-
 func TestValidateToken_Correct(t *testing.T) {
 	s, database := testStore(t)
 	hhID := createTestHousehold(t, database, "Token Household")
@@ -289,7 +281,7 @@ func TestValidateToken_Correct(t *testing.T) {
 
 	// Simulate what pairing does: store hashed token, mark as paired
 	plaintext := "deadbeef01234567890abcdef01234567890abcdef01234567890abcdef012345"
-	hashed := hashToken(plaintext)
+	hashed := HashToken(plaintext)
 	_, err = database.DB.Exec(
 		`UPDATE devices SET device_token = $1, paired_at = NOW() WHERE id = $2`,
 		hashed, dev.ID,
@@ -318,7 +310,7 @@ func TestValidateToken_Wrong(t *testing.T) {
 	}
 
 	plaintext := "deadbeef01234567890abcdef01234567890abcdef01234567890abcdef012345"
-	hashed := hashToken(plaintext)
+	hashed := HashToken(plaintext)
 	_, err = database.DB.Exec(
 		`UPDATE devices SET device_token = $1, paired_at = NOW() WHERE id = $2`,
 		hashed, dev.ID,

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -2,6 +2,7 @@ package pairing
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"errors"
@@ -116,14 +117,15 @@ func (s *Store) ClaimDevice(code, lineNumber, lineName, householdID string) (str
 	}
 
 	token := randomHex(32)
+	tokenHash := hashToken(token)
 
-	// Update device: set line_id, device_token, mark as paired, clear pairing code
+	// Update device: set line_id, device_token (hashed), mark as paired, clear pairing code
 	res, err := s.db.Exec(`
 		UPDATE devices
 		SET line_id = $2, device_token = $3,
 		    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
 		WHERE id = $1 AND paired_at IS NULL
-	`, deviceID, lineID, token)
+	`, deviceID, lineID, tokenHash)
 	if err != nil {
 		return "", "", fmt.Errorf("claim device: %w", err)
 	}
@@ -190,6 +192,11 @@ func (s *Store) RegenerateCode(hardwareID string) (string, error) {
 		return s.GenerateCode(hardwareID)
 	}
 	return code, nil
+}
+
+func hashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
 }
 
 func randomHex(n int) string {

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -2,13 +2,14 @@ package pairing
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
 	"time"
+
+	"github.com/justinlindh/digits/server/internal/device"
 )
 
 const (
@@ -117,7 +118,7 @@ func (s *Store) ClaimDevice(code, lineNumber, lineName, householdID string) (str
 	}
 
 	token := randomHex(32)
-	tokenHash := hashToken(token)
+	tokenHash := device.HashToken(token)
 
 	// Update device: set line_id, device_token (hashed), mark as paired, clear pairing code
 	res, err := s.db.Exec(`
@@ -192,11 +193,6 @@ func (s *Store) RegenerateCode(hardwareID string) (string, error) {
 		return s.GenerateCode(hardwareID)
 	}
 	return code, nil
-}
-
-func hashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
 }
 
 func randomHex(n int) string {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1159,11 +1159,28 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If hardware ID is provided and pairing is enabled, check pairing status
-	if msg.HardwareID != "" && h.pairingStore != nil {
+	// Require hardware ID for all connections
+	if msg.HardwareID == "" {
+		slog.Warn("ws register without hardware_id", "number", msg.Number)
+		ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+			Type:  signaling.TypeError,
+			Error: "hardware_id required",
+		}))
+		ws.Close()
+		return
+	}
+
+	// Check pairing status
+	if h.pairingStore != nil {
 		paired, err := h.pairingStore.IsPaired(msg.HardwareID)
 		if err != nil {
 			slog.Error("pairing check failed", "hardware_id", msg.HardwareID, "err", err)
+			ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+				Type:  signaling.TypeError,
+				Error: "internal error",
+			}))
+			ws.Close()
+			return
 		}
 		if !paired {
 			code, err := h.pairingStore.GenerateCode(msg.HardwareID)
@@ -1174,6 +1191,37 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 					Type:        signaling.TypePairingCode,
 					PairingCode: code,
 				}))
+			}
+			// Continue to register so the device can receive the TypePaired message
+		} else {
+			// Paired device -- validate token
+			if msg.DeviceToken == "" {
+				slog.Warn("ws register without device_token", "hardware_id", msg.HardwareID)
+				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+					Type:  signaling.TypeError,
+					Error: "device_token required",
+				}))
+				ws.Close()
+				return
+			}
+			valid, err := h.deviceStore.ValidateToken(msg.HardwareID, msg.DeviceToken)
+			if err != nil {
+				slog.Error("token validation failed", "hardware_id", msg.HardwareID, "err", err)
+				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+					Type:  signaling.TypeError,
+					Error: "internal error",
+				}))
+				ws.Close()
+				return
+			}
+			if !valid {
+				slog.Warn("ws invalid device_token", "hardware_id", msg.HardwareID)
+				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+					Type:  signaling.TypeError,
+					Error: "invalid device_token",
+				}))
+				ws.Close()
+				return
 			}
 		}
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1131,6 +1131,15 @@ func (h *Handler) handleAPIActiveCalls(w http.ResponseWriter, r *http.Request) {
 
 // ---- WebSocket ----
 
+// wsReject sends an error message to the WebSocket client and closes the connection.
+func wsReject(ws *websocket.Conn, errMsg string) {
+	ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
+		Type:  signaling.TypeError,
+		Error: errMsg,
+	}))
+	ws.Close()
+}
+
 func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	ws, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -1151,35 +1160,23 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	msg, err := signaling.ParseMessage(data)
 	if err != nil || msg.Type != signaling.TypeRegister || msg.Number == "" {
 		slog.Warn("invalid register message")
-		ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-			Type:  signaling.TypeError,
-			Error: "must send register message first",
-		}))
-		ws.Close()
+		wsReject(ws, "must send register message first")
 		return
 	}
 
 	// Require hardware ID for all connections
 	if msg.HardwareID == "" {
 		slog.Warn("ws register without hardware_id", "number", msg.Number)
-		ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-			Type:  signaling.TypeError,
-			Error: "hardware_id required",
-		}))
-		ws.Close()
+		wsReject(ws, "hardware_id required")
 		return
 	}
 
-	// Check pairing status
+	// Check pairing and token status
 	if h.pairingStore != nil {
-		paired, err := h.pairingStore.IsPaired(msg.HardwareID)
+		paired, tokenValid, err := h.deviceStore.AuthStatus(msg.HardwareID, msg.DeviceToken)
 		if err != nil {
-			slog.Error("pairing check failed", "hardware_id", msg.HardwareID, "err", err)
-			ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-				Type:  signaling.TypeError,
-				Error: "internal error",
-			}))
-			ws.Close()
+			slog.Error("device auth check failed", "hardware_id", msg.HardwareID, "err", err)
+			wsReject(ws, "internal error")
 			return
 		}
 		if !paired {
@@ -1193,36 +1190,14 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 				}))
 			}
 			// Continue to register so the device can receive the TypePaired message
-		} else {
-			// Paired device -- validate token
-			if msg.DeviceToken == "" {
-				slog.Warn("ws register without device_token", "hardware_id", msg.HardwareID)
-				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-					Type:  signaling.TypeError,
-					Error: "device_token required",
-				}))
-				ws.Close()
-				return
-			}
-			valid, err := h.deviceStore.ValidateToken(msg.HardwareID, msg.DeviceToken)
-			if err != nil {
-				slog.Error("token validation failed", "hardware_id", msg.HardwareID, "err", err)
-				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-					Type:  signaling.TypeError,
-					Error: "internal error",
-				}))
-				ws.Close()
-				return
-			}
-			if !valid {
-				slog.Warn("ws invalid device_token", "hardware_id", msg.HardwareID)
-				ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-					Type:  signaling.TypeError,
-					Error: "invalid device_token",
-				}))
-				ws.Close()
-				return
-			}
+		} else if msg.DeviceToken == "" {
+			slog.Warn("ws register without device_token", "hardware_id", msg.HardwareID)
+			wsReject(ws, "device_token required")
+			return
+		} else if !tokenValid {
+			slog.Warn("ws invalid device_token", "hardware_id", msg.HardwareID)
+			wsReject(ws, "invalid device_token")
+			return
 		}
 	}
 

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -11,8 +10,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/gorilla/websocket"
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
@@ -299,20 +296,6 @@ func TestNotFound(t *testing.T) {
 	}
 }
 
-// readWSMessage reads one JSON message from the WebSocket with a timeout.
-func readWSMessage(t *testing.T, ws *websocket.Conn) signaling.Message {
-	t.Helper()
-	ws.SetReadDeadline(time.Now().Add(3 * time.Second))
-	_, data, err := ws.ReadMessage()
-	if err != nil {
-		t.Fatalf("read ws message: %v", err)
-	}
-	var msg signaling.Message
-	if err := json.Unmarshal(data, &msg); err != nil {
-		t.Fatalf("unmarshal ws message: %v", err)
-	}
-	return msg
-}
 
 // setupPairedDevice creates a paired device via the pairing flow and returns
 // the hardware ID and plaintext device token.
@@ -368,7 +351,7 @@ func TestWSRegister_MissingHardwareID(t *testing.T) {
 		Number: "1001",
 	})
 
-	msg := readWSMessage(t, ws)
+	msg := recvMsg(t, ws)
 	if msg.Type != signaling.TypeError {
 		t.Fatalf("expected error message, got %q", msg.Type)
 	}
@@ -391,7 +374,7 @@ func TestWSRegister_PairedDevice_MissingToken(t *testing.T) {
 		HardwareID: hwID,
 	})
 
-	msg := readWSMessage(t, ws)
+	msg := recvMsg(t, ws)
 	if msg.Type != signaling.TypeError {
 		t.Fatalf("expected error message, got %q", msg.Type)
 	}
@@ -415,7 +398,7 @@ func TestWSRegister_PairedDevice_WrongToken(t *testing.T) {
 		DeviceToken: "wrong-token-value",
 	})
 
-	msg := readWSMessage(t, ws)
+	msg := recvMsg(t, ws)
 	if msg.Type != signaling.TypeError {
 		t.Fatalf("expected error message, got %q", msg.Type)
 	}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"encoding/json"
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +10,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
@@ -291,5 +296,159 @@ func TestNotFound(t *testing.T) {
 	// Unauthenticated: redirects to login; authenticated: the dashboard handler returns 404 for unknown paths
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// readWSMessage reads one JSON message from the WebSocket with a timeout.
+func readWSMessage(t *testing.T, ws *websocket.Conn) signaling.Message {
+	t.Helper()
+	ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, data, err := ws.ReadMessage()
+	if err != nil {
+		t.Fatalf("read ws message: %v", err)
+	}
+	var msg signaling.Message
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal ws message: %v", err)
+	}
+	return msg
+}
+
+// setupPairedDevice creates a paired device via the pairing flow and returns
+// the hardware ID and plaintext device token.
+func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairing.Store, householdStore *household.Store, authStore *auth.Store) (hardwareID, token string) {
+	t.Helper()
+
+	hardwareID = fmt.Sprintf("test-hw-%d", time.Now().UnixNano())
+	number := fmt.Sprintf("99%05d", time.Now().UnixNano()%100000)
+
+	// Create a household for the line
+	user, err := authStore.GetUserByEmail("test@example.com")
+	if err != nil {
+		user, err = authStore.CreateUser("test@example.com", "Test User", nil)
+		if err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+	hh, err := householdStore.Create("Test Household", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	// Generate pairing code (creates the device row)
+	code, err := pairingStore.GenerateCode(hardwareID)
+	if err != nil {
+		t.Fatalf("generate code: %v", err)
+	}
+
+	// Claim the device (pairs it, sets hashed token)
+	token, _, err = pairingStore.ClaimDevice(code, number, "Test Phone", hh.ID)
+	if err != nil {
+		t.Fatalf("claim device: %v", err)
+	}
+
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM devices WHERE hardware_id = $1", hardwareID)
+		database.DB.Exec("DELETE FROM lines WHERE number = $1", number)
+		database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+
+	return hardwareID, token
+}
+
+func TestWSRegister_MissingHardwareID(t *testing.T) {
+	h, _, _ := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:   signaling.TypeRegister,
+		Number: "1001",
+	})
+
+	msg := readWSMessage(t, ws)
+	if msg.Type != signaling.TypeError {
+		t.Fatalf("expected error message, got %q", msg.Type)
+	}
+	if msg.Error != "hardware_id required" {
+		t.Errorf("expected 'hardware_id required', got %q", msg.Error)
+	}
+}
+
+func TestWSRegister_PairedDevice_MissingToken(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:       signaling.TypeRegister,
+		Number:     "1001",
+		HardwareID: hwID,
+	})
+
+	msg := readWSMessage(t, ws)
+	if msg.Type != signaling.TypeError {
+		t.Fatalf("expected error message, got %q", msg.Type)
+	}
+	if msg.Error != "device_token required" {
+		t.Errorf("expected 'device_token required', got %q", msg.Error)
+	}
+}
+
+func TestWSRegister_PairedDevice_WrongToken(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      "1001",
+		HardwareID:  hwID,
+		DeviceToken: "wrong-token-value",
+	})
+
+	msg := readWSMessage(t, ws)
+	if msg.Type != signaling.TypeError {
+		t.Fatalf("expected error message, got %q", msg.Type)
+	}
+	if msg.Error != "invalid device_token" {
+		t.Errorf("expected 'invalid device_token', got %q", msg.Error)
+	}
+}
+
+func TestWSRegister_PairedDevice_CorrectToken(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      "1001",
+		HardwareID:  hwID,
+		DeviceToken: token,
+	})
+
+	// The connection should stay open. If there was an auth error, we'd get
+	// an error message. Try reading with a short deadline; no error message
+	// means auth succeeded.
+	ws.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	_, _, err := ws.ReadMessage()
+	if err == nil {
+		t.Fatal("expected no message (timeout), but got one")
+	}
+	// A timeout (deadline exceeded) means no error was sent, which is success.
+	if !strings.Contains(err.Error(), "i/o timeout") {
+		t.Fatalf("expected timeout error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Requires paired devices to present their device token when connecting to `/ws`. Tokens are now stored as SHA-256 hashes instead of plaintext.

## Why

The `/ws` endpoint is exposed to the public internet with no authentication. Any client can connect and register as any phone number, impersonating a real device. This adds device-level authentication using the token already issued during pairing.

Follow-up to the security review on #73.

## Test plan

- [x] Unit tests for `ValidateToken` (correct, wrong, non-existent)
- [x] Integration tests for WS auth rejection (missing hardware_id, missing token, wrong token, correct token)
- [x] `go test ./...` passes for both server and digitsd
- [x] `go vet ./...` clean
- [x] Server builds