### PR TITLE
feat: remote device restart from web UI

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -567,10 +567,6 @@ type statusFunc func(status, detail string)
 // to avoid racing (e.g. double-flashing the Pico).
 var updateInProgress atomic.Bool
 
-func runUpdate(serverURL, piVersion, fwVersion string, flashCapable bool, reportStatus statusFunc) {
-	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, reportStatus)
-}
-
 func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc) {
 	if !updateInProgress.CompareAndSwap(false, true) {
 		slog.Warn("updater: skipping, another update is already in progress")
@@ -1034,7 +1030,7 @@ func main() {
 
 	svcCodes.SetUpdateCallback(func() {
 		slog.Info("service code: *#UPDATE# (*#873283#), checking for updates")
-		go runUpdate(effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), nil)
+		go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion, "", "", flashCapable.Load(), nil)
 	})
 
 	svcCodes.SetFactoryResetCallback(func() {
@@ -1106,12 +1102,6 @@ func main() {
 		for range ticker.C {
 			requestICEServers(sig)
 		}
-	}()
-
-	// Check for updates on startup (non-blocking)
-	go func() {
-		time.Sleep(10 * time.Second) // let things settle
-		runUpdate(effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), nil)
 	}()
 
 	// OS signal handling

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1369,7 +1369,7 @@ func main() {
 				slog.Info("received restart command", "mode", mode)
 				switch mode {
 				case "service":
-					sig.Send(&sigclient.Message{
+					sig.Send(&sigclient.Message{ //nolint:errcheck
 						Type:         sigclient.TypeUpdateStatus,
 						UpdateStatus: "restarting",
 						UpdateDetail: "Service restart requested",
@@ -1380,7 +1380,7 @@ func main() {
 						os.Exit(0)
 					}()
 				case "reboot":
-					sig.Send(&sigclient.Message{
+					sig.Send(&sigclient.Message{ //nolint:errcheck
 						Type:         sigclient.TypeUpdateStatus,
 						UpdateStatus: "rebooting",
 						UpdateDetail: "Device reboot requested",

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1374,6 +1374,38 @@ func main() {
 					}()
 				}
 
+			case sigclient.TypeRestart:
+				mode := msg.RestartMode
+				slog.Info("received restart command", "mode", mode)
+				switch mode {
+				case "service":
+					sig.Send(&sigclient.Message{
+						Type:         sigclient.TypeUpdateStatus,
+						UpdateStatus: "restarting",
+						UpdateDetail: "Service restart requested",
+					})
+					go func() {
+						time.Sleep(500 * time.Millisecond)
+						slog.Info("restarting service via exit (systemd will restart)")
+						os.Exit(0)
+					}()
+				case "reboot":
+					sig.Send(&sigclient.Message{
+						Type:         sigclient.TypeUpdateStatus,
+						UpdateStatus: "rebooting",
+						UpdateDetail: "Device reboot requested",
+					})
+					go func() {
+						time.Sleep(500 * time.Millisecond)
+						slog.Info("rebooting device")
+						if err := exec.Command("sudo", "reboot").Run(); err != nil {
+							slog.Error("reboot command failed", "err", err)
+						}
+					}()
+				default:
+					slog.Warn("unknown restart mode", "mode", mode)
+				}
+
 			default:
 				slog.Warn("signal: unhandled message type", "type", msg.Type)
 			}

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -40,6 +40,9 @@ const (
 	// TypeICERestart is sent by either peer to initiate an ICE restart.
 	// Carries a new SDP offer with rotated ICE credentials.
 	TypeICERestart = "ice_restart"
+
+	// TypeRestart is sent by the server to restart the service or reboot the device.
+	TypeRestart = "restart"
 )
 
 // ContactEntry represents a single contact in a sync payload.
@@ -86,6 +89,9 @@ type Message struct {
 
 	// Flash capability (device_info messages)
 	FlashCapable bool `json:"flash_capable,omitempty"`
+
+	// Restart fields (restart messages)
+	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"
 }
 
 // ParseMessage deserializes a JSON-encoded signaling message.

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -1,8 +1,9 @@
-# Allow the digits service user to perform OTA updates:
+# Allow the digits service user to perform OTA updates and device management:
 #   - remount rootfs rw/ro for binary replacement
 #   - copy and chmod the new binary into /usr/local/bin
 #   - run openocd for SWD firmware flashing
 #   - stop/start digitsd service
+#   - reboot the device (remote restart from web UI or service code)
 digits ALL=(root) NOPASSWD: /usr/bin/mount -o remount\,rw /, /usr/bin/mount -o remount\,ro /
 digits ALL=(root) NOPASSWD: /usr/bin/cp /data/digits/staging/digitsd-aarch64 /usr/local/bin/digitsd.tmp
 digits ALL=(root) NOPASSWD: /usr/bin/chmod 0755 /usr/local/bin/digitsd.tmp
@@ -10,3 +11,4 @@ digits ALL=(root) NOPASSWD: /usr/bin/mv /usr/local/bin/digitsd.tmp /usr/local/bi
 digits ALL=(root) NOPASSWD: /usr/bin/rm -f /usr/local/bin/digitsd.tmp
 digits ALL=(root) NOPASSWD: /usr/bin/openocd
 digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service
+digits ALL=(root) NOPASSWD: /usr/sbin/reboot

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -28,6 +28,22 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 	}
 }
 
+func TestHubGetReturnsNilForOffline(t *testing.T) {
+	hub := NewHub()
+	if hub.Get("3140099") != nil {
+		t.Fatal("expected nil for unregistered number")
+	}
+}
+
+func TestHubGetReturnsConnForOnline(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn)
+	if hub.Get("3140001") == nil {
+		t.Fatal("expected connection for registered number")
+	}
+}
+
 func TestRegisterHandlesAlreadyClosedSendChannel(t *testing.T) {
 	hub := NewHub()
 	number := "3140001"

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -21,6 +21,7 @@ const (
 	TypeUpdateTrigger   = "update_trigger"    // Server → Phone: check and apply updates
 	TypeUpdateStatus    = "update_status"     // Phone → Server: update progress report
 	TypeICERestart      = "ice_restart"       // Bidirectional: ICE restart offer with new credentials
+	TypeRestart         = "restart"          // Server -> Phone: restart service or reboot
 )
 
 // ICEServer represents a STUN or TURN server configuration.
@@ -59,6 +60,9 @@ type Message struct {
 
 	// Flash capability (device_info messages)
 	FlashCapable bool `json:"flash_capable,omitempty"`
+
+	// Restart fields (restart messages)
+	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"
 }
 
 func ParseMessage(data []byte) (*Message, error) {

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -21,7 +21,7 @@ const (
 	TypeUpdateTrigger   = "update_trigger"    // Server → Phone: check and apply updates
 	TypeUpdateStatus    = "update_status"     // Phone → Server: update progress report
 	TypeICERestart      = "ice_restart"       // Bidirectional: ICE restart offer with new credentials
-	TypeRestart         = "restart"          // Server -> Phone: restart service or reboot
+	TypeRestart         = "restart"            // Server → Phone: restart service or reboot
 )
 
 // ICEServer represents a STUN or TURN server configuration.

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -74,6 +74,8 @@ func (r *Relay) HandleMessage(from string, msg *Message) {
 			"status", msg.UpdateStatus, "detail", msg.UpdateDetail)
 		r.Hub.SetUpdateStatus(from, msg.UpdateStatus, msg.UpdateDetail)
 		return // No relay — server consumes this
+	case TypeRestart:
+		return // Server → device only; ignore if echoed back
 	default:
 		slog.Warn("unknown message type", "type", msg.Type, "from", from)
 	}

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -452,3 +452,15 @@ func TestHubOnlineNumbers(t *testing.T) {
 		t.Fatalf("expected 2 online, got %d", len(nums))
 	}
 }
+
+func TestRelayRestartMessageNotPanics(t *testing.T) {
+	hub := NewHub()
+	relay := NewRelay(hub, nil, nil)
+
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn)
+
+	// Restart messages are server->device, not relayed through HandleMessage.
+	// But verify it doesn't crash if one passes through.
+	relay.HandleMessage("3140001", &Message{Type: TypeRestart, RestartMode: "service"})
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -155,6 +155,11 @@ func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling
 	}, nil
 }
 
+// Hub returns the signaling hub (used in tests).
+func (h *Handler) Hub() *signaling.Hub {
+	return h.hub
+}
+
 func (h *Handler) Router() http.Handler {
 	mux := http.NewServeMux()
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -203,6 +203,8 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)
 	protected.HandleFunc("GET /phones/{number}/update-status", h.handlePhoneUpdateStatus)
+	protected.HandleFunc("POST /phones/{number}/restart", h.handlePhoneRestart)
+	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)
@@ -739,6 +741,54 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 	if err := json.NewEncoder(w).Encode(status); err != nil {
 		slog.Error("update status: json encode failed", "err", err)
 	}
+}
+
+func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	mode := strings.TrimSpace(r.FormValue("mode"))
+
+	if mode != "service" && mode != "reboot" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "mode must be 'service' or 'reboot'"})
+		return
+	}
+
+	msg := &signaling.Message{
+		Type:        signaling.TypeRestart,
+		RestartMode: mode,
+	}
+
+	var sendErr string
+	if err := h.hub.SendTo(number, msg); err != nil {
+		slog.Warn("restart command failed", "number", number, "mode", mode, "err", err)
+		sendErr = err.Error()
+	} else {
+		slog.Info("restart command sent", "number", number, "mode", mode)
+	}
+
+	if r.Header.Get("Accept") == "application/json" {
+		w.Header().Set("Content-Type", "application/json")
+		if sendErr != "" {
+			w.WriteHeader(http.StatusBadGateway)
+			json.NewEncoder(w).Encode(map[string]string{"error": sendErr})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"status": "triggered"})
+		}
+		return
+	}
+	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
+}
+
+func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	online := h.hub.Get(number) != nil
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"online": online})
 }
 
 func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -340,6 +340,138 @@ func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairin
 	return hardwareID, token
 }
 
