### PR TITLE
chore: bump digits-setup Go version and remove emoji from firmware log

### DIFF
--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -290,7 +290,7 @@ void phone_fsm_update(void) {
             char key_msg[8];
             snprintf(key_msg, sizeof(key_msg), "KEY:%c", key);
             uart_proto_send(key_msg);
-            printf("🔢 RAW %s\n", key_msg);
+            printf("[KEY] RAW %s\n", key_msg);
             stdio_flush();
         }
         led_update();

--- a/pi/digits-setup/go.mod
+++ b/pi/digits-setup/go.mod
@@ -1,3 +1,3 @@
 module github.com/justinlindh/digits/pi/digits-setup
 
-go 1.22
+go 1.26


### PR DESCRIPTION
## Summary
- Bump `pi/digits-setup/go.mod` from Go 1.22 to 1.26 (matches digitsd and digits-recovery)
- Replace emoji `printf` in firmware keytest mode with ASCII `[KEY]` prefix

## Context
Full audit of remaining directories (firmware/, scripts/, docs/, tools/, pi/digitsd/, pi/digits-setup/, pi/digits-recovery/, root configs). Everything else is clean and current. These were the only two items found.

## Test plan
- [x] `go build ./...` passes in pi/digits-setup
- [x] Firmware change is a printf format string only (no logic change)