### PR TITLE
feat(image): add auto-detect flash and one-step image-flash target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ flash: ## Flash the most recent image to SD card (auto-detects or SD=/dev/sdX)
 	if [ -n "$(SD)" ]; then \
 		SD_DEV="$(SD)"; \
 	else \
-		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN | awk '/usb/ && /[0-9]+\.?[0-9]*G/ { dev="/dev/"$$1; size=$$2+0; if (size >= 4 && size <= 64) print dev }' | head -1); \
+		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN,SUBSYSTEMS | awk '/(usb|mmc)/ && /[0-9]+\.?[0-9]*G/ { dev="/dev/"$$1; size=$$2+0; if (size >= 4 && size <= 64) print dev }' | head -1); \
 		if [ -z "$$SD_DEV" ]; then echo "No SD card detected. Specify manually: make flash SD=/dev/sdX"; exit 1; fi; \
 	fi; \
 	echo "Flashing $$IMAGE -> $$SD_DEV"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help server server-test pi-build pi-test firmware image image-dev flash clean
+.PHONY: help server server-test pi-build pi-test firmware image image-dev flash image-flash clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -35,15 +35,25 @@ image: ## Build flashable Pi SD card image (Docker)
 image-dev: ## Build Pi image with SSH enabled (Docker)
 	./pi/image/build-docker.sh --dev
 
-flash: ## Flash the most recent image to SD card (SD=<device>, e.g. make flash SD=/dev/sdd)
-	@if [ -z "$(SD)" ]; then echo "Usage: make flash SD=/dev/sdX"; exit 1; fi
+flash: ## Flash the most recent image to SD card (auto-detects or SD=/dev/sdX)
 	@IMAGE=$$(ls -t digits-pi-*.img.gz 2>/dev/null | head -1); \
 	if [ -z "$$IMAGE" ]; then echo "No image found -- run 'make image-dev' first"; exit 1; fi; \
-	echo "Flashing $$IMAGE → $(SD)"; \
-	echo "WARNING: This will overwrite all data on $(SD). Press Ctrl-C to cancel."; \
+	if [ -n "$(SD)" ]; then \
+		SD_DEV="$(SD)"; \
+	else \
+		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN | awk '/usb/ && /[0-9]+\.?[0-9]*G/ { dev="/dev/"$$1; size=$$2+0; if (size >= 4 && size <= 64) print dev }' | head -1); \
+		if [ -z "$$SD_DEV" ]; then echo "No SD card detected. Specify manually: make flash SD=/dev/sdX"; exit 1; fi; \
+	fi; \
+	echo "Flashing $$IMAGE -> $$SD_DEV"; \
+	lsblk "$$SD_DEV"; \
+	echo "WARNING: This will overwrite all data on $$SD_DEV."; \
 	read -r -p "Continue? [y/N] " ans; \
 	if [ "$$ans" != "y" ] && [ "$$ans" != "Y" ]; then echo "Aborted."; exit 1; fi; \
-	gunzip -c "$$IMAGE" | sudo dd of=$(SD) bs=4M status=progress conv=fsync
+	sudo umount "$$SD_DEV"* 2>/dev/null || true; \
+	gunzip -c "$$IMAGE" | sudo dd of="$$SD_DEV" bs=4M status=progress conv=fsync && \
+	sync && echo "Flash complete. Safe to remove SD card."
+
+image-flash: image-dev flash ## Build dev image and flash in one step
 
 # ── Utilities ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `make flash` now auto-detects the SD card (USB disk 4-64GB) instead of requiring `SD=/dev/sdX`. Shows `lsblk` output and confirms before writing. Still accepts `SD=` override.
- `make image-flash` builds the dev image and flashes in one step.

## Test plan
- [ ] `make flash` with SD card inserted (auto-detect)
- [ ] `make flash SD=/dev/sdX` (manual override)
- [ ] `make image-flash` end-to-end