+func TestPhoneRestartOnline(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+
+	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+	})
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	form := url.Values{"mode": {"service"}}
+	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, _ := signaling.ParseMessage(data)
+		if msg.Type != signaling.TypeRestart {
+			t.Fatalf("expected restart message, got %s", msg.Type)
+		}
+		if msg.RestartMode != "service" {
+			t.Fatalf("expected mode=service, got %s", msg.RestartMode)
+		}
+	default:
+		t.Fatal("device did not receive restart message")
+	}
+}
+
+func TestPhoneRestartOffline(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+
+	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+	})
+
+	form := url.Values{"mode": {"service"}}
+	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 502 {
+		t.Fatalf("expected 502 for offline device, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPhoneRestartInvalidMode(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+
+	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+	})
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	form := url.Values{"mode": {"explode"}}
+	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for invalid mode, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPhoneOnlineStatus(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+
+	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
+	t.Cleanup(func() {
+		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+	})
+
+	req := httptest.NewRequest("GET", "/phones/3140001/online", nil)
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"online":false`) {
+		t.Fatalf("expected online:false, got %s", w.Body.String())
+	}
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	req = httptest.NewRequest("GET", "/phones/3140001/online", nil)
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w = httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"online":true`) {
+		t.Fatalf("expected online:true, got %s", w.Body.String())
+	}
+}
+
 func TestWSRegister_MissingHardwareID(t *testing.T) {
 	h, _, _ := setupHandler(t)
 	srv := httptest.NewServer(h.Router())

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -547,7 +547,18 @@
       status.className = 'text-sm text-[#3fb950]';
     } else {
       status.className = 'text-sm text-[#f85149]';
-      // Keep progress visible so user sees the error
+      // Add a "try again" link below the error
+      var retryLink = document.createElement('a');
+      retryLink.textContent = 'Try again';
+      retryLink.href = '#';
+      retryLink.className = 'text-sm text-[#58a6ff] hover:underline ml-2';
+      retryLink.onclick = function(e) {
+        e.preventDefault();
+        document.getElementById('restart-progress').classList.add('hidden');
+        document.getElementById('restart-buttons').classList.remove('hidden');
+        restartMode = null;
+      };
+      status.parentNode.appendChild(retryLink);
     }
   }
   </script>

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -401,5 +401,153 @@
     </div>
 
   </div>
