### PR TITLE
test(server): add auth handler and middleware tests

### DIFF
--- a/server/internal/auth/google_test.go
+++ b/server/internal/auth/google_test.go
@@ -6,30 +6,6 @@ import (
 	"testing"
 )
 
-func TestGoogleAuth_Enabled(t *testing.T) {
-	s := testDB(t)
-
-	tests := []struct {
-		name     string
-		clientID string
-		secret   string
-		want     bool
-	}{
-		{"both set", "id", "secret", true},
-		{"empty id", "", "secret", false},
-		{"empty secret", "id", "", false},
-		{"both empty", "", "", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewGoogleAuth(tt.clientID, tt.secret, "http://localhost/callback", "", s)
-			if got := g.Enabled(); got != tt.want {
-				t.Errorf("Enabled() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestGoogleAuth_HandleLogin_SetsStateCookie(t *testing.T) {
 	s := testDB(t)
 	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)

--- a/server/internal/auth/google_test.go
+++ b/server/internal/auth/google_test.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGoogleAuth_Enabled(t *testing.T) {
+	s := testDB(t)
+
+	tests := []struct {
+		name     string
+		clientID string
+		secret   string
+		want     bool
+	}{
+		{"both set", "id", "secret", true},
+		{"empty id", "", "secret", false},
+		{"empty secret", "id", "", false},
+		{"both empty", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGoogleAuth(tt.clientID, tt.secret, "http://localhost/callback", "", s)
+			if got := g.Enabled(); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGoogleAuth_HandleLogin_SetsStateCookie(t *testing.T) {
+	s := testDB(t)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/login", nil)
+	w := httptest.NewRecorder()
+	g.HandleLogin(w, req)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Errorf("expected 307, got %d", w.Code)
+	}
+
+	// Should set an oauth_state cookie
+	cookies := w.Result().Cookies()
+	var stateCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "oauth_state" {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("expected oauth_state cookie to be set")
+	}
+	if stateCookie.Value == "" {
+		t.Error("oauth_state cookie should not be empty")
+	}
+	if !stateCookie.HttpOnly {
+		t.Error("oauth_state cookie should be HttpOnly")
+	}
+
+	// Redirect URL should point to Google
+	loc := w.Header().Get("Location")
+	if loc == "" {
+		t.Error("expected redirect Location header")
+	}
+}
+
+func TestGoogleAuth_HandleCallback_MissingStateCookie(t *testing.T) {
+	s := testDB(t)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state=abc&code=xyz", nil)
+	w := httptest.NewRecorder()
+	g.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGoogleAuth_HandleCallback_StateMismatch(t *testing.T) {
+	s := testDB(t)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state=abc&code=xyz", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "different-state"})
+	w := httptest.NewRecorder()
+	g.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/server/internal/auth/handlers_test.go
+++ b/server/internal/auth/handlers_test.go
@@ -1,0 +1,263 @@
+package auth
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/email"
+)
+
+// minimalTemplate builds a trivial template that satisfies ExecuteTemplate("layout.html", data).
+func minimalTemplate(t *testing.T) *template.Template {
+	t.Helper()
+	tmpl, err := template.New("layout.html").Parse(`{{.Page}} google={{.GoogleEnabled}} error={{.Error}} success={{.Success}}`)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	return tmpl
+}
+
+func newTestHandlers(t *testing.T) (*Handlers, *Store, *email.NoopSender) {
+	t.Helper()
+	s := testDB(t)
+	sender := email.NewNoopSender()
+	google := NewGoogleAuth("", "", "", "", s)
+	tmpl := minimalTemplate(t)
+	h := NewHandlers(s, google, sender, "http://localhost", "", tmpl, false)
+	return h, s, sender
+}
+
+func TestHandleLoginPage(t *testing.T) {
+	h, _, _ := newTestHandlers(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login?error=bad+thing&success=good+thing", nil)
+	w := httptest.NewRecorder()
+	h.HandleLoginPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "login") {
+		t.Errorf("expected Page=login in body, got: %s", body)
+	}
+	if !strings.Contains(body, "error=bad thing") {
+		t.Errorf("expected error param in body, got: %s", body)
+	}
+	if !strings.Contains(body, "success=good thing") {
+		t.Errorf("expected success param in body, got: %s", body)
+	}
+}
+
+func TestHandleLoginPage_GoogleEnabled(t *testing.T) {
+	s := testDB(t)
+	sender := email.NewNoopSender()
+	google := NewGoogleAuth("client-id", "client-secret", "http://localhost/callback", "", s)
+	tmpl := minimalTemplate(t)
+	h := NewHandlers(s, google, sender, "http://localhost", "", tmpl, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+	h.HandleLoginPage(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "google=true") {
+		t.Errorf("expected GoogleEnabled=true in body, got: %s", body)
+	}
+}
+
+func TestHandleMagicLinkRequest_EmptyEmail(t *testing.T) {
+	h, _, _ := newTestHandlers(t)
+
+	form := url.Values{"email": {""}}
+	req := httptest.NewRequest(http.MethodPost, "/auth/magic", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleMagicLinkRequest(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "error=email+required") {
+		t.Errorf("redirect location = %q, expected email required error", loc)
+	}
+}
+
+func TestHandleMagicLinkRequest_Success(t *testing.T) {
+	h, _, sender := newTestHandlers(t)
+
+	form := url.Values{"email": {"user@example.com"}}
+	req := httptest.NewRequest(http.MethodPost, "/auth/magic", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.HandleMagicLinkRequest(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "success=check+your+email") {
+		t.Errorf("redirect location = %q, expected success message", loc)
+	}
+	if len(sender.Sent) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(sender.Sent))
+	}
+	if sender.Sent[0].To != "user@example.com" {
+		t.Errorf("email sent to %q, want user@example.com", sender.Sent[0].To)
+	}
+	if !strings.Contains(sender.Sent[0].Body, "http://localhost/auth/magic/") {
+		t.Errorf("email body missing magic link URL: %s", sender.Sent[0].Body)
+	}
+}
+
+func TestHandleMagicLinkVerify_InvalidToken(t *testing.T) {
+	h, _, _ := newTestHandlers(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/magic/bad-token", nil)
+	req.SetPathValue("token", "bad-token")
+	w := httptest.NewRecorder()
+	h.HandleMagicLinkVerify(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "error=invalid+or+expired+link") {
+		t.Errorf("redirect location = %q, expected invalid link error", loc)
+	}
+}
+
+func TestHandleMagicLinkVerify_ValidToken_NewUser(t *testing.T) {
+	h, s, _ := newTestHandlers(t)
+
+	token, err := s.CreateMagicLink("newuser@test.com", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateMagicLink: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/magic/"+token, nil)
+	req.SetPathValue("token", token)
+	w := httptest.NewRecorder()
+	h.HandleMagicLinkVerify(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Errorf("redirect location = %q, want /", loc)
+	}
+
+	// Should have set a session cookie
+	cookies := w.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == CookieName {
+			sessionCookie = c
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected session cookie to be set")
+	}
+	if sessionCookie.Value == "" {
+		t.Error("session cookie value should not be empty")
+	}
+
+	// User should exist now
+	user, err := s.GetUserByEmail("newuser@test.com")
+	if err != nil {
+		t.Fatalf("expected user to be created, got: %v", err)
+	}
+	if user.LastLoginAt == nil {
+		t.Error("expected last_login_at to be set")
+	}
+}
+
+func TestHandleMagicLinkVerify_ValidToken_ExistingUser(t *testing.T) {
+	h, s, _ := newTestHandlers(t)
+
+	_, err := s.CreateUser("existing@test.com", "Existing", nil)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	token, err := s.CreateMagicLink("existing@test.com", 15*time.Minute)
+	if err != nil {
+		t.Fatalf("CreateMagicLink: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/magic/"+token, nil)
+	req.SetPathValue("token", token)
+	w := httptest.NewRecorder()
+	h.HandleMagicLinkVerify(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Errorf("redirect location = %q, want /", loc)
+	}
+}
+
+func TestHandleLogout_WithSession(t *testing.T) {
+	h, s, _ := newTestHandlers(t)
+
+	user, err := s.CreateUser("logout@test.com", "Logout User", nil)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	token, _, err := s.CreateSession(user.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+	w := httptest.NewRecorder()
+	h.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/auth/login" {
+		t.Errorf("redirect location = %q, want /auth/login", loc)
+	}
+
+	// Cookie should be cleared
+	cookies := w.Result().Cookies()
+	found := false
+	for _, c := range cookies {
+		if c.Name == CookieName && c.MaxAge < 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected session cookie to be cleared")
+	}
+
+	// Session should be deleted from DB
+	_, err = s.ValidateSession(token)
+	if err == nil {
+		t.Error("session should be invalid after logout")
+	}
+}
+
+func TestHandleLogout_NoCookie(t *testing.T) {
+	h, _, _ := newTestHandlers(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	w := httptest.NewRecorder()
+	h.HandleLogout(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/auth/login" {
+		t.Errorf("redirect location = %q, want /auth/login", loc)
+	}
+}

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -96,22 +95,3 @@ func TestRequireAuth_ValidSession(t *testing.T) {
 	}
 }
 
-func TestUserFromContext_NoUser(t *testing.T) {
-	ctx := context.Background()
-	u := UserFromContext(ctx)
-	if u != nil {
-		t.Errorf("expected nil user from empty context, got %+v", u)
-	}
-}
-
-func TestUserFromContext_WithUser(t *testing.T) {
-	user := &User{ID: "test-id", Email: "ctx@test.com"}
-	ctx := context.WithValue(context.Background(), UserContextKey, user)
-	got := UserFromContext(ctx)
-	if got == nil {
-		t.Fatal("expected user from context, got nil")
-	}
-	if got.ID != "test-id" {
-		t.Errorf("user ID = %s, want test-id", got.ID)
-	}
-}

--- a/server/internal/auth/middleware_test.go
+++ b/server/internal/auth/middleware_test.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequireAuth_MissingCookie(t *testing.T) {
+	s := testDB(t)
+
+	handler := s.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called without a cookie")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303 redirect, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/auth/login" {
+		t.Errorf("redirect location = %q, want /auth/login", loc)
+	}
+}
+
+func TestRequireAuth_InvalidSession(t *testing.T) {
+	s := testDB(t)
+
+	handler := s.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called with an invalid session")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: "totally-bogus-token"})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expected 303 redirect, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/auth/login" {
+		t.Errorf("redirect location = %q, want /auth/login", loc)
+	}
+
+	// Should clear the invalid cookie
+	cookies := w.Result().Cookies()
+	found := false
+	for _, c := range cookies {
+		if c.Name == CookieName && c.MaxAge < 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected invalid session cookie to be cleared")
+	}
+}
+
+func TestRequireAuth_ValidSession(t *testing.T) {
+	s := testDB(t)
+
+	user, err := s.CreateUser("middleware@test.com", "MW User", nil)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	token, _, err := s.CreateSession(user.ID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	var ctxUser *User
+	handler := s.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctxUser = UserFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if ctxUser == nil {
+		t.Fatal("expected user in context, got nil")
+	}
+	if ctxUser.ID != user.ID {
+		t.Errorf("context user ID = %s, want %s", ctxUser.ID, user.ID)
+	}
+	if ctxUser.Email != "middleware@test.com" {
+		t.Errorf("context user email = %s, want middleware@test.com", ctxUser.Email)
+	}
+}
+
+func TestUserFromContext_NoUser(t *testing.T) {
+	ctx := context.Background()
+	u := UserFromContext(ctx)
+	if u != nil {
+		t.Errorf("expected nil user from empty context, got %+v", u)
+	}
+}
+
+func TestUserFromContext_WithUser(t *testing.T) {
+	user := &User{ID: "test-id", Email: "ctx@test.com"}
+	ctx := context.WithValue(context.Background(), UserContextKey, user)
+	got := UserFromContext(ctx)
+	if got == nil {
+		t.Fatal("expected user from context, got nil")
+	}
+	if got.ID != "test-id" {
+		t.Errorf("user ID = %s, want test-id", got.ID)
+	}
+}


### PR DESCRIPTION
## What

Add unit tests for the previously untested auth handlers, middleware, and Google OAuth code in `server/internal/auth/`.

## Why

The auth package had test coverage only for `store.go`. The HTTP handlers (`handlers.go`), middleware (`middleware.go`), and Google OAuth (`google.go`) had zero tests, leaving critical authentication logic unverified.

## Test plan

- `cd server && make test` passes
- `cd server && go vet ./...` clean
- New tests cover:
  - **middleware**: valid session (user injected into context), invalid/expired session (redirect + cookie cleared), missing cookie (redirect)
  - **handlers**: login page rendering with error/success params, magic link request (empty email rejected, valid email sends mail), magic link verify (invalid token rejected, valid token creates user + session), logout (clears session + cookie)
  - **google**: `Enabled()` with various credential combos, `HandleLogin` sets state cookie + redirects, `HandleCallback` rejects missing/mismatched state