### PR TITLE
fix(digitsd): match POTS Bellcore timings for remote hangup

### DIFF
--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -297,15 +297,15 @@ func (c *Controller) onSignalHangup() {
 		log.Printf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state)
 		return
 	}
-	// Full POTS remote-hangup sequence:
+	// POTS remote-hangup sequence (Bellcore GR-506-CORE permanent signal treatment):
 	//   1. Tear down call, brief silence (~1s, CO processing delay)
-	//   2. Reorder tone (fast busy, 480+620 Hz) for ~10s
-	//   3. Intercept voice message ("If you'd like to make a call...")
-	//   4. Howler tone (loud multi-freq) until user hangs up
+	//   2. Reorder tone (fast busy, 480+620 Hz) for ~45s
+	//   3. Howler/ROH tone (loud multi-freq) for ~3 min
+	//   4. Line lockout (silence until user hangs up)
 	c.state = StateREMOTE_HANGUP
 	c.cb.HangupCall()
 	c.cb.SendTone("STOPALL")
-	log.Println("phone: remote hangup — starting POTS off-hook sequence")
+	log.Println("phone: remote hangup -- starting POTS off-hook sequence")
 	go func() {
 		// Helper to check we're still in REMOTE_HANGUP state
 		stillOffHook := func() bool {
@@ -320,31 +320,25 @@ func (c *Controller) onSignalHangup() {
 			return
 		}
 
-		// 2. Reorder tone for ~10 seconds
-		log.Println("phone: remote hangup — reorder tone")
+		// 2. Reorder tone for ~45 seconds
+		log.Println("phone: remote hangup -- reorder tone")
 		c.cb.SendTone("REORDER")
-		time.Sleep(10 * time.Second)
+		time.Sleep(45 * time.Second)
 		if !stillOffHook() {
 			return
 		}
 
-		// 3. Intercept voice message
-		log.Println("phone: remote hangup — intercept message")
-		c.cb.SendTone("STOP")
-		c.cb.SendTone("INTERCEPT")
-		for c.cb.OncePlaying() {
-			time.Sleep(200 * time.Millisecond)
-			if !stillOffHook() {
-				return
-			}
-		}
-		if !stillOffHook() {
-			return
-		}
-
-		// 4. Howler tone until hang-up
-		log.Println("phone: remote hangup — howler tone")
+		// 3. Howler tone for ~3 minutes
+		log.Println("phone: remote hangup -- howler tone")
 		c.cb.SendTone("HOWLER")
+		time.Sleep(3 * time.Minute)
+		if !stillOffHook() {
+			return
+		}
+
+		// 4. Line lockout -- silence until hang-up
+		log.Println("phone: remote hangup -- line lockout")
+		c.cb.SendTone("STOP")
 	}()
 }
 


### PR DESCRIPTION
## What

Corrects the remote hangup off-hook sequence to match real US POTS behavior per Bellcore GR-506-CORE permanent signal treatment.

## Why

The previous timings didn't match what a real phone line does when the far end hangs up:
- Reorder tone was 10s instead of ~45s
- An intercept message (SIT tones) played between reorder and howler -- intercept is for invalid/disconnected numbers, not far-end hangup
- Howler ran indefinitely with no line lockout

Corrected sequence: 1s silence, 45s reorder, 3 min howler, then line lockout (silence until hangup).

## Test plan

- Existing unit tests pass (`go test ./internal/phone/...`)
- Manual test: place a call between two phones, hang up one end, verify the remaining handset hears ~45s of reorder tone followed by howler, then silence after ~3 min