### PR TITLE
docs(pi): add READMEs for digitsd, digits-setup, and digits-recovery

### DIFF
--- a/pi/digits-recovery/README.md
+++ b/pi/digits-recovery/README.md
@@ -1,0 +1,33 @@
+# digits-recovery
+
+Minimal recovery server that runs when the phone fails to boot. Provides factory reset and "try again" options via a web UI.
+
+## When it runs
+
+Recovery mode activates in two situations:
+
+- **Boot failure:** The initramfs tracks a boot counter on the data partition. If it reaches 3 consecutive failed boots, recovery starts automatically.
+- **Factory reset:** When triggered from the web UI or by dialing `*#00000#`, digitsd sets the counter to the threshold and reboots into recovery.
+
+See [docs/architecture/updates-and-recovery.md](../../docs/architecture/updates-and-recovery.md) for the full design.
+
+## What it does
+
+1. Starts a WiFi AP (SSID: `Digits-Recovery`) at `192.168.4.1`
+2. Serves a web UI with two options:
+   - **Try Again** -- clears the boot counter and reboots normally
+   - **Factory Reset** -- restores rootfs from the recovery partition's compressed image, formats the data partition, restores the skeleton directory structure, and reboots into first-boot setup
+
+## Key design constraint
+
+The recovery binary runs from the recovery partition (p3), not from the main rootfs (p2). It uses statically linked tools (`zstd`, `dd`, `mkfs.ext4`, `hostapd`, `dnsmasq`) bundled on the recovery partition, because the rootfs may be overwritten during factory reset.
+
+## Build
+
+```bash
+make build       # cross-compile to linux/arm64
+make build-local # native build
+make test
+```
+
+Pure Go, no CGO dependencies.

--- a/pi/digits-setup/README.md
+++ b/pi/digits-setup/README.md
@@ -1,0 +1,44 @@
+# digits-setup
+
+Captive portal for first-boot WiFi configuration. Runs on the Pi when the phone has no saved WiFi credentials.
+
+## How it works
+
+On first boot (or after a factory reset), `digits-ap-check` detects that no WiFi config exists on the data partition. It starts the phone in AP mode:
+
+1. **hostapd** broadcasts a WiFi network (SSID: `Digits-XXXX`)
+2. **dnsmasq** serves DHCP and redirects all DNS to `192.168.4.1`
+3. **digits-setup** serves a captive portal on port 80
+
+The user connects to the Digits WiFi network from their phone or laptop, gets redirected to the portal, selects their home WiFi network, and enters the password. `digits-setup` writes a NetworkManager connection file to `/data/wifi/`, then reboots. On the next boot, `digits-ap-check` finds the saved config and connects normally.
+
+## Boot sequence
+
+```
+digits-first-boot.service  (generates hostname, SSH keys, device UUID)
+        |
+digits-ap-check.service    (no WiFi config? start AP mode)
+        |
+digits-ap.service          (hostapd)
+        |
+digits-dnsmasq-ap.service  (DHCP + captive portal DNS)
+        |
+digits-setup.service       (this binary, serves the portal on :80)
+```
+
+## Build
+
+```bash
+make build       # cross-compile to linux/arm64
+make build-local # native build
+make test
+```
+
+Pure Go, no CGO dependencies.
+
+## Packages
+
+| Package | Purpose |
+|---------|---------|
+| `portal` | HTTP handler, embedded static UI |
+| `wifi` | WiFi network scanning (`iw`) and NetworkManager config writing |

