### PR TITLE
fix(server,digitsd): clear stale call tracker on disconnect and play busy tone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ PRs required to merge into main. No direct pushes. Use the PR template at `.gith
 
 **Never force push.** Always push new commits on top of existing branches. No `--force`, no `--force-with-lease`, no amending pushed commits.
 
+When addressing PR review comments, always reply to each comment on GitHub (via `gh api`) acknowledging the feedback and noting what was changed. Do this at the same time as pushing the fix.
+
 ## CI
 
 GitHub Actions workflows (`.github/workflows/`):

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -347,7 +347,7 @@ func (c *Controller) onSignalBusy() {
 		log.Printf("phone: busy signal ignored in state %s (not CALLING)", c.state)
 		return
 	}
-	log.Printf("phone: busy signal received — call rejected")
-	c.cb.SendTone("STOP")
-	// Stay in CALLING — caller should hang up
+	log.Printf("phone: busy signal received -- call rejected")
+	c.cb.SendTone("BUSY")
+	// Stay in CALLING -- caller should hang up
 }

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -220,7 +220,7 @@ func TestController_HangupDuringCalling(t *testing.T) {
 	}
 }
 
-// 6. Busy signal during CALLING → SendTone("STOP"), stays in CALLING or logs
+// 6. Busy signal during CALLING → SendTone("BUSY"), stays in CALLING
 func TestController_BusySignal(t *testing.T) {
 	cb := &mockCallbacks{}
 	c := NewController(cb, "")
@@ -241,8 +241,8 @@ func TestController_BusySignal(t *testing.T) {
 		t.Error("expected SendTone to be called on busy")
 	}
 	lastTone := cb.tones[len(cb.tones)-1]
-	if lastTone != "STOP" {
-		t.Errorf("expected SendTone(STOP) on busy, got %s", lastTone)
+	if lastTone != "BUSY" {
+		t.Errorf("expected SendTone(BUSY) on busy, got %s", lastTone)
 	}
 	// No hangup call triggered by signal
 	if cb.hangups != 0 {

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -93,6 +93,31 @@ func (t *Tracker) OnCallEnded(caller, callee string) error {
 	return err
 }
 
+// ClearByNumber removes all active calls involving the given number and ends
+// them in the database. Used when a WebSocket disconnects unexpectedly.
+func (t *Tracker) ClearByNumber(number string) {
+	t.mu.Lock()
+	var toDelete []string
+	for key, c := range t.active {
+		if c.Caller == number || c.Callee == number {
+			toDelete = append(toDelete, key)
+		}
+	}
+	for _, key := range toDelete {
+		delete(t.active, key)
+	}
+	t.mu.Unlock()
+
+	// End any open calls in the database
+	t.db.DB.Exec(
+		`UPDATE calls SET status = 'ended', ended_at = CURRENT_TIMESTAMP,
+		 duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT
+		 WHERE (caller = $1 OR callee = $1)
+		 AND status IN ('initiated', 'ringing', 'connected')`,
+		number,
+	)
+}
+
 func (t *Tracker) Busy(number string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -2,6 +2,7 @@ package calls
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -109,13 +110,15 @@ func (t *Tracker) ClearByNumber(number string) {
 	t.mu.Unlock()
 
 	// End any open calls in the database
-	t.db.DB.Exec(
+	if _, err := t.db.DB.Exec(
 		`UPDATE calls SET status = 'ended', ended_at = CURRENT_TIMESTAMP,
 		 duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT
 		 WHERE (caller = $1 OR callee = $1)
 		 AND status IN ('initiated', 'ringing', 'connected')`,
 		number,
-	)
+	); err != nil {
+		slog.Warn("clear calls on disconnect failed", "number", number, "err", err)
+	}
 }
 
 func (t *Tracker) Busy(number string) bool {

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -11,6 +11,7 @@ type CallTracker interface {
 	OnCallInitiated(from, to string) error
 	OnCallAnswered(caller, callee string) error
 	OnCallEnded(caller, callee string) error
+	ClearByNumber(number string)
 	InCall(a, b string) bool
 	Busy(number string) bool
 }
@@ -160,6 +161,13 @@ func (r *Relay) handleRequestICE(from string, _ *Message) {
 
 	if err := r.Hub.SendTo(from, resp); err != nil {
 		slog.Error("send ice-servers failed", "to", from, "err", err)
+	}
+}
+
+// OnDisconnect cleans up any active calls for a phone that disconnected.
+func (r *Relay) OnDisconnect(number string) {
+	if r.Tracker != nil {
+		r.Tracker.ClearByNumber(number)
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -425,17 +425,18 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	}
 
 	// Phone 3 can now call Phone 2 (once reconnected)
-	hub.Register("3140002", &Conn{Send: make(chan []byte, 10)})
+	newConn2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140002", newConn2)
 	relay.HandleMessage("3140003", &Message{Type: TypeCall, To: "3140002"})
 
 	select {
-	case data := <-conn3.Send:
+	case data := <-newConn2.Send:
 		msg, _ := ParseMessage(data)
-		if msg.Type == TypeBusy {
-			t.Fatal("phone 2 should not be busy after disconnect cleanup")
+		if msg.Type != TypeRing {
+			t.Fatalf("expected ring on reconnected phone 2, got: %+v", msg)
 		}
 	default:
-		// No busy signal sent to caller - check callee got ring
+		t.Fatal("reconnected phone 2 did not receive ring")
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -32,6 +32,14 @@ func (m *mockTracker) OnCallEnded(caller, callee string) error {
 	delete(m.calls, callee+"→"+caller)
 	return nil
 }
+func (m *mockTracker) ClearByNumber(number string) {
+	for k := range m.calls {
+		a, b, _ := strings.Cut(k, "→")
+		if a == number || b == number {
+			delete(m.calls, k)
+		}
+	}
+}
 func (m *mockTracker) Busy(number string) bool {
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
@@ -380,6 +388,54 @@ func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
 		t.Fatalf("target should not receive anything, got: %+v", msg)
 	default:
 		// correct
+	}
+}
+
+func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	conn3 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+	hub.Register("3140003", conn3)
+
+	// Establish a call: Phone 1 → Phone 2
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140002"})
+	<-conn2.Send // drain ring
+
+	// Verify Phone 2 is busy
+	if !tracker.Busy("3140002") {
+		t.Fatal("expected phone 2 to be busy after call initiated")
+	}
+
+	// Simulate Phone 2 disconnecting (WebSocket drops)
+	relay.OnDisconnect("3140002")
+
+	// Phone 2 should no longer be busy
+	if tracker.Busy("3140002") {
+		t.Fatal("expected phone 2 to not be busy after disconnect cleanup")
+	}
+	// Phone 1 should also be freed (its call was with Phone 2)
+	if tracker.Busy("3140001") {
+		t.Fatal("expected phone 1 to not be busy after peer disconnected")
+	}
+
+	// Phone 3 can now call Phone 2 (once reconnected)
+	hub.Register("3140002", &Conn{Send: make(chan []byte, 10)})
+	relay.HandleMessage("3140003", &Message{Type: TypeCall, To: "3140002"})
+
+	select {
+	case data := <-conn3.Send:
+		msg, _ := ParseMessage(data)
+		if msg.Type == TypeBusy {
+			t.Fatal("phone 2 should not be busy after disconnect cleanup")
+		}
+	default:
+		// No busy signal sent to caller - check callee got ring
 	}
 }
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1342,6 +1342,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read pump (blocks until disconnect)
 	defer h.hub.Unregister(number, conn)
+	defer h.relay.OnDisconnect(number)
 	defer func() {
 		if msg.HardwareID != "" && h.deviceStore != nil {
 			if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {


### PR DESCRIPTION
## What

Two fixes for broken calling:

1. **Server**: Clear active call tracker entries when a phone's WebSocket disconnects, preventing stale "busy" state from accumulating.
2. **digitsd**: Play the actual BUSY tone (instead of silence) when the server rejects a call as busy.

## Why

After a WebSocket disconnects mid-call (network drop, reboot, etc.), the server's in-memory call tracker never cleaned up the active call entry. Both the caller and callee numbers stayed permanently marked as "busy", so all subsequent calls were rejected. The phones also played dead air instead of a busy tone because `onSignalBusy` sent `STOP` instead of `BUSY`.

## Test plan

- Added `TestRelayOnDisconnectClearsActiveCalls` covering the full scenario: establish call, disconnect one side, verify both numbers are freed, verify a new call goes through
- Updated `TestController_BusySignal` to expect `BUSY` tone instead of `STOP`
- `go test ./...` and `go vet ./...` pass for both server and digitsd
- Tested on Digits 1/Digits 2 hardware by deploying and verifying calls connect after a WebSocket reconnect