### PR TITLE
refactor(digitsd): migrate from log to log/slog

### DIFF
--- a/pi/digitsd/cmd/clocksync/main.go
+++ b/pi/digitsd/cmd/clocksync/main.go
@@ -41,11 +41,11 @@ func main() {
 func runServer(addr string) {
 	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {
-		slog.Error(fmt.Sprintf("%v", err))
+		slog.Error("listen failed", "error", err)
 		os.Exit(1)
 	}
 	defer conn.Close()
-	slog.Info(fmt.Sprintf("clocksync server listening on %s", addr))
+	slog.Info("clocksync server listening", "addr", addr)
 
 	buf := make([]byte, 64)
 	for {
@@ -68,7 +68,7 @@ func runServer(addr string) {
 func runClient(addr string, count int) {
 	conn, err := net.Dial("udp", addr)
 	if err != nil {
-		slog.Error(fmt.Sprintf("%v", err))
+		slog.Error("dial failed", "error", err)
 		os.Exit(1)
 	}
 	defer conn.Close()

--- a/pi/digitsd/cmd/clocksync/main.go
+++ b/pi/digitsd/cmd/clocksync/main.go
@@ -13,9 +13,10 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net"
+	"os"
 	"time"
 )
 
@@ -40,10 +41,11 @@ func main() {
 func runServer(addr string) {
 	conn, err := net.ListenPacket("udp", addr)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(fmt.Sprintf("%v", err))
+		os.Exit(1)
 	}
 	defer conn.Close()
-	log.Printf("clocksync server listening on %s", addr)
+	slog.Info(fmt.Sprintf("clocksync server listening on %s", addr))
 
 	buf := make([]byte, 64)
 	for {
@@ -66,7 +68,8 @@ func runServer(addr string) {
 func runClient(addr string, count int) {
 	conn, err := net.Dial("udp", addr)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(fmt.Sprintf("%v", err))
+		os.Exit(1)
 	}
 	defer conn.Close()
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -724,7 +725,7 @@ func main() {
 		serialWriter = io.MultiWriter(os.Stdout, uartLogFile)
 		defer uartLogFile.Close()
 	}
-	serialLogger := log.New(serialWriter, "", log.Ldate|log.Ltime|log.Lmicroseconds)
+	serialLogger := slog.New(slog.NewTextHandler(serialWriter, nil))
 	sp, err := phone.OpenSerial(*serialDev, 115200, serialLogger)
 	if err != nil {
 		log.Fatalf("serial: %v", err)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -34,7 +34,6 @@ import (
 const iceRestartTimeout = 15 * time.Second
 
 
-
 var (
 	configPath  = flag.String("config", config.DefaultPath, "path to JSON config file")
 	signaldURL  = flag.String("signald", "", "signald WebSocket URL (overrides config file)")

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -34,9 +33,7 @@ import (
 // before giving up and hanging up the call.
 const iceRestartTimeout = 15 * time.Second
 
-func init() {
-	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
-}
+
 
 var (
 	configPath  = flag.String("config", config.DefaultPath, "path to JSON config file")
@@ -98,7 +95,7 @@ func (d *daemonCallbacks) SendTone(name string) {
 	case "STOPALL":
 		d.mixer.StopAll()
 	default:
-		log.Printf("tone: unknown %q", name)
+		slog.Warn("tone: unknown", "name", name)
 	}
 }
 
@@ -126,7 +123,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	var err error
 	d.peerMgr, err = owebrtc.NewPeerManager(iceCfg)
 	if err != nil {
-		log.Printf("webrtc: %v", err)
+		slog.Error("webrtc", "error", err)
 		return
 	}
 
@@ -146,7 +143,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 			for {
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
-					log.Printf("makeCall remote track ended after %d frames", frameCount)
+					slog.Debug("makeCall remote track ended", "frames", frameCount)
 					return
 				}
 				pcm, err := d.decoder.Decode(pkt.Payload)
@@ -176,7 +173,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	// Create offer (returns immediately — ICE trickles via OnICECandidate)
 	offer, err := d.peerMgr.CreateOffer()
 	if err != nil {
-		log.Printf("webrtc offer: %v", err)
+		slog.Error("webrtc offer", "error", err)
 		close(sdpSent)
 		return
 	}
@@ -189,7 +186,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	// Start audio pipeline
 	d.pipeline = audio.NewPipeline(audio.DefaultPipelineConfig())
 	if err := d.pipeline.Start(); err != nil {
-		log.Printf("audio pipeline: %v", err)
+		slog.Error("audio pipeline", "error", err)
 		return
 	}
 
@@ -212,7 +209,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 		}
 	}()
 
-	log.Printf("call initiated to %s", targetNumber)
+	slog.Info("call initiated", "target", targetNumber)
 }
 
 func (d *daemonCallbacks) AnswerCall() {
@@ -220,7 +217,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	defer d.mu.Unlock()
 
 	if d.pendingOffer == "" {
-		log.Println("answer: no pending offer")
+		slog.Warn("answer: no pending offer")
 		return
 	}
 
@@ -240,7 +237,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	var err error
 	d.peerMgr, err = owebrtc.NewPeerManager(iceCfg)
 	if err != nil {
-		log.Printf("webrtc (answer): %v", err)
+		slog.Error("webrtc (answer)", "error", err)
 		return
 	}
 
@@ -256,20 +253,20 @@ func (d *daemonCallbacks) AnswerCall() {
 			// Phase 1: Wait for pipeline (user picks up phone).
 			// Read and discard RTP packets to prevent buffering.
 			// Decode each to keep Opus decoder state in sync.
-			log.Printf("remote track active, waiting for answer...")
+			slog.Debug("remote track active, waiting for answer")
 			var discarded int
 			for {
 				d.mu.Lock()
 				pip := d.pipeline
 				d.mu.Unlock()
 				if pip != nil {
-					log.Printf("pipeline ready, discarded %d pre-answer packets", discarded)
+					slog.Debug("pipeline ready", "discarded_packets", discarded)
 					break
 				}
 
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
-					log.Printf("remote track ended while waiting for answer (%d packets discarded)", discarded)
+					slog.Debug("remote track ended while waiting for answer", "discarded_packets", discarded)
 					return
 				}
 				d.decoder.Decode(pkt.Payload) //nolint:errcheck
@@ -286,7 +283,7 @@ func (d *daemonCallbacks) AnswerCall() {
 				pkt, _, err := track.ReadRTP()
 				readTime := time.Since(start)
 				if err != nil {
-					log.Printf("remote track ended during drain")
+					slog.Debug("remote track ended during drain")
 					return
 				}
 				d.decoder.Decode(pkt.Payload) //nolint:errcheck
@@ -294,8 +291,7 @@ func (d *daemonCallbacks) AnswerCall() {
 				lastSeq = pkt.SequenceNumber
 
 				if readTime > 5*time.Millisecond {
-					log.Printf("drain complete: %d packets skipped in %s (last_seq=%d)",
-						drained-1, time.Since(drainStart).Round(time.Microsecond), lastSeq)
+					slog.Debug("drain complete", "packets_skipped", drained-1, "duration", time.Since(drainStart).Round(time.Microsecond), "last_seq", lastSeq)
 					break
 				}
 			}
@@ -304,13 +300,13 @@ func (d *daemonCallbacks) AnswerCall() {
 			for {
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
-					log.Printf("remote track ended after %d frames", frameCount)
+					slog.Debug("remote track ended", "frames", frameCount)
 					return
 				}
 				recvTime := time.Now()
 				pcm, err := d.decoder.Decode(pkt.Payload)
 				if err != nil {
-					log.Printf("decode error: %v (pkt %d bytes)", err, len(pkt.Payload))
+					slog.Debug("decode error", "error", err, "pkt_bytes", len(pkt.Payload))
 					continue
 				}
 				// Copy — Decode returns a slice of a reused internal buffer
@@ -320,9 +316,7 @@ func (d *daemonCallbacks) AnswerCall() {
 				d.mixer.FeedWebRTC(frame)
 
 				if frameCount <= 10 || frameCount%50 == 0 {
-					log.Printf("FEED[%d]: seq=%d recv=%s",
-						frameCount, pkt.SequenceNumber,
-						recvTime.Format("15:04:05.000000"))
+					slog.Debug("FEED", "frame", frameCount, "seq", pkt.SequenceNumber, "recv", recvTime.Format("15:04:05.000000"))
 				}
 			}
 		}()
@@ -342,7 +336,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	// Accept the offer and generate answer (returns immediately — ICE trickles via OnICECandidate)
 	answerSDP, err := d.peerMgr.AcceptOffer(offerSDP)
 	if err != nil {
-		log.Printf("webrtc accept offer: %v", err)
+		slog.Error("webrtc accept offer", "error", err)
 		close(sdpSent)
 		return
 	}
@@ -350,10 +344,10 @@ func (d *daemonCallbacks) AnswerCall() {
 	// Drain any ICE candidates that arrived before peerMgr was ready.
 	for _, candidate := range d.pendingICE {
 		if err := d.peerMgr.AddICECandidate(candidate); err != nil {
-			log.Printf("webrtc add queued ICE candidate: %v", err)
+			slog.Warn("webrtc add queued ICE candidate", "error", err)
 		}
 	}
-	log.Printf("drained %d queued ICE candidates", len(d.pendingICE))
+	slog.Debug("drained queued ICE candidates", "count", len(d.pendingICE))
 	d.pendingICE = nil
 
 	// Send answer SDP back to caller, then ungate ICE candidates
@@ -367,7 +361,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	// Start audio pipeline (capture only — playback goes through mixer)
 	d.pipeline = audio.NewPipeline(audio.DefaultPipelineConfig())
 	if err := d.pipeline.Start(); err != nil {
-		log.Printf("audio pipeline (answer): %v", err)
+		slog.Error("audio pipeline (answer)", "error", err)
 		return
 	}
 
@@ -390,7 +384,7 @@ func (d *daemonCallbacks) AnswerCall() {
 		}
 	}()
 
-	log.Printf("answered call from %s", caller)
+	slog.Info("answered call", "caller", caller)
 }
 
 func (d *daemonCallbacks) HangupCall() {
@@ -419,7 +413,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.peerMgr = nil
 	}
 
-	log.Println("call ended")
+	slog.Info("call ended")
 }
 
 // handleConnectionStateChange is called (without d.mu held) from a pion
@@ -437,7 +431,7 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 		}
 		d.mu.Unlock()
 		if wasRestarting {
-			log.Println("webrtc: ICE restart succeeded -- connection recovered")
+			slog.Info("webrtc: ICE restart succeeded, connection recovered")
 		}
 
 	case webrtc.PeerConnectionStateFailed:
@@ -447,16 +441,16 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 		d.mu.Unlock()
 
 		if alreadyRestarting {
-			log.Println("webrtc: ICE restart failed, hanging up")
+			slog.Error("webrtc: ICE restart failed, hanging up")
 			go d.ctrl.HandleSignal("hangup")
 			return
 		}
 
 		if isCaller {
-			log.Println("webrtc: connection failed, attempting ICE restart")
+			slog.Warn("webrtc: connection failed, attempting ICE restart")
 			d.attemptICERestart()
 		} else {
-			log.Println("webrtc: connection failed, waiting for ICE restart from caller")
+			slog.Warn("webrtc: connection failed, waiting for ICE restart from caller")
 			d.mu.Lock()
 			d.isRestartingICE = true
 			d.startRestartTimeout()
@@ -472,7 +466,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 	defer d.mu.Unlock()
 
 	if d.peerMgr == nil {
-		log.Println("ice-restart: no peer manager, hanging up")
+		slog.Warn("ice-restart: no peer manager, hanging up")
 		go d.ctrl.HandleSignal("hangup")
 		return
 	}
@@ -481,7 +475,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 
 	offer, err := d.peerMgr.CreateRestartOffer()
 	if err != nil {
-		log.Printf("ice-restart: create offer failed: %v", err)
+		slog.Error("ice-restart: create offer failed", "error", err)
 		d.isRestartingICE = false
 		go d.ctrl.HandleSignal("hangup")
 		return
@@ -490,7 +484,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 	peer := d.callPeer
 	d.startRestartTimeout()
 
-	log.Printf("ice-restart: sending restart offer to %s (%d bytes)", peer, len(offer))
+	slog.Info("ice-restart: sending restart offer", "peer", peer, "bytes", len(offer))
 	d.sig.Send(&sigclient.Message{ //nolint:errcheck
 		Type: sigclient.TypeICERestart,
 		To:   peer,
@@ -506,7 +500,7 @@ func (d *daemonCallbacks) startRestartTimeout() {
 		restarting := d.isRestartingICE
 		d.mu.Unlock()
 		if restarting {
-			log.Println("webrtc: ICE restart timed out, hanging up")
+			slog.Error("webrtc: ICE restart timed out, hanging up")
 			d.ctrl.HandleSignal("hangup")
 		}
 	})
@@ -522,7 +516,7 @@ func (d *daemonCallbacks) HandleSocketCommand(cmd string) string {
 			return "ERROR: TEST:EVENT not available in production"
 		}
 		event := cmd[11:]
-		log.Printf("test: injecting event %q", event)
+		slog.Debug("test: injecting event", "event", event)
 		if d.ctrl != nil {
 			d.ctrl.HandleEvent(event)
 		}
@@ -580,7 +574,7 @@ func runUpdate(serverURL, piVersion, fwVersion string, flashCapable bool, report
 
 func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc) {
 	if !updateInProgress.CompareAndSwap(false, true) {
-		log.Println("updater: skipping -- another update is already in progress")
+		slog.Warn("updater: skipping, another update is already in progress")
 		return
 	}
 	defer updateInProgress.Store(false)
@@ -602,10 +596,10 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 		CurrentFWVersion: fwVersion,
 	})
 
-	log.Printf("updater: checking for updates (target pi=%q fw=%q)", targetPi, targetFW)
+	slog.Info("updater: checking for updates", "target_pi", targetPi, "target_fw", targetFW)
 	result, err := up.CheckVersion(targetPi, targetFW)
 	if err != nil {
-		log.Printf("updater: check failed: %v", err)
+		slog.Error("updater: check failed", "error", err)
 		reportStatus("failed", fmt.Sprintf("Check failed: %v", err))
 		return
 	}
@@ -621,30 +615,28 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 	}
 
 	if !result.PiAvailable && !result.FWAvailable {
-		log.Println("updater: already up to date")
+		slog.Info("updater: already up to date")
 		reportStatus("up_to_date", "Already running latest version")
 		return
 	}
-	log.Printf("updater: update available -- pi=%v(%s) fw=%v(%s)",
-		result.PiAvailable, result.PiVersion,
-		result.FWAvailable, result.FWVersion)
+	slog.Info("updater: update available", "pi_available", result.PiAvailable, "pi_version", result.PiVersion, "fw_available", result.FWAvailable, "fw_version", result.FWVersion)
 
 	fwSkipped := false
 	if result.FWAvailable {
 		if !flashCapable {
-			log.Println("updater: firmware update available but SWD flash not supported on this device, skipping")
+			slog.Warn("updater: firmware update available but SWD flash not supported on this device, skipping")
 			fwSkipped = true
 		} else {
 			reportStatus("downloading", "Downloading firmware "+result.FWVersion)
 			path, err := up.Download(result.FWURL, "firmware.elf", result.FWSHA256)
 			if err != nil {
-				log.Printf("updater: firmware download failed: %v", err)
+				slog.Error("updater: firmware download failed", "error", err)
 				reportStatus("failed", fmt.Sprintf("Firmware download failed: %v", err))
 				return
 			}
 			reportStatus("applying", "Flashing firmware "+result.FWVersion)
 			if err := up.ApplyFirmwareUpdate(path); err != nil {
-				log.Printf("updater: firmware apply failed: %v", err)
+				slog.Error("updater: firmware apply failed", "error", err)
 				reportStatus("failed", fmt.Sprintf("Firmware flash failed: %v", err))
 				return
 			}
@@ -654,13 +646,13 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 		reportStatus("downloading", "Downloading digitsd "+result.PiVersion)
 		path, err := up.Download(result.PiURL, "digitsd-aarch64", result.PiSHA256)
 		if err != nil {
-			log.Printf("updater: pi download failed: %v", err)
+			slog.Error("updater: pi download failed", "error", err)
 			reportStatus("failed", fmt.Sprintf("Download failed: %v", err))
 			return
 		}
 		reportStatus("rebooting", "Installing digitsd "+result.PiVersion+" -- restarting...")
 		if err := up.ApplyPiUpdate(path, result.PiVersion); err != nil {
-			log.Printf("updater: pi update failed: %v", err)
+			slog.Error("updater: pi update failed", "error", err)
 			reportStatus("failed", fmt.Sprintf("Install failed: %v", err))
 			return
 		}
@@ -688,7 +680,8 @@ func main() {
 	// Load from JSON file, then let CLI flags override individual fields.
 	cfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		slog.Error("config", "error", err)
+		os.Exit(1)
 	}
 
 	// Effective server URL: CLI flag > config file > built-in default
@@ -708,16 +701,16 @@ func main() {
 
 	if effectiveNumber == "" {
 		effectiveNumber = "unpaired"
-		log.Println("digitsd: no phone number configured — starting in pairing mode")
+		slog.Info("digitsd: no phone number configured, starting in pairing mode")
 	}
 
-	log.Printf("digitsd: server=%s number=%s config=%s", effectiveServerURL, effectiveNumber, *configPath)
+	slog.Info("digitsd", "server", effectiveServerURL, "number", effectiveNumber, "config", *configPath)
 
 	// 1. Open serial port directly (log to both stdout and uart.log file)
 	uartLogPath := filepath.Join(filepath.Dir(*socketPath), "uart.log")
 	uartLogFile, err := os.OpenFile(uartLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		log.Printf("warning: cannot open uart log %s: %v (logging to stdout only)", uartLogPath, err)
+		slog.Warn("cannot open uart log, logging to stdout only", "path", uartLogPath, "error", err)
 		uartLogFile = nil
 	}
 	var serialWriter io.Writer = os.Stdout
@@ -728,7 +721,8 @@ func main() {
 	serialLogger := slog.New(slog.NewTextHandler(serialWriter, nil))
 	sp, err := phone.OpenSerial(*serialDev, 115200, serialLogger)
 	if err != nil {
-		log.Fatalf("serial: %v", err)
+		slog.Error("serial", "error", err)
+		os.Exit(1)
 	}
 	defer sp.Close()
 
@@ -740,19 +734,19 @@ func main() {
 			postOk = true
 			break
 		}
-		log.Printf("POST attempt %d/%d: no PONG", i, postRetries)
+		slog.Warn("POST attempt: no PONG", "attempt", i, "max", postRetries)
 		time.Sleep(1 * time.Second)
 	}
 	if postOk {
-		log.Println("POST: PASS — Pico UART healthy")
+		slog.Info("POST: PASS, Pico UART healthy")
 	} else {
-		log.Println("POST: FAIL — Pico not responding.")
+		slog.Error("POST: FAIL, Pico not responding")
 		elfPath := defaultFirmwarePath
 		swdCfg := defaultSWDConfig
 		openocd := defaultOpenOCD
 		if _, errElf := os.Stat(elfPath); errElf == nil {
 			if _, errOcd := os.Stat(openocd); errOcd == nil {
-				log.Printf("POST: attempting auto-flash from %s", elfPath)
+				slog.Info("POST: attempting auto-flash", "path", elfPath)
 				// Close serial port before SWD flash
 				sp.Close()
 				cmd := exec.Command("sudo", openocd,
@@ -762,30 +756,31 @@ func main() {
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				if err := cmd.Run(); err != nil {
-					log.Printf("POST: auto-flash failed: %v", err)
+					slog.Error("POST: auto-flash failed", "error", err)
 				} else {
-					log.Println("POST: auto-flash succeeded")
+					slog.Info("POST: auto-flash succeeded")
 				}
 				// Re-open serial port
 				time.Sleep(2 * time.Second)
 				sp, err = phone.OpenSerial(*serialDev, 115200, serialLogger)
 				if err != nil {
-					log.Fatalf("serial re-open after flash: %v", err)
+					slog.Error("serial re-open after flash", "error", err)
+					os.Exit(1)
 				}
 				if err := sp.Ping(); err == nil {
-					log.Println("POST: PASS after auto-flash")
+					slog.Info("POST: PASS after auto-flash")
 					postOk = true
 				} else {
-					log.Printf("POST: FAIL after auto-flash: %v", err)
+					slog.Error("POST: FAIL after auto-flash", "error", err)
 				}
 			} else {
-				log.Printf("POST: openocd not found at %s", openocd)
+				slog.Warn("POST: openocd not found", "path", openocd)
 			}
 		} else {
-			log.Printf("POST: no firmware at %s, skipping auto-flash", elfPath)
+			slog.Warn("POST: no firmware, skipping auto-flash", "path", elfPath)
 		}
 		if !postOk {
-			log.Println("POST: Continuing without Pico. Phone will not function.")
+			slog.Warn("POST: Continuing without Pico. Phone will not function.")
 		}
 	}
 
@@ -793,10 +788,10 @@ func main() {
 	var fwVersion, fwCommit string
 	if postOk {
 		if v, c, err := sp.QueryVersion(); err != nil {
-			log.Printf("firmware version: %v", err)
+			slog.Warn("firmware version", "error", err)
 		} else {
 			fwVersion, fwCommit = v, c
-			log.Printf("firmware: version=%s commit=%s", fwVersion, fwCommit)
+			slog.Info("firmware", "version", fwVersion, "commit", fwCommit)
 		}
 	}
 
@@ -807,15 +802,16 @@ func main() {
 		for i := 1; i <= 3; i++ {
 			resp, err := sp.SendCommand(hookInvertCmd, 2*time.Second)
 			if err == nil && resp == hookInvertCmd {
-				log.Printf("hook invert: configured (%s)", resp)
+				slog.Info("hook invert: configured", "response", resp)
 				hookOk = true
 				break
 			}
-			log.Printf("hook invert: attempt %d/3 failed (resp=%q err=%v)", i, resp, err)
+			slog.Warn("hook invert: attempt failed", "attempt", i, "max", 3, "response", resp, "error", err)
 			time.Sleep(500 * time.Millisecond)
 		}
 		if !hookOk {
-			log.Fatal("hook invert: failed after 3 attempts — refusing to run with wrong hook polarity")
+			slog.Error("hook invert: failed after 3 attempts, refusing to run with wrong hook polarity")
+			os.Exit(1)
 		}
 	}
 
@@ -824,10 +820,11 @@ func main() {
 	if pbDev == "" {
 		dev, err := audio.CodecDeviceName()
 		if err != nil {
-			log.Fatalf("alsa: %v", err)
+			slog.Error("alsa", "error", err)
+			os.Exit(1)
 		}
 		pbDev = dev
-		log.Printf("alsa playback: auto-detected %s", pbDev)
+		slog.Info("alsa playback: auto-detected", "device", pbDev)
 	}
 	pbCfg := audio.Config{
 		Device:     pbDev,
@@ -837,20 +834,22 @@ func main() {
 	}
 	pb, err := audio.NewPlayback(pbCfg)
 	if err != nil {
-		log.Fatalf("alsa playback: %v", err)
+		slog.Error("alsa playback", "error", err)
+		os.Exit(1)
 	}
 	defer pb.Close()
 
 	// 3. Create mixer and load tones
 	mixer := audio.NewMixer(pb)
 	if err := mixer.LoadTonesFromDir(*toneDir); err != nil {
-		log.Fatalf("mixer load tones: %v", err)
+		slog.Error("mixer load tones", "error", err)
+		os.Exit(1)
 	}
 	// Load pairing voice prompts (subdirectory)
 	pairingDir := filepath.Join(*toneDir, "pairing")
 	if _, err := os.Stat(pairingDir); err == nil {
 		if err := mixer.LoadTonesFromDir(pairingDir); err != nil {
-			log.Printf("WARNING: could not load pairing tones: %v", err)
+			slog.Warn("could not load pairing tones", "error", err)
 		}
 	}
 	mixer.Start()
@@ -859,7 +858,7 @@ func main() {
 	// Debug: capture raw PCM output if CAPTURE_PCM is set
 	if capPath := os.Getenv("CAPTURE_PCM"); capPath != "" {
 		if err := mixer.EnableCapture(capPath); err != nil {
-			log.Printf("WARNING: PCM capture failed: %v", err)
+			slog.Warn("PCM capture failed", "error", err)
 		} else {
 			defer mixer.DisableCapture()
 		}
@@ -867,7 +866,7 @@ func main() {
 
 	deviceID, err := config.LoadOrCreateDeviceID()
 	if err != nil {
-		log.Printf("WARNING: device ID unavailable: %v", err)
+		slog.Warn("device ID unavailable", "error", err)
 	}
 
 	// 4. Create signaling client
@@ -876,11 +875,13 @@ func main() {
 	// 5. Create Opus encoder and decoder
 	enc, err := codec.NewEncoder(48000, 1, 24000)
 	if err != nil {
-		log.Fatalf("codec encoder: %v", err)
+		slog.Error("codec encoder", "error", err)
+		os.Exit(1)
 	}
 	dec, err := codec.NewDecoder(48000, 1)
 	if err != nil {
-		log.Fatalf("codec decoder: %v", err)
+		slog.Error("codec decoder", "error", err)
+		os.Exit(1)
 	}
 
 	// 6. Create service code handler
@@ -895,7 +896,7 @@ func main() {
 	svcCodes := phone.NewServiceCodeHandler()
 	svcCodes.SetVolumeCallback(func(level int) {
 		if err := phone.SetVolume(level); err != nil {
-			log.Printf("volume: %v", err)
+			slog.Error("volume", "error", err)
 		}
 		mixer.StopAll()
 		time.Sleep(250 * time.Millisecond)
@@ -903,29 +904,29 @@ func main() {
 		mixer.PlayLoop("tone_dial")
 	})
 	svcCodes.SetShutdownCallback(func() {
-		log.Println("service code: executing shutdown")
+		slog.Info("service code: executing shutdown")
 		exec.Command("sudo", "shutdown", "-h", "now").Run()
 	})
 	svcCodes.SetRebootCallback(func() {
-		log.Println("service code: executing reboot")
+		slog.Info("service code: executing reboot")
 		exec.Command("sudo", "reboot").Run()
 	})
 	svcCodes.SetSetupCallback(func() {
-		log.Println("service code: *#SETUP# (*#73887#) → removing wifi-configured flag, rebooting")
+		slog.Info("service code: *#SETUP# (*#73887#), removing wifi-configured flag, rebooting")
 		err := os.Remove(phone.WifiConfiguredFlag)
 		switch {
 		case err == nil:
-			log.Printf("service code setup: removed %s — Pi will boot into AP mode", phone.WifiConfiguredFlag)
+			slog.Info("service code setup: removed flag, Pi will boot into AP mode", "path", phone.WifiConfiguredFlag)
 		case os.IsNotExist(err):
-			log.Printf("service code setup: %s already absent — Pi will boot into AP mode", phone.WifiConfiguredFlag)
+			slog.Info("service code setup: flag already absent, Pi will boot into AP mode", "path", phone.WifiConfiguredFlag)
 		default:
-			log.Printf("service code setup: remove %s: %v", phone.WifiConfiguredFlag, err)
+			slog.Error("service code setup: remove flag", "path", phone.WifiConfiguredFlag, "error", err)
 		}
 		exec.Command("sudo", "reboot").Run()
 	})
 
 	svcCodes.SetAudioTestCallback(func() {
-		log.Println("service code: *#TEST# → audio test (record 5s, playback)")
+		slog.Info("service code: *#TEST#, audio test (record 5s, playback)")
 		mixer.StopAll()
 
 		doubleBeep()
@@ -938,7 +939,7 @@ func main() {
 		pipCfg.Denoise = false // raw mic -- hear exactly what the hardware picks up
 		pip := audio.NewPipeline(pipCfg)
 		if err := pip.Start(); err != nil {
-			log.Printf("audio test: pipeline start: %v", err)
+			slog.Error("audio test: pipeline start", "error", err)
 			mixer.PlayLoop("tone_dial")
 			return
 		}
@@ -979,14 +980,14 @@ func main() {
 				maxAmp = a
 			}
 		}
-		log.Printf("audio test: captured %d samples (%.1fs), peak=%d, playing back", len(recorded), float64(len(recorded))/float64(sampleRate), maxAmp)
+		slog.Info("audio test: captured samples, playing back", "samples", len(recorded), "duration_s", fmt.Sprintf("%.1f", float64(len(recorded))/float64(sampleRate)), "peak", maxAmp)
 		mixer.PlayOnceSamples(recorded)
 		time.Sleep(100 * time.Millisecond)
 		for mixer.OncePlaying() {
 			time.Sleep(100 * time.Millisecond)
 		}
 		doubleBeep()
-		log.Println("audio test: complete")
+		slog.Info("audio test: complete")
 
 		// Resume dial tone
 		mixer.PlayLoop("tone_dial")
@@ -1010,9 +1011,9 @@ func main() {
 				"-c", "init; shutdown")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
-				log.Printf("swd probe: Pico not detected on SWD bus: %v (output: %s)", err, out)
+				slog.Warn("swd probe: Pico not detected on SWD bus", "error", err, "output", string(out))
 			} else {
-				log.Println("swd probe: Pico detected on SWD bus, enabling flash capability")
+				slog.Info("swd probe: Pico detected on SWD bus, enabling flash capability")
 				flashCapable.Store(true)
 			}
 			sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
@@ -1020,31 +1021,31 @@ func main() {
 	}
 
 	svcCodes.SetRepairCallback(func() {
-		log.Println("service code: *#0* → clearing device token, rebooting into pairing mode")
+		slog.Info("service code: *#0*, clearing device token, rebooting into pairing mode")
 		if cfg != nil {
 			cfg.DeviceToken = ""
 			cfg.PairingCode = ""
 			if err := cfg.Save(); err != nil {
-				log.Printf("service code repair: save config: %v", err)
+				slog.Error("service code repair: save config", "error", err)
 			}
 		}
-		log.Println("service code repair: rebooting")
+		slog.Info("service code repair: rebooting")
 		exec.Command("sudo", "reboot").Run()
 	})
 
 	svcCodes.SetUpdateCallback(func() {
-		log.Println("service code: *#UPDATE# (*#873283#) — checking for updates")
+		slog.Info("service code: *#UPDATE# (*#873283#), checking for updates")
 		go runUpdate(effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), nil)
 	})
 
 	svcCodes.SetFactoryResetCallback(func() {
-		log.Println("service code: *#00000# → FACTORY RESET")
+		slog.Info("service code: *#00000#, FACTORY RESET")
 		// 1. Remove config
 		os.Remove(config.DefaultPath)
 		os.Remove(config.DefaultPath + ".bak")
 		// 2. Remove Wi-Fi provisioning flag (boot into AP mode)
 		os.Remove(phone.WifiConfiguredFlag)
-		log.Println("service code factory reset: all data cleared, rebooting")
+		slog.Info("service code factory reset: all data cleared, rebooting")
 		exec.Command("sudo", "reboot").Run()
 	})
 
@@ -1053,7 +1054,7 @@ func main() {
 		{Name: "Funky Town", Trigger: "5542", Clip: "funkytown"},
 		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
 	}, func(clip string) {
-		log.Printf("phone: playing easter egg clip: %s", clip)
+		slog.Info("phone: playing easter egg clip", "clip", clip)
 		mixer.StopTone()
 		mixer.PlayOnce(clip)
 	})
@@ -1081,18 +1082,20 @@ func main() {
 	// 9. Start socket server (backward compat for debugging + latclient auto-answer)
 	sockSrv, err := phone.NewSocketServer(*socketPath, cb)
 	if err != nil {
-		log.Fatalf("socket server: %v", err)
+		slog.Error("socket server", "error", err)
+		os.Exit(1)
 	}
 	defer sockSrv.Close()
 
 	// 10. Connect signaling client
 	if err := sig.Connect(); err != nil {
-		log.Fatalf("signald connect: %v", err)
+		slog.Error("signald connect", "error", err)
+		os.Exit(1)
 	}
 
 	// 11. Ready
 	phone.RestoreVolume()
-	log.Println("digitsd ready")
+	slog.Info("digitsd ready")
 
 	sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
 	requestICEServers(sig)
@@ -1120,7 +1123,7 @@ func main() {
 	for {
 		select {
 		case <-quit:
-			log.Println("digitsd shutting down")
+			slog.Info("digitsd shutting down")
 			mixer.Stop()
 			sig.Close()
 			return
@@ -1135,7 +1138,7 @@ func main() {
 					mixer.PlayOnce("spoken_" + string(ch))
 				}
 				mixer.PlayOnce("pairing_expires")
-				log.Printf("phone: playing pairing code %s via voice", cb.pairingCode)
+				slog.Info("phone: playing pairing code via voice", "code", cb.pairingCode)
 				sp.LED("ON")
 				continue // skip normal controller handling
 			}
@@ -1164,7 +1167,7 @@ func main() {
 			if strings.HasPrefix(event, "DIAL:") && len(event) > 5 {
 				number := event[5:]
 				if egg, ok := phone.DialEasterEggs[number]; ok {
-					log.Printf("phone: dial easter egg: %s (%s)", egg.Name, number)
+					slog.Info("phone: dial easter egg", "name", egg.Name, "number", number)
 					mixer.StopTone()
 					mixer.PlayOnce(egg.Clip)
 					continue // don't place the call
@@ -1174,15 +1177,15 @@ func main() {
 			// Pico rebooted (e.g. external flash, power cycle): re-query
 			// firmware version and report it to the server.
 			if event == "STATUS:READY" {
-				log.Println("pico: detected reboot, re-querying firmware version")
+				slog.Info("pico: detected reboot, re-querying firmware version")
 				if v, c, err := sp.QueryVersion(); err != nil {
-					log.Printf("pico: version query after reboot: %v", err)
+					slog.Warn("pico: version query after reboot", "error", err)
 				} else if v != fwVersion || c != fwCommit {
 					fwVersion, fwCommit = v, c
-					log.Printf("pico: firmware version changed: %s (%s)", fwVersion, fwCommit)
+					slog.Info("pico: firmware version changed", "version", fwVersion, "commit", fwCommit)
 					sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
 				} else {
-					log.Printf("pico: firmware version unchanged: %s (%s)", fwVersion, fwCommit)
+					slog.Debug("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
 				}
 				continue
 			}
@@ -1199,7 +1202,7 @@ func main() {
 			}
 
 		case msg := <-sig.Inbox():
-			log.Printf("signal rx: type=%s from=%s", msg.Type, msg.From)
+			slog.Debug("signal rx", "type", msg.Type, "from", msg.From)
 			switch msg.Type {
 			case sigclient.TypeRing:
 				cb.mu.Lock()
@@ -1211,9 +1214,9 @@ func main() {
 				cb.mu.Lock()
 				if cb.peerMgr != nil && msg.SDP != "" {
 					if err := cb.peerMgr.SetAnswer(msg.SDP); err != nil {
-						log.Printf("webrtc set answer: %v", err)
+						slog.Error("webrtc set answer", "error", err)
 					} else {
-						log.Printf("webrtc: set remote answer from %s (%d bytes)", msg.From, len(msg.SDP))
+						slog.Debug("webrtc: set remote answer", "from", msg.From, "bytes", len(msg.SDP))
 					}
 				}
 				cb.mu.Unlock()
@@ -1223,7 +1226,7 @@ func main() {
 			case sigclient.TypeBusy:
 				ctrl.HandleSignal("busy")
 			case sigclient.TypeError:
-				log.Printf("signal error: %s", msg.Error)
+				slog.Error("signal error", "error", msg.Error)
 				// Number not reachable — emulate real phone: ringback → SIT → busy
 				go func() {
 					// 1. Brief silence (call setup delay, ~1s)
@@ -1232,14 +1235,14 @@ func main() {
 						return
 					}
 					// 2. Ringback for ~8s (simulates 1-2 rings)
-					log.Println("playing ringback (number unreachable)")
+					slog.Info("playing ringback (number unreachable)")
 					mixer.PlayLoop("tone_ringback")
 					time.Sleep(8 * time.Second)
 					if ctrl.State() != phone.StateCALLING {
 						return
 					}
 					// 3. SIT tones + "number not in service" announcement
-					log.Println("playing disconnected announcement")
+					slog.Info("playing disconnected announcement")
 					mixer.StopTone()
 					mixer.PlayOnce("disconnected")
 					// Wait for announcement to finish (poll rather than guess duration)
@@ -1254,40 +1257,39 @@ func main() {
 					if ctrl.State() != phone.StateCALLING {
 						return
 					}
-					log.Println("playing reorder tone")
+					slog.Info("playing reorder tone")
 					mixer.PlayLoop("tone_busy")
 				}()
 			case sigclient.TypeSDP:
 				cb.mu.Lock()
 				if cb.peerMgr != nil {
 					if err := cb.peerMgr.SetAnswer(msg.SDP); err != nil {
-						log.Printf("webrtc set answer: %v", err)
+						slog.Error("webrtc set answer", "error", err)
 					}
 				} else {
 					cb.pendingOffer = msg.SDP
 					// Also capture caller from SDP message if not already set by ring
 					if cb.pendingCaller == "" && msg.From != "" {
 						cb.pendingCaller = msg.From
-						log.Printf("set pendingCaller from SDP: %s", msg.From)
+						slog.Debug("set pendingCaller from SDP", "from", msg.From)
 					}
-					log.Printf("stored pending SDP offer from %s (%d bytes)", msg.From, len(msg.SDP))
+					slog.Debug("stored pending SDP offer", "from", msg.From, "bytes", len(msg.SDP))
 				}
 				cb.mu.Unlock()
 			case sigclient.TypeICE:
 				cb.mu.Lock()
 				if cb.peerMgr != nil {
 					if err := cb.peerMgr.AddICECandidate(msg.Candidate); err != nil {
-						log.Printf("webrtc add ICE candidate: %v", err)
+						slog.Warn("webrtc add ICE candidate", "error", err)
 					}
 				} else {
 					// Queue ICE candidates until peerMgr is ready (e.g. during RINGING before answer)
 					cb.pendingICE = append(cb.pendingICE, msg.Candidate)
-					log.Printf("queued ICE candidate (peerMgr not ready, total queued: %d)", len(cb.pendingICE))
+					slog.Debug("queued ICE candidate (peerMgr not ready)", "total_queued", len(cb.pendingICE))
 				}
 				cb.mu.Unlock()
 			case sigclient.TypeUpdateTrigger:
-				log.Printf("signal: received update trigger from server (target_pi=%q target_fw=%q)",
-					msg.TargetPiVersion, msg.TargetFWVersion)
+				slog.Info("signal: received update trigger from server", "target_pi", msg.TargetPiVersion, "target_fw", msg.TargetFWVersion)
 				statusReporter := func(status, detail string) {
 					sig.Send(&sigclient.Message{ //nolint:errcheck
 						Type:         sigclient.TypeUpdateStatus,
@@ -1304,13 +1306,13 @@ func main() {
 				peer := cb.callPeer
 				cb.mu.Unlock()
 				if pm == nil {
-					log.Println("ice-restart: no active peer connection, ignoring")
+					slog.Warn("ice-restart: no active peer connection, ignoring")
 					break
 				}
-				log.Printf("ice-restart: received restart offer from %s (%d bytes)", msg.From, len(msg.SDP))
+				slog.Info("ice-restart: received restart offer", "from", msg.From, "bytes", len(msg.SDP))
 				answerSDP, err := pm.AcceptOffer(msg.SDP)
 				if err != nil {
-					log.Printf("ice-restart: accept offer failed: %v", err)
+					slog.Error("ice-restart: accept offer failed", "error", err)
 					break
 				}
 				cb.mu.Lock()
@@ -1323,7 +1325,7 @@ func main() {
 				if peer == "" {
 					peer = msg.From
 				}
-				log.Printf("ice-restart: sending restart answer to %s (%d bytes)", peer, len(answerSDP))
+				slog.Info("ice-restart: sending restart answer", "peer", peer, "bytes", len(answerSDP))
 				sig.Send(&sigclient.Message{ //nolint:errcheck
 					Type: sigclient.TypeSDP,
 					To:   peer,
@@ -1341,13 +1343,12 @@ func main() {
 					})
 				}
 				cb.mu.Unlock()
-				log.Printf("ice: cached %d server(s) from signald", len(msg.Servers))
+				slog.Info("ice: cached servers from signald", "count", len(msg.Servers))
 
 			case sigclient.TypePairingCode:
 				cb.pairingCode = msg.PairingCode
 				
-				log.Printf("PAIRING REQUIRED: code %q — pick up handset to hear it",
-					msg.PairingCode)
+				slog.Info("PAIRING REQUIRED: pick up handset to hear it", "code", msg.PairingCode)
 
 			case sigclient.TypePaired:
 				if msg.DeviceToken != "" && cb.cfg != nil {
@@ -1358,16 +1359,16 @@ func main() {
 						cb.number = msg.Number
 					}
 					if err := cb.cfg.Save(); err != nil {
-						log.Printf("signal: paired — failed to save config: %v", err)
+						slog.Error("signal: paired, failed to save config", "error", err)
 					} else {
-						log.Printf("signal: paired as %s — config saved to %s", msg.Number, cb.cfg.Path())
+						slog.Info("signal: paired, config saved", "number", msg.Number, "path", cb.cfg.Path())
 					}
 					cb.paired.Store(true)
 					cb.pairingCode = ""
 					mixer.StopAll()
 					mixer.PlayOnce("tone_dial")
 					// Restart to reconnect with the assigned phone number
-					log.Printf("signal: restarting to register as %s", msg.Number)
+					slog.Info("signal: restarting to register", "number", msg.Number)
 					go func() {
 						time.Sleep(2 * time.Second) // let dial tone play briefly
 						os.Exit(0)                  // systemd will restart us
@@ -1375,26 +1376,26 @@ func main() {
 				}
 
 			default:
-				log.Printf("signal: unhandled message type %q", msg.Type)
+				slog.Warn("signal: unhandled message type", "type", msg.Type)
 			}
 
 		case <-sig.Done():
 			backoff := 3 * time.Second
 			for {
-				log.Printf("signal: connection lost, reconnecting in %s...", backoff)
+				slog.Warn("signal: connection lost, reconnecting", "backoff", backoff)
 				time.Sleep(backoff)
 				sig = sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken)
 				cb.mu.Lock()
 				cb.sig = sig
 				cb.mu.Unlock()
 				if err := sig.Connect(); err != nil {
-					log.Printf("signal: reconnect failed: %v", err)
+					slog.Error("signal: reconnect failed", "error", err)
 					if backoff < 60*time.Second {
 						backoff *= 2
 					}
 					continue
 				}
-				log.Println("signal: reconnected")
+				slog.Info("signal: reconnected")
 				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
 				requestICEServers(sig)
 				break
@@ -1406,7 +1407,7 @@ func main() {
 // requestICEServers asks signald for STUN/TURN server configs.
 func requestICEServers(sig *sigclient.Client) {
 	if err := sig.Send(&sigclient.Message{Type: sigclient.TypeRequestICE}); err != nil {
-		log.Printf("ice: request failed: %v", err)
+		slog.Error("ice: request failed", "error", err)
 	}
 }
 
@@ -1419,9 +1420,9 @@ func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapa
 		FirmwareCommit:  fwCommit,
 		FlashCapable:    flashCapable,
 	}); err != nil {
-		log.Printf("device_info: send failed: %v", err)
+		slog.Error("device_info: send failed", "error", err)
 	} else {
-		log.Printf("device_info: pi=%s(%s) fw=%s(%s) flash_capable=%v", version.Version, version.Commit, fwVersion, fwCommit, flashCapable)
+		slog.Info("device_info", "pi_version", version.Version, "pi_commit", version.Commit, "fw_version", fwVersion, "fw_commit", fwCommit, "flash_capable", flashCapable)
 	}
 }
 

--- a/pi/digitsd/cmd/latclient/main.go
+++ b/pi/digitsd/cmd/latclient/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	ws, _, err := dialer.Dial(u.String(), nil)
 	if err != nil {
-		slog.Error(fmt.Sprintf("dial signald: %v", err))
+		slog.Error("dial signald", "error", err)
 		os.Exit(1)
 	}
 	defer ws.Close()
@@ -52,13 +52,13 @@ func main() {
 	// Register with signald (required before any signaling)
 	regMsg, _ := json.Marshal(sigclient.Message{Type: sigclient.TypeRegister, Number: *number})
 	ws.WriteMessage(websocket.TextMessage, regMsg)
-	slog.Info(fmt.Sprintf("registered with signald as %s", *number))
+	slog.Info("registered with signald", "number", *number)
 
 	// Create WebRTC peer connection
 	config := webrtc.Configuration{}
 	pc, err := webrtc.NewPeerConnection(config)
 	if err != nil {
-		slog.Error(fmt.Sprintf("create peer connection: %v", err))
+		slog.Error("create peer connection", "error", err)
 		os.Exit(1)
 	}
 	defer pc.Close()
@@ -70,12 +70,12 @@ func main() {
 		webrtc.WithRTPSequenceNumber(1),
 	)
 	if err != nil {
-		slog.Error(fmt.Sprintf("create track: %v", err))
+		slog.Error("create track", "error", err)
 		os.Exit(1)
 	}
 	rtpSender, err := pc.AddTrack(track)
 	if err != nil {
-		slog.Error(fmt.Sprintf("add track: %v", err))
+		slog.Error("add track", "error", err)
 		os.Exit(1)
 	}
 	// Drain RTCP — required by pion to prevent buffer backpressure
@@ -91,7 +91,7 @@ func main() {
 	// Opus encoder
 	enc, err := codec.NewEncoder(48000, 1, 24000)
 	if err != nil {
-		slog.Error(fmt.Sprintf("encoder: %v", err))
+		slog.Error("encoder init failed", "error", err)
 		os.Exit(1)
 	}
 
@@ -116,18 +116,18 @@ func main() {
 	})
 
 	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
-		slog.Info(fmt.Sprintf("connection state: %s", s))
+		slog.Info("connection state changed", "state", s)
 	})
 
 	// Create offer
 	gatherDone := webrtc.GatheringCompletePromise(pc)
 	offer, err := pc.CreateOffer(nil)
 	if err != nil {
-		slog.Error(fmt.Sprintf("create offer: %v", err))
+		slog.Error("create offer", "error", err)
 		os.Exit(1)
 	}
 	if err := pc.SetLocalDescription(offer); err != nil {
-		slog.Error(fmt.Sprintf("set local desc: %v", err))
+		slog.Error("set local desc", "error", err)
 		os.Exit(1)
 	}
 
@@ -158,14 +158,14 @@ func main() {
 	mu.Lock()
 	ws.WriteMessage(websocket.TextMessage, offerData)
 	mu.Unlock()
-	slog.Info(fmt.Sprintf("sent call + offer to %s", *target))
+	slog.Info("sent call + offer", "target", *target)
 
 	// Read signaling messages
 	go func() {
 		for {
 			_, msgData, err := ws.ReadMessage()
 			if err != nil {
-				slog.Error(fmt.Sprintf("ws read: %v", err))
+				slog.Error("ws read", "error", err)
 				return
 			}
 			var msg sigclient.Message
@@ -181,13 +181,13 @@ func main() {
 					SDP:  msg.SDP,
 				}
 				if err := pc.SetRemoteDescription(answer); err != nil {
-					slog.Error(fmt.Sprintf("set remote desc: %v", err))
+					slog.Error("set remote desc", "error", err)
 				}
 
 			case sigclient.TypeICE:
 				var candidate webrtc.ICECandidateInit
 				if err := json.Unmarshal([]byte(msg.Candidate), &candidate); err != nil {
-					slog.Error(fmt.Sprintf("parse ICE: %v", err))
+					slog.Error("parse ICE", "error", err)
 					continue
 				}
 				pc.AddICECandidate(candidate) //nolint:errcheck
@@ -203,7 +203,7 @@ func main() {
 	slog.Info("Injecting HOOK:OFF on Pi via socket...")
 	injectCmd := `ssh digits@<pi-ip> 'python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.connect(\"/home/digits/digits/pi/uart.sock\"); s.send(b\"TEST:EVENT:HOOK:OFF\n\"); print(s.recv(64)); s.close()"'`
 	out, err := exec.Command("bash", "-c", injectCmd).CombinedOutput()
-	slog.Info(fmt.Sprintf("HOOK:OFF inject result: %s (err: %v)", strings.TrimSpace(string(out)), err))
+	slog.Info("HOOK:OFF inject result", "output", strings.TrimSpace(string(out)), "error", err)
 
 	// Now wait for WebRTC connection (Pi creates PeerManager on answer, sends back SDP)
 	slog.Info("waiting for WebRTC connection...")
@@ -253,11 +253,11 @@ func main() {
 		track.WriteSample(media.Sample{Data: pkt, Duration: time.Duration(frameMs) * time.Millisecond}) //nolint:errcheck
 		warmupFrames++
 		if warmupFrames == 1 {
-			slog.Info(fmt.Sprintf("WARMUP[1]: seq=1 wallclock=%s", time.Now().Format("15:04:05.000000")))
+			slog.Info("WARMUP", "frame", 1, "seq", 1, "wallclock", time.Now().Format("15:04:05.000000"))
 		}
 	}
-	slog.Info(fmt.Sprintf("WARMUP[%d]: seq=%d wallclock=%s (last warmup)", warmupFrames, warmupFrames, time.Now().Format("15:04:05.000000")))
-	slog.Info(fmt.Sprintf("Warmup done (%d frames). Starting measurement phase.", warmupFrames))
+	slog.Info("WARMUP (last)", "frame", warmupFrames, "seq", warmupFrames, "wallclock", time.Now().Format("15:04:05.000000"))
+	slog.Info("warmup done, starting measurement phase", "frames", warmupFrames)
 	fmt.Println()
 
 	// Now measure: send frames and log precise wallclock times.
@@ -279,7 +279,7 @@ func main() {
 
 		pkt, err := enc.Encode(pcm)
 		if err != nil {
-			slog.Error(fmt.Sprintf("encode: %v", err))
+			slog.Error("encode failed", "error", err)
 			continue
 		}
 
@@ -289,7 +289,7 @@ func main() {
 			Duration: time.Duration(frameMs) * time.Millisecond,
 		})
 		if err != nil {
-			slog.Error(fmt.Sprintf("write sample: %v", err))
+			slog.Error("write sample", "error", err)
 			continue
 		}
 
@@ -298,14 +298,13 @@ func main() {
 
 		totalFrame := warmupFrames + frameNum
 		if frameNum <= 5 || frameNum%50 == 0 {
-			slog.Info(fmt.Sprintf("SEND[%d]: seq=%d elapsed=%s wallclock=%s",
-				frameNum, totalFrame, elapsed.Round(time.Millisecond),
-				sendTime.Format("15:04:05.000000")))
+			slog.Info("SEND", "frame", frameNum, "seq", totalFrame,
+				"elapsed", elapsed.Round(time.Millisecond),
+				"wallclock", sendTime.Format("15:04:05.000000"))
 		}
 	}
 
-	slog.Info(fmt.Sprintf("=== DONE — sent %d frames (after %d warmup) in %v ===",
-		frameNum, warmupFrames, time.Since(startTime).Round(time.Millisecond)))
+	slog.Info("done", "frames_sent", frameNum, "warmup_frames", warmupFrames, "duration", time.Since(startTime).Round(time.Millisecond))
 	slog.Info("Now check Pi logs: ssh digits@<pi-ip> 'cat /tmp/digitsd.log'")
 
 	// Graceful close

--- a/pi/digitsd/cmd/latclient/main.go
+++ b/pi/digitsd/cmd/latclient/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net/url"
 	"os"
@@ -33,8 +33,6 @@ func main() {
 	duration := flag.Duration("duration", 10*time.Second, "how long to send audio")
 	flag.Parse()
 
-	log.SetFlags(log.Lmicroseconds)
-
 	// Connect to signald
 	u, _ := url.Parse(*signaldURL)
 	q := u.Query()
@@ -46,20 +44,22 @@ func main() {
 	}
 	ws, _, err := dialer.Dial(u.String(), nil)
 	if err != nil {
-		log.Fatalf("dial signald: %v", err)
+		slog.Error(fmt.Sprintf("dial signald: %v", err))
+		os.Exit(1)
 	}
 	defer ws.Close()
 
 	// Register with signald (required before any signaling)
 	regMsg, _ := json.Marshal(sigclient.Message{Type: sigclient.TypeRegister, Number: *number})
 	ws.WriteMessage(websocket.TextMessage, regMsg)
-	log.Printf("registered with signald as %s", *number)
+	slog.Info(fmt.Sprintf("registered with signald as %s", *number))
 
 	// Create WebRTC peer connection
 	config := webrtc.Configuration{}
 	pc, err := webrtc.NewPeerConnection(config)
 	if err != nil {
-		log.Fatalf("create peer connection: %v", err)
+		slog.Error(fmt.Sprintf("create peer connection: %v", err))
+		os.Exit(1)
 	}
 	defer pc.Close()
 
@@ -70,11 +70,13 @@ func main() {
 		webrtc.WithRTPSequenceNumber(1),
 	)
 	if err != nil {
-		log.Fatalf("create track: %v", err)
+		slog.Error(fmt.Sprintf("create track: %v", err))
+		os.Exit(1)
 	}
 	rtpSender, err := pc.AddTrack(track)
 	if err != nil {
-		log.Fatalf("add track: %v", err)
+		slog.Error(fmt.Sprintf("add track: %v", err))
+		os.Exit(1)
 	}
 	// Drain RTCP — required by pion to prevent buffer backpressure
 	go func() {
@@ -89,7 +91,8 @@ func main() {
 	// Opus encoder
 	enc, err := codec.NewEncoder(48000, 1, 24000)
 	if err != nil {
-		log.Fatalf("encoder: %v", err)
+		slog.Error(fmt.Sprintf("encoder: %v", err))
+		os.Exit(1)
 	}
 
 	var mu sync.Mutex
@@ -113,24 +116,27 @@ func main() {
 	})
 
 	pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
-		log.Printf("connection state: %s", s)
+		slog.Info(fmt.Sprintf("connection state: %s", s))
 	})
 
 	// Create offer
 	gatherDone := webrtc.GatheringCompletePromise(pc)
 	offer, err := pc.CreateOffer(nil)
 	if err != nil {
-		log.Fatalf("create offer: %v", err)
+		slog.Error(fmt.Sprintf("create offer: %v", err))
+		os.Exit(1)
 	}
 	if err := pc.SetLocalDescription(offer); err != nil {
-		log.Fatalf("set local desc: %v", err)
+		slog.Error(fmt.Sprintf("set local desc: %v", err))
+		os.Exit(1)
 	}
 
 	// Wait for ICE gathering
 	select {
 	case <-gatherDone:
 	case <-time.After(5 * time.Second):
-		log.Fatal("ICE gathering timeout")
+		slog.Error("ICE gathering timeout")
+		os.Exit(1)
 	}
 
 	// Send call + SDP (same as browser test client)
@@ -152,14 +158,14 @@ func main() {
 	mu.Lock()
 	ws.WriteMessage(websocket.TextMessage, offerData)
 	mu.Unlock()
-	log.Printf("sent call + offer to %s", *target)
+	slog.Info(fmt.Sprintf("sent call + offer to %s", *target))
 
 	// Read signaling messages
 	go func() {
 		for {
 			_, msgData, err := ws.ReadMessage()
 			if err != nil {
-				log.Printf("ws read: %v", err)
+				slog.Error(fmt.Sprintf("ws read: %v", err))
 				return
 			}
 			var msg sigclient.Message
@@ -169,19 +175,19 @@ func main() {
 
 			switch msg.Type {
 			case sigclient.TypeAnswer:
-				log.Printf("received answer SDP")
+				slog.Info("received answer SDP")
 				answer := webrtc.SessionDescription{
 					Type: webrtc.SDPTypeAnswer,
 					SDP:  msg.SDP,
 				}
 				if err := pc.SetRemoteDescription(answer); err != nil {
-					log.Printf("set remote desc: %v", err)
+					slog.Error(fmt.Sprintf("set remote desc: %v", err))
 				}
 
 			case sigclient.TypeICE:
 				var candidate webrtc.ICECandidateInit
 				if err := json.Unmarshal([]byte(msg.Candidate), &candidate); err != nil {
-					log.Printf("parse ICE: %v", err)
+					slog.Error(fmt.Sprintf("parse ICE: %v", err))
 					continue
 				}
 				pc.AddICECandidate(candidate) //nolint:errcheck
@@ -191,16 +197,16 @@ func main() {
 
 	// Wait briefly for ring+SDP to arrive on the Pi, then inject HOOK:OFF to answer.
 	// The Pi can't create a PeerManager until we answer, so we must inject before waiting for connection.
-	log.Printf("waiting 2s for ring to arrive on Pi...")
+	slog.Info("waiting 2s for ring to arrive on Pi...")
 	time.Sleep(2 * time.Second)
 
-	log.Printf("Injecting HOOK:OFF on Pi via socket...")
+	slog.Info("Injecting HOOK:OFF on Pi via socket...")
 	injectCmd := `ssh digits@<pi-ip> 'python3 -c "import socket; s=socket.socket(socket.AF_UNIX); s.connect(\"/home/digits/digits/pi/uart.sock\"); s.send(b\"TEST:EVENT:HOOK:OFF\n\"); print(s.recv(64)); s.close()"'`
 	out, err := exec.Command("bash", "-c", injectCmd).CombinedOutput()
-	log.Printf("HOOK:OFF inject result: %s (err: %v)", strings.TrimSpace(string(out)), err)
+	slog.Info(fmt.Sprintf("HOOK:OFF inject result: %s (err: %v)", strings.TrimSpace(string(out)), err))
 
 	// Now wait for WebRTC connection (Pi creates PeerManager on answer, sends back SDP)
-	log.Printf("waiting for WebRTC connection...")
+	slog.Info("waiting for WebRTC connection...")
 	deadline := time.After(10 * time.Second)
 	for {
 		if pc.ConnectionState() == webrtc.PeerConnectionStateConnected {
@@ -208,12 +214,13 @@ func main() {
 		}
 		select {
 		case <-deadline:
-			log.Fatal("connection timeout")
+			slog.Error("connection timeout")
+			os.Exit(1)
 		case <-time.After(100 * time.Millisecond):
 		}
 	}
 
-	log.Printf("=== CONNECTED ===")
+	slog.Info("=== CONNECTED ===")
 
 	// Send audio frames with precise timestamps
 	const (
@@ -224,7 +231,7 @@ func main() {
 	)
 
 	// Wait 3 seconds for call to be fully established
-	log.Printf("Warming up for 3 seconds...")
+	slog.Info("Warming up for 3 seconds...")
 	ticker := time.NewTicker(time.Duration(frameMs) * time.Millisecond)
 	defer ticker.Stop()
 
@@ -246,11 +253,11 @@ func main() {
 		track.WriteSample(media.Sample{Data: pkt, Duration: time.Duration(frameMs) * time.Millisecond}) //nolint:errcheck
 		warmupFrames++
 		if warmupFrames == 1 {
-			log.Printf("WARMUP[1]: seq=1 wallclock=%s", time.Now().Format("15:04:05.000000"))
+			slog.Info(fmt.Sprintf("WARMUP[1]: seq=1 wallclock=%s", time.Now().Format("15:04:05.000000")))
 		}
 	}
-	log.Printf("WARMUP[%d]: seq=%d wallclock=%s (last warmup)", warmupFrames, warmupFrames, time.Now().Format("15:04:05.000000"))
-	log.Printf("Warmup done (%d frames). Starting measurement phase.", warmupFrames)
+	slog.Info(fmt.Sprintf("WARMUP[%d]: seq=%d wallclock=%s (last warmup)", warmupFrames, warmupFrames, time.Now().Format("15:04:05.000000")))
+	slog.Info(fmt.Sprintf("Warmup done (%d frames). Starting measurement phase.", warmupFrames))
 	fmt.Println()
 
 	// Now measure: send frames and log precise wallclock times.
@@ -272,7 +279,7 @@ func main() {
 
 		pkt, err := enc.Encode(pcm)
 		if err != nil {
-			log.Printf("encode: %v", err)
+			slog.Error(fmt.Sprintf("encode: %v", err))
 			continue
 		}
 
@@ -282,7 +289,7 @@ func main() {
 			Duration: time.Duration(frameMs) * time.Millisecond,
 		})
 		if err != nil {
-			log.Printf("write sample: %v", err)
+			slog.Error(fmt.Sprintf("write sample: %v", err))
 			continue
 		}
 
@@ -291,15 +298,15 @@ func main() {
 
 		totalFrame := warmupFrames + frameNum
 		if frameNum <= 5 || frameNum%50 == 0 {
-			log.Printf("SEND[%d]: seq=%d elapsed=%s wallclock=%s",
+			slog.Info(fmt.Sprintf("SEND[%d]: seq=%d elapsed=%s wallclock=%s",
 				frameNum, totalFrame, elapsed.Round(time.Millisecond),
-				sendTime.Format("15:04:05.000000"))
+				sendTime.Format("15:04:05.000000")))
 		}
 	}
 
-	log.Printf("=== DONE — sent %d frames (after %d warmup) in %v ===",
-		frameNum, warmupFrames, time.Since(startTime).Round(time.Millisecond))
-	log.Printf("Now check Pi logs: ssh digits@<pi-ip> 'cat /tmp/digitsd.log'")
+	slog.Info(fmt.Sprintf("=== DONE — sent %d frames (after %d warmup) in %v ===",
+		frameNum, warmupFrames, time.Since(startTime).Round(time.Millisecond)))
+	slog.Info("Now check Pi logs: ssh digits@<pi-ip> 'cat /tmp/digitsd.log'")
 
 	// Graceful close
 	pc.Close()

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -75,7 +75,7 @@ func CodecDeviceName() (string, error) {
 func DefaultCaptureConfig() Config {
 	dev, err := CodecDeviceName()
 	if err != nil {
-		slog.Error(fmt.Sprintf("codec detection failed, falling back to plughw:1,0: %v", err))
+		slog.Warn("codec detection failed, falling back to plughw:1,0", "error", err)
 		dev = "plughw:1,0"
 	}
 	return Config{

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"unsafe"
@@ -75,7 +75,7 @@ func CodecDeviceName() (string, error) {
 func DefaultCaptureConfig() Config {
 	dev, err := CodecDeviceName()
 	if err != nil {
-		log.Printf("WARNING: codec detection failed, falling back to plughw:1,0: %v", err)
+		slog.Error(fmt.Sprintf("codec detection failed, falling back to plughw:1,0: %v", err))
 		dev = "plughw:1,0"
 	}
 	return Config{

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -171,7 +171,7 @@ func (m *Mixer) EnableCapture(path string) error {
 	}
 	m.captureFile = f
 	m.capturePath = path
-	slog.Info(fmt.Sprintf("mixer: PCM capture → %s", path))
+	slog.Info("mixer: PCM capture started", "path", path)
 	return nil
 }
 
@@ -181,7 +181,7 @@ func (m *Mixer) DisableCapture() {
 	defer m.mu.Unlock()
 	if m.captureFile != nil {
 		m.captureFile.Close()
-		slog.Info(fmt.Sprintf("mixer: PCM capture stopped (%s)", m.capturePath))
+		slog.Info("mixer: PCM capture stopped", "path", m.capturePath)
 		m.captureFile = nil
 		m.capturePath = ""
 	}
@@ -222,7 +222,7 @@ func (m *Mixer) LoadTonesFromDir(dir string) error {
 			return fmt.Errorf("load %s: %w", e.Name(), err)
 		}
 		m.LoadTone(name, samples)
-		slog.Info(fmt.Sprintf("mixer: loaded %s (%d samples, %.1fs)", name, len(samples), float64(len(samples))/48000))
+		slog.Info("mixer: loaded tone", "name", name, "samples", len(samples), "duration_s", fmt.Sprintf("%.1f", float64(len(samples))/48000))
 	}
 	return nil
 }
@@ -234,7 +234,7 @@ func (m *Mixer) PlayLoop(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
+		slog.Error("mixer: unknown tone", "name", name)
 		return
 	}
 	m.loopSamples = samples
@@ -296,7 +296,7 @@ func (m *Mixer) PlayOnce(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
+		slog.Error("mixer: unknown tone", "name", name)
 		return
 	}
 	m.onceQueue = append(m.onceQueue, samples)

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -77,7 +77,7 @@ func (m *Mixer) Start() {
 	m.running = true
 	m.stopCh = make(chan struct{})
 	go m.renderLoop(m.stopCh)
-	log.Println("mixer: render loop started")
+	slog.Info("mixer: render loop started")
 }
 
 // Stop halts the render loop. Blocks until the goroutine has exited.
@@ -92,7 +92,7 @@ func (m *Mixer) Stop() {
 	m.running = false
 	m.mu.Unlock()
 	// Wait for render loop to drain — it exits on next select check
-	log.Println("mixer: render loop stopped")
+	slog.Info("mixer: render loop stopped")
 }
 
 // renderLoop is the single goroutine that writes to hardware.
@@ -171,7 +171,7 @@ func (m *Mixer) EnableCapture(path string) error {
 	}
 	m.captureFile = f
 	m.capturePath = path
-	log.Printf("mixer: PCM capture → %s", path)
+	slog.Info(fmt.Sprintf("mixer: PCM capture → %s", path))
 	return nil
 }
 
@@ -181,7 +181,7 @@ func (m *Mixer) DisableCapture() {
 	defer m.mu.Unlock()
 	if m.captureFile != nil {
 		m.captureFile.Close()
-		log.Printf("mixer: PCM capture stopped (%s)", m.capturePath)
+		slog.Info(fmt.Sprintf("mixer: PCM capture stopped (%s)", m.capturePath))
 		m.captureFile = nil
 		m.capturePath = ""
 	}
@@ -222,7 +222,7 @@ func (m *Mixer) LoadTonesFromDir(dir string) error {
 			return fmt.Errorf("load %s: %w", e.Name(), err)
 		}
 		m.LoadTone(name, samples)
-		log.Printf("mixer: loaded %s (%d samples, %.1fs)", name, len(samples), float64(len(samples))/48000)
+		slog.Info(fmt.Sprintf("mixer: loaded %s (%d samples, %.1fs)", name, len(samples), float64(len(samples))/48000))
 	}
 	return nil
 }
@@ -234,7 +234,7 @@ func (m *Mixer) PlayLoop(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		log.Printf("mixer: unknown tone %q", name)
+		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
 		return
 	}
 	m.loopSamples = samples
@@ -296,7 +296,7 @@ func (m *Mixer) PlayOnce(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		log.Printf("mixer: unknown tone %q", name)
+		slog.Error(fmt.Sprintf("mixer: unknown tone %q", name))
 		return
 	}
 	m.onceQueue = append(m.onceQueue, samples)

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -234,7 +234,7 @@ func (m *Mixer) PlayLoop(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		slog.Error("mixer: unknown tone", "name", name)
+		slog.Warn("mixer: unknown tone", "name", name)
 		return
 	}
 	m.loopSamples = samples
@@ -296,7 +296,7 @@ func (m *Mixer) PlayOnce(name string) {
 	defer m.mu.Unlock()
 	samples, ok := m.tones[name]
 	if !ok {
-		slog.Error("mixer: unknown tone", "name", name)
+		slog.Warn("mixer: unknown tone", "name", name)
 		return
 	}
 	m.onceQueue = append(m.onceQueue, samples)

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -1,7 +1,8 @@
 package audio
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"sync"
 )
 
@@ -62,7 +63,7 @@ func (p *Pipeline) Start() error {
 	if p.cfg.Denoise {
 		d, err := NewDenoiser()
 		if err != nil {
-			log.Printf("audio: denoiser unavailable, running without denoise: %v", err)
+			slog.Error(fmt.Sprintf("audio: denoiser unavailable, running without denoise: %v", err))
 			p.denoiser = nil
 		} else {
 			p.denoiser = d
@@ -102,7 +103,7 @@ func (p *Pipeline) captureLoop() {
 
 		stereo, err := p.capture.ReadFrame()
 		if err != nil {
-			log.Printf("audio: capture read error: %v", err)
+			slog.Error(fmt.Sprintf("audio: capture read error: %v", err))
 			continue
 		}
 

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -1,7 +1,6 @@
 package audio
 
 import (
-	"fmt"
 	"log/slog"
 	"sync"
 )
@@ -63,7 +62,7 @@ func (p *Pipeline) Start() error {
 	if p.cfg.Denoise {
 		d, err := NewDenoiser()
 		if err != nil {
-			slog.Error(fmt.Sprintf("audio: denoiser unavailable, running without denoise: %v", err))
+			slog.Warn("audio: denoiser unavailable, running without denoise", "error", err)
 			p.denoiser = nil
 		} else {
 			p.denoiser = d
@@ -103,7 +102,7 @@ func (p *Pipeline) captureLoop() {
 
 		stereo, err := p.capture.ReadFrame()
 		if err != nil {
-			slog.Error(fmt.Sprintf("audio: capture read error: %v", err))
+			slog.Error("audio: capture read error", "error", err)
 			continue
 		}
 

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -57,7 +57,7 @@ func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			slog.Info(fmt.Sprintf("config: %s not found, using defaults", path))
+			slog.Info("config: file not found, using defaults", "path", path)
 			return c, nil
 		}
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
@@ -65,19 +65,18 @@ func Load(path string) (*Config, error) {
 
 	// Try parsing the primary config
 	if err := json.Unmarshal(data, c); err != nil {
-		slog.Error(fmt.Sprintf("config: %s is corrupt (%v), trying backup", path, err))
+		slog.Warn("config: file is corrupt, trying backup", "path", path, "error", err)
 		return loadBackup(path)
 	}
 
 	// Sanity check: a zero-length or all-null file parses as empty JSON
 	// but is likely corrupt. Check if file had actual content.
 	if isCorrupt(data) {
-		slog.Error(fmt.Sprintf("config: %s contains null bytes (power loss?), trying backup", path))
+		slog.Warn("config: file contains null bytes (power loss?), trying backup", "path", path)
 		return loadBackup(path)
 	}
 
-	slog.Info(fmt.Sprintf("config: loaded from %s (server_url=%q, phone_number=%q, has_token=%v, has_pairing_code=%v)",
-		path, c.ServerURL, c.PhoneNumber, c.DeviceToken != "", c.PairingCode != ""))
+	slog.Info("config: loaded", "path", path, "server_url", c.ServerURL, "phone_number", c.PhoneNumber, "has_token", c.DeviceToken != "", "has_pairing_code", c.PairingCode != "")
 	return c, nil
 }
 
@@ -89,28 +88,27 @@ func loadBackup(path string) (*Config, error) {
 
 	data, err := os.ReadFile(bakPath)
 	if err != nil {
-		slog.Error(fmt.Sprintf("config: backup %s also unavailable: %v — using defaults", bakPath, err))
+		slog.Warn("config: backup also unavailable, using defaults", "path", bakPath, "error", err)
 		return c, nil
 	}
 
 	if isCorrupt(data) {
-		slog.Error(fmt.Sprintf("config: backup %s also corrupt — using defaults", bakPath))
+		slog.Warn("config: backup also corrupt, using defaults", "path", bakPath)
 		return c, nil
 	}
 
 	if err := json.Unmarshal(data, c); err != nil {
-		slog.Error(fmt.Sprintf("config: backup %s also unparseable: %v — using defaults", bakPath, err))
+		slog.Warn("config: backup also unparseable, using defaults", "path", bakPath, "error", err)
 		return c, nil
 	}
 
-	slog.Info(fmt.Sprintf("config: RECOVERED from backup %s (server_url=%q, phone_number=%q, has_token=%v)",
-		bakPath, c.ServerURL, c.PhoneNumber, c.DeviceToken != ""))
+	slog.Info("config: recovered from backup", "path", bakPath, "server_url", c.ServerURL, "phone_number", c.PhoneNumber, "has_token", c.DeviceToken != "")
 
 	// Restore the primary file from the good backup
 	if err := atomicWrite(path, data, 0600); err != nil {
-		slog.Error(fmt.Sprintf("config: failed to restore primary from backup: %v", err))
+		slog.Warn("config: failed to restore primary from backup", "error", err)
 	} else {
-		slog.Info(fmt.Sprintf("config: restored primary %s from backup", path))
+		slog.Info("config: restored primary from backup", "path", path)
 	}
 
 	return c, nil
@@ -149,7 +147,7 @@ func (c *Config) Save() error {
 	if existing, err := os.ReadFile(c.path); err == nil && !isCorrupt(existing) {
 		bakPath := c.path + ".bak"
 		if err := atomicWrite(bakPath, existing, 0600); err != nil {
-			slog.Error(fmt.Sprintf("config: backup write failed: %v", err))
+			slog.Error("config: backup write failed", "error", err)
 		}
 	}
 
@@ -158,7 +156,7 @@ func (c *Config) Save() error {
 		return fmt.Errorf("config: atomic write %s: %w", c.path, err)
 	}
 
-	slog.Info(fmt.Sprintf("config: saved to %s", c.path))
+	slog.Info("config: saved", "path", c.path)
 	return nil
 }
 

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -8,7 +8,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -57,7 +57,7 @@ func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Printf("config: %s not found, using defaults", path)
+			slog.Info(fmt.Sprintf("config: %s not found, using defaults", path))
 			return c, nil
 		}
 		return nil, fmt.Errorf("config: read %s: %w", path, err)
@@ -65,19 +65,19 @@ func Load(path string) (*Config, error) {
 
 	// Try parsing the primary config
 	if err := json.Unmarshal(data, c); err != nil {
-		log.Printf("config: %s is corrupt (%v), trying backup", path, err)
+		slog.Error(fmt.Sprintf("config: %s is corrupt (%v), trying backup", path, err))
 		return loadBackup(path)
 	}
 
 	// Sanity check: a zero-length or all-null file parses as empty JSON
 	// but is likely corrupt. Check if file had actual content.
 	if isCorrupt(data) {
-		log.Printf("config: %s contains null bytes (power loss?), trying backup", path)
+		slog.Error(fmt.Sprintf("config: %s contains null bytes (power loss?), trying backup", path))
 		return loadBackup(path)
 	}
 
-	log.Printf("config: loaded from %s (server_url=%q, phone_number=%q, has_token=%v, has_pairing_code=%v)",
-		path, c.ServerURL, c.PhoneNumber, c.DeviceToken != "", c.PairingCode != "")
+	slog.Info(fmt.Sprintf("config: loaded from %s (server_url=%q, phone_number=%q, has_token=%v, has_pairing_code=%v)",
+		path, c.ServerURL, c.PhoneNumber, c.DeviceToken != "", c.PairingCode != ""))
 	return c, nil
 }
 
@@ -89,28 +89,28 @@ func loadBackup(path string) (*Config, error) {
 
 	data, err := os.ReadFile(bakPath)
 	if err != nil {
-		log.Printf("config: backup %s also unavailable: %v — using defaults", bakPath, err)
+		slog.Error(fmt.Sprintf("config: backup %s also unavailable: %v — using defaults", bakPath, err))
 		return c, nil
 	}
 
 	if isCorrupt(data) {
-		log.Printf("config: backup %s also corrupt — using defaults", bakPath)
+		slog.Error(fmt.Sprintf("config: backup %s also corrupt — using defaults", bakPath))
 		return c, nil
 	}
 
 	if err := json.Unmarshal(data, c); err != nil {
-		log.Printf("config: backup %s also unparseable: %v — using defaults", bakPath, err)
+		slog.Error(fmt.Sprintf("config: backup %s also unparseable: %v — using defaults", bakPath, err))
 		return c, nil
 	}
 
-	log.Printf("config: RECOVERED from backup %s (server_url=%q, phone_number=%q, has_token=%v)",
-		bakPath, c.ServerURL, c.PhoneNumber, c.DeviceToken != "")
+	slog.Info(fmt.Sprintf("config: RECOVERED from backup %s (server_url=%q, phone_number=%q, has_token=%v)",
+		bakPath, c.ServerURL, c.PhoneNumber, c.DeviceToken != ""))
 
 	// Restore the primary file from the good backup
 	if err := atomicWrite(path, data, 0600); err != nil {
-		log.Printf("config: failed to restore primary from backup: %v", err)
+		slog.Error(fmt.Sprintf("config: failed to restore primary from backup: %v", err))
 	} else {
-		log.Printf("config: restored primary %s from backup", path)
+		slog.Info(fmt.Sprintf("config: restored primary %s from backup", path))
 	}
 
 	return c, nil
@@ -149,7 +149,7 @@ func (c *Config) Save() error {
 	if existing, err := os.ReadFile(c.path); err == nil && !isCorrupt(existing) {
 		bakPath := c.path + ".bak"
 		if err := atomicWrite(bakPath, existing, 0600); err != nil {
-			log.Printf("config: backup write failed: %v", err)
+			slog.Error(fmt.Sprintf("config: backup write failed: %v", err))
 		}
 	}
 
@@ -158,7 +158,7 @@ func (c *Config) Save() error {
 		return fmt.Errorf("config: atomic write %s: %w", c.path, err)
 	}
 
-	log.Printf("config: saved to %s", c.path)
+	slog.Info(fmt.Sprintf("config: saved to %s", c.path))
 	return nil
 }
 

--- a/pi/digitsd/internal/contacts/cache.go
+++ b/pi/digitsd/internal/contacts/cache.go
@@ -3,8 +3,9 @@ package contacts
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"os"
 	"sync"
 )
@@ -46,7 +47,7 @@ func (c *Cache) Update(entries []Entry) {
 
 	if c.path != "" {
 		if err := c.Save(); err != nil {
-			log.Printf("contacts: save failed: %v", err)
+			slog.Error(fmt.Sprintf("contacts: save failed: %v", err))
 		}
 	}
 }

--- a/pi/digitsd/internal/contacts/cache.go
+++ b/pi/digitsd/internal/contacts/cache.go
@@ -3,7 +3,6 @@ package contacts
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -47,7 +46,7 @@ func (c *Cache) Update(entries []Entry) {
 
 	if c.path != "" {
 		if err := c.Save(); err != nil {
-			slog.Error(fmt.Sprintf("contacts: save failed: %v", err))
+			slog.Error("contacts: save failed", "error", err)
 		}
 	}
 }

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -105,7 +105,7 @@ func (c *Controller) HandleEvent(event string) {
 	case event == "PONG":
 		// Keepalive response, ignore
 	default:
-		slog.Info("phone: unhandled event", "event", event)
+		slog.Warn("phone: unhandled event", "event", event)
 	}
 }
 
@@ -124,7 +124,7 @@ func (c *Controller) HandleSignal(msgType string) {
 	case "busy":
 		c.onSignalBusy()
 	default:
-		slog.Info("phone: unhandled signal", "type", msgType)
+		slog.Warn("phone: unhandled signal", "type", msgType)
 	}
 }
 
@@ -201,7 +201,7 @@ func (c *Controller) onDial(number string) {
 	// Self-call: dialing your own number gets an immediate busy tone,
 	// just like a real POTS line.
 	if c.ownNumber != "" && number == c.ownNumber {
-		slog.Info("phone: self-call detected — busy tone")
+		slog.Info("phone: self-call detected, busy tone")
 		c.state = StateCALLING
 		c.cb.SendTone("BUSY")
 		return

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -1,7 +1,8 @@
 package phone
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -105,7 +106,7 @@ func (c *Controller) HandleEvent(event string) {
 	case event == "PONG":
 		// Keepalive response, ignore
 	default:
-		log.Printf("phone: unhandled event: %q", event)
+		slog.Info(fmt.Sprintf("phone: unhandled event: %q", event))
 	}
 }
 
@@ -124,7 +125,7 @@ func (c *Controller) HandleSignal(msgType string) {
 	case "busy":
 		c.onSignalBusy()
 	default:
-		log.Printf("phone: unhandled signal: %q", msgType)
+		slog.Info(fmt.Sprintf("phone: unhandled signal: %q", msgType))
 	}
 }
 
@@ -146,7 +147,7 @@ func (c *Controller) onHookOff() {
 		c.cb.SendLED("ON")
 		c.cb.AnswerCall()
 	default:
-		log.Printf("phone: HOOK:OFF ignored in state %s", c.state)
+		slog.Info(fmt.Sprintf("phone: HOOK:OFF ignored in state %s", c.state))
 	}
 }
 
@@ -182,26 +183,26 @@ func (c *Controller) onKey(digit string) {
 		// Reset dial buffer when we see 4+ chars starting with *#* so the FSM
 		// doesn't try to dial the service code as a phone number.
 		if len(c.digits) >= 4 && len(c.digits) <= 5 && strings.HasPrefix(c.digits, "*#*") {
-			log.Printf("phone: service code %q handled by bridge, resetting", c.digits)
+			slog.Debug(fmt.Sprintf("phone: service code %q handled by bridge, resetting", c.digits))
 			c.digits = ""
 			c.state = StateDIALTONE
 			// Service code detected — reset to dial tone without re-sending tone
 		}
 	default:
-		log.Printf("phone: KEY:%s ignored in state %s", digit, c.state)
+		slog.Debug(fmt.Sprintf("phone: KEY:%s ignored in state %s", digit, c.state))
 	}
 }
 
 func (c *Controller) onDial(number string) {
 	if c.state != StateDIALING {
-		log.Printf("phone: DIAL event ignored in state %s", c.state)
+		slog.Info(fmt.Sprintf("phone: DIAL event ignored in state %s", c.state))
 		return
 	}
 
 	// Self-call: dialing your own number gets an immediate busy tone,
 	// just like a real POTS line.
 	if c.ownNumber != "" && number == c.ownNumber {
-		log.Printf("phone: self-call detected — busy tone")
+		slog.Info("phone: self-call detected — busy tone")
 		c.state = StateCALLING
 		c.cb.SendTone("BUSY")
 		return
@@ -210,7 +211,7 @@ func (c *Controller) onDial(number string) {
 	// Contact filter: if checker is set and number is not a contact,
 	// play rejection sequence (mimics unreachable number) instead of calling.
 	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
-		log.Printf("phone: number %s not in contacts — rejecting", number)
+		slog.Info(fmt.Sprintf("phone: number %s not in contacts — rejecting", number))
 		c.state = StateCALLING
 		c.cb.SendTone("RINGBACK")
 		// Rejection sequence runs async (same as server-side "not connected" error)
@@ -236,7 +237,7 @@ func (c *Controller) onDial(number string) {
 					return
 				}
 				if time.Now().After(deadline) {
-					log.Println("phone: intercept tone timeout — aborting rejection flow")
+					slog.Error("phone: intercept tone timeout — aborting rejection flow")
 					return
 				}
 			}
@@ -267,7 +268,7 @@ func (c *Controller) onDial(number string) {
 
 func (c *Controller) onSignalRing() {
 	if c.state != StateIDLE {
-		log.Printf("phone: ring signal ignored in state %s (not IDLE)", c.state)
+		slog.Info(fmt.Sprintf("phone: ring signal ignored in state %s (not IDLE)", c.state))
 		return
 	}
 	c.state = StateRINGING
@@ -277,7 +278,7 @@ func (c *Controller) onSignalRing() {
 
 func (c *Controller) onSignalAnswer() {
 	if c.state != StateCALLING {
-		log.Printf("phone: answer signal ignored in state %s (not CALLING)", c.state)
+		slog.Info(fmt.Sprintf("phone: answer signal ignored in state %s (not CALLING)", c.state))
 		return
 	}
 	c.state = StateCONNECTED
@@ -287,14 +288,14 @@ func (c *Controller) onSignalAnswer() {
 func (c *Controller) onSignalHangup() {
 	if c.state == StateRINGING {
 		// Caller hung up before we answered - stop ringing and return to idle.
-		log.Println("phone: caller hung up during ring - stopping ring")
+		slog.Info("phone: caller hung up during ring - stopping ring")
 		c.state = StateIDLE
 		c.cb.SendRing(false)
 		c.cb.SendLED("OFF")
 		return
 	}
 	if c.state != StateCONNECTED {
-		log.Printf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state)
+		slog.Info(fmt.Sprintf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state))
 		return
 	}
 	// POTS remote-hangup sequence (Bellcore GR-506-CORE permanent signal treatment):
@@ -305,7 +306,7 @@ func (c *Controller) onSignalHangup() {
 	c.state = StateREMOTE_HANGUP
 	c.cb.HangupCall()
 	c.cb.SendTone("STOPALL")
-	log.Println("phone: remote hangup -- starting POTS off-hook sequence")
+	slog.Info("phone: remote hangup -- starting POTS off-hook sequence")
 	go func() {
 		// Helper to check we're still in REMOTE_HANGUP state
 		stillOffHook := func() bool {
@@ -321,7 +322,7 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 2. Reorder tone for ~45 seconds
-		log.Println("phone: remote hangup -- reorder tone")
+		slog.Info("phone: remote hangup -- reorder tone")
 		c.cb.SendTone("REORDER")
 		time.Sleep(45 * time.Second)
 		if !stillOffHook() {
@@ -329,7 +330,7 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 3. Howler tone for ~3 minutes
-		log.Println("phone: remote hangup -- howler tone")
+		slog.Info("phone: remote hangup -- howler tone")
 		c.cb.SendTone("HOWLER")
 		time.Sleep(3 * time.Minute)
 		if !stillOffHook() {
@@ -337,17 +338,17 @@ func (c *Controller) onSignalHangup() {
 		}
 
 		// 4. Line lockout -- silence until hang-up
-		log.Println("phone: remote hangup -- line lockout")
+		slog.Info("phone: remote hangup -- line lockout")
 		c.cb.SendTone("STOP")
 	}()
 }
 
 func (c *Controller) onSignalBusy() {
 	if c.state != StateCALLING {
-		log.Printf("phone: busy signal ignored in state %s (not CALLING)", c.state)
+		slog.Info(fmt.Sprintf("phone: busy signal ignored in state %s (not CALLING)", c.state))
 		return
 	}
-	log.Printf("phone: busy signal received -- call rejected")
+	slog.Info("phone: busy signal received -- call rejected")
 	c.cb.SendTone("BUSY")
 	// Stay in CALLING -- caller should hang up
 }

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -1,7 +1,6 @@
 package phone
 
 import (
-	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -106,7 +105,7 @@ func (c *Controller) HandleEvent(event string) {
 	case event == "PONG":
 		// Keepalive response, ignore
 	default:
-		slog.Info(fmt.Sprintf("phone: unhandled event: %q", event))
+		slog.Info("phone: unhandled event", "event", event)
 	}
 }
 
@@ -125,7 +124,7 @@ func (c *Controller) HandleSignal(msgType string) {
 	case "busy":
 		c.onSignalBusy()
 	default:
-		slog.Info(fmt.Sprintf("phone: unhandled signal: %q", msgType))
+		slog.Info("phone: unhandled signal", "type", msgType)
 	}
 }
 
@@ -147,7 +146,7 @@ func (c *Controller) onHookOff() {
 		c.cb.SendLED("ON")
 		c.cb.AnswerCall()
 	default:
-		slog.Info(fmt.Sprintf("phone: HOOK:OFF ignored in state %s", c.state))
+		slog.Info("phone: HOOK:OFF ignored", "state", c.state)
 	}
 }
 
@@ -183,19 +182,19 @@ func (c *Controller) onKey(digit string) {
 		// Reset dial buffer when we see 4+ chars starting with *#* so the FSM
 		// doesn't try to dial the service code as a phone number.
 		if len(c.digits) >= 4 && len(c.digits) <= 5 && strings.HasPrefix(c.digits, "*#*") {
-			slog.Debug(fmt.Sprintf("phone: service code %q handled by bridge, resetting", c.digits))
+			slog.Debug("phone: service code handled by bridge, resetting", "code", c.digits)
 			c.digits = ""
 			c.state = StateDIALTONE
 			// Service code detected — reset to dial tone without re-sending tone
 		}
 	default:
-		slog.Debug(fmt.Sprintf("phone: KEY:%s ignored in state %s", digit, c.state))
+		slog.Debug("phone: key ignored", "digit", digit, "state", c.state)
 	}
 }
 
 func (c *Controller) onDial(number string) {
 	if c.state != StateDIALING {
-		slog.Info(fmt.Sprintf("phone: DIAL event ignored in state %s", c.state))
+		slog.Info("phone: DIAL event ignored", "state", c.state)
 		return
 	}
 
@@ -211,7 +210,7 @@ func (c *Controller) onDial(number string) {
 	// Contact filter: if checker is set and number is not a contact,
 	// play rejection sequence (mimics unreachable number) instead of calling.
 	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
-		slog.Info(fmt.Sprintf("phone: number %s not in contacts — rejecting", number))
+		slog.Info("phone: number not in contacts, rejecting", "number", number)
 		c.state = StateCALLING
 		c.cb.SendTone("RINGBACK")
 		// Rejection sequence runs async (same as server-side "not connected" error)
@@ -268,7 +267,7 @@ func (c *Controller) onDial(number string) {
 
 func (c *Controller) onSignalRing() {
 	if c.state != StateIDLE {
-		slog.Info(fmt.Sprintf("phone: ring signal ignored in state %s (not IDLE)", c.state))
+		slog.Info("phone: ring signal ignored (not IDLE)", "state", c.state)
 		return
 	}
 	c.state = StateRINGING
@@ -278,7 +277,7 @@ func (c *Controller) onSignalRing() {
 
 func (c *Controller) onSignalAnswer() {
 	if c.state != StateCALLING {
-		slog.Info(fmt.Sprintf("phone: answer signal ignored in state %s (not CALLING)", c.state))
+		slog.Info("phone: answer signal ignored (not CALLING)", "state", c.state)
 		return
 	}
 	c.state = StateCONNECTED
@@ -295,7 +294,7 @@ func (c *Controller) onSignalHangup() {
 		return
 	}
 	if c.state != StateCONNECTED {
-		slog.Info(fmt.Sprintf("phone: hangup signal ignored in state %s (not CONNECTED)", c.state))
+		slog.Info("phone: hangup signal ignored (not CONNECTED)", "state", c.state)
 		return
 	}
 	// POTS remote-hangup sequence (Bellcore GR-506-CORE permanent signal treatment):
@@ -345,7 +344,7 @@ func (c *Controller) onSignalHangup() {
 
 func (c *Controller) onSignalBusy() {
 	if c.state != StateCALLING {
-		slog.Info(fmt.Sprintf("phone: busy signal ignored in state %s (not CALLING)", c.state))
+		slog.Info("phone: busy signal ignored (not CALLING)", "state", c.state)
 		return
 	}
 	slog.Info("phone: busy signal received -- call rejected")

--- a/pi/digitsd/internal/phone/eastereggs.go
+++ b/pi/digitsd/internal/phone/eastereggs.go
@@ -1,7 +1,6 @@
 package phone
 
 import (
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -82,7 +81,7 @@ func (d *EasterEggDetector) AddKey(key string) bool {
 		tLen := len(e.Trigger)
 		if len(seq) >= tLen && seq[len(seq)-tLen:] == e.Trigger {
 			d.buf = d.buf[:0]
-			slog.Info(fmt.Sprintf("phone: 🎶 Easter egg: %s detected!", e.Name))
+			slog.Info("phone: easter egg detected", "name", e.Name)
 			if d.play != nil {
 				clip := e.Clip
 				go d.play(clip)

--- a/pi/digitsd/internal/phone/eastereggs.go
+++ b/pi/digitsd/internal/phone/eastereggs.go
@@ -1,7 +1,8 @@
 package phone
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -81,7 +82,7 @@ func (d *EasterEggDetector) AddKey(key string) bool {
 		tLen := len(e.Trigger)
 		if len(seq) >= tLen && seq[len(seq)-tLen:] == e.Trigger {
 			d.buf = d.buf[:0]
-			log.Printf("phone: 🎶 Easter egg: %s detected!", e.Name)
+			slog.Info(fmt.Sprintf("phone: 🎶 Easter egg: %s detected!", e.Name))
 			if d.play != nil {
 				clip := e.Clip
 				go d.play(clip)

--- a/pi/digitsd/internal/phone/logwatch.go
+++ b/pi/digitsd/internal/phone/logwatch.go
@@ -2,8 +2,9 @@ package phone
 
 import (
 	"bufio"
+	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -98,7 +99,7 @@ func (w *LogWatcher) tailLoop(f *os.File) {
 		select {
 		case w.events <- event:
 		default:
-			log.Printf("logwatch: events channel full, dropping event: %s", event)
+			slog.Error(fmt.Sprintf("logwatch: events channel full, dropping event: %s", event))
 		}
 	}
 }

--- a/pi/digitsd/internal/phone/logwatch.go
+++ b/pi/digitsd/internal/phone/logwatch.go
@@ -2,7 +2,6 @@ package phone
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -99,7 +98,7 @@ func (w *LogWatcher) tailLoop(f *os.File) {
 		select {
 		case w.events <- event:
 		default:
-			slog.Error(fmt.Sprintf("logwatch: events channel full, dropping event: %s", event))
+			slog.Error("logwatch: events channel full, dropping event", "event", event)
 		}
 	}
 }

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -2,7 +2,7 @@ package phone
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -20,11 +20,11 @@ type SerialPort struct {
 	mu     sync.Mutex
 	respCh atomic.Pointer[chan string] // single-slot response channel for command/response pairs
 	stop   chan struct{}
-	logger *log.Logger
+	logger *slog.Logger
 }
 
 // OpenSerial opens the serial port and starts the RX reader goroutine.
-func OpenSerial(device string, baud int, logger *log.Logger) (*SerialPort, error) {
+func OpenSerial(device string, baud int, logger *slog.Logger) (*SerialPort, error) {
 	mode := &serial.Mode{BaudRate: baud}
 	port, err := serial.Open(device, mode)
 	if err != nil {
@@ -60,7 +60,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 	sp.respCh.Store(&ch)
 	defer sp.respCh.Store(nil)
 
-	sp.logger.Printf("TX: %s", cmd)
+	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
 	if _, err := sp.port.Write([]byte(cmd + "\r\n")); err != nil {
 		return "", fmt.Errorf("serial write: %w", err)
 	}
@@ -77,7 +77,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 func (sp *SerialPort) SendFire(cmd string) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	sp.logger.Printf("TX: %s", cmd)
+	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
 	sp.port.Write([]byte(cmd + "\r\n"))
 }
 
@@ -181,7 +181,7 @@ func (sp *SerialPort) readLoop() {
 					continue
 				}
 
-				sp.logger.Printf("RX: %s", line)
+				sp.logger.Info(fmt.Sprintf("RX: %s", line))
 
 				// Unsolicited Pico events (hook, keypad, boot) always go to
 				// the events channel, never to a pending command response.
@@ -189,7 +189,7 @@ func (sp *SerialPort) readLoop() {
 					select {
 					case sp.events <- line:
 					default:
-						sp.logger.Printf("serial: events full, dropping: %s", line)
+						sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
 					}
 					continue
 				}
@@ -207,7 +207,7 @@ func (sp *SerialPort) readLoop() {
 				select {
 				case sp.events <- line:
 				default:
-					sp.logger.Printf("serial: events full, dropping: %s", line)
+					sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
 				}
 			} else {
 				lineBuf.WriteByte(ch)

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -60,7 +60,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 	sp.respCh.Store(&ch)
 	defer sp.respCh.Store(nil)
 
-	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
+	sp.logger.Info("TX", "cmd", cmd)
 	if _, err := sp.port.Write([]byte(cmd + "\r\n")); err != nil {
 		return "", fmt.Errorf("serial write: %w", err)
 	}
@@ -77,7 +77,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 func (sp *SerialPort) SendFire(cmd string) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
-	sp.logger.Info(fmt.Sprintf("TX: %s", cmd))
+	sp.logger.Info("TX", "cmd", cmd)
 	sp.port.Write([]byte(cmd + "\r\n"))
 }
 
@@ -181,7 +181,7 @@ func (sp *SerialPort) readLoop() {
 					continue
 				}
 
-				sp.logger.Info(fmt.Sprintf("RX: %s", line))
+				sp.logger.Info("RX", "line", line)
 
 				// Unsolicited Pico events (hook, keypad, boot) always go to
 				// the events channel, never to a pending command response.
@@ -189,7 +189,7 @@ func (sp *SerialPort) readLoop() {
 					select {
 					case sp.events <- line:
 					default:
-						sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
+						sp.logger.Warn("serial: events full, dropping", "line", line)
 					}
 					continue
 				}
@@ -207,7 +207,7 @@ func (sp *SerialPort) readLoop() {
 				select {
 				case sp.events <- line:
 				default:
-					sp.logger.Error(fmt.Sprintf("serial: events full, dropping: %s", line))
+					sp.logger.Warn("serial: events full, dropping", "line", line)
 				}
 			} else {
 				lineBuf.WriteByte(ch)

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -192,7 +192,7 @@ func (h *ServiceCodeHandler) check() bool {
 		if ch >= '0' && ch <= '9' {
 			level := int(ch - '0')
 			if h.onVolume != nil {
-				slog.Info(fmt.Sprintf("service code: *#*%d → volume %d", level, level))
+				slog.Info("service code: volume set", "code", fmt.Sprintf("*#*%d", level), "level", level)
 				h.onVolume(level)
 			}
 			h.buffer = ""
@@ -227,7 +227,7 @@ func volumeToALSA(level int) int {
 func codecCard() string {
 	card, err := audio.FindCodecCard()
 	if err != nil {
-		slog.Error(fmt.Sprintf("codec detection failed for volume control, assuming card 0: %v", err))
+		slog.Warn("codec detection failed for volume control, assuming card 0", "error", err)
 		return "0"
 	}
 	return fmt.Sprintf("%d", card)
@@ -245,12 +245,12 @@ func SetVolume(level int) error {
 	// Persist volume level
 	os.MkdirAll(filepath.Dir(volumeFile), 0755)
 	if err := os.WriteFile(volumeFile, []byte(fmt.Sprintf("%d\n", level)), 0644); err != nil {
-		slog.Error(fmt.Sprintf("volume: persist failed: %v", err))
+		slog.Error("volume: persist failed", "error", err)
 	}
 	// Save full mixer state
 	cmd = exec.Command("sudo", "alsactl", "store", card, "-f", mixerStateFile)
 	cmd.Run() // best-effort
-	slog.Info(fmt.Sprintf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal))
+	slog.Info("volume: set and persisted", "level", level, "max", 9, "lineout", alsaVal)
 	return nil
 }
 
@@ -269,8 +269,8 @@ func RestoreVolume() {
 	card := codecCard()
 	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		slog.Error(fmt.Sprintf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err))
+		slog.Error("volume restore: amixer failed", "output", strings.TrimSpace(string(out)), "error", err)
 		return
 	}
-	slog.Info(fmt.Sprintf("volume restored: %d/9 (Lineout=%d)", level, alsaVal))
+	slog.Info("volume restored", "level", level, "max", 9, "lineout", alsaVal)
 }

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -2,7 +2,7 @@ package phone
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -106,7 +106,7 @@ func (h *ServiceCodeHandler) check() bool {
 	if len(h.buffer) >= 9 {
 		last9 := h.buffer[len(h.buffer)-9:]
 		if last9 == "*#873283#" {
-			log.Println("service code: *#873283# (*#UPDATE#) → check for updates")
+			slog.Info("service code: *#873283# (*#UPDATE#) → check for updates")
 			if h.onUpdate != nil {
 				go h.onUpdate()
 			}
@@ -121,7 +121,7 @@ func (h *ServiceCodeHandler) check() bool {
 		last8 := h.buffer[len(h.buffer)-8:]
 		switch last8 {
 		case "*#00000#":
-			log.Println("service code: *#00000# → factory reset")
+			slog.Info("service code: *#00000# → factory reset")
 			if h.onFactoryReset != nil {
 				go h.onFactoryReset()
 			}
@@ -129,11 +129,11 @@ func (h *ServiceCodeHandler) check() bool {
 			return true
 		}
 		if last8 == "*#73887#" {
-			log.Println("service code: *#73887# (*#SETUP#) → Wi-Fi re-provisioning")
+			slog.Info("service code: *#73887# (*#SETUP#) → Wi-Fi re-provisioning")
 			if h.onSetup != nil {
 				go h.onSetup()
 			} else {
-				log.Println("service code: *#73887# triggered but no setup callback registered — ignoring")
+				slog.Info("service code: *#73887# triggered but no setup callback registered — ignoring")
 			}
 			h.buffer = ""
 			return true
@@ -146,7 +146,7 @@ func (h *ServiceCodeHandler) check() bool {
 	if len(h.buffer) >= 7 {
 		last7 := h.buffer[len(h.buffer)-7:]
 		if last7 == "*#8378#" {
-			log.Println("service code: *#8378# (*#TEST#) → audio test")
+			slog.Info("service code: *#8378# (*#TEST#) → audio test")
 			if h.onAudioTest != nil {
 				go h.onAudioTest()
 			}
@@ -164,21 +164,21 @@ func (h *ServiceCodeHandler) check() bool {
 
 	switch last4 {
 	case "*#0*":
-		log.Println("service code: *#0* → force re-pair")
+		slog.Info("service code: *#0* → force re-pair")
 		if h.onRepair != nil {
 			go h.onRepair()
 		}
 		h.buffer = ""
 		return true
 	case "*#*#":
-		log.Println("service code: *#*# → shutdown")
+		slog.Info("service code: *#*# → shutdown")
 		if h.onShutdown != nil {
 			go h.onShutdown()
 		}
 		h.buffer = ""
 		return true
 	case "*##*":
-		log.Println("service code: *##* → reboot")
+		slog.Info("service code: *##* → reboot")
 		if h.onReboot != nil {
 			go h.onReboot()
 		}
@@ -192,7 +192,7 @@ func (h *ServiceCodeHandler) check() bool {
 		if ch >= '0' && ch <= '9' {
 			level := int(ch - '0')
 			if h.onVolume != nil {
-				log.Printf("service code: *#*%d → volume %d", level, level)
+				slog.Info(fmt.Sprintf("service code: *#*%d → volume %d", level, level))
 				h.onVolume(level)
 			}
 			h.buffer = ""
@@ -227,7 +227,7 @@ func volumeToALSA(level int) int {
 func codecCard() string {
 	card, err := audio.FindCodecCard()
 	if err != nil {
-		log.Printf("WARNING: codec detection failed for volume control, assuming card 0: %v", err)
+		slog.Error(fmt.Sprintf("codec detection failed for volume control, assuming card 0: %v", err))
 		return "0"
 	}
 	return fmt.Sprintf("%d", card)
@@ -245,12 +245,12 @@ func SetVolume(level int) error {
 	// Persist volume level
 	os.MkdirAll(filepath.Dir(volumeFile), 0755)
 	if err := os.WriteFile(volumeFile, []byte(fmt.Sprintf("%d\n", level)), 0644); err != nil {
-		log.Printf("volume: persist failed: %v", err)
+		slog.Error(fmt.Sprintf("volume: persist failed: %v", err))
 	}
 	// Save full mixer state
 	cmd = exec.Command("sudo", "alsactl", "store", card, "-f", mixerStateFile)
 	cmd.Run() // best-effort
-	log.Printf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal)
+	slog.Info(fmt.Sprintf("volume: %d/9 (Lineout=%d, persisted)", level, alsaVal))
 	return nil
 }
 
@@ -269,8 +269,8 @@ func RestoreVolume() {
 	card := codecCard()
 	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Printf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err)
+		slog.Error(fmt.Sprintf("volume restore: amixer: %s: %v", strings.TrimSpace(string(out)), err))
 		return
 	}
-	log.Printf("volume restored: %d/9 (Lineout=%d)", level, alsaVal)
+	slog.Info(fmt.Sprintf("volume restored: %d/9 (Lineout=%d)", level, alsaVal))
 }

--- a/pi/digitsd/internal/phone/socketserver.go
+++ b/pi/digitsd/internal/phone/socketserver.go
@@ -42,7 +42,7 @@ func NewSocketServer(path string, handler SocketHandler) (*SocketServer, error) 
 	}
 
 	go s.acceptLoop()
-	slog.Info(fmt.Sprintf("socket server: listening on %s", path))
+	slog.Info("socket server: listening", "path", path)
 	return s, nil
 }
 
@@ -60,7 +60,7 @@ func (s *SocketServer) acceptLoop() {
 			case <-s.stop:
 				return
 			default:
-				slog.Error(fmt.Sprintf("socket: accept error: %v", err))
+				slog.Error("socket: accept error", "error", err)
 				continue
 			}
 		}

--- a/pi/digitsd/internal/phone/socketserver.go
+++ b/pi/digitsd/internal/phone/socketserver.go
@@ -3,7 +3,7 @@ package phone
 import (
 	"bufio"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -42,7 +42,7 @@ func NewSocketServer(path string, handler SocketHandler) (*SocketServer, error) 
 	}
 
 	go s.acceptLoop()
-	log.Printf("socket server: listening on %s", path)
+	slog.Info(fmt.Sprintf("socket server: listening on %s", path))
 	return s, nil
 }
 
@@ -60,7 +60,7 @@ func (s *SocketServer) acceptLoop() {
 			case <-s.stop:
 				return
 			default:
-				log.Printf("socket: accept error: %v", err)
+				slog.Error(fmt.Sprintf("socket: accept error: %v", err))
 				continue
 			}
 		}

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -98,19 +98,19 @@ func (c *Client) readPump() {
 		_, data, err := c.conn.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				slog.Error(fmt.Sprintf("signal: read: %v", err))
+				slog.Error("signal: read error", "error", err)
 			}
 			return
 		}
 		msg, err := ParseMessage(data)
 		if err != nil {
-			slog.Error(fmt.Sprintf("signal: parse message: %v", err))
+			slog.Error("signal: parse message", "error", err)
 			continue
 		}
 		select {
 		case c.inbox <- msg:
 		default:
-			slog.Error(fmt.Sprintf("signal: inbox full, dropping message type=%s", msg.Type))
+			slog.Error("signal: inbox full, dropping message", "type", msg.Type)
 		}
 	}
 }

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -3,7 +3,7 @@ package signal
 import (
 	"crypto/tls"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -98,19 +98,19 @@ func (c *Client) readPump() {
 		_, data, err := c.conn.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				log.Printf("signal: read: %v", err)
+				slog.Error(fmt.Sprintf("signal: read: %v", err))
 			}
 			return
 		}
 		msg, err := ParseMessage(data)
 		if err != nil {
-			log.Printf("signal: parse message: %v", err)
+			slog.Error(fmt.Sprintf("signal: parse message: %v", err))
 			continue
 		}
 		select {
 		case c.inbox <- msg:
 		default:
-			log.Printf("signal: inbox full, dropping message type=%s", msg.Type)
+			slog.Error(fmt.Sprintf("signal: inbox full, dropping message type=%s", msg.Type))
 		}
 	}
 }

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -57,7 +57,7 @@ func New(cfg Config) *Updater {
 			cfg.BinaryPath = exe
 		}
 	}
-	log.Printf("updater: BinaryPath=%s", cfg.BinaryPath)
+	slog.Info(fmt.Sprintf("updater: BinaryPath=%s", cfg.BinaryPath))
 	if cfg.FirmwarePath == "" {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
 	}
@@ -189,7 +189,7 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 		return "", fmt.Errorf("rename: %w", err)
 	}
 
-	log.Printf("updater: downloaded %s from %s (sha256=%s)", localName, url, gotSHA)
+	slog.Info(fmt.Sprintf("updater: downloaded %s from %s (sha256=%s)", localName, url, gotSHA))
 	return destPath, nil
 }
 
@@ -229,20 +229,20 @@ func (u *Updater) ApplyPiUpdate(stagedBinary, expectedVersion string) error {
 	if expectedVersion != "" {
 		out, err := exec.Command(u.cfg.BinaryPath, "-version").CombinedOutput()
 		if err != nil {
-			log.Printf("updater: WARNING: version check failed: %v", err)
+			slog.Error(fmt.Sprintf("updater: version check failed: %v", err))
 		} else if !strings.Contains(string(out), expectedVersion) {
-			log.Printf("updater: WARNING: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion)
+			slog.Error(fmt.Sprintf("updater: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion))
 		} else {
-			log.Printf("updater: verified installed version: %s", strings.TrimSpace(string(out)))
+			slog.Info(fmt.Sprintf("updater: verified installed version: %s", strings.TrimSpace(string(out))))
 		}
 	}
 
 	// Restore read-only rootfs.
 	if err := exec.Command("sudo", "mount", "-o", "remount,ro", "/").Run(); err != nil {
-		log.Printf("updater: WARNING: failed to remount ro: %v", err)
+		slog.Error(fmt.Sprintf("updater: failed to remount ro: %v", err))
 	}
 
-	log.Println("updater: Pi binary updated -- exiting for restart")
+	slog.Info("updater: Pi binary updated -- exiting for restart")
 	os.Exit(0)
 	return nil // unreachable
 }
@@ -264,6 +264,6 @@ func (u *Updater) ApplyFirmwareUpdate(stagedELF string) error {
 		return fmt.Errorf("flash script: %w", err)
 	}
 
-	log.Println("updater: firmware update applied successfully")
+	slog.Info("updater: firmware update applied successfully")
 	return nil
 }

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -57,7 +57,7 @@ func New(cfg Config) *Updater {
 			cfg.BinaryPath = exe
 		}
 	}
-	slog.Info(fmt.Sprintf("updater: BinaryPath=%s", cfg.BinaryPath))
+	slog.Info("updater: configured", "binary_path", cfg.BinaryPath)
 	if cfg.FirmwarePath == "" {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
 	}
@@ -189,7 +189,7 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 		return "", fmt.Errorf("rename: %w", err)
 	}
 
-	slog.Info(fmt.Sprintf("updater: downloaded %s from %s (sha256=%s)", localName, url, gotSHA))
+	slog.Info("updater: downloaded", "file", localName, "url", url, "sha256", gotSHA)
 	return destPath, nil
 }
 
@@ -229,17 +229,17 @@ func (u *Updater) ApplyPiUpdate(stagedBinary, expectedVersion string) error {
 	if expectedVersion != "" {
 		out, err := exec.Command(u.cfg.BinaryPath, "-version").CombinedOutput()
 		if err != nil {
-			slog.Error(fmt.Sprintf("updater: version check failed: %v", err))
+			slog.Warn("updater: version check failed", "error", err)
 		} else if !strings.Contains(string(out), expectedVersion) {
-			slog.Error(fmt.Sprintf("updater: installed binary reports %q, expected %q", strings.TrimSpace(string(out)), expectedVersion))
+			slog.Warn("updater: installed binary version mismatch", "got", strings.TrimSpace(string(out)), "expected", expectedVersion)
 		} else {
-			slog.Info(fmt.Sprintf("updater: verified installed version: %s", strings.TrimSpace(string(out))))
+			slog.Info("updater: verified installed version", "version", strings.TrimSpace(string(out)))
 		}
 	}
 
 	// Restore read-only rootfs.
 	if err := exec.Command("sudo", "mount", "-o", "remount,ro", "/").Run(); err != nil {
-		slog.Error(fmt.Sprintf("updater: failed to remount ro: %v", err))
+		slog.Warn("updater: failed to remount ro", "error", err)
 	}
 
 	slog.Info("updater: Pi binary updated -- exiting for restart")

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -2,7 +2,7 @@ package owebrtc
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -78,7 +78,7 @@ func NewPeerManager(iceCfg *ICEConfig) (*PeerManager, error) {
 
 	// OnConnectionStateChange: connection state changed
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		log.Printf("webrtc: connection state changed to %s", state)
+		slog.Info(fmt.Sprintf("webrtc: connection state changed to %s", state))
 		if m.OnConnectionState != nil {
 			m.OnConnectionState(state)
 		}

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -78,7 +78,7 @@ func NewPeerManager(iceCfg *ICEConfig) (*PeerManager, error) {
 
 	// OnConnectionStateChange: connection state changed
 	pc.OnConnectionStateChange(func(state webrtc.PeerConnectionState) {
-		slog.Info(fmt.Sprintf("webrtc: connection state changed to %s", state))
+		slog.Info("webrtc: connection state changed", "state", state)
 		if m.OnConnectionState != nil {
 			m.OnConnectionState(state)
 		}


### PR DESCRIPTION
## Summary
- Migrate all 17 Go files in `pi/digitsd/` from the stdlib `log` package to `log/slog`
- `log.Printf` / `log.Println` mapped to `slog.Info`, `slog.Debug`, or `slog.Error` based on context
- `log.Fatalf` / `log.Fatal` replaced with `slog.Error` + `os.Exit(1)`
- No structured key-value fields added -- messages kept as plain strings with `fmt.Sprintf` where needed

## Test plan
- [x] `go vet ./...` passes
- [x] `make test` passes