### PR TITLE
fix(ci): use negation pattern in pi release catch-all rule

### DIFF
--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -13,7 +13,7 @@ module.exports = {
         { scope: 'digitsd', type: 'fix', release: 'patch' },
         { scope: 'digitsd', type: 'perf', release: 'patch' },
         { scope: 'digitsd', breaking: true, release: 'major' },
-        { release: false },
+        { scope: '!(pi|digitsd)', release: false },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],


### PR DESCRIPTION
## What

Fix the pi semantic-release config so digitsd commits actually trigger releases again.

## Why

PR #80 added a bare `{ release: false }` catch-all to the pi release rules. The commit-analyzer collects *all* matching rules and picks the "highest" release type. Because `indexOf(false)` returns `-1`, it was treated as higher priority than `patch`/`minor`/`major`, silently overriding every scope-specific rule. This suppressed the pi/v1.4.1 release that should have been created by PR #81.

The server and firmware configs already use `{ scope: '!server', release: false }` and `{ scope: '!firmware', release: false }` respectively, which correctly limit the catch-all to out-of-scope commits. This PR applies the same pattern to pi: `{ scope: '!(pi|digitsd)', release: false }`.

## Test plan

- Merge this PR and verify the Pi Release workflow creates `pi/v1.4.1` (picking up the missed `fix(digitsd)` from PR #81)
- Verify future `fix(digitsd)` and `feat(digitsd)` commits trigger releases
- Verify `fix(server)` or `fix(ci)` commits still do *not* trigger pi releases