+
+  {{if .Online}}
+  <!-- Device restart controls -->
+  <div class="mt-6 bg-[#161b22] border border-[#21262d] rounded-lg">
+    <div class="px-4 py-3 border-b border-[#21262d]">
+      <h2 class="text-sm font-medium text-[#e6edf3]">Device Controls</h2>
+    </div>
+    <div class="p-4">
+      <div class="flex flex-wrap gap-3">
+        <!-- Restart Service button -->
+        <div id="restart-service-wrap">
+          <button type="button" id="restart-service-btn" onclick="showRestartConfirm('service')"
+                  class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
+            Restart Service
+          </button>
+          <div id="restart-service-confirm" class="hidden flex items-center gap-2 mt-2">
+            <span class="text-sm text-[#d29922]">Restart digitsd service?</span>
+            <button type="button" onclick="doRestart('service')"
+                    class="px-3 py-1 bg-[#d29922] hover:bg-[#e3b341] text-[#0d1117] text-xs font-medium rounded transition-colors">
+              Confirm
+            </button>
+            <button type="button" onclick="cancelRestartConfirm('service')"
+                    class="px-3 py-1 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#8b949e] text-xs rounded transition-colors">
+              Cancel
+            </button>
+          </div>
+        </div>
+
+        <!-- Reboot Device button -->
+        <div id="restart-reboot-wrap">
+          <button type="button" id="restart-reboot-btn" onclick="showRestartConfirm('reboot')"
+                  class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
+            Reboot Device
+          </button>
+          <div id="restart-reboot-confirm" class="hidden flex items-center gap-2 mt-2">
+            <span class="text-sm text-[#d29922]">Reboot the entire device?</span>
+            <button type="button" onclick="doRestart('reboot')"
+                    class="px-3 py-1 bg-[#da3633] hover:bg-[#f85149] text-white text-xs font-medium rounded transition-colors">
+              Confirm
+            </button>
+            <button type="button" onclick="cancelRestartConfirm('reboot')"
+                    class="px-3 py-1 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#8b949e] text-xs rounded transition-colors">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Restart progress indicator -->
+      <div id="restart-progress" class="hidden mt-3">
+        <div class="flex items-center gap-2 px-3 py-2 rounded bg-[#0d1117] border border-[#21262d]">
+          <div id="restart-spinner" class="w-4 h-4 border-2 border-[#58a6ff] border-t-transparent rounded-full animate-spin"></div>
+          <span id="restart-status" class="text-sm text-[#c9d1d9]">Sending command...</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  var restartPollTimer = null;
+
+  function showRestartConfirm(mode) {
+    document.getElementById('restart-' + mode + '-btn').classList.add('hidden');
+    document.getElementById('restart-' + mode + '-confirm').classList.remove('hidden');
+  }
+
+  function cancelRestartConfirm(mode) {
+    document.getElementById('restart-' + mode + '-btn').classList.remove('hidden');
+    document.getElementById('restart-' + mode + '-confirm').classList.add('hidden');
+  }
+
+  function doRestart(mode) {
+    // Hide both button groups, show progress
+    document.getElementById('restart-service-wrap').querySelector('button').disabled = true;
+    document.getElementById('restart-reboot-wrap').querySelector('button').disabled = true;
+    document.getElementById('restart-' + mode + '-confirm').classList.add('hidden');
+    document.getElementById('restart-' + mode + '-btn').classList.add('hidden');
+    var progress = document.getElementById('restart-progress');
+    var status = document.getElementById('restart-status');
+    progress.classList.remove('hidden');
+    status.textContent = mode === 'reboot' ? 'Sending reboot command...' : 'Sending restart command...';
+
+    var body = new URLSearchParams({mode: mode});
+    fetch('/phones/' + phoneNumber + '/restart', {
+      method: 'POST',
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+      body: body.toString()
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data.error) {
+        showRestartResult('failed', 'Failed: ' + data.error);
+        return;
+      }
+      var maxAttempts = mode === 'reboot' ? 90 : 15;
+      status.textContent = mode === 'reboot' ? 'Rebooting device...' : 'Restarting service...';
+      pollOnline(maxAttempts);
+    })
+    .catch(function(err) {
+      showRestartResult('failed', 'Network error: ' + err.message);
+    });
+  }
+
+  function pollOnline(maxAttempts) {
+    if (restartPollTimer) clearInterval(restartPollTimer);
+    var attempts = 0;
+    var sawOffline = false;
+    restartPollTimer = setInterval(function() {
+      attempts++;
+      if (attempts > maxAttempts) {
+        clearInterval(restartPollTimer);
+        showRestartResult('failed', 'Timed out waiting for device to come back online');
+        return;
+      }
+      fetch('/phones/' + phoneNumber + '/online')
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (!data.online) {
+          sawOffline = true;
+          document.getElementById('restart-status').textContent = 'Waiting for device to reconnect...';
+        } else if (sawOffline) {
+          clearInterval(restartPollTimer);
+          showRestartResult('success', 'Device is back online');
+          setTimeout(function() { location.reload(); }, 1500);
+        }
+      })
+      .catch(function() {});
+    }, 1000);
+  }
+
+  function showRestartResult(type, message) {
+    var spinner = document.getElementById('restart-spinner');
+    var status = document.getElementById('restart-status');
+    spinner.classList.add('hidden');
+    status.textContent = message;
+    if (type === 'success') {
+      status.className = 'text-sm text-[#3fb950]';
+    } else {
+      status.className = 'text-sm text-[#f85149]';
+      // Re-enable buttons on failure
+      document.getElementById('restart-service-btn').classList.remove('hidden');
+      document.getElementById('restart-service-btn').disabled = false;
+      document.getElementById('restart-reboot-btn').classList.remove('hidden');
+      document.getElementById('restart-reboot-btn').disabled = false;
+    }
+  }
+  </script>
+  {{end}}
 </div>
 {{end}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -356,7 +356,7 @@
           var btn = document.getElementById(prefix + '-install-btn');
           if (spinner) spinner.classList.add('hidden');
           if (progress) progress.classList.remove('hidden');
-          if (resultType === 'success') {
+          if (type === 'success') {
             if (progressText) {
               progressText.textContent = message;
               progressText.className = 'text-sm text-[#3fb950]';

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -512,27 +512,30 @@
     if (restartPollTimer) clearInterval(restartPollTimer);
     var attempts = 0;
     var sawOffline = false;
-    restartPollTimer = setInterval(function() {
-      attempts++;
-      if (attempts > maxAttempts) {
-        clearInterval(restartPollTimer);
-        showRestartResult('failed', 'Timed out waiting for device to come back online');
-        return;
-      }
-      fetch('/phones/' + phoneNumber + '/online')
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
-        if (!data.online) {
-          sawOffline = true;
-          document.getElementById('restart-status').textContent = 'Waiting for device to reconnect...';
-        } else if (sawOffline) {
+    // Give the device a moment to disconnect before we start polling
+    setTimeout(function() {
+      restartPollTimer = setInterval(function() {
+        attempts++;
+        if (attempts > maxAttempts) {
           clearInterval(restartPollTimer);
-          showRestartResult('success', 'Device is back online');
-          setTimeout(function() { location.reload(); }, 1500);
+          showRestartResult('failed', 'Timed out waiting for device to come back online');
+          return;
         }
-      })
-      .catch(function() {});
-    }, 1000);
+        fetch('/phones/' + phoneNumber + '/online')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (!data.online) {
+            sawOffline = true;
+            document.getElementById('restart-status').textContent = 'Waiting for device to reconnect...';
+          } else if (sawOffline) {
+            clearInterval(restartPollTimer);
+            showRestartResult('success', 'Device is back online');
+            setTimeout(function() { location.reload(); }, 1500);
+          }
+        })
+        .catch(function() {});
+      }, 1000);
+    }, 2000);
   }
 
   function showRestartResult(resultType, message) {
@@ -544,10 +547,7 @@
       status.className = 'text-sm text-[#3fb950]';
     } else {
       status.className = 'text-sm text-[#f85149]';
-      // Show buttons again on failure
-      document.getElementById('restart-progress').classList.add('hidden');
-      document.getElementById('restart-buttons').classList.remove('hidden');
-      restartMode = null;
+      // Keep progress visible so user sees the error
     }
   }
   </script>

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -356,7 +356,7 @@
           var btn = document.getElementById(prefix + '-install-btn');
           if (spinner) spinner.classList.add('hidden');
           if (progress) progress.classList.remove('hidden');
