### PR TITLE
feat(server): add live polling for phone online/offline status badge

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -205,7 +205,6 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
 	protected.HandleFunc("GET /phones/{number}/update-status", h.handlePhoneUpdateStatus)
 	protected.HandleFunc("POST /phones/{number}/restart", h.handlePhoneRestart)
-	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)
@@ -651,7 +650,14 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
 	online := h.hub.Get(number) != nil
-	renderWith(w, h.tmplPhoneDetail, "phone-status", struct{ Online bool }{online})
+	if isHTMX(r) {
+		renderWith(w, h.tmplPhoneDetail, "phone-status", struct{ Online bool }{online})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]bool{"online": online}); err != nil {
+		slog.Error("encode online status failed", "err", err)
+	}
 }
 
 func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {
@@ -761,7 +767,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	if mode != "service" && mode != "reboot" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "mode must be 'service' or 'reboot'"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "mode must be 'service' or 'reboot'"})
 		return
 	}
 
@@ -782,20 +788,13 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if sendErr != "" {
 			w.WriteHeader(http.StatusBadGateway)
-			json.NewEncoder(w).Encode(map[string]string{"error": sendErr})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": sendErr})
 		} else {
-			json.NewEncoder(w).Encode(map[string]string{"status": "triggered"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "triggered"})
 		}
 		return
 	}
 	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
-}
-
-func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
-	number := r.PathValue("number")
-	online := h.hub.Get(number) != nil
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]bool{"online": online})
 }
 
 func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -197,6 +197,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/edit", h.handlePhoneEditPost)
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)
+	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
 	protected.HandleFunc("GET /phones/{number}/update-status", h.handlePhoneUpdateStatus)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
@@ -638,6 +639,12 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		PiReleases:            piReleases,
 		FWReleases:            fwReleases,
 	})
+}
+
+func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	online := h.hub.Get(number) != nil
+	renderWith(w, h.tmplPhoneDetail, "phone-status", struct{ Online bool }{online})
 }
 
 func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -347,8 +347,8 @@ func TestPhoneRestartOnline(t *testing.T) {
 	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
 	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
 	t.Cleanup(func() {
-		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
-		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
@@ -387,8 +387,8 @@ func TestPhoneRestartOffline(t *testing.T) {
 	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
 	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
 	t.Cleanup(func() {
-		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
-		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
 	})
 
 	form := url.Values{"mode": {"service"}}
@@ -411,8 +411,8 @@ func TestPhoneRestartInvalidMode(t *testing.T) {
 	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
 	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
 	t.Cleanup(func() {
-		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
-		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
@@ -438,8 +438,8 @@ func TestPhoneOnlineStatus(t *testing.T) {
 	_, _ = database.DB.Exec("INSERT INTO households (id, name) VALUES ('h1', 'Test') ON CONFLICT DO NOTHING")
 	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', 'h1') ON CONFLICT DO NOTHING`)
 	t.Cleanup(func() {
-		database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
-		database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = 'h1'")
 	})
 
 	req := httptest.NewRequest("GET", "/phones/3140001/online", nil)

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -13,17 +13,9 @@
     </a>
     <div class="flex items-center gap-3">
       <h1 class="text-xl font-semibold text-[#e6edf3]">{{.Line.Name}}</h1>
-      {{if .Online}}
-        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs bg-[#1a3a25] text-[#3fb950]">
-          <span class="w-1.5 h-1.5 rounded-full bg-[#3fb950]"></span>
-          online
-        </span>
-      {{else}}
-        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs bg-[#1c2128] text-[#8b949e]">
-          <span class="w-1.5 h-1.5 rounded-full bg-[#484f58]"></span>
-          offline
-        </span>
-      {{end}}
+      <div id="status-badge" hx-get="/phones/{{.Line.Number}}/online" hx-trigger="every 10s" hx-swap="innerHTML">
+        {{template "phone-status" .}}
+      </div>
     </div>
     <p class="text-sm text-[#8b949e] mt-1 font-mono">{{.Line.Number}}</p>
   </div>
@@ -49,11 +41,13 @@
         </div>
         <div>
           <label class="block text-xs text-[#8b949e] mb-1">Status</label>
-          {{if .Online}}
-            <span class="text-sm text-[#3fb950]">Online</span>
-          {{else}}
-            <span class="text-sm text-[#8b949e]">Offline</span>
-          {{end}}
+          <span id="status-detail">
+            {{if .Online}}
+              <span class="text-sm text-[#3fb950]">Online</span>
+            {{else}}
+              <span class="text-sm text-[#8b949e]">Offline</span>
+            {{end}}
+          </span>
         </div>
         {{if .Devices}}
         <div>
@@ -402,4 +396,25 @@
 
   </div>
 </div>
+{{end}}
+
+{{define "phone-status"}}
+{{if .Online}}
+  <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs bg-[#1a3a25] text-[#3fb950]">
+    <span class="w-1.5 h-1.5 rounded-full bg-[#3fb950]"></span>
+    online
+  </span>
+{{else}}
+  <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs bg-[#1c2128] text-[#8b949e]">
+    <span class="w-1.5 h-1.5 rounded-full bg-[#484f58]"></span>
+    offline
+  </span>
+{{end}}
+<span id="status-detail" hx-swap-oob="innerHTML">
+  {{if .Online}}
+    <span class="text-sm text-[#3fb950]">Online</span>
+  {{else}}
+    <span class="text-sm text-[#8b949e]">Offline</span>
+  {{end}}
+</span>
 {{end}}


### PR DESCRIPTION
Add htmx polling (every 10s) to the phone detail page status badge so it updates automatically without requiring a page refresh. Uses a new `GET /phones/{number}/online` endpoint that returns just the status badge HTML fragment. The details card status field is also updated via htmx OOB swap.

Closes #100