### PR TITLE
fix(ci): scope semantic-release configs to their own modules

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -15,7 +15,13 @@ module.exports = {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      parserOpts: {
+        headerPattern: /^(\w*)(?:\((firmware)\))?: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject'],
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+    }],
     ['@semantic-release/exec', {
       prepareCmd: 'bash ../tools/build-firmware.sh ${nextRelease.version}',
     }],

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -12,7 +12,13 @@ module.exports = {
         { scope: '!firmware', release: false },
       ],
     }],
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      parserOpts: {
+        headerPattern: /^(\w*)(?:\((firmware)\))?: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject'],
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+    }],
     ['@semantic-release/github', { assets: [], successComment: false, failComment: false }],
   ],
 };

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -13,12 +13,19 @@ module.exports = {
         { scope: 'digitsd', type: 'fix', release: 'patch' },
         { scope: 'digitsd', type: 'perf', release: 'patch' },
         { scope: 'digitsd', breaking: true, release: 'major' },
+        { release: false },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      parserOpts: {
+        headerPattern: /^(\w*)(?:\((pi|digitsd)\))?: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject'],
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+    }],
     ['@semantic-release/exec', {
       prepareCmd: 'bash tools/build-pi.sh ${nextRelease.version}',
     }],

--- a/server/.releaserc.cjs
+++ b/server/.releaserc.cjs
@@ -5,13 +5,23 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       releaseRules: [
-        { type: 'feat', release: 'minor' },
-        { type: 'fix', release: 'patch' },
-        { type: 'perf', release: 'patch' },
-        { breaking: true, release: 'major' },
+        { scope: 'server', type: 'feat', release: 'minor' },
+        { scope: 'server', type: 'fix', release: 'patch' },
+        { scope: 'server', type: 'perf', release: 'patch' },
+        { scope: 'server', breaking: true, release: 'major' },
+        { scope: '!server', release: false },
       ],
+      parserOpts: {
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
     }],
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      parserOpts: {
+        headerPattern: /^(\w*)(?:\((server)\))?: (.*)$/,
+        headerCorrespondence: ['type', 'scope', 'subject'],
+        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+    }],
     ['@semantic-release/github', { assets: [], successComment: false, failComment: false }],
   ],
 };


### PR DESCRIPTION
## What

Adds scope filtering to all four semantic-release configs so each module's release pipeline only considers its own commits for both version bumps and release notes.

## Why

Releases were including commits from other modules. For example, [fw/v1.0.1](https://github.com/justinlindh/digits/releases/tag/fw%2Fv1.0.1) listed server and digitsd tickets in its release notes.

Two bugs:
1. **commit-analyzer**: Server config had no scope qualifiers at all. Pi config had scope-specific rules but no catch-all, so unmatched scopes fell through to default angular rules (any `feat` = minor release).
2. **release-notes-generator**: All configs used the bare plugin with no filtering. Even when the analyzer scoped correctly (firmware), the notes generator independently parsed all commits since the last tag.

## Test plan

- [ ] Trigger a dry-run release for each module (`workflow_dispatch` with `dry_run: true`) and confirm only matching-scope commits appear in the planned release notes
- [ ] Verify that a commit like `feat(server): ...` does not trigger firmware or pi releases