### PR TITLE
fix(digitsd): eliminate UART event race and concurrent update guard

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -568,11 +568,21 @@ const (
 // statusFunc is a callback to report update progress back to the server.
 type statusFunc func(status, detail string)
 
+// updateInProgress guards against concurrent firmware update runs.
+// The startup update goroutine and server-triggered updates both check this
+// to avoid racing (e.g. double-flashing the Pico).
+var updateInProgress atomic.Bool
+
 func runUpdate(serverURL, piVersion, fwVersion string, flashCapable bool, reportStatus statusFunc) {
-	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, reportStatus, nil)
+	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, reportStatus)
 }
 
-func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc, onFWFlashed func()) {
+func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc) {
+	if !updateInProgress.CompareAndSwap(false, true) {
+		log.Println("updater: skipping -- another update is already in progress")
+		return
+	}
+	defer updateInProgress.Store(false)
 	// When a specific component is targeted, don't auto-upgrade the other.
 	// A targeted trigger with only target_pi set should not also install firmware.
 	targeted := targetPi != "" || targetFW != ""
@@ -636,9 +646,6 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 				log.Printf("updater: firmware apply failed: %v", err)
 				reportStatus("failed", fmt.Sprintf("Firmware flash failed: %v", err))
 				return
-			}
-			if onFWFlashed != nil {
-				onFWFlashed()
 			}
 		}
 	}
@@ -1288,15 +1295,7 @@ func main() {
 					})
 				}
 				go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion,
-					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable.Load(), statusReporter, func() {
-						if v, c, err := sp.QueryVersion(); err != nil {
-							log.Printf("updater: re-query firmware version after flash: %v", err)
-						} else {
-							fwVersion, fwCommit = v, c
-							log.Printf("updater: firmware version after flash: %s (%s)", fwVersion, fwCommit)
-							sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
-						}
-					})
+					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable.Load(), statusReporter)
 
 			case sigclient.TypeICERestart:
 				cb.mu.Lock()

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -127,6 +127,28 @@ func (sp *SerialPort) Close() error {
 	return sp.port.Close()
 }
 
