### PR TITLE
fix(server): configure database connection pool limits

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	_ "github.com/lib/pq"
 )
@@ -20,6 +21,9 @@ func Open(databaseURL string) (*Database, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
 	d := &Database{DB: db}
 	if err := d.migrate(); err != nil {
 		_ = db.Close()


### PR DESCRIPTION
## What

Configure database connection pool settings in `db.Open()` to prevent unbounded connection growth.

## Why

Without explicit pool configuration, Go's `database/sql` defaults to unlimited open connections and only 2 idle connections, which can exhaust database connections under load.

## Test plan

- `go build ./...` passes
- `go test -race ./...` passes
- `go vet ./...` passes