-          if (type === 'success') {
+          if (resultType === 'success') {
             if (progressText) {
               progressText.textContent = message;
               progressText.className = 'text-sm text-[#3fb950]';
@@ -474,10 +474,12 @@
 
   function doRestart(mode) {
     // Hide both button groups, show progress
-    document.getElementById('restart-service-wrap').querySelector('button').disabled = true;
-    document.getElementById('restart-reboot-wrap').querySelector('button').disabled = true;
-    document.getElementById('restart-' + mode + '-confirm').classList.add('hidden');
-    document.getElementById('restart-' + mode + '-btn').classList.add('hidden');
+    // Disable all buttons in both wraps to prevent double-clicks
+    document.querySelectorAll('#restart-service-wrap button, #restart-reboot-wrap button').forEach(function(b) { b.disabled = true; });
+    document.getElementById('restart-service-confirm').classList.add('hidden');
+    document.getElementById('restart-reboot-confirm').classList.add('hidden');
+    document.getElementById('restart-service-btn').classList.add('hidden');
+    document.getElementById('restart-reboot-btn').classList.add('hidden');
     var progress = document.getElementById('restart-progress');
     var status = document.getElementById('restart-status');
     progress.classList.remove('hidden');
@@ -531,12 +533,12 @@
     }, 1000);
   }
 
-  function showRestartResult(type, message) {
+  function showRestartResult(resultType, message) {
     var spinner = document.getElementById('restart-spinner');
     var status = document.getElementById('restart-status');
     spinner.classList.add('hidden');
     status.textContent = message;
-    if (type === 'success') {
+    if (resultType === 'success') {
       status.className = 'text-sm text-[#3fb950]';
     } else {
       status.className = 'text-sm text-[#f85149]';

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -409,48 +409,35 @@
       <h2 class="text-sm font-medium text-[#e6edf3]">Device Controls</h2>
     </div>
     <div class="p-4">
-      <div class="flex flex-wrap gap-3">
-        <!-- Restart Service button -->
-        <div id="restart-service-wrap">
-          <button type="button" id="restart-service-btn" onclick="showRestartConfirm('service')"
-                  class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
-            Restart Service
-          </button>
-          <div id="restart-service-confirm" class="hidden flex items-center gap-2 mt-2">
-            <span class="text-sm text-[#d29922]">Restart digitsd service?</span>
-            <button type="button" onclick="doRestart('service')"
-                    class="px-3 py-1 bg-[#d29922] hover:bg-[#e3b341] text-[#0d1117] text-xs font-medium rounded transition-colors">
-              Confirm
-            </button>
-            <button type="button" onclick="cancelRestartConfirm('service')"
-                    class="px-3 py-1 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#8b949e] text-xs rounded transition-colors">
-              Cancel
-            </button>
-          </div>
-        </div>
+      <!-- Default: show both action buttons -->
+      <div id="restart-buttons" class="flex flex-wrap gap-3">
+        <button type="button" onclick="showRestartConfirm('service')"
+                class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
+          Restart Service
+        </button>
+        <button type="button" onclick="showRestartConfirm('reboot')"
+                class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
+          Reboot Device
+        </button>
+      </div>
 
-        <!-- Reboot Device button -->
-        <div id="restart-reboot-wrap">
-          <button type="button" id="restart-reboot-btn" onclick="showRestartConfirm('reboot')"
-                  class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
-            Reboot Device
+      <!-- Confirmation: replaces buttons entirely -->
+      <div id="restart-confirm" class="hidden">
+        <p id="restart-confirm-text" class="text-sm text-[#c9d1d9] mb-3"></p>
+        <div class="flex gap-3">
+          <button type="button" id="restart-confirm-btn" onclick="doRestart()"
+                  class="px-4 py-2 text-sm font-medium rounded transition-colors">
+            Confirm
           </button>
-          <div id="restart-reboot-confirm" class="hidden flex items-center gap-2 mt-2">
-            <span class="text-sm text-[#d29922]">Reboot the entire device?</span>
-            <button type="button" onclick="doRestart('reboot')"
-                    class="px-3 py-1 bg-[#da3633] hover:bg-[#f85149] text-white text-xs font-medium rounded transition-colors">
-              Confirm
-            </button>
-            <button type="button" onclick="cancelRestartConfirm('reboot')"
-                    class="px-3 py-1 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#8b949e] text-xs rounded transition-colors">
-              Cancel
-            </button>
-          </div>
+          <button type="button" onclick="cancelRestartConfirm()"
+                  class="px-4 py-2 bg-[#21262d] hover:bg-[#30363d] border border-[#30363d] text-[#c9d1d9] text-sm rounded transition-colors">
+            Cancel
+          </button>
         </div>
       </div>
 
-      <!-- Restart progress indicator -->
-      <div id="restart-progress" class="hidden mt-3">
+      <!-- Progress: replaces confirmation -->
+      <div id="restart-progress" class="hidden">
         <div class="flex items-center gap-2 px-3 py-2 rounded bg-[#0d1117] border border-[#21262d]">
           <div id="restart-spinner" class="w-4 h-4 border-2 border-[#58a6ff] border-t-transparent rounded-full animate-spin"></div>
           <span id="restart-status" class="text-sm text-[#c9d1d9]">Sending command...</span>
@@ -461,29 +448,44 @@
 
   <script>
   var restartPollTimer = null;
+  var restartMode = null;
 
   function showRestartConfirm(mode) {
-    document.getElementById('restart-' + mode + '-btn').classList.add('hidden');
-    document.getElementById('restart-' + mode + '-confirm').classList.remove('hidden');
+    restartMode = mode;
+    var buttons = document.getElementById('restart-buttons');
+    var confirm = document.getElementById('restart-confirm');
+    var confirmText = document.getElementById('restart-confirm-text');
+    var confirmBtn = document.getElementById('restart-confirm-btn');
+
+    buttons.classList.add('hidden');
+    confirm.classList.remove('hidden');
+
+    if (mode === 'reboot') {
+      confirmText.textContent = 'Reboot the entire device? This will take about 30 seconds.';
+      confirmBtn.className = 'px-4 py-2 bg-[#da3633] hover:bg-[#f85149] text-white text-sm font-medium rounded transition-colors';
+    } else {
+      confirmText.textContent = 'Restart the service on this device? It will reconnect in a few seconds.';
+      confirmBtn.className = 'px-4 py-2 bg-[#1f6feb] hover:bg-[#388bfd] text-white text-sm font-medium rounded transition-colors';
+    }
   }
 
-  function cancelRestartConfirm(mode) {
-    document.getElementById('restart-' + mode + '-btn').classList.remove('hidden');
-    document.getElementById('restart-' + mode + '-confirm').classList.add('hidden');
+  function cancelRestartConfirm() {
+    restartMode = null;
+    document.getElementById('restart-confirm').classList.add('hidden');
+    document.getElementById('restart-buttons').classList.remove('hidden');
   }
 
-  function doRestart(mode) {
-    // Hide both button groups, show progress
-    // Disable all buttons in both wraps to prevent double-clicks
-    document.querySelectorAll('#restart-service-wrap button, #restart-reboot-wrap button').forEach(function(b) { b.disabled = true; });
-    document.getElementById('restart-service-confirm').classList.add('hidden');
-    document.getElementById('restart-reboot-confirm').classList.add('hidden');
-    document.getElementById('restart-service-btn').classList.add('hidden');
-    document.getElementById('restart-reboot-btn').classList.add('hidden');
+  function doRestart() {
+    var mode = restartMode;
+    var confirm = document.getElementById('restart-confirm');
     var progress = document.getElementById('restart-progress');
     var status = document.getElementById('restart-status');
+
+    confirm.classList.add('hidden');
     progress.classList.remove('hidden');
     status.textContent = mode === 'reboot' ? 'Sending reboot command...' : 'Sending restart command...';
+    status.className = 'text-sm text-[#c9d1d9]';
+    document.getElementById('restart-spinner').classList.remove('hidden');
 
     var body = new URLSearchParams({mode: mode});
     fetch('/phones/' + phoneNumber + '/restart', {
@@ -542,11 +544,10 @@
       status.className = 'text-sm text-[#3fb950]';
     } else {
       status.className = 'text-sm text-[#f85149]';
-      // Re-enable buttons on failure
-      document.getElementById('restart-service-btn').classList.remove('hidden');
-      document.getElementById('restart-service-btn').disabled = false;
-      document.getElementById('restart-reboot-btn').classList.remove('hidden');
-      document.getElementById('restart-reboot-btn').disabled = false;
+      // Show buttons again on failure
+      document.getElementById('restart-progress').classList.add('hidden');
+      document.getElementById('restart-buttons').classList.remove('hidden');
+      restartMode = null;
     }
   }
   </script>


### PR DESCRIPTION
## What

Adds controls to the phone detail page to remotely restart the digitsd service or reboot the entire Pi device. Also removes the automatic update check on startup so updates are always user-initiated.

## Why

No way to restart a device without SSH access. The auto-updater was also silently overwriting dev/test binaries with released versions, making testing impossible.

## Test plan

- [x] Tested "Restart Service" on Digits 1 from app.digits.family -- service restarted, device reconnected, UI showed success
- [x] Tested "Reboot Device" on Digits 1 -- full reboot completed, device came back online
- [x] Confirmed inline confirmation flow works (both buttons hide, full-width confirm replaces them)
- [x] Confirmed error state shows message with "Try again" link
- [x] Confirmed auto-updater no longer runs on startup
- [x] `go test ./...` and `go vet ./...` pass for both server and digitsd
- [ ] Verify `*#UPDATE#` service code still triggers updates (preserved path)
- [ ] Verify web UI "Update" buttons still work (preserved path)