### PR TITLE
docs(server): add TURN/ICE relay config to .env.example

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -50,3 +50,14 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 # Must match exactly what's registered in Google Cloud Console.
 GOOGLE_REDIRECT_URL=https://digits.example.com/auth/google/callback
+
+# ─────────────────────────────────────────────
+# TURN / ICE Relay (optional)
+# ─────────────────────────────────────────────
+# Enable a TURN relay for NAT traversal.
+# The shared secret is used to generate time-limited HMAC credentials.
+# Generate with: openssl rand -hex 32
+
+SIGNALD_TURN_ENABLED=false
+SIGNALD_TURN_SECRET=
+SIGNALD_TURN_DOMAIN=turn.example.com


### PR DESCRIPTION
## Summary
- Adds TURN/ICE relay environment variables (`SIGNALD_TURN_ENABLED`, `SIGNALD_TURN_SECRET`, `SIGNALD_TURN_DOMAIN`) to `server/.env.example`
- These vars are used in production but were not documented in the example config

## Test plan
- [ ] Verify `.env.example` renders correctly and new section follows existing formatting conventions