### PR TITLE
fix(server,digitsd): include peer in hangup to prevent stale busy state

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -399,6 +399,7 @@ func (d *daemonCallbacks) HangupCall() {
 	d.pendingOffer = ""
 	d.pendingCaller = ""
 	d.pendingICE = nil
+	peer := d.callPeer
 	d.callPeer = ""
 	d.isCaller = false
 	d.isRestartingICE = false
@@ -407,7 +408,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.restartTimer = nil
 	}
 
-	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup}) //nolint:errcheck
+	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup, To: peer}) //nolint:errcheck
 
 	if d.pipeline != nil {
 		d.pipeline.Stop()

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -104,6 +104,22 @@ func (t *Tracker) Busy(number string) bool {
 	return false
 }
 
+// PeerOf returns the other party in an active call involving number,
+// or "" if number is not in any active call.
+func (t *Tracker) PeerOf(number string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, c := range t.active {
+		if c.Caller == number {
+			return c.Callee
+		}
+		if c.Callee == number {
+			return c.Caller
+		}
+	}
+	return ""
+}
+
 func (t *Tracker) InCall(a, b string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -13,6 +13,7 @@ type CallTracker interface {
 	OnCallEnded(caller, callee string) error
 	InCall(a, b string) bool
 	Busy(number string) bool
+	PeerOf(number string) string
 }
 
 // CallAuthorizer determines whether a call from one number to another is permitted.
@@ -128,6 +129,12 @@ func (r *Relay) handleAnswer(from string, msg *Message) {
 }
 
 func (r *Relay) handleHangup(from string, msg *Message) {
+	// Resolve peer if client didn't specify a To field
+	if msg.To == "" && r.Tracker != nil {
+		if peer := r.Tracker.PeerOf(from); peer != "" {
+			msg.To = peer
+		}
+	}
 	if r.Tracker != nil {
 		r.Tracker.OnCallEnded(from, msg.To)
 	}

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -46,6 +46,19 @@ func (m *mockTracker) InCall(a, b string) bool {
 	return m.calls[a+"→"+b] || m.calls[b+"→"+a]
 }
 
+func (m *mockTracker) PeerOf(number string) string {
+	for k := range m.calls {
+		a, b, _ := strings.Cut(k, "→")
+		if a == number {
+			return b
+		}
+		if b == number {
+			return a
+		}
+	}
+	return ""
+}
+
 type mockCallAuthorizer struct {
 	allowed map[[2]string]bool
 }
@@ -295,6 +308,50 @@ func TestRelayBusySignal(t *testing.T) {
 		t.Fatalf("phone 3 should not have received anything, got: %+v", msg)
 	default:
 		// correct
+	}
+}
+
+func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn1)
+	hub.Register("3140002", conn2)
+
+	// Phone 1 calls Phone 2
+	relay.HandleMessage("3140001", &Message{Type: TypeCall, To: "3140002"})
+	<-conn2.Send // drain ring
+
+	if !tracker.Busy("3140001") {
+		t.Fatal("expected 3140001 to be busy after call initiated")
+	}
+
+	// Phone 1 hangs up WITHOUT specifying To (reproduces the client bug)
+	relay.HandleMessage("3140001", &Message{Type: TypeHangup})
+
+	// Tracker should have resolved the peer and ended the call
+	if tracker.Busy("3140001") {
+		t.Fatal("expected 3140001 to no longer be busy after hangup")
+	}
+	if tracker.Busy("3140002") {
+		t.Fatal("expected 3140002 to no longer be busy after hangup")
+	}
+
+	// Phone 2 should have received the hangup (forwarded with resolved To)
+	select {
+	case data := <-conn2.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if msg.Type != TypeHangup {
+			t.Fatalf("expected hangup, got: %s", msg.Type)
+		}
+	default:
+		t.Fatal("phone 2 did not receive hangup")
 	}
 }
 


### PR DESCRIPTION
## What

Include the call peer in hangup messages and resolve missing `To` field server-side when a hangup arrives without one.

## Why

`HangupCall()` cleared `callPeer` to `""` before sending the hangup message, so the server received `TypeHangup` with an empty `To` field. `OnCallEnded(from, "")` then tried to delete tracker keys like `"2456390→""` which matched nothing. The active call entry was never removed, permanently marking both numbers as busy. Every subsequent call attempt was rejected.

## Test plan

- Added `TestRelayHangupWithoutToResolvesPeer` covering the exact scenario: initiate call, send hangup with empty To, verify tracker clears both numbers and hangup is forwarded to peer
- `go test ./...` and `go vet ./...` pass for both server and digitsd
- Deployed to production server and both Digits devices; verified calls connect and tracker shows 0 active calls after hangup