### PR TITLE
fix(image): raise mic gain and route Mic 1 to both Mixin sides

### DIFF
--- a/pi/digits_mixer.state
+++ b/pi/digits_mixer.state
@@ -46,8 +46,8 @@ state.Zero {
 	control.4 {
 		iface MIXER
 		name 'Mixin PGA Volume'
-		value.0 7
-		value.1 5
+		value.0 15
+		value.1 15
 		comment {
 			access 'read write'
 			type INTEGER
@@ -55,8 +55,8 @@ state.Zero {
 			range '0 - 15'
 			dbmin -450
 			dbmax 1800
-			dbvalue.0 600
-			dbvalue.1 300
+			dbvalue.0 1800
+			dbvalue.1 1800
 		}
 	}
 	control.5 {
@@ -978,7 +978,7 @@ state.Zero {
 	control.78 {
 		iface MIXER
 		name 'Mixin Right Mic 1 Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN


### PR DESCRIPTION
## Summary

- Mixin PGA was set to +6/+3 dB (asymmetric, well below the +18 dB max), and Mic 1 was only routed to Mixin Left. Capture is mono via `plughw` which averages L+R, so the silent right channel cost another ~6 dB on top of the undergained PGA.
- Bumps Mixin PGA to +18/+18 dB and enables `Mixin Right Mic 1` in `pi/digits_mixer.state`.
- `tools/build-image.sh` already copies this file to `/data/digits_mixer.state` on image build, so future flashes inherit the fix automatically.

## Measurements

Verified live on Digits 2 with the same loud music source before and after:

| Metric | Before | After | Delta |
|---|---|---|---|
| Peak | 0.120 (-18.4 dBFS) | 0.372 (-8.6 dBFS) | +9.8 dB |
| RMS | 0.0116 (-38.7 dBFS) | 0.0600 (-24.4 dBFS) | +14.3 dB |

Healthy headroom remains on peaks. Capture format is unchanged (mono, S16_LE, 48 kHz); no digitsd code changes required.

## Test plan

- [ ] Flash a fresh image and confirm `amixer -c Zero sget 'Mixin PGA'` reports +18/+18 dB after boot
- [ ] Confirm `amixer -c Zero sget 'Mixin Right Mic 1'` is on after boot
- [ ] Place a call and verify mic audio level sounds correct on the far end