--- a/pi/digitsd/README.md
+++ b/pi/digitsd/README.md
@@ -1,0 +1,84 @@
+# digitsd
+
+The Pi-side daemon that runs on each Digits phone. Manages the hardware (audio codec, keypad, ringer, hook switch) via UART to the Pico, connects to the signaling server over WebSocket, and handles WebRTC calls.
+
+## Architecture
+
+```
+                       signaling server (WebSocket)
+                              |
+                         signal.Client
+                              |
+    phone.Controller  <-->  main loop  <-->  webrtc.PeerManager
+         |                                        |
+    phone.SerialPort                         audio.Pipeline
+    (UART to Pico)                           (Opus + ALSA)
+```
+
+### Internal packages
+
+| Package | Purpose |
+|---------|---------|
+| `audio` | ALSA capture/playback, RNNoise denoising, mixer control |
+| `bootcount` | Tracks consecutive boot failures for recovery triggering |
+| `codec` | Opus encoder/decoder wrappers |
+| `config` | JSON config file at `/data/digits/config.json` |
+| `contacts` | Phone directory from linked households |
+| `phone` | FSM controller, UART serial protocol, service codes |
+| `signal` | WebSocket client to signaling server |
+| `updater` | OTA binary updates from GitHub releases |
+| `version` | Build version/commit injection via ldflags |
+| `watchdog` | Hardware watchdog keepalive (`/dev/watchdog0`) |
+| `webrtc` | Pion WebRTC peer connection lifecycle |
+| `assets` | Embedded rootfs overlay and tone files (see below) |
+
+## Build
+
+Requires CGO for ALSA and Opus bindings. Cross-compiled to `linux/arm64` for the Pi Zero 2 W.
+
+```bash
+# Docker cross-compile (recommended, no host toolchain needed)
+make build
+
+# Local cross-compile (requires aarch64-linux-gnu-gcc, libopus-dev, libasound2-dev)
+make build-local
+
+# Run tests (host architecture, some audio tests skip without ALSA)
+make test
+```
+
+The build embeds assets from `pi/image/rootfs-overlay/` and `pi/tones/` into the binary via `make embed`. The `build` target runs this automatically.
+
+## Embedded assets
+
+`make embed` copies rootfs overlay files (systemd services, hostapd config, SWD config, boot scripts) and tone WAVs into `internal/assets/embed/`. These are compiled into the binary with `//go:embed` so digitsd can deploy them to the filesystem for OTA updates and factory resets.
+
+Some overlay files are excluded from embedding (boot fragments, sudoers) because they're only needed at image build time, not runtime.
+
+## Runtime
+
+Started by `digitsd.service` on the Pi. Key flags:
+
+```
+digitsd \
+  -config /data/digits/config.json \
+  -serial /dev/serial0 \
+  -tones /data/digits/tones \
+  -socket /data/digits/uart.sock
+```
+
+Requires supplementary groups: `dialout` (serial), `audio` (ALSA), `gpio`, `i2c`, `spi`.
+
+## Debug utilities
+
+The `cmd/` directory contains additional binaries for hardware debugging and latency profiling. These are not built by default and are not deployed to devices.
+
+| Binary | Purpose |
+|--------|---------|
+| `alsatest` | 440 Hz ALSA playback test |
+| `clocksync` | One-way clock offset measurement between hosts |
+| `dmixlat` | ALSA output latency via `snd_pcm_delay()` |
+| `latbench` | End-to-end Opus encode/decode/playback latency |
+| `latclient` | WebRTC call latency measurement |
+| `memprofile` | WebRTC peer connection memory profiling |
+| `pipetest` | Opus pipeline throughput test |


### PR DESCRIPTION
## Summary
Add READMEs to the three Go binaries under `pi/`:

- **`pi/digitsd/README.md`** -- Architecture diagram, internal package table, build instructions, embedded assets explanation, runtime flags, debug utility inventory
- **`pi/digits-setup/README.md`** -- Captive portal purpose, boot sequence diagram, how WiFi provisioning works
- **`pi/digits-recovery/README.md`** -- When recovery activates, what it does (try again vs factory reset), design constraint about running from recovery partition

## Context
Audit found these were the only `pi/` subdirectories needing documentation. The others are either too small (swd: 2 files), pure assets (tones: WAV files), or already documented elsewhere (image: `tools/README-image-builder.md`). `pi/rnnoise/` already has a good README.

## Test plan
- [x] READMEs accurately reflect current code, build targets, and boot sequences
- [x] Cross-references (e.g., link to updates-and-recovery.md) are valid