### PR TITLE
feat(firmware): add --release flag to flash.sh

### DIFF
--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -1,8 +1,67 @@
 #!/usr/bin/env bash
-# flash.sh — Copy UF2 firmware to RP2040 in BOOTSEL mode
+# flash.sh — Flash Digits firmware to an RP2040
+#
+# Usage:
+#   flash.sh                        Flash local UF2 build (BOOTSEL mount)
+#   flash.sh --release <version>    Download + flash a GitHub release ELF
+#   flash.sh [mount-point]          Flash local UF2 build to specific mount
+#
+# Examples:
+#   flash.sh --release 1.0.1
+#   flash.sh
+#   flash.sh /media/user/RPI-RP2
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="justinlindh/digits"
+
+# --- Release mode: download ELF from GitHub and flash via picotool ---
+if [ "${1:-}" = "--release" ]; then
+    VERSION="${2:?Usage: flash.sh --release <version>}"
+
+    if ! command -v picotool &>/dev/null; then
+        echo "ERROR: picotool is required for flashing release ELFs." >&2
+        echo "Install it: https://github.com/raspberrypi/picotool" >&2
+        exit 1
+    fi
+
+    if ! command -v gh &>/dev/null; then
+        echo "ERROR: gh (GitHub CLI) is required for downloading releases." >&2
+        exit 1
+    fi
+
+    TAG="fw/v${VERSION}"
+    ELF_NAME="firmware-${VERSION}.elf"
+    SHA_NAME="${ELF_NAME}.sha256"
+
+    TMPDIR="$(mktemp -d)"
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    echo "Downloading $ELF_NAME from release $TAG..."
+    gh release download "$TAG" \
+        --repo "$REPO" \
+        --pattern "$ELF_NAME" \
+        --pattern "$SHA_NAME" \
+        --dir "$TMPDIR"
+
+    echo "Verifying checksum..."
+    EXPECTED="$(cat "$TMPDIR/$SHA_NAME")"
+    ACTUAL="$(sha256sum "$TMPDIR/$ELF_NAME" | cut -d' ' -f1)"
+    if [ "$EXPECTED" != "$ACTUAL" ]; then
+        echo "ERROR: Checksum mismatch!" >&2
+        echo "  Expected: $EXPECTED" >&2
+        echo "  Got:      $ACTUAL" >&2
+        exit 1
+    fi
+    echo "  OK ($ACTUAL)"
+
+    echo "Flashing via picotool..."
+    picotool load -f -v -x "$TMPDIR/$ELF_NAME"
+    echo "Flash complete."
+    exit 0
+fi
+
+# --- Local mode: copy UF2 to BOOTSEL mount ---
 UF2_FILE="$SCRIPT_DIR/../firmware/build/digits.uf2"
 
 if [ ! -f "$UF2_FILE" ]; then


### PR DESCRIPTION
## What

Adds a `--release <version>` flag to `scripts/flash.sh` that downloads and flashes a firmware ELF from GitHub releases.

## Why

Flashing a specific release version currently requires manually downloading the artifact and using picotool. This streamlines the workflow to a single command: `./scripts/flash.sh --release 1.0.1`.

## Test plan

- [x] Ran `./scripts/flash.sh --release 1.0.1` against a connected Pico H -- downloaded, verified checksum, flashed and rebooted successfully
- [x] Verified graceful error when `picotool` is missing
- [x] Verified graceful error when `gh` is missing
- [x] Confirmed existing no-args UF2/BOOTSEL behavior is unchanged