### PR TITLE
fix(pi): wait for Codec Zero before restoring mixer state

### DIFF
--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-mixer.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-mixer.service
@@ -6,6 +6,7 @@ Before=digitsd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=/bin/sh -c 'for i in 1 2 3 4 5 6 7 8 9 10; do [ -d /proc/asound/Zero ] && exit 0; sleep 1; done; exit 1'
 ExecStart=/usr/sbin/alsactl restore Zero -f /data/digits_mixer.state
 
 [Install]


### PR DESCRIPTION
## Summary
- Follows up on #142 -- `alsactl restore Zero` now targets the right card, but fails on boot because `sound.target` fires before the DA7213 driver finishes initializing (exit code 19)
- Adds `ExecStartPre` that polls for `/proc/asound/Zero` up to 10 seconds before attempting restore
- Verified on both Digits 1 and Digits 2: service succeeds on cold boot, all mixer routing switches are correctly set

## Test plan
- [x] Deployed to Digits 1, rebooted, service starts successfully
- [x] Confirmed headphone audio output works after reboot
- [ ] Flash a fresh image and confirm first-boot behavior