### PR TITLE
feat(server): real-time line number availability check during pairing

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -220,6 +220,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /links/{id}/revoke", h.handleLinksRevokePost)
 	protected.HandleFunc("GET /api/status", h.handleAPIStatus)
 	protected.HandleFunc("GET /api/active-calls", h.handleAPIActiveCalls)
+	protected.HandleFunc("GET /api/lines/number-available", h.handleAPINumberAvailable)
 
 	// Onboarding gate: redirect users without a household to /onboard
 	// Only active when householdStore is set (nil means feature disabled)
@@ -1301,6 +1302,22 @@ func (h *Handler) handleAPIActiveCalls(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(pairs); err != nil {
 		slog.Error("active calls: json encode failed", "err", err)
 	}
+}
+
+func (h *Handler) handleAPINumberAvailable(w http.ResponseWriter, r *http.Request) {
+	number := line.StripNumber(r.URL.Query().Get("number"))
+	if err := line.ValidateNumber(number); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	exists, err := h.lineStore.NumberExists(number)
+	if err != nil {
+		slog.Error("number available check failed", "err", err)
+		jsonError(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"available": !exists}) //nolint:errcheck
 }
 
 // ---- WebSocket ----

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -37,6 +37,7 @@
                  maxlength="8"
                  required
                  class="w-full bg-[#0d1117] border border-[#21262d] rounded px-3 py-2 text-sm text-[#e6edf3] placeholder-[#484f58] font-mono focus:outline-none focus:border-[#58a6ff] focus:ring-1 focus:ring-[#58a6ff]">
+          <p id="number-hint" class="hidden mt-1 text-xs text-[#f85149]">Line number is already in use</p>
         </div>
         <div>
           <label class="block text-xs text-[#8b949e] mb-1.5">Line Name</label>
@@ -49,22 +50,78 @@
       </div>
       <div class="mt-4">
         <button type="submit"
-                class="w-full md:w-auto px-4 py-2 bg-[#238636] hover:bg-[#2ea043] text-white text-sm rounded transition-colors">
+                id="pair-submit"
+                disabled
+                class="w-full md:w-auto px-4 py-2 text-white text-sm rounded transition-colors bg-[#238636] hover:bg-[#2ea043] disabled:bg-[#21262d] disabled:text-[#484f58] disabled:cursor-not-allowed">
           Pair
         </button>
       </div>
     </form>
     <script>
     (function() {
-      var input = document.getElementById('line-number-input');
-      input.addEventListener('input', function() {
+      var numberInput = document.getElementById('line-number-input');
+      var numberHint = document.getElementById('number-hint');
+      var codeInput = document.querySelector('input[name="code"]');
+      var nameInput = document.querySelector('input[name="name"]');
+      var submitBtn = document.getElementById('pair-submit');
+      var checkTimer = null;
+
+      function setNumberError() {
+        numberInput.setCustomValidity('Line number is already in use');
+        numberInput.classList.add('border-[#f85149]');
+        numberHint.classList.remove('hidden');
+      }
+
+      function clearNumberError() {
+        numberInput.setCustomValidity('');
+        numberInput.classList.remove('border-[#f85149]');
+        numberHint.classList.add('hidden');
+      }
+
+      function updateSubmit() {
+        var codeDigits = codeInput.value.replace(/\D/g, '');
+        var numDigits = numberInput.value.replace(/\D/g, '');
+        var hasName = nameInput.value.trim().length > 0;
+        submitBtn.disabled = codeDigits.length !== 6 || numDigits.length !== 7 || !hasName || numberInput.validity.customError;
+      }
+
+      function checkNumber() {
+        var digits = numberInput.value.replace(/\D/g, '');
+        if (digits.length !== 7) {
+          clearNumberError();
+          updateSubmit();
+          return;
+        }
+        fetch('/api/lines/number-available?number=' + digits, {credentials: 'same-origin'})
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (numberInput.value.replace(/\D/g, '') !== digits) return;
+            if (data.available) { clearNumberError(); } else { setNumberError(); }
+            updateSubmit();
+          })
+          .catch(function() {
+            clearNumberError();
+            updateSubmit();
+          });
+      }
+
+      numberInput.addEventListener('input', function() {
         var digits = this.value.replace(/\D/g, '').slice(0, 7);
         if (digits.length > 3) {
           this.value = digits.slice(0, 3) + '-' + digits.slice(3);
         } else {
           this.value = digits;
         }
+        clearNumberError();
+        updateSubmit();
+        clearTimeout(checkTimer);
+        if (digits.length === 7) {
+          checkTimer = setTimeout(checkNumber, 300);
+        }
       });
+
+      codeInput.addEventListener('input', updateSubmit);
+      nameInput.addEventListener('input', updateSubmit);
     })();
     </script>
     {{if .PairError}}


### PR DESCRIPTION
## What

Adds interactive validation to the pairing form that checks line number availability in real-time as the user types, and disables the Pair button until all fields are valid.

## Why

Previously, the only feedback for a duplicate line number was a server-side error after submitting the form, which cleared all input. This provides immediate inline feedback instead.

## Test plan

- Deployed to production and verified:
  - Typing an existing line number shows red border + "Line number is already in use" hint below the field
  - Pair button stays disabled until pairing code (6 digits), line number (7 digits, not taken), and name are all populated
  - Changing a taken number clears the error state immediately
  - Typing a new/available number shows no error and enables the button
  - Server-side validation still works as a fallback