### PR TITLE
fix(pi): fix SWD flash reset and include firmware in image build

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -819,7 +819,10 @@ func main() {
 				cmd := exec.Command("sudo", openocd,
 					"-f", swdCfg,
 					"-f", "target/rp2040.cfg",
-					"-c", fmt.Sprintf("program %s verify reset exit", elfPath))
+					"-c", "rp2040.core0 configure -event reset-init {}",
+					"-c", fmt.Sprintf("program %s verify", elfPath),
+					"-c", "reset run",
+					"-c", "exit")
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				if err := cmd.Run(); err != nil {

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -100,6 +100,28 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
 
 info "Binaries ready in tools/build/"
 
+# Download latest firmware ELF from GitHub releases
+info "Downloading latest Pico firmware from GitHub releases..."
+FW_API_URL="https://api.github.com/repos/justinlindh/digits/releases"
+FW_TAG=$(curl -sf "$FW_API_URL" | python3 -c "
+import json, sys
+for r in json.load(sys.stdin):
+    if r['tag_name'].startswith('fw/'):
+        print(r['tag_name']); break
+" 2>/dev/null || true)
+if [[ -n "$FW_TAG" ]]; then
+    FW_VERSION="${FW_TAG#fw/}"
+    FW_DOWNLOAD_URL="https://github.com/justinlindh/digits/releases/download/${FW_TAG}/firmware-${FW_VERSION}.elf"
+    info "  Downloading firmware ${FW_VERSION}..."
+    if curl -sfL -o /digits/tools/build/firmware.elf "$FW_DOWNLOAD_URL"; then
+        info "  Firmware downloaded: tools/build/firmware.elf"
+    else
+        echo "WARN: Failed to download firmware from $FW_DOWNLOAD_URL -- image will not include firmware" >&2
+    fi
+else
+    echo "WARN: Could not determine latest firmware release tag -- image will not include firmware" >&2
+fi
+
 # Run the image builder in a working directory, then copy output back
 BUILD_WD="/build"
 mkdir -p "$BUILD_WD"

--- a/pi/swd/flash-pico.sh
+++ b/pi/swd/flash-pico.sh
@@ -43,7 +43,10 @@ echo "Flashing via SWD..."
 if ! sudo "$OPENOCD" \
     -f "$SWD_CFG" \
     -f target/rp2040.cfg \
-    -c "program $ELF verify reset exit"; then
+    -c "rp2040.core0 configure -event reset-init {}" \
+    -c "program $ELF verify" \
+    -c "reset run" \
+    -c "exit"; then
     echo "ERROR: OpenOCD flash failed" >&2
     echo "Restarting digitsd anyway..."
     sudo systemctl start digitsd.service

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -620,6 +620,18 @@ else
     warn "No tone WAV files found in $TONES_DIR — skipping"
 fi
 
+# ── step 14a: copy Pico firmware to /data (host-side) ────────────────────────
+
+FW_ELF="${BUILD_DIR}/firmware.elf"
+if [[ -f "$FW_ELF" ]]; then
+    info "Copying Pico firmware to /data/digits/firmware.elf..."
+    cp "$FW_ELF" "${DATA_MNT}/digits/firmware.elf"
+    chown 999:992 "${DATA_MNT}/digits/firmware.elf"
+    chmod 644 "${DATA_MNT}/digits/firmware.elf"
+else
+    warn "No firmware.elf found in tools/build/ -- Pico will need OTA flash after first boot"
+fi
+
 # ── step 14b: copy mixer state to /data (host-side) ─────────────────────────
 
 MIXER_STATE="${REPO_DIR}/pi/digits_mixer.state"


### PR DESCRIPTION
## What

Fixes the OpenOCD SWD flash command so the Pico reboots cleanly after flashing, and adds Pico firmware to the SD card image build so new devices can auto-flash on first boot.

## Why

The system `rp2040.cfg` reset-init handler calls `rp2xxx rom_api_call 0 CX` which isn't supported by our OpenOCD 0.12.0 build. This caused `program ... verify reset exit` to error and leave the Pico halted after flashing -- requiring a manual power cycle to boot the new firmware.

Fresh images also had no firmware.elf on the data partition, meaning the Pico couldn't be auto-flashed until digitsd connected to the server and downloaded it via OTA.

## Test plan

- [x] Flashed Pico via SWD on digits-e760 (192.168.2.140) with the new OpenOCD command sequence
- [x] Verified PONG response on UART immediately after flash (no power cycle needed)
- [x] Verified OpenOCD exits cleanly with no reset-init errors
- [ ] Build a test image and verify firmware.elf is present on the data partition