### PR TITLE
fix(server): batch line queries on family page to fix N+1

### DIFF
--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/justinlindh/digits/server/internal/db"
 )
 
@@ -153,6 +155,33 @@ func (s *Store) ListByHousehold(householdID string) ([]Line, error) {
 		lines = append(lines, l)
 	}
 	return lines, rows.Err()
+}
+
+// ListByHouseholds returns all lines for the given household IDs, grouped by
+// household ID and ordered by number within each group.
+func (s *Store) ListByHouseholds(householdIDs []string) (map[string][]Line, error) {
+	if len(householdIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := s.db.Query(
+		`SELECT id, number, name, household_id, created_at, updated_at
+		 FROM lines WHERE household_id = ANY($1) ORDER BY number`,
+		pq.Array(householdIDs),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list lines by households: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string][]Line, len(householdIDs))
+	for rows.Next() {
+		var l Line
+		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan line: %w", err)
+		}
+		result[l.HouseholdID] = append(result[l.HouseholdID], l)
+	}
+	return result, rows.Err()
 }
 
 // Update modifies the number and name of the line with the given ID.

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1042,26 +1042,32 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Error("get linked households failed", "err", err)
 	}
+
+	// Collect linked household IDs for a single batched line query
+	otherIDs := make([]string, 0, len(activeLinks))
 	for _, l := range activeLinks {
 		otherID := l.HouseholdAID
 		if otherID == myHousehold.ID && l.HouseholdBID != nil {
 			otherID = *l.HouseholdBID
 		}
+		otherIDs = append(otherIDs, otherID)
+	}
+	linesByHousehold, err := h.lineStore.ListByHouseholds(otherIDs)
+	if err != nil {
+		slog.Error("batch list lines for linked households failed", "err", err)
+	}
+
+	for i, l := range activeLinks {
+		otherID := otherIDs[i]
 		otherName := otherID
 		if other, err := h.householdStore.GetByID(otherID); err == nil {
 			otherName = other.Name
 		}
 
-		// Look up the other household's lines
-		otherLines, err := h.lineStore.ListByHousehold(otherID)
-		if err != nil {
-			slog.Error("list lines for linked household failed", "household_id", otherID, "err", err)
-		}
-
 		data.LinkedFamilies = append(data.LinkedFamilies, linkedFamilyRow{
 			ID:         l.ID,
 			Name:       otherName,
-			Lines:      otherLines,
+			Lines:      linesByHousehold[otherID],
 			Status:     l.Status,
 			AcceptedAt: l.AcceptedAt,
 		})


### PR DESCRIPTION
## What

Replace per-household `ListByHousehold` calls in the links/family page handler with a single `ListByHouseholds` batch query.

## Why

The family page had an N+1 query problem: for each linked household, it issued a separate `SELECT` to fetch lines. With many links this creates unnecessary database round-trips.

## Test plan

- `go build ./...` passes
- `go test -race ./...` passes (all packages)
- `go vet ./...` passes