### PR TITLE
fix(server): show real version in prod builds

### DIFF
--- a/server/docker-compose.prod.yml
+++ b/server/docker-compose.prod.yml
@@ -2,6 +2,9 @@ services:
   signald:
     build:
       context: .
+      args:
+        VERSION: ${BUILD_VERSION:-dev}
+        COMMIT: ${BUILD_COMMIT:-unknown}
     restart: unless-stopped
     environment:
       SIGNALD_ADDR: ":8080"


### PR DESCRIPTION
## What

Passes `BUILD_VERSION` and `BUILD_COMMIT` env vars as Docker build args in the prod compose file, so the server binary gets a real version string from git tags instead of defaulting to "dev".

## Why

The web UI always showed "dev" in the version corner because the prod docker compose build never passed version info to the Dockerfile.

## Test plan

- [x] Deployed with `BUILD_VERSION=$(git describe ...) BUILD_COMMIT=$(git rev-parse --short HEAD)` -- `/api/version` returns `1.5.1-13-gcc1a24e`
- [x] Without env vars, falls back to `dev`/`unknown` (existing behavior)

Deploy command becomes:
```
BUILD_VERSION=$(git describe --tags --match 'server/v*' --always | sed 's|^server/v||') \
BUILD_COMMIT=$(git rev-parse --short HEAD) \
docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
```