### PR TITLE
fix(server): remove duplicate status display on phone detail

### DIFF
--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -39,16 +39,6 @@
           <label class="block text-xs text-[#8b949e] mb-1">Added</label>
           <span class="text-sm text-[#c9d1d9]">{{.Line.CreatedAt.Format "January 2, 2006"}}</span>
         </div>
-        <div>
-          <label class="block text-xs text-[#8b949e] mb-1">Status</label>
-          <span id="status-detail">
-            {{if .Online}}
-              <span class="text-sm text-[#3fb950]">Online</span>
-            {{else}}
-              <span class="text-sm text-[#8b949e]">Offline</span>
-            {{end}}
-          </span>
-        </div>
         {{if .Devices}}
         <div>
           <label class="block text-xs text-[#8b949e] mb-1">Devices</label>
@@ -572,11 +562,4 @@
     offline
   </span>
 {{end}}
-<span id="status-detail" hx-swap-oob="innerHTML">
-  {{if .Online}}
-    <span class="text-sm text-[#3fb950]">Online</span>
-  {{else}}
-    <span class="text-sm text-[#8b949e]">Offline</span>
-  {{end}}
-</span>
 {{end}}


### PR DESCRIPTION
## What

Removes the static "Status: Online/Offline" field from the Details card on the phone detail page, and the corresponding OOB swap in the phone-status template.

## Why

The live-polling badge in the page header (added in #102) already shows online/offline status. The static Status field in the Details card was redundant and the OOB swap targeting it caused a brief text flash on each poll cycle.

## Test plan

- [x] Verify only the header badge shows status (no duplicate in Details card)
- [x] Verify badge updates live via htmx polling
- [x] `go test ./...` passes