### PR TITLE
fix(pi): use card name instead of index in digits-mixer.service

### DIFF
--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-mixer.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-mixer.service
@@ -6,7 +6,7 @@ Before=digitsd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/sbin/alsactl restore 0 -f /data/digits_mixer.state
+ExecStart=/usr/sbin/alsactl restore Zero -f /data/digits_mixer.state
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- `digits-mixer.service` was running `alsactl restore 0`, targeting card 0 (HDMI) instead of the Codec Zero on card 1
- The state file is keyed to `state.Zero`, so restoring by numeric index fails (exit 99) and leaves all mixer routing switches off -- no headset audio
- Changed to `alsactl restore Zero` to match by card name, stable regardless of enumeration order

## Test plan
- [x] Verified fix on Digits 2: service succeeds, headphone output confirmed working
- [ ] Flash a fresh image and confirm `digits-mixer.service` succeeds on first boot