### PR TITLE
fix(server): replace remote deploy with local docker compose target

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -42,6 +42,9 @@ clean:
 print-version:
 	@echo $(VERSION)
 
-# Deploy to production server (set DEPLOY_HOST)
+# Deploy locally via Docker Compose (fetches tags for accurate version)
 deploy:
-	ssh $(DEPLOY_HOST) 'cd ~/digits/server && git pull && docker compose -p digits-prod -f docker-compose.prod.yml --env-file .env.prod build signald && docker compose -p digits-prod -f docker-compose.prod.yml --env-file .env.prod up -d signald'
+	git fetch --tags
+	BUILD_VERSION=$$(git describe --tags --match 'server/v*' --always | sed 's|^server/v||') \
+	BUILD_COMMIT=$$(git rev-parse --short HEAD) \
+	docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build signald


### PR DESCRIPTION
## What

Replaces the old `make deploy` target (which SSH'd to a remote host) with a local Docker Compose deploy that fetches tags and passes version/commit as build args.

## Why

We deploy from the local machine now. The old target was dead code. The new target also ensures `git fetch --tags` runs first so `git describe` resolves the correct version.

## Test plan

- [x] `make deploy` builds and deploys with correct version (`1.8.2`)