### PR TITLE
refactor(digitsd): migrate from log to log/slog

### DIFF
--- a/pi/digitsd/cmd/clocksync/main.go
+++ b/pi/digitsd/cmd/clocksync/main.go
@@ -13,9 +13,10 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net"
+	"os"
 	"time"
 )
 
@@ -40,10 +41,11 @@ func main() {
 func runServer(addr string) {
 	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(fmt.Sprintf("%v", err))
+		os.Exit(1)
 	}
 	defer conn.Close()
-	log.Printf("clocksync server listening on %s", addr)
+	slog.Info(fmt.Sprintf("clocksync server listening on %s", addr))
 
 	buf := make([]byte, 64)
 	for {
@@ -66,7 +68,8 @@ func runServer(addr string) {
 func runClient(addr string, count int) {
 	conn, err := net.Dial("udp", addr)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(fmt.Sprintf("%v", err))
+		os.Exit(1)
 	}
 	defer conn.Close()
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -724,7 +725,7 @@ func main() {
 		serialWriter = io.MultiWriter(os.Stdout, uartLogFile)
 		defer uartLogFile.Close()
 	}
-	serialLogger := log.New(serialWriter, "", log.Ldate|log.Ltime|log.Lmicroseconds)
+	serialLogger := slog.New(slog.NewTextHandler(serialWriter, nil))
 	sp, err := phone.OpenSerial(*serialDev, 115200, serialLogger)
 	if err != nil {
 		log.Fatalf("serial: %v", err)

--- a/pi/digitsd/cmd/latclient/main.go
+++ b/pi/digitsd/cmd/latclient/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net/url"
 	"os"
@@ -33,8 +33,6 @@ func main() {
 	duration := flag.Duration("duration", 10*time.Second, "how long to send audio")
 	flag.Parse()
 
-	log.SetFlags(log.Lmicroseconds)
-
 	// Connect to signald
 	u, _ := url.Parse(*signaldURL)
 	q := u.Query()
@@ -46,20 +44,22 @@ func main() {
 	}
 	ws, _, err := dialer.Dial(u.String(), nil)
 	if err != nil {
-		log.Fatalf("dial signald: %v", err)
+		slog.Error(fmt.Sprintf("dial signald: %v", err))
+		os.Exit(1)
 	}
 	defer ws.Close()
 
 	// Register with signald (required before any signaling)
 	regMsg, _ := json.Marshal(sigclient.Message{Type: sigclient.TypeRegister, Number: *number})
 	ws.WriteMessage(websocket.TextMessage, regMsg)
-	log.Printf("registered with signald as %s", *number)
+	slog.Info(fmt.Sprintf("registered with signald as %s", *number))
 
 	// Create WebRTC peer connection
 	config := webrtc.Configuration{}
 	pc, err := webrtc.NewPeerConnection(config)
 	if err != nil {
-		log.Fatalf("create peer connection: %v", err)
+		slog.Error(fmt.Sprintf("create peer connection: %v", err))
+		os.Exit(1)
 	}
 	defer pc.Close()
 
@@ -70,11 +70,13 @@ func main() {
 		webrtc.WithRTPSequenceNumber(1),
 	)
 	if err != nil {
-		log.Fatalf("create track: %v", err)
+		slog.Error(fmt.Sprintf("create track: %v", err))
+		os.Exit(1)
 	}
 	rtpSender, err := pc.AddTrack(track)
 	if err != nil {
-		log.Fatalf("add track: %v", err)
+		slog.Error(fmt.Sprintf("add track: %v", err))
+		os.Exit(1)
 	}
 	// Drain RTCP — required by pion to prevent buffer backpressure
 	go func() {
@@ -89,7 +91,8 @@ func main() {
 	// Opus encoder
 	enc, err := codec.NewEncoder(48000, 1, 24000)
 	if err != nil {
-		log.Fatalf("encoder: %v", err)
+		slog.Error(fmt.Sprintf("encoder: %v", err))
+		os.Exit(1)
 	}
 
 	var mu sync.Mutex
@@ -113,24 +116,27 @@ func main() {
 	})
 
 	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
-		log.Printf("connection state: %s", s)
+		slog.Info(fmt.Sprintf("connection state: %s", s))
 	})
 
 	// Create offer
 	gatherDone := webrtc.GatheringCompletePromise(pc)
 	offer, err := pc.CreateOffer(nil)
 	if err != nil {
-		log.Fatalf("create offer: %v", err)
+		slog.Error(fmt.Sprintf("create offer: %v", err))
+		os.Exit(1)
 	}
 	if err := pc.SetLocalDescription(offer); err != nil {
-		log.Fatalf("set local desc: %v", err)
+		slog.Error(fmt.Sprintf("set local desc: %v", err))
+		os.Exit(1)
 	}
 
 	// Wait for ICE gathering
 	select {
 	case <-gatherDone:
 	case <-time.After(5 * time.Second):
-		log.Fatal("ICE gathering timeout")
+		slog.Error("ICE gathering timeout")
+		os.Exit(1)
 	}
 
 	// Send call + SDP (same as browser test client)
@@ -152,14 +158,14 @@ func main() {
 	mu.Lock()
 	ws.WriteMessage(websocket.TextMessage, offerData)
 	mu.Unlock()
-	log.Printf("sent call + offer to %s", *target)
+	slog.Info(fmt.Sprintf("sent call + offer to %s", *target))
 
 	// Read signaling messages
 	go func() {
 		for {
 			_, msgData, err := ws.ReadMessage()
 			if err != nil {
-				log.Printf("ws read: %v", err)
+				slog.Error(fmt.Sprintf("ws read: %v", err))
 				return
 			}
 			var msg sigclient.Message
@@ -169,19 +175,19 @@ func main() {
 
 			switch msg.Type {
 			case sigclient.TypeAnswer:
-				log.Printf("received answer SDP")
+				slog.Info("received answer SDP")
 				answer := webrtc.SessionDescription{
 					Type: webrtc.SDPTypeAnswer,
 					SDP:  msg.SDP,
 				}
 				if err := pc.SetRemoteDescription(answer); err != nil {
-					log.Printf("set remote desc: %v", err)
+					slog.Error(fmt.Sprintf("set remote desc: %v", err))
 				}
 
 			case sigclient.TypeICE:
 				var candidate webrtc.ICECandidateInit
 				if err := json.Unmarshal([]byte(msg.Candidate), &candidate); err != nil {
-					log.Printf("parse ICE: %v", err)
+					slog.Error(fmt.Sprintf("parse ICE: %v", err))
 					continue
 				}
 				pc.AddICECandidate(candidate) //nolint:errcheck
@@ -191,16 +197,16 @@ func main() {
 
 	// Wait briefly for ring+SDP to arrive on the Pi, then inject HOOK:OFF to answer.
 	// The Pi can't create a PeerManager until we answer, so we must inject before waiting for connection.
-	log.Printf("waiting 2s for ring to arrive on Pi...")
+	slog.Info("waiting 2s for ring to arrive on Pi...")
 	time.Sleep(2 * time.Second)
 
-	log.Printf("Injecting HOOK:OFF on Pi via socket...")
+	slog.Info("Injecting HOOK:OFF on Pi via socket...")
 	injectCmd := `ssh digits@<pi-ip> 'python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.connect(\"/home/digits/digits/pi/uart.sock\"); s.send(b\"TEST:EVENT:HOOK:OFF\n\"); print(s.recv(64)); s.close()"'`
 	out, err := exec.Command("bash", "-c", injectCmd).CombinedOutput()
-	log.Printf("HOOK:OFF inject result: %s (err: %v)", strings.TrimSpace(string(out)), err)
+	slog.Info(fmt.Sprintf("HOOK:OFF inject result: %s (err: %v)", strings.TrimSpace(string(out)), err))
 
 	// Now wait for WebRTC connection (Pi creates PeerManager on answer, sends back SDP)
-	log.Printf("waiting for WebRTC connection...")
+	slog.Info("waiting for WebRTC connection...")
 	deadline := time.After(10 * time.Second)
 	for {
 		if pc.ConnectionState() == webrtc.PeerConnectionStateConnected {
@@ -208,12 +214,13 @@ func main() {
 		}
 		select {
 		case <-deadline:
-			log.Fatal("connection timeout")
+			slog.Error("connection timeout")
+			os.Exit(1)
 		case <-time.After(100 * time.Millisecond):
 		}
 	}
 
-	log.Printf("=== CONNECTED ===")
+	slog.Info("=== CONNECTED ===")
 
 	// Send audio frames with precise timestamps
 	const (
@@ -224,7 +231,7 @@ func main() {
 	)
 
 	// Wait 3 seconds for call to be fully established
-	log.Printf("Warming up for 3 seconds...")
+	slog.Info("Warming up for 3 seconds...")
 	ticker := time.NewTicker(time.Duration(frameMs) * time.Millisecond)
 	defer ticker.Stop()
 
@@ -246,11 +253,11 @@ func main() {
 		track.WriteSample(media.Sample{Data: pkt, Duration: time.Duration(frameMs) * time.Millisecond}) //nolint:errcheck
 		warmupFrames++
 		if warmupFrames == 1 {
-			log.Printf("WARMUP[1]: seq=1 wallclock=%s", time.Now().Format("15:04:05.000000"))
+			slog.Info(fmt.Sprintf("WARMUP[1]: seq=1 wallclock=%s", time.Now().Format("15:04:05.000000")))
 		}
 	}
-	log.Printf("WARMUP[%d]: seq=%d wallclock=%s (last warmup)", warmupFrames, warmupFrames, time.Now().Format("15:04:05.000000"))
-	log.Printf("Warmup done (%d frames). Starting measurement phase.", warmupFrames)
+	slog.Info(fmt.Sprintf("WARMUP[%d]: seq=%d wallclock=%s (last warmup)", warmupFrames, warmupFrames, time.Now().Format("15:04:05.000000")))
+	slog.Info(fmt.Sprintf("Warmup done (%d frames). Starting measurement phase.", warmupFrames))
 	fmt.Println()
 
 	// Now measure: send frames and log precise wallclock times.
@@ -272,7 +279,7 @@ func main() {
 
 		pkt, err := enc.Encode(pcm)
 		if err != nil {
-			log.Printf("encode: %v", err)
+			slog.Error(fmt.Sprintf("encode: %v", err))
 			continue
 		}
 
@@ -282,7 +289,7 @@ func main() {
 			Duration: time.Duration(frameMs) * time.Millisecond,
 		})
 		if err != nil {
-			log.Printf("write sample: %v", err)
+			slog.Error(fmt.Sprintf("write sample: %v", err))
 			continue
 		}
 
@@ -291,15 +298,15 @@ func main() {
 
 		totalFrame := warmupFrames + frameNum
 		if frameNum <= 5 || frameNum%50 == 0 {
-			log.Printf("SEND[%d]: seq=%d elapsed=%s wallclock=%s",
+			slog.Info(fmt.Sprintf("SEND[%d]: seq=%d elapsed=%s wallclock=%s",
 				frameNum, totalFrame, elapsed.Round(time.Millisecond),
-				sendTime.Format("15:04:05.000000"))
+				sendTime.Format("15:04:05.000000")))
 		}
 	}
 
-	log.Printf("=== DONE — sent %d frames (after %d warmup) in %v ===",
-		frameNum, warmupFrames, time.Since(startTime).Round(time.Millisecond))
-	log.Printf("Now check Pi logs: ssh digits@<pi-ip> 'cat /tmp/digitsd.log'")
+	slog.Info(fmt.Sprintf("=== DONE — sent %d frames (after %d warmup) in %v ===",
+		frameNum, warmupFrames, time.Since(startTime).Round(time.Millisecond)))
+	slog.Info("Now check Pi logs: ssh digits@<pi-ip> 'cat /tmp/digitsd.log'")
 
 	// Graceful close
 	pc.Close()

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"unsafe"
@@ -75,7 +75,7 @@ func CodecDeviceName() (string, error) {
 func DefaultCaptureConfig() Config {
 	dev, err := CodecDeviceName()
 	if err != nil {
-		log.Printf("WARNING: codec detection failed, falling back to plughw:1,0: %v", err)
+		slog.Error(fmt.Sprintf("codec detection failed, falling back to plughw:1,0: %v", err))
 		dev = "plughw:1,0"
 	}
 	return Config{

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -77,7 +77,7 @@ func (m *Mixer) Start() {
 	m.running = true
 	m.stopCh = make(chan struct{})
 	go m.renderLoop(m.stopCh)
-	log.Println("mixer: render loop started")
+	slog.Info("mixer: render loop started")
 }
 
 // Stop halts the render loop. Blocks until the goroutine has exited.
@@ -92,7 +92,7 @@ func (m *Mixer) Stop() {
 	m.running = false
 	m.mu.Unlock()
 	// Wait for render loop to drain — it exits on next select check
-	log.Println("mixer: render loop stopped")
+	slog.Info("mixer: render loop stopped")
 }
 
 // renderLoop is the single goroutine that writes to hardware.
@@ -171,7 +171,7 @@ func (m *Mixer) EnableCapture(path string) error {
 	}
 	m.captureFile = f
 	m.capturePath = path
-	log.Printf("mixer: PCM capture → %s", path)
+	slog.Info(fmt.Sprintf("mixer: PCM capture → %s", path))
 	return nil
 }
 
@@ -181,7 +181,7 @@ func (m *Mixer) DisableCapture() {
 	defer m.mu.Unlock()
 	if m.captureFile != nil {
 		m.captureFile.Close()
-		log.Printf("mixer: PCM capture stopped (%s)", m.capturePath)
+		slog.Info(fmt.Sprintf("mixer: PCM capture stopped (%s)", m.capturePath))
 		m.captureFile = nil
 		m.capturePath = ""
 	}
@@ -222,7 +222,7 @@ func (m *Mixer) LoadTonesFromDir(dir string) error {
 			return fmt.Errorf("load %s: %w", e.Name(), err)
 		}
 		m.LoadTone(name, samples)
-		log.Printf("mixer: loaded %s (%d samples, %.1fs)", name, len(samples), float64(len(samples))/48000)
+		slog.Info(fmt.Sprintf("mixer: loaded %s (%d samples, %.1fs)", name, len(samples), float64(len(samples))/48000))
 	}
 	return nil
 }
@@ -234,7 +234,7 @@ func (m *Mixer) PlayLoop(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		log.Printf("mixer: unknown tone %q", name)
+		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
 		return
 	}
 	m.loopSamples = samples
@@ -296,7 +296,7 @@ func (m *Mixer) PlayOnce(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		log.Printf("mixer: unknown tone %q", name)
+		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
 		return
 	}
 	m.onceQueue = append(m.onceQueue, samples)

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -1,7 +1,8 @@
 package audio
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"sync"
 )
 
@@ -62,7 +63,7 @@ func (p *Pipeline) Start() error {
 	if p.cfg.Denoise {
 		d, err := NewDenoiser()
 		if err != nil {
-			log.Printf("audio: denoiser unavailable, running without denoise: %v", err)
+			slog.Error(fmt.Sprintf("audio: denoiser unavailable, running without denoise: %v", err))
 			p.denoiser = nil
 		} else {
 			p.denoiser = d
@@ -102,7 +103,7 @@ func (p *Pipeline) captureLoop() {
 
 		stereo, err := p.capture.ReadFrame()
 		if err != nil {
-			log.Printf("audio: capture read error: %v", err)
+			slog.Error(fmt.Sprintf("audio: capture read error: %v", err))
 			continue
 		}
 

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -8,7 +8,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -57,7 +57,7 @@ func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("config: %s not found, using defaults", path)
+			slog.Info(fmt.Sprintf("config: %s not found, using defaults", path))
 			return c, nil
 		}
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
@@ -65,19 +65,19 @@ func Load(path string) (*Config, error) {
 
 	// Try parsing the primary config
 	if err := json.Unmarshal(data, c); err != nil {
-		log.Printf("config: %s is corrupt (%v), trying backup", path, err)
+		slog.Error(fmt.Sprintf("config: %s is corrupt (%v), trying backup", path, err))
 		return loadBackup(path)
 	}
 
 	// Sanity check: a zero-length or all-null file parses as empty JSON
 	// but is likely corrupt. Check if file had actual content.
 	if isCorrupt(data) {
-		log.Printf("config: %s contains null bytes (power loss?), trying backup", path)
+		slog.Error(fmt.Sprintf("config: %s contains null bytes (power loss?), trying backup", path))
 		return loadBackup(path)
 	}
 
-	log.Printf("config: loaded from %s (server_url=%q, phone_number=%q, has_token=%v, has_pairing_code=%v)",
-		path, c.ServerURL, c.PhoneNumber, c.DeviceToken != "", c.PairingCode != "")
+	slog.Info(fmt.Sprintf("config: loaded from %s (server_url=%q, phone_number=%q, has_token=%v, has_pairing_code=%v)",
+		path, c.ServerURL, c.PhoneNumber, c.DeviceToken != "", c.PairingCode != ""))
 	return c, nil
 }
 
@@ -89,28 +89,28 @@ func loadBackup(path string) (*Config, error) {
 
 	data, err := os.ReadFile(bakPath)
 	if err != nil {
-		log.Printf("config: backup %s also unavailable: %v — using defaults", bakPath, err)
+		slog.Error(fmt.Sprintf("config: backup %s also unavailable: %v — using defaults", bakPath, err))
 		return c, nil
 	}
 
 	if isCorrupt(data) {
-		log.Printf("config: backup %s also corrupt — using defaults", bakPath)
+		slog.Error(fmt.Sprintf("config: backup %s also corrupt — using defaults", bakPath))
 		return c, nil
 	}
 
 	if err := json.Unmarshal(data, c); err != nil {
-		log.Printf("config: backup %s also unparseable: %v — using defaults", bakPath, err)
+		slog.Error(fmt.Sprintf("config: backup %s also unparseable: %v — using defaults", bakPath, err))
 		return c, nil
 	}
 
-	log.Printf("config: RECOVERED from backup %s (server_url=%q, phone_number=%q, has_token=%v)",
-		bakPath, c.ServerURL, c.PhoneNumber, c.DeviceToken != "")
+	slog.Info(fmt.Sprintf("config: RECOVERED from backup %s (server_url=%q, phone_number=%q, has_token=%v)",
+		bakPath, c.ServerURL, c.PhoneNumber, c.DeviceToken != ""))
 
 	// Restore the primary file from the good backup
 	if err := atomicWrite(path, data, 0600); err != nil {
-		log.Printf("config: failed to restore primary from backup: %v", err)
+		slog.Error(fmt.Sprintf("config: failed to restore primary from backup: %v", err))
 	} else {
-		log.Printf("config: restored primary %s from backup", path)
+		slog.Info(fmt.Sprintf("config: restored primary %s from backup", path))
 	}
 
 	return c, nil
@@ -149,7 +149,7 @@ func (c *Config) Save() error {
 	if existing, err := os.ReadFile(c.path); err == nil && !isCorrupt(existing) {
 		bakPath := c.path + ".bak"
 		if err := atomicWrite(bakPath, existing, 0600); err != nil {
-			log.Printf("config: backup write failed: %v", err)
+			slog.Error(fmt.Sprintf("config: backup write failed: %v", err))
 		}
 	}
 
@@ -158,7 +158,7 @@ func (c *Config) Save() error {
 		return fmt.Errorf("config: atomic write %s: %w", c.path, err)
 	}
 
-	log.Printf("config: saved to %s", c.path)
+	slog.Info(fmt.Sprintf("config: saved to %s", c.path))
 	return nil
 }
 

--- a/pi/digitsd/internal/contacts/cache.go
+++ b/pi/digitsd/internal/contacts/cache.go
@@ -3,8 +3,9 @@ package contacts
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"sync"
 )
@@ -46,7 +47,7 @@ func (c *Cache) Update(entries []Entry) {
 
 	if c.path != "" {
 		if err := c.Save(); err != nil {
-			log.Printf("contacts: save failed: %v", err)
+			slog.Error(fmt.Sprintf("contacts: save failed: %v", err))
 		}
 	}
 }

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -1,7 +1,8 @@
 package phone
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -105,7 +106,7 @@ func (c *Controller) HandleEvent(event string) {
 	case event == "PONG":
 		// Keepalive response, ignore
 	default:
-		log.Printf("phone: unhandled event: %q", event)
+		slog.Info(fmt.Sprintf("phone: unhandled event: %q", event))
 	}
 }
 
@@ -124,7 +125,7 @@ func (c *Controller) HandleSignal(msgType string) {
 	case "busy":
 		c.onSignalBusy()
 	default:
-		log.Printf("phone: unhandled signal: %q", msgType)
+		slog.Info(fmt.Sprintf("phone: unhandled signal: %q", msgType))
 	}
 }
 
@@ -146,7 +147,7 @@ func (c *Controller) onHookOff() {
 		c.cb.SendLED("ON")
 		c.cb.AnswerCall()
 	default:
-		log.Printf("phone: HOOK:OFF ignored in state %s", c.state)
+		slog.Info(fmt.Sprintf("phone: HOOK:OFF ignored in state %s", c.state))
 	}
 }
 
@@ -182,26 +183,26 @@ func (c *Controller) onKey(digit string) {
 		// Reset dial buffer when we see 4+ chars starting with *#* so the FSM
 		// doesn't try to dial the service code as a phone number.
 		if len(c.digits) >= 4 && len(c.digits) <= 5 && strings.HasPrefix(c.digits, "*#*") {
-			log.Printf("phone: service code %q handled by bridge, resetting", c.digits)
+			slog.Debug(fmt.Sprintf("phone: service code %q handled by bridge, resetting", c.digits))
 			c.digits = ""
 			c.state = StateDIALTONE
 			// Service code detected — reset to dial tone without re-sending tone
 		}
 	default:
-		log.Printf("phone: KEY:%s ignored in state %s", digit, c.state)
+		slog.Debug(fmt.Sprintf("phone: KEY:%s ignored in state %s", digit, c.state))
 	}
 }
 
 func (c *Controller) onDial(number string) {
 	if c.state != StateDIALING {
-		log.Printf("phone: DIAL event ignored in state %s", c.state)
+		slog.Info(fmt.Sprintf("phone: DIAL event ignored in state %s", c.state))
 		return
 	}
 
 	// Self-call: dialing your own number gets an immediate busy tone,
 	// just like a real POTS line.
 	if c.ownNumber != "" && number == c.ownNumber {
-		log.Printf("phone: self-call detected — busy tone")
+		slog.Info("phone: self-call detected — busy tone")
 		c.state = StateCALLING
 		c.cb.SendTone("BUSY")
 		return
@@ -210,7 +211,7 @@ func (c *Controller) onDial(number string) {
 	// Contact filter: if checker is set and number is not a contact,
 	// play rejection sequence (mimics unreachable number) instead of calling.
 	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
-		log.Printf("phone: number %s not in contacts — rejecting", number)
+		slog.Info(fmt.Sprintf("phone: number %s not in contacts — rejecting", number))
 		c.state = StateCALLING
 		c.cb.SendTone("RINGBACK")
 		// Rejection sequence runs async (same as server-side "not connected" error)
@@ -236,7 +237,7 @@ func (c *Controller) onDial(number string) {
 					return
 				}
 				if time.Now().After(deadline) {
-					log.Println("phone: intercept tone timeout — aborting rejection flow")
+					slog.Error("phone: intercept tone timeout — aborting rejection flow")
 					return
 				}
 			}
@@ -267,7 +268,7 @@ func (c *Controller) onDial(number string) {
 
 func (c *Controller) onSignalRing() {
 	if c.state != StateIDLE {
-		log.Printf("phone: ring signal ignored in state %s (not IDLE)", c.state)
+		slog.Info(fmt.Sprintf("phone: ring signal ignored in state %s (not IDLE)", c.state))
 		return
 	}
 	c.state = StateRINGING
@@ -277,7 +278,7 @@ func (c *Controller) onSignalRing() {
 
 func (c *Controller) onSignalAnswer() {
 	if c.state != StateCALLING {
-		log.Printf("phone: answer signal ignored in state %s (not CALLING)", c.state)
+		slog.Info(fmt.Sprintf("phone: answer signal ignored in state %s (not CALLING)", c.state))
 		return
 	}
 	c.state = StateCONNECTED
@@ -287,14 +288,14 @@ func (c *Controller) onSignalAnswer() {
 func (c *Controller) onSignalHangup() {
 	if c.state == StateRINGING {
 		// Caller hung up before we answered - stop ringing and return to idle.
-		log.Println("phone: caller hung up during ring - stopping ring")
+		slog.Info("phone: caller hung up during ring - stopping ring")
 		c.state = StateIDLE
 		c.cb.SendRing(false)
 		c.cb.SendLED("OFF")
 		return
 	}
 	if c.state != StateCONNECTED {
-		log.Printf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state)
+		slog.Info(fmt.Sprintf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state))
 		return
 	}
 	// Full POTS remote-hangup sequence:
@@ -305,7 +306,7 @@ func (c *Controller) onSignalHangup() {
 	c.state = StateREMOTE_HANGUP
 	c.cb.HangupCall()
 	c.cb.SendTone("STOPALL")
-	log.Println("phone: remote hangup — starting POTS off-hook sequence")
+	slog.Info("phone: remote hangup — starting POTS off-hook sequence")
 	go func() {
 		// Helper to check we're still in REMOTE_HANGUP state
 		stillOffHook := func() bool {
@@ -321,7 +322,7 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 2. Reorder tone for ~10 seconds
-		log.Println("phone: remote hangup — reorder tone")
+		slog.Info("phone: remote hangup — reorder tone")
 		c.cb.SendTone("REORDER")
 		time.Sleep(10 * time.Second)
 		if !stillOffHook() {
@@ -329,7 +330,7 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 3. Intercept voice message
-		log.Println("phone: remote hangup — intercept message")
+		slog.Info("phone: remote hangup — intercept message")
 		c.cb.SendTone("STOP")
 		c.cb.SendTone("INTERCEPT")
 		for c.cb.OncePlaying() {
@@ -343,17 +344,17 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 4. Howler tone until hang-up
-		log.Println("phone: remote hangup — howler tone")
+		slog.Info("phone: remote hangup — howler tone")
 		c.cb.SendTone("HOWLER")
 	}()
 }
 
 func (c *Controller) onSignalBusy() {
 	if c.state != StateCALLING {
-		log.Printf("phone: busy signal ignored in state %s (not CALLING)", c.state)
+		slog.Info(fmt.Sprintf("phone: busy signal ignored in state %s (not CALLING)", c.state))
 		return
 	}
-	log.Printf("phone: busy signal received — call rejected")
+	slog.Info("phone: busy signal received — call rejected")
 	c.cb.SendTone("STOP")
 	// Stay in CALLING — caller should hang up
 }

--- a/pi/digitsd/internal/phone/eastereggs.go
+++ b/pi/digitsd/internal/phone/eastereggs.go
@@ -1,7 +1,8 @@
 package phone
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -81,7 +82,7 @@ func (d *EasterEggDetector) AddKey(key string) bool {
 		tLen := len(e.Trigger)
 		if len(seq) >= tLen && seq[len(seq)-tLen:] == e.Trigger {
 			d.buf = d.buf[:0]
-			log.Printf("phone: 🎶 Easter egg: %s detected!", e.Name)
+			slog.Info(fmt.Sprintf("phone: 🎶 Easter egg: %s detected!", e.Name))
 			if d.play != nil {
 				clip := e.Clip
 				go d.play(clip)

--- a/pi/digitsd/internal/phone/logwatch.go
+++ b/pi/digitsd/internal/phone/logwatch.go
@@ -2,8 +2,9 @@ package phone
 
 import (
 	"bufio"
+	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -98,7 +99,7 @@ func (w *LogWatcher) tailLoop(f *os.File) {
 		select {
 		case w.events <- event:
 		default:
-			log.Printf("logwatch: events channel full, dropping event: %s", event)
+			slog.Error(fmt.Sprintf("logwatch: events channel full, dropping event: %s", event))
 		}
 	}
 }

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -2,7 +2,7 @@ package phone
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -20,11 +20,11 @@ type SerialPort struct {
 	mu     sync.Mutex
 	respCh atomic.Pointer[chan string] // single-slot response channel for command/response pairs
 	stop   chan struct{}
-	logger *log.Logger
+	logger *slog.Logger
 }
 
 // OpenSerial opens the serial port and starts the RX reader goroutine.
-func OpenSerial(device string, baud int, logger *log.Logger) (*SerialPort, error) {
+func OpenSerial(device string, baud int, logger *slog.Logger) (*SerialPort, error) {
 	mode := &serial.Mode{BaudRate: baud}
 	port, err := serial.Open(device, mode)
 	if err != nil {
@@ -60,7 +60,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 	sp.respCh.Store(&ch)
 	defer sp.respCh.Store(nil)
 
-	sp.logger.Printf("TX: %s", cmd)
+	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
 	if _, err := sp.port.Write([]byte(cmd + "\r\n")); err != nil {
 		return "", fmt.Errorf("serial write: %w", err)
 	}
@@ -77,7 +77,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 func (sp *SerialPort) SendFire(cmd string) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	sp.logger.Printf("TX: %s", cmd)
+	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
 	sp.port.Write([]byte(cmd + "\r\n"))
 }
 
@@ -181,7 +181,7 @@ func (sp *SerialPort) readLoop() {
 					continue
 				}
 
-				sp.logger.Printf("RX: %s", line)
+				sp.logger.Info(fmt.Sprintf("RX: %s", line))
 
 				// Unsolicited Pico events (hook, keypad, boot) always go to
 				// the events channel, never to a pending command response.
@@ -189,7 +189,7 @@ func (sp *SerialPort) readLoop() {
 					select {
 					case sp.events <- line:
 					default:
-						sp.logger.Printf("serial: events full, dropping: %s", line)
+						sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
 					}
 					continue
 				}
@@ -207,7 +207,7 @@ func (sp *SerialPort) readLoop() {
 				select {
 				case sp.events <- line:
 				default:
-					sp.logger.Printf("serial: events full, dropping: %s", line)
+					sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
 				}
 			} else {
 				lineBuf.WriteByte(ch)

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -2,7 +2,7 @@ package phone
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -106,7 +106,7 @@ func (h *ServiceCodeHandler) check() bool {
 	if len(h.buffer) >= 9 {
 		last9 := h.buffer[len(h.buffer)-9:]
 		if last9 == "*#873283#" {
-			log.Println("service code: *#873283# (*#UPDATE#) → check for updates")
+			slog.Info("service code: *#873283# (*#UPDATE#) → check for updates")
 			if h.onUpdate != nil {
 				go h.onUpdate()
 			}
@@ -121,7 +121,7 @@ func (h *ServiceCodeHandler) check() bool {
 		last8 := h.buffer[len(h.buffer)-8:]
 		switch last8 {
 		case "*#00000#":
-			log.Println("service code: *#00000# → factory reset")
+			slog.Info("service code: *#00000# → factory reset")
 			if h.onFactoryReset != nil {
 				go h.onFactoryReset()
 			}
@@ -129,11 +129,11 @@ func (h *ServiceCodeHandler) check() bool {
 			return true
 		}
 		if last8 == "*#73887#" {
-			log.Println("service code: *#73887# (*#SETUP#) → Wi-Fi re-provisioning")
+			slog.Info("service code: *#73887# (*#SETUP#) → Wi-Fi re-provisioning")
 			if h.onSetup != nil {
 				go h.onSetup()
 			} else {
-				log.Println("service code: *#73887# triggered but no setup callback registered — ignoring")
+				slog.Info("service code: *#73887# triggered but no setup callback registered — ignoring")
 			}
 			h.buffer = ""
 			return true
@@ -146,7 +146,7 @@ func (h *ServiceCodeHandler) check() bool {
 	if len(h.buffer) >= 7 {
 		last7 := h.buffer[len(h.buffer)-7:]
 		if last7 == "*#8378#" {
-			log.Println("service code: *#8378# (*#TEST#) → audio test")
+			slog.Info("service code: *#8378# (*#TEST#) → audio test")
 			if h.onAudioTest != nil {
 				go h.onAudioTest()
 			}
@@ -164,21 +164,21 @@ func (h *ServiceCodeHandler) check() bool {
 
 	switch last4 {
 	case "*#0*":
-		log.Println("service code: *#0* → force re-pair")
+		slog.Info("service code: *#0* → force re-pair")
 		if h.onRepair != nil {
 			go h.onRepair()
 		}
 		h.buffer = ""
 		return true
 	case "*#*#":
-		log.Println("service code: *#*# → shutdown")
+		slog.Info("service code: *#*# → shutdown")
 		if h.onShutdown != nil {
 			go h.onShutdown()
 		}
 		h.buffer = ""
 		return true
 	case "*##*":
-		log.Println("service code: *##* → reboot")
+		slog.Info("service code: *##* → reboot")
 		if h.onReboot != nil {
 			go h.onReboot()
 		}
@@ -192,7 +192,7 @@ func (h *ServiceCodeHandler) check() bool {
 		if ch >= '0' && ch <= '9' {
 			level := int(ch - '0')
 			if h.onVolume != nil {
-				log.Printf("service code: *#*%d → volume %d", level, level)
+				slog.Info(fmt.Sprintf("service code: *#*%d → volume %d", level, level))
 				h.onVolume(level)
 			}
 			h.buffer = ""
@@ -227,7 +227,7 @@ func volumeToALSA(level int) int {
 func codecCard() string {
 	card, err := audio.FindCodecCard()
 	if err != nil {
-		log.Printf("WARNING: codec detection failed for volume control, assuming card 0: %v", err)
+		slog.Error(fmt.Sprintf("codec detection failed for volume control, assuming card 0: %v", err))
 		return "0"
 	}
 	return fmt.Sprintf("%d", card)
@@ -245,12 +245,12 @@ func SetVolume(level int) error {
 	// Persist volume level
 	os.MkdirAll(filepath.Dir(volumeFile), 0755)
 	if err := os.WriteFile(volumeFile, []byte(fmt.Sprintf("%d\n", level)), 0644); err != nil {
-		log.Printf("volume: persist failed: %v", err)
+		slog.Error(fmt.Sprintf("volume: persist failed: %v", err))
 	}
 	// Save full mixer state
 	cmd = exec.Command("sudo", "alsactl", "store", card, "-f", mixerStateFile)
 	cmd.Run() // best-effort
-	log.Printf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal)
+	slog.Info(fmt.Sprintf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal))
 	return nil
 }
 
@@ -269,8 +269,8 @@ func RestoreVolume() {
 	card := codecCard()
 	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Printf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err)
+		slog.Error(fmt.Sprintf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err))
 		return
 	}
-	log.Printf("volume restored: %d/9 (Lineout=%d)", level, alsaVal)
+	slog.Info(fmt.Sprintf("volume restored: %d/9 (Lineout=%d)", level, alsaVal))
 }

--- a/pi/digitsd/internal/phone/socketserver.go
+++ b/pi/digitsd/internal/phone/socketserver.go
@@ -3,7 +3,7 @@ package phone
 import (
 	"bufio"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -42,7 +42,7 @@ func NewSocketServer(path string, handler SocketHandler) (*SocketServer, error) 
 	}
 
 	go s.acceptLoop()
-	log.Printf("socket server: listening on %s", path)
+	slog.Info(fmt.Sprintf("socket server: listening on %s", path))
 	return s, nil
 }
 
@@ -60,7 +60,7 @@ func (s *SocketServer) acceptLoop() {
 			case <-s.stop:
 				return
 			default:
-				log.Printf("socket: accept error: %v", err)
+				slog.Error(fmt.Sprintf("socket: accept error: %v", err))
 				continue
 			}
 		}

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -3,7 +3,7 @@ package signal
 import (
 	"crypto/tls"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -98,19 +98,19 @@ func (c *Client) readPump() {
 		_, data, err := c.conn.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				log.Printf("signal: read: %v", err)
+				slog.Error(fmt.Sprintf("signal: read: %v", err))
 			}
 			return
 		}
 		msg, err := ParseMessage(data)
 		if err != nil {
-			log.Printf("signal: parse message: %v", err)
+			slog.Error(fmt.Sprintf("signal: parse message: %v", err))
 			continue
 		}
 		select {
 		case c.inbox <- msg:
 		default:
-			log.Printf("signal: inbox full, dropping message type=%s", msg.Type)
+			slog.Error(fmt.Sprintf("signal: inbox full, dropping message type=%s", msg.Type))
 		}
 	}
 }

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -57,7 +57,7 @@ func New(cfg Config) *Updater {
 			cfg.BinaryPath = exe
 		}
 	}
-	log.Printf("updater: BinaryPath=%s", cfg.BinaryPath)
+	slog.Info(fmt.Sprintf("updater: BinaryPath=%s", cfg.BinaryPath))
 	if cfg.FirmwarePath == "" {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
 	}
@@ -189,7 +189,7 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 		return "", fmt.Errorf("rename: %w", err)
 	}
 
-	log.Printf("updater: downloaded %s from %s (sha256=%s)", localName, url, gotSHA)
+	slog.Info(fmt.Sprintf("updater: downloaded %s from %s (sha256=%s)", localName, url, gotSHA))
 	return destPath, nil
 }
 
@@ -229,20 +229,20 @@ func (u *Updater) ApplyPiUpdate(stagedBinary, expectedVersion string) error {
 	if expectedVersion != "" {
 		out, err := exec.Command(u.cfg.BinaryPath, "-version").CombinedOutput()
 		if err != nil {
-			log.Printf("updater: WARNING: version check failed: %v", err)
+			slog.Error(fmt.Sprintf("updater: version check failed: %v", err))
 		} else if !strings.Contains(string(out), expectedVersion) {
-			log.Printf("updater: WARNING: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion)
+			slog.Error(fmt.Sprintf("updater: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion))
 		} else {
-			log.Printf("updater: verified installed version: %s", strings.TrimSpace(string(out)))
+			slog.Info(fmt.Sprintf("updater: verified installed version: %s", strings.TrimSpace(string(out))))
 		}
 	}
 
 	// Restore read-only rootfs.
 	if err := exec.Command("sudo", "mount", "-o", "remount,ro", "/").Run(); err != nil {
-		log.Printf("updater: WARNING: failed to remount ro: %v", err)
+		slog.Error(fmt.Sprintf("updater: failed to remount ro: %v", err))
 	}
 
-	log.Println("updater: Pi binary updated -- exiting for restart")
+	slog.Info("updater: Pi binary updated -- exiting for restart")
 	os.Exit(0)
 	return nil // unreachable
 }
@@ -264,6 +264,6 @@ func (u *Updater) ApplyFirmwareUpdate(stagedELF string) error {
 		return fmt.Errorf("flash script: %w", err)
 	}
 
-	log.Println("updater: firmware update applied successfully")
+	slog.Info("updater: firmware update applied successfully")
 	return nil
 }

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -2,7 +2,7 @@ package owebrtc
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -78,7 +78,7 @@ func NewPeerManager(iceCfg *ICEConfig) (*PeerManager, error) {
 
 	// OnConnectionStateChange: connection state changed
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		log.Printf("webrtc: connection state changed to %s", state)
+		slog.Info(fmt.Sprintf("webrtc: connection state changed to %s", state))
 		if m.OnConnectionState != nil {
 			m.OnConnectionState(state)
 		}


### PR DESCRIPTION
## Summary
- Migrate all 17 Go files in `pi/digitsd/` from the stdlib `log` package to `log/slog`
- `log.Printf` / `log.Println` mapped to `slog.Info`, `slog.Debug`, or `slog.Error` based on context
- `log.Fatalf` / `log.Fatal` replaced with `slog.Error` + `os.Exit(1)`
- No structured key-value fields added -- messages kept as plain strings with `fmt.Sprintf` where needed

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` passes