### PR TITLE
fix(server): move device last-seen tracking to in-memory Hub

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -14,6 +14,7 @@ type Conn struct {
 	Number     string
 	HardwareID string
 	Send       chan []byte
+	LastSeen   time.Time
 
 	// Device info (reported on connect via device_info message)
 	PiVersion       string
@@ -198,6 +199,30 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string, 
 	conn.FirmwareCommit = fwCommit
 	conn.FlashCapable = flashCapable
 	return true
+}
+
+// TouchLastSeen updates the in-memory last-seen timestamp for a connected phone.
+func (h *Hub) TouchLastSeen(number string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if conn, ok := h.conns[number]; ok {
+		conn.LastSeen = time.Now()
+	}
+}
+
+// LastSeenAt returns the last-seen timestamp for a connected phone, or nil if offline.
+func (h *Hub) LastSeenAt(number string) *time.Time {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	conn, ok := h.conns[number]
+	if !ok {
+		return nil
+	}
+	if conn.LastSeen.IsZero() {
+		return nil
+	}
+	t := conn.LastSeen
+	return &t
 }
 
 func (h *Hub) OnlineNumbers() []string {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1389,10 +1389,12 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	conn := &signaling.Conn{
 		WS:         ws,
+	conn := &signaling.Conn{
+		WS:         ws,
 		HardwareID: msg.HardwareID,
 		Send:       make(chan []byte, 32),
+		LastSeen:   time.Now(),
 	}
-	conn.LastSeen = time.Now()
 	h.hub.Register(msg.Number, conn)
 	number := msg.Number
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -75,6 +76,9 @@ type Handler struct {
 	pairingLimiter *ratelimit.Limiter
 	// Updates
 	Releases *updates.GitHubReleases
+	// Last-seen throttle
+	lastSeenMu    sync.Mutex
+	lastSeenTimes map[string]time.Time
 }
 
 type HandlerConfig struct {
@@ -155,7 +159,21 @@ func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling
 		adminSecret:     adminSecret,
 		authLimiter:     ratelimit.New(5, time.Minute),
 		pairingLimiter:  ratelimit.New(5, time.Minute),
+		lastSeenTimes:   make(map[string]time.Time),
 	}, nil
+}
+
+const lastSeenThrottle = 5 * time.Minute
+
+func (h *Handler) shouldUpdateLastSeen(hardwareID string) bool {
+	h.lastSeenMu.Lock()
+	defer h.lastSeenMu.Unlock()
+	now := time.Now()
+	if last, ok := h.lastSeenTimes[hardwareID]; ok && now.Sub(last) < lastSeenThrottle {
+		return false
+	}
+	h.lastSeenTimes[hardwareID] = now
+	return true
 }
 
 // Hub returns the signaling hub (used in tests).
@@ -1398,7 +1416,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
 	ws.SetPongHandler(func(string) error {
 		_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
-		if msg.HardwareID != "" && h.deviceStore != nil {
+		if msg.HardwareID != "" && h.deviceStore != nil && h.shouldUpdateLastSeen(msg.HardwareID) {
 			if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
 				slog.Warn("touch last seen on pong failed", "hardware_id", msg.HardwareID, "err", err)
 			}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -76,9 +75,6 @@ type Handler struct {
 	pairingLimiter *ratelimit.Limiter
 	// Updates
 	Releases *updates.GitHubReleases
-	// Last-seen throttle
-	lastSeenMu    sync.Mutex
-	lastSeenTimes map[string]time.Time
 }
 
 type HandlerConfig struct {
@@ -159,21 +155,7 @@ func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling
 		adminSecret:     adminSecret,
 		authLimiter:     ratelimit.New(5, time.Minute),
 		pairingLimiter:  ratelimit.New(5, time.Minute),
-		lastSeenTimes:   make(map[string]time.Time),
 	}, nil
-}
-
-const lastSeenThrottle = 5 * time.Minute
-
-func (h *Handler) shouldUpdateLastSeen(hardwareID string) bool {
-	h.lastSeenMu.Lock()
-	defer h.lastSeenMu.Unlock()
-	now := time.Now()
-	if last, ok := h.lastSeenTimes[hardwareID]; ok && now.Sub(last) < lastSeenThrottle {
-		return false
-	}
-	h.lastSeenTimes[hardwareID] = now
-	return true
 }
 
 // Hub returns the signaling hub (used in tests).
@@ -625,10 +607,16 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		devices, _ = h.deviceStore.ListByLine(ln.ID)
 	}
 
+	// For online devices, use the real-time in-memory timestamp from the Hub.
+	// For offline devices, fall back to the last disconnect time from the DB.
 	var lastSeenAt *time.Time
-	for _, d := range devices {
-		if d.LastSeenAt != nil && (lastSeenAt == nil || d.LastSeenAt.After(*lastSeenAt)) {
-			lastSeenAt = d.LastSeenAt
+	if online {
+		lastSeenAt = h.hub.LastSeenAt(number)
+	} else {
+		for _, d := range devices {
+			if d.LastSeenAt != nil && (lastSeenAt == nil || d.LastSeenAt.After(*lastSeenAt)) {
+				lastSeenAt = d.LastSeenAt
+			}
 		}
 	}
 
@@ -1404,23 +1392,15 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		HardwareID: msg.HardwareID,
 		Send:       make(chan []byte, 32),
 	}
+	conn.LastSeen = time.Now()
 	h.hub.Register(msg.Number, conn)
 	number := msg.Number
-	if msg.HardwareID != "" && h.deviceStore != nil {
-		if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
-			slog.Warn("touch last seen on connect failed", "hardware_id", msg.HardwareID, "err", err)
-		}
-	}
 
 	// Configure pong handler to extend read deadline on each pong
 	_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
 	ws.SetPongHandler(func(string) error {
 		_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
-		if msg.HardwareID != "" && h.deviceStore != nil && h.shouldUpdateLastSeen(msg.HardwareID) {
-			if err := h.deviceStore.TouchLastSeen(msg.HardwareID); err != nil {
-				slog.Warn("touch last seen on pong failed", "hardware_id", msg.HardwareID, "err", err)
-			}
-		}
+		h.hub.TouchLastSeen(number)
 		return nil
 	})
 


### PR DESCRIPTION
## Summary
- Track device last-seen timestamps in memory on the Hub's `Conn` struct, updated on every WebSocket pong with zero DB cost
- Phone detail page reads the real-time in-memory timestamp for online devices, falls back to the DB `last_seen_at` column for offline devices
- Write `last_seen_at` to Postgres only once on disconnect, so offline devices still show a meaningful timestamp
- Remove all periodic DB writes from the pong handler (previously wrote every ~30s per device)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [ ] Verify online devices show a recent "last seen" timestamp on phone detail page
- [ ] Verify offline devices show last disconnect time
- [ ] Confirm no `TouchLastSeen` DB writes during normal WebSocket operation (only on disconnect)