### PR TITLE
fix(digitsd): use ALSA card name instead of numeric index for stable device addressing

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -94,7 +94,7 @@ Digits uses WebRTC for media transport. DTLS-SRTP provides end-to-end encryption
 
 ### Audio Pipeline
 
-- **Capture:** ALSA `plughw:1,0` at 48kHz stereo -- right channel extracted (external mic on TRS jack)
+- **Capture:** ALSA `plughw:CARD=Zero,DEV=0` at 48kHz stereo -- right channel extracted (external mic on TRS jack)
 - **Processing:** Optional RNNoise ML denoiser for background noise suppression
 - **Encode:** Opus 48kHz mono, 24kbps, VoIP mode, in-band FEC, 20ms frames
 - **Transport:** RTP/SRTP via Pion WebRTC

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -819,12 +819,8 @@ func main() {
 	// 2. Open ALSA playback (direct hardware, no dmix)
 	pbDev := *alsaDevice
 	if pbDev == "" {
-		dev, err := audio.CodecDeviceName()
-		if err != nil {
-			log.Fatalf("alsa: %v", err)
-		}
-		pbDev = dev
-		slog.Info("alsa playback: auto-detected", "device", pbDev)
+		pbDev = audio.CodecDeviceName
+		slog.Info("alsa playback: using codec", "device", pbDev)
 	}
 	pbCfg := audio.Config{
 		Device:     pbDev,

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -8,13 +8,8 @@ package audio
 import "C"
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"io"
-	"log/slog"
-	"os"
-	"strings"
 	"unsafe"
 )
 
@@ -22,6 +17,17 @@ import (
 // occurred and was recovered. The frame was still written successfully,
 // but the caller should drain stale data to re-sync.
 var ErrUnderrun = errors.New("alsa: buffer underrun recovered")
+
+const (
+	// CodecCardName is the ALSA card name for the RPi Codec Zero (DA7212).
+	// Used with amixer/alsactl which accept -c <name>.
+	CodecCardName = "Zero"
+
+	// CodecDeviceName is the stable ALSA device identifier for the Codec Zero.
+	// Uses the card name instead of a numeric index so it works regardless of
+	// card enumeration order (HDMI vs codec).
+	CodecDeviceName = "plughw:CARD=Zero,DEV=0"
+)
 
 // Config holds ALSA device parameters.
 type Config struct {
@@ -31,59 +37,11 @@ type Config struct {
 	FrameSize  int // samples per frame per channel (960 = 20ms at 48kHz)
 }
 
-// findCodecCardIn scans ALSA card list output for the Codec Zero (DA7212)
-// and returns its card number. The input should be the contents of
-// /proc/asound/cards. Lines look like:
-//
-//	 0 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero
-func findCodecCardIn(r io.Reader) (int, error) {
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "RPi Codec Zero") || strings.Contains(line, "RPi_Codec_Zero") {
-			var num int
-			if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d", &num); err == nil {
-				return num, nil
-			}
-		}
-	}
-	return 0, fmt.Errorf("codec Zero card not found in /proc/asound/cards")
-}
-
-// FindCodecCard scans /proc/asound/cards for the Codec Zero (DA7212) and
-// returns its ALSA card number. Returns an error if not found.
-func FindCodecCard() (int, error) {
-	f, err := os.Open("/proc/asound/cards")
-	if err != nil {
-		return 0, fmt.Errorf("open /proc/asound/cards: %w", err)
-	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil {
-			slog.Warn("close /proc/asound/cards", "error", cerr)
-		}
-	}()
-	return findCodecCardIn(f)
-}
-
-// CodecDeviceName returns "plughw:N,0" for the Codec Zero card.
-func CodecDeviceName() (string, error) {
-	card, err := FindCodecCard()
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("plughw:%d,0", card), nil
-}
-
 // DefaultCaptureConfig returns config for the DA7212 codec: stereo capture at 48kHz.
 // Uses plughw to bypass dmix (which is playback-only).
 func DefaultCaptureConfig() Config {
-	dev, err := CodecDeviceName()
-	if err != nil {
-		slog.Warn("codec detection failed, falling back to plughw:1,0", "error", err)
-		dev = "plughw:1,0"
-	}
 	return Config{
-		Device:     dev,
+		Device:     CodecDeviceName,
 		SampleRate: 48000,
 		Channels:   2,
 		FrameSize:  960,

--- a/pi/digitsd/internal/audio/alsa_test.go
+++ b/pi/digitsd/internal/audio/alsa_test.go
@@ -2,65 +2,14 @@ package audio
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
-func TestFindCodecCardIn(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    int
-		wantErr bool
-	}{
-		{
-			name:  "card 0",
-			input: " 0 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n                      RPi Codec Zero\n",
-			want:  0,
-		},
-		{
-			name:  "card 1 with HDMI first",
-			input: " 0 [vc4hdmi        ]: vc4-hdmi - vc4-hdmi\n                      vc4-hdmi\n 1 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n                      RPi Codec Zero\n",
-			want:  1,
-		},
-		{
-			name:  "card 2",
-			input: " 0 [foo            ]: bar\n 1 [baz            ]: qux\n 2 [Zero           ]: RPi_Codec_Zero - RPi Codec Zero\n",
-			want:  2,
-		},
-		{
-			name:    "no codec zero",
-			input:   " 0 [vc4hdmi        ]: vc4-hdmi - vc4-hdmi\n",
-			wantErr: true,
-		},
-		{
-			name:    "empty",
-			input:   "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := findCodecCardIn(strings.NewReader(tt.input))
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("expected error, got card %d", got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("got card %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestDefaultCaptureConfig(t *testing.T) {
 	cfg := DefaultCaptureConfig()
+	if cfg.Device != CodecDeviceName {
+		t.Errorf("Device = %q, want %q", cfg.Device, CodecDeviceName)
+	}
 	if cfg.SampleRate != 48000 {
 		t.Errorf("SampleRate = %d, want 48000", cfg.SampleRate)
 	}

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -222,15 +222,10 @@ func volumeToALSA(level int) int {
 	return 20 + (level * (58 - 20) / 9)
 }
 
-// codecCard returns the Codec Zero ALSA card number as a string for use
-// in amixer/alsactl commands. Falls back to "0" if detection fails.
+// codecCard returns the Codec Zero ALSA card name for use in
+// amixer/alsactl commands (which accept -c <name>).
 func codecCard() string {
-	card, err := audio.FindCodecCard()
-	if err != nil {
-		slog.Warn("codec detection failed for volume control, assuming card 0", "error", err)
-		return "0"
-	}
-	return fmt.Sprintf("%d", card)
+	return audio.CodecCardName
 }
 
 // SetVolume sets Lineout volume. Level 0-9 maps to ALSA 20-58.

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -222,17 +222,11 @@ func volumeToALSA(level int) int {
 	return 20 + (level * (58 - 20) / 9)
 }
 
-// codecCard returns the Codec Zero ALSA card name for use in
-// amixer/alsactl commands (which accept -c <name>).
-func codecCard() string {
-	return audio.CodecCardName
-}
-
 // SetVolume sets Lineout volume. Level 0-9 maps to ALSA 20-58.
 // Persists the level to /data/digits/volume and saves full mixer state.
 func SetVolume(level int) error {
 	alsaVal := volumeToALSA(level)
-	card := codecCard()
+	card := audio.CodecCardName
 	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("amixer: %s: %w", strings.TrimSpace(string(out)), err)
@@ -263,7 +257,7 @@ func RestoreVolume() {
 		}
 	}
 	alsaVal := volumeToALSA(level)
-	card := codecCard()
+	card := audio.CodecCardName
 	cmd := exec.Command("amixer", "-c", card, "sset", "Lineout", fmt.Sprintf("%d", alsaVal))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		slog.Warn("volume restore: amixer failed", "output", strings.TrimSpace(string(out)), "error", err)

--- a/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
@@ -8,7 +8,7 @@ Type=simple
 User=digits
 Group=digits
 ExecStart=/usr/local/bin/digitsd \
-    -alsa-playback plughw:0,0 \
+    -alsa-playback plughw:CARD=Zero,DEV=0 \
     -config /data/digits/config.json \
     -serial /dev/serial0 \
     -tones /data/digits/tones \

--- a/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
@@ -8,7 +8,6 @@ Type=simple
 User=digits
 Group=digits
 ExecStart=/usr/local/bin/digitsd \
-    -alsa-playback plughw:CARD=Zero,DEV=0 \
     -config /data/digits/config.json \
     -serial /dev/serial0 \
     -tones /data/digits/tones \


### PR DESCRIPTION
Closes #104

ALSA card numbering is non-deterministic across SD card flashes -- the RPi Codec Zero can appear as card 0 or card 1 depending on enumeration order with HDMI audio. This replaces numeric card indices with name-based identifiers (`plughw:CARD=Zero,DEV=0`) which are stable regardless of enumeration order.

The runtime `/proc/asound/cards` parsing (`FindCodecCard`, `findCodecCardIn`, `CodecDeviceName` function) is replaced with exported constants that use the card name directly. The `amixer` and `alsactl` commands for volume control also switch from `-c <number>` to `-c Zero`.