### PR TITLE
fix(server): switch healthchecks from wget to curl

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ ARG COMMIT=unknown
 RUN CGO_ENABLED=0 go build -ldflags "-X github.com/justinlindh/digits/server/internal/version.Version=${VERSION} -X github.com/justinlindh/digits/server/internal/version.Commit=${COMMIT}" -o signald ./cmd/signald/
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/signald .
 COPY --from=builder /build/static ./static

--- a/server/cmd/admind/Dockerfile
+++ b/server/cmd/admind/Dockerfile
@@ -13,7 +13,7 @@ RUN set -e; \
 RUN CGO_ENABLED=0 go build -o admind ./cmd/admind/
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /build/admind .
 EXPOSE 9090

--- a/server/docker-compose.prod.yml
+++ b/server/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "8090:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3
@@ -50,7 +50,7 @@ services:
     ports:
       - "9094:9090"
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:9090/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:9090/healthz || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     expose:
       - "8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3
@@ -44,7 +44,7 @@ services:
     expose:
       - "9090"
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:9090/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:9090/healthz || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## What

Install curl in runtime Docker images and switch healthcheck commands from `wget --spider` to `curl -sf`.

## Why

The runtime images use `debian:bookworm-slim` which includes neither wget nor curl. Healthchecks were permanently failing, leaving containers in "unhealthy" state despite serving traffic correctly.

## Test plan

- Rebuilt and deployed production containers
- Verified all four containers report `(healthy)` via `docker compose ps`