### PR TITLE
docs: add FAQ to hardware kill switch guide

### DIFF
--- a/docs/build/hardware-kill-switch.md
+++ b/docs/build/hardware-kill-switch.md
@@ -50,3 +50,11 @@ The V-153-1C25 is SPDT with a shared Common terminal. GP10's internal pull-up so
 
 ### Why Not a Second V-153-1C25?
 The V-153-1C25 has a 51mm lever arm. Two of them would be difficult to fit inside the phone body. The D2F-01F is ~1/10th the size and actuates with a pin plunger, making placement trivial.
+
+## FAQ
+
+### Why not route the mic through the existing hook switch instead of adding a second switch?
+
+The V-153-1C25 hook switch is SPDT with a single Common terminal. COM is wired to GP10, where the Pico H's internal pull-up sources 3.3V through ~50k ohms to read hook state. If the mic hot wire shared that same COM terminal, the 3.3V pull-up would swamp the millivolt-level electret mic signal whenever the handset is off-hook (COM-NO closed). You can't split the two signals across NO and NC either, because COM is shared -- both signals would always be on whichever terminal COM is currently connected to.
+
+You would need a DPDT switch (two independent poles, one mechanical actuator) to switch both the GPIO and mic circuits from one cradle action. The D2F-01F is simpler: a dedicated SPDT switch for the mic circuit alone, tiny enough to mount anywhere, with no firmware changes required.


### PR DESCRIPTION
## What

Adds an FAQ section to the hardware mic kill switch doc explaining why the mic circuit needs its own dedicated switch rather than reusing the existing hook switch.

## Why

This is a common question when reviewing the hardware design. The answer involves SPDT switch physics (shared COM terminal, pull-up voltage conflict) that isn't obvious without thinking through the circuit.

## Test plan

- Documentation only, no code changes