+// isUnsolicitedEvent returns true for messages the Pico sends on its own
+// (not in response to a command). These must always be delivered to the
+// events channel, even when a synchronous command is in flight, so that
+// e.g. a STATUS:READY boot message doesn't get swallowed by a pending
+// VERSION query.
+func isUnsolicitedEvent(line string) bool {
+	switch {
+	case line == "HOOK:OFF" || line == "HOOK:ON":
+		return true
+	case line == "STATUS:READY":
+		return true
+	case strings.HasPrefix(line, "KEY:"):
+		return true
+	case strings.HasPrefix(line, "DIAL:"):
+		return true
+	case strings.HasPrefix(line, "FSM:"):
+		return true
+	default:
+		return false
+	}
+}
+
 func (sp *SerialPort) readLoop() {
 	buf := make([]byte, 256)
 	var lineBuf strings.Builder
@@ -160,7 +182,18 @@ func (sp *SerialPort) readLoop() {
 
 				sp.logger.Printf("RX: %s", line)
 
-				// If there's a pending command waiting for response, deliver to it
+				// Unsolicited Pico events (hook, keypad, boot) always go to
+				// the events channel, never to a pending command response.
+				if isUnsolicitedEvent(line) {
+					select {
+					case sp.events <- line:
+					default:
+						sp.logger.Printf("serial: events full, dropping: %s", line)
+					}
+					continue
+				}
+
+				// Command response: deliver to pending command if one is waiting.
 				if sp.respCh != nil {
 					select {
 					case sp.respCh <- line:
@@ -169,7 +202,7 @@ func (sp *SerialPort) readLoop() {
 					}
 				}
 
-				// Otherwise, deliver as event
+				// No pending command — deliver as event (shouldn't normally happen).
 				select {
 				case sp.events <- line:
 				default:

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.bug.st/serial"
@@ -17,7 +18,7 @@ type SerialPort struct {
 	events chan string // parsed RX events (HOOK:OFF, KEY:5, etc.)
 
 	mu     sync.Mutex
-	respCh chan string // single-slot response channel for command/response pairs
+	respCh atomic.Pointer[chan string] // single-slot response channel for command/response pairs
 	stop   chan struct{}
 	logger *log.Logger
 }
@@ -56,8 +57,8 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 	defer sp.mu.Unlock()
 
 	ch := make(chan string, 1)
-	sp.respCh = ch
-	defer func() { sp.respCh = nil }()
+	sp.respCh.Store(&ch)
+	defer sp.respCh.Store(nil)
 
 	sp.logger.Printf("TX: %s", cmd)
 	if _, err := sp.port.Write([]byte(cmd + "\r\n")); err != nil {
@@ -194,9 +195,9 @@ func (sp *SerialPort) readLoop() {
 				}
 
 				// Command response: deliver to pending command if one is waiting.
-				if sp.respCh != nil {
+				if chp := sp.respCh.Load(); chp != nil {
 					select {
-					case sp.respCh <- line:
+					case *chp <- line:
 						continue
 					default:
 					}

--- a/pi/digitsd/internal/phone/serial_test.go
+++ b/pi/digitsd/internal/phone/serial_test.go
@@ -17,3 +17,35 @@ func TestSerialPortInterface(t *testing.T) {
 		Close() error
 	} = (*SerialPort)(nil)
 }
+
+func TestIsUnsolicitedEvent(t *testing.T) {
+	unsolicited := []string{
+		"HOOK:OFF", "HOOK:ON",
+		"STATUS:READY",
+		"KEY:5", "KEY:*", "KEY:#",
+		"DIAL:5551234",
+		"FSM:IDLE", "FSM:DIALING", "FSM:RINGING",
+	}
+	for _, msg := range unsolicited {
+		if !isUnsolicitedEvent(msg) {
+			t.Errorf("expected %q to be unsolicited", msg)
+		}
+	}
+
+	commandResponses := []string{
+		"PONG",
+		"VERSION:1.0.0:abc1234",
+		"RING:ACK", "RING:DONE", "RING:TEST:ACK",
+		"HOOK:FORCED:ON_HOOK", "HOOK:FORCED:OFF_HOOK",
+		"HOOK:RELEASED",
+		"HOOK:INVERT:ON", "HOOK:INVERT:OFF",
+		"RST:OK",
+		"STATE:IDLE",
+		"MODE:KEYTEST", "MODE:NORMAL",
+	}
+	for _, msg := range commandResponses {
+		if isUnsolicitedEvent(msg) {
+			t.Errorf("expected %q to be a command response, not unsolicited", msg)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fix a race condition where the Pico's `STATUS:READY` boot message was consumed by a pending `VERSION` query's response channel after firmware flash, causing the version re-query to fail and triggering a flash loop.

## Why

After a firmware flash, `STATUS:READY` is an unsolicited event from the Pico, but the serial layer was routing it to whichever synchronous command was waiting for a response. This left `fwVersion` stale, which made the startup update goroutine think the firmware was outdated and flash again in a loop.

## Changes

- **`serial.go`**: Add `isUnsolicitedEvent()` classifier so known Pico events (`HOOK`, `KEY`, `DIAL`, `FSM`, `STATUS:READY`) always route to the events channel, even when a synchronous command is pending
- **`serial.go`**: Switch `respCh` from mutex-guarded pointer to `atomic.Pointer[chan string]` to eliminate a data race between `SendCommand` and `readLoop`
- **`main.go`**: Add `updateInProgress` atomic guard to prevent concurrent update runs
- **`main.go`**: Remove `onFWFlashed` callback (now redundant with the `STATUS:READY` event handler)

## Test plan

- `make test` passes
- `go vet ./...` clean
- Verified on device: firmware flash completes, `STATUS:READY` triggers version re-query, no flash loop