### PR TITLE
feat(digitsd): re-query firmware version on Pico reboot

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1163,6 +1163,22 @@ func main() {
 				}
 			}
 
+			// Pico rebooted (e.g. external flash, power cycle): re-query
+			// firmware version and report it to the server.
+			if event == "STATUS:READY" {
+				log.Println("pico: detected reboot, re-querying firmware version")
+				if v, c, err := sp.QueryVersion(); err != nil {
+					log.Printf("pico: version query after reboot: %v", err)
+				} else if v != fwVersion || c != fwCommit {
+					fwVersion, fwCommit = v, c
+					log.Printf("pico: firmware version changed: %s (%s)", fwVersion, fwCommit)
+					sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+				} else {
+					log.Printf("pico: firmware version unchanged: %s (%s)", fwVersion, fwCommit)
+				}
+				continue
+			}
+
 			// Forward all events to the FSM controller
 			ctrl.HandleEvent(event)
 


### PR DESCRIPTION
## What

Detects Pico reboots via the existing `STATUS:READY` UART event and re-queries the firmware version, sending an updated `device_info` to the server if it changed.

## Why

When firmware is flashed externally (e.g. `picotool load`, power cycle), the Pico reboots and sends `STATUS:READY` over UART. digitsd was ignoring this event and keeping the stale version from startup, so the web UI showed the old firmware version until digitsd was manually restarted.

## Test plan

- [ ] Flash firmware externally via picotool on a connected device
- [ ] Confirm digitsd logs show "detected reboot, re-querying firmware version" and "firmware version changed"
- [ ] Confirm web UI updates to show the new version without restarting digitsd
- [ ] Power cycle the Pico and confirm version is re-reported (unchanged case)