### PR TITLE
docs: use Pico H instead of RP2040 Pico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Digits
 
-Private encrypted phone network built from gutted vintage desk phones. Three components talk to each other: firmware on an RP2040, a Go daemon on a Pi Zero 2 W, and a Go signaling server.
+Private encrypted phone network built from gutted vintage desk phones. Three components talk to each other: firmware on a Pico H, a Go daemon on a Pi Zero 2 W, and a Go signaling server.
 
 ## Repo layout
 
 ```
-firmware/       RP2040 Pico firmware (C, CMake, Pico SDK)
+firmware/       Pico H firmware (C, CMake, Pico SDK)
 pi/digitsd/     Pi-side daemon (Go, cross-compiled to arm64)
 pi/digits-setup/ First-boot setup tool (Go)
 pi/image/       Pi OS image builder

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ---
 
 Each Digits endpoint combines:
-- **RP2040 Pico** -- phone UX and real-time hardware control (hook switch, keypad, bell, tones, indicators)
+- **Pico H** -- phone UX and real-time hardware control (hook switch, keypad, bell, tones, indicators)
 - **Raspberry Pi Zero 2 W** -- Linux-side services (VoIP stack, crypto/session logic, orchestration)
 - **Raspberry Pi Codec Zero (DA7212)** -- audio input/output on the Pi side
 
@@ -36,7 +36,7 @@ A single phone unit is split into two cooperating processors:
 
 | Component | Role |
 |-----------|------|
-| **RP2040 Pico** (firmware) | Low-level telephony, timing-sensitive I/O, UART protocol to Pi |
+| **Pico H** (firmware) | Low-level telephony, timing-sensitive I/O, UART protocol to Pi |
 | **Pi Zero 2 W** (digitsd) | Go daemon for VoIP, signaling, WebRTC media, Opus codec, call control |
 | **Codec Zero** (DA7212) | Audio pHAT with mic input (3.5mm TRS), speaker output (screw terminal) |
 | **Signaling Server** (Go) | WebSocket relay for SDP/ICE, PostgreSQL persistence, web app + admin |
@@ -46,7 +46,7 @@ See [Architecture deep-dive](docs/architecture/overview.md) for the full call pa
 ## Project Structure
 
 ```text
-firmware/   RP2040 Pico firmware (C/CMake + Pico SDK)
+firmware/   Pico H firmware (C/CMake + Pico SDK)
 pi/         Pi Zero userland -- digitsd VoIP daemon, setup tools, image builder
 server/     Go signaling server (WebSocket relay, web app, admin panel)
 docs/       Hardware build guides, architecture, self-hosting
@@ -66,7 +66,7 @@ make test      # go test ./...
 
 Requires Go 1.26+ and PostgreSQL. The server reads `DATABASE_URL` and runs migrations automatically on startup.
 
-### Firmware (RP2040 Pico)
+### Firmware (Pico H)
 
 ```bash
 export PICO_SDK_PATH=/path/to/pico-sdk

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -25,7 +25,7 @@ Digits is a point-to-point encrypted phone network built from gutted vintage des
                              └─────────────┘
 ```
 
-### RP2040 Pico
+### Pico H
 
 Real-time hardware controller. Manages the hook switch, keypad scanning, bell driver, tone generation (dial tone, ringback, busy), and status LED. Communicates with the Pi Zero over UART using a line-based ASCII protocol -- see [uart-protocol.md](uart-protocol.md) for the full spec.
 

--- a/docs/architecture/uart-protocol.md
+++ b/docs/architecture/uart-protocol.md
@@ -1,6 +1,6 @@
 # Digits -- UART Protocol Specification
 
-Line-based ASCII protocol between RP2040 Pico and Pi Zero 2 W.
+Line-based ASCII protocol between Pico H and Pi Zero 2 W.
 
 ## Transport
 


### PR DESCRIPTION
## What

Updates documentation to say "Pico H" instead of "RP2040 Pico" where referring to the board.

## Why

We use the Pico H everywhere. Saying "RP2040" (the chip) or "RP2040 Pico" (not a real product name) is confusing. References to the RP2040 chip itself (GPIO maps, PCB plan discussing bare chip) are left as-is.

## Test plan

- Docs-only change, no code affected
- Verified chip-specific references (wiring GPIO map, PCB plan, datasheets) were left unchanged