### PR TITLE
fix(pi): resolve AP SSID placeholder before starting hostapd

### DIFF
--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-ap-check.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-ap-check.service
@@ -3,6 +3,7 @@ Description=Digits AP Mode Boot Check
 Documentation=https://github.com/digits/digits
 # Run after filesystem and first-boot are done, before networking
 DefaultDependencies=no
+Wants=digits-first-boot.service
 After=local-fs.target digits-first-boot.service
 Before=network-pre.target
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -102,6 +102,28 @@ else
     # Stop digitsd in AP mode
     systemctl stop digitsd.service 2>/dev/null || true
 
+    # Ensure hostapd SSID is not the build-time placeholder.
+    # digits-first-boot.sh normally sets this, but if first-boot was skipped
+    # (e.g. /data/.initialized already existed) or failed, the placeholder
+    # persists. Resolve it here before starting hostapd.
+    HOSTAPD_CONF="/etc/hostapd/digits-ap.conf"
+    CURRENT_SSID=$(grep '^ssid=' "$HOSTAPD_CONF" | cut -d= -f2)
+    if [ "$CURRENT_SSID" = "Digits-XXXX" ]; then
+        log "SSID is still placeholder — resolving"
+        DEVICE_ID_FILE="/data/digits/device-id"
+        if [ -f "$DEVICE_ID_FILE" ]; then
+            SUFFIX=$(cat "$DEVICE_ID_FILE" | tail -c 4)
+        else
+            SUFFIX=$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
+        fi
+        NEW_SSID="Digits-${SUFFIX}"
+        mount -o remount,rw / 2>/dev/null || true
+        sed -i "s/^ssid=.*/ssid=${NEW_SSID}/" "$HOSTAPD_CONF"
+        sync
+        mount -o remount,ro / 2>/dev/null || true
+        log "Updated SSID to: ${NEW_SSID}"
+    fi
+
     # Start AP services (--no-block to avoid deadlock with network.target)
     systemctl start --no-block digits-ap.service
     systemctl start --no-block digits-dnsmasq-ap.service

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -112,7 +112,7 @@ else
         log "SSID is still placeholder — resolving"
         DEVICE_ID_FILE="/data/digits/device-id"
         if [ -f "$DEVICE_ID_FILE" ]; then
-            SUFFIX=$(cat "$DEVICE_ID_FILE" | tail -c 4)
+            SUFFIX=$(tr -d '\n' < "$DEVICE_ID_FILE" | tail -c 4)
         else
             SUFFIX=$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
         fi


### PR DESCRIPTION
Closes #118

## Summary

- Add defensive SSID resolution in `digits-ap-check` to replace the build-time placeholder `Digits-XXXX` before starting hostapd
- Add `Wants=digits-first-boot.service` to `digits-ap-check.service` for explicit systemd dependency

## Test plan

- [ ] Flash a fresh image and verify the AP SSID shows a generated suffix (e.g. `Digits-e3b4`) instead of `Digits-XXXX`
- [ ] Verify that subsequent reboots retain the generated SSID
- [ ] Test factory reset flow to confirm SSID is re-generated

Generated with [Claude Code](https://claude.ai/code)