### PR TITLE
fix(server): log swallowed tracker and device store errors

### DIFF
--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -106,7 +106,9 @@ func (r *Relay) handleCall(from string, msg *Message) {
 			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}
-		_ = r.Tracker.OnCallInitiated(from, msg.To)
+		if err := r.Tracker.OnCallInitiated(from, msg.To); err != nil {
+			slog.Error("failed to track call initiation", "err", err)
+		}
 	}
 
 	_ = r.Hub.SendTo(msg.To, &Message{
@@ -126,7 +128,9 @@ func (r *Relay) handleICERestart(from string, msg *Message) {
 
 func (r *Relay) handleAnswer(from string, msg *Message) {
 	if r.Tracker != nil {
-		_ = r.Tracker.OnCallAnswered(msg.To, from)
+		if err := r.Tracker.OnCallAnswered(msg.To, from); err != nil {
+			slog.Error("failed to track call answer", "err", err)
+		}
 	}
 	r.forward(msg)
 }
@@ -139,7 +143,9 @@ func (r *Relay) handleHangup(from string, msg *Message) {
 		}
 	}
 	if r.Tracker != nil {
-		_ = r.Tracker.OnCallEnded(from, msg.To)
+		if err := r.Tracker.OnCallEnded(from, msg.To); err != nil {
+			slog.Error("failed to track call end", "err", err)
+		}
 	}
 	r.forward(msg)
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -604,7 +604,11 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 
 	var devices []device.Device
 	if h.deviceStore != nil {
-		devices, _ = h.deviceStore.ListByLine(ln.ID)
+		var err error
+		devices, err = h.deviceStore.ListByLine(ln.ID)
+		if err != nil {
+			slog.Error("failed to list devices by line", "err", err, "line_id", ln.ID)
+		}
 	}
 
 	var lastSeenAt *time.Time


### PR DESCRIPTION
## Summary
- Replace `_ =` error discards with `slog.Error` logging in `relay.go` for `OnCallInitiated`, `OnCallAnswered`, and `OnCallEnded` tracker calls
- Replace `_ =` error discard with `slog.Error` logging in `handler.go` for `ListByLine` device store call
- No behavioral changes -- errors are logged but do not alter control flow

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes