### PR TITLE
feat(server): add favicon for app.digits.family

### DIFF
--- a/server/internal/web/static/favicon.svg
+++ b/server/internal/web/static/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#c9d1d9" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+</svg>

--- a/server/internal/web/templates/layout.html
+++ b/server/internal/web/templates/layout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{block "title" .}}Digits{{end}} — Digits</title>
+    <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="/static/tailwind.css">
     <script src="/static/htmx.min.js"></script>
     <style>


### PR DESCRIPTION
## What

Add an SVG phone icon favicon to the web UI.

## Why

The app.digits.family site has no favicon, so browser tabs show the default blank page icon.

## Test plan

- Run the server and verify the phone icon appears in the browser tab
- Confirm favicon loads at `/static/favicon.svg`