### PR TITLE
fix(digitsd): retry Pico VERSION query after reboot

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1187,6 +1187,14 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
+	// Post-reboot firmware version results. STATUS:READY spawns a goroutine
+	// that retries QueryVersion (the Pico's UART command loop isn't quite
+	// awake yet at the instant it emits STATUS:READY). The goroutine sends
+	// the result here so the main loop can update fwVersion/fwCommit without
+	// any shared-state synchronization.
+	type fwVersionResult struct{ version, commit string }
+	fwVersionCh := make(chan fwVersionResult, 1)
+
 	// Main select loop
 	for {
 		select {
@@ -1259,30 +1267,30 @@ func main() {
 			// Pico rebooted (e.g. external flash, power cycle): re-query
 			// firmware version and report it to the server. The Pico emits
 			// STATUS:READY before its UART command loop is fully accepting
-			// commands, so retry a few times before giving up.
+			// commands, so retry a few times in a goroutine. Running this
+			// inline would block the event loop for up to ~15s during which
+			// HOOK/KEY events would queue up or be dropped.
 			if event == "STATUS:READY" {
 				slog.Info("pico: detected reboot, re-querying firmware version")
-				var (
-					v, c string
-					err  error
-				)
-				for attempt := 1; attempt <= 5; attempt++ {
-					v, c, err = sp.QueryVersion()
-					if err == nil {
-						break
+				go func() {
+					const attempts = 5
+					for attempt := 1; attempt <= attempts; attempt++ {
+						v, c, err := sp.QueryVersion()
+						if err == nil {
+							select {
+							case fwVersionCh <- fwVersionResult{version: v, commit: c}:
+							default:
+								slog.Warn("pico: version result channel full, dropping")
+							}
+							return
+						}
+						slog.Warn("pico: version query attempt failed", "attempt", attempt, "error", err)
+						if attempt < attempts {
+							time.Sleep(500 * time.Millisecond)
+						}
 					}
-					slog.Warn("pico: version query after reboot failed", "attempt", attempt, "error", err)
-					time.Sleep(500 * time.Millisecond)
-				}
-				if err != nil {
-					slog.Warn("pico: version query after reboot gave up", "error", err)
-				} else if v != fwVersion || c != fwCommit {
-					fwVersion, fwCommit = v, c
-					slog.Info("pico: firmware version changed", "version", fwVersion, "commit", fwCommit)
-					sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
-				} else {
-					slog.Info("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
-				}
+					slog.Warn("pico: version query after reboot gave up")
+				}()
 				continue
 			}
 
@@ -1295,6 +1303,15 @@ func main() {
 				easterEggs.Reset()
 				svcCodes.Reset()
 				svcCodes.Reset()
+			}
+
+		case r := <-fwVersionCh:
+			if r.version != fwVersion || r.commit != fwCommit {
+				fwVersion, fwCommit = r.version, r.commit
+				slog.Info("pico: firmware version changed", "version", fwVersion, "commit", fwCommit)
+				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+			} else {
+				slog.Info("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
 			}
 
 		case msg := <-sig.Inbox():

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1257,11 +1257,25 @@ func main() {
 			}
 
 			// Pico rebooted (e.g. external flash, power cycle): re-query
-			// firmware version and report it to the server.
+			// firmware version and report it to the server. The Pico emits
+			// STATUS:READY before its UART command loop is fully accepting
+			// commands, so retry a few times before giving up.
 			if event == "STATUS:READY" {
 				slog.Info("pico: detected reboot, re-querying firmware version")
-				if v, c, err := sp.QueryVersion(); err != nil {
-					slog.Warn("pico: version query after reboot failed", "error", err)
+				var (
+					v, c string
+					err  error
+				)
+				for attempt := 1; attempt <= 5; attempt++ {
+					v, c, err = sp.QueryVersion()
+					if err == nil {
+						break
+					}
+					slog.Warn("pico: version query after reboot failed", "attempt", attempt, "error", err)
+					time.Sleep(500 * time.Millisecond)
+				}
+				if err != nil {
+					slog.Warn("pico: version query after reboot gave up", "error", err)
 				} else if v != fwVersion || c != fwCommit {
 					fwVersion, fwCommit = v, c
 					slog.Info("pico: firmware version changed", "version", fwVersion, "commit", fwCommit)

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -69,7 +69,7 @@ func (sp *SerialPort) SendCommand(cmd string, timeout time.Duration) (string, er
 	case resp := <-ch:
 		return resp, nil
 	case <-time.After(timeout):
-		return "", nil
+		return "", fmt.Errorf("serial: timeout waiting for response to %q", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

After flashing the Pico over SWD, `digitsd` sees `STATUS:READY` and immediately queries `VERSION`, but the firmware's UART command loop is not yet accepting commands that early in boot. The query times out, the warning `pico: version query after reboot failed error="unexpected version response: \"\""` is logged, and the cached `fw_version` stays at the pre-flash value. The web UI then keeps showing the old firmware version even though the flash succeeded.

Retry the query up to 5 times with 500 ms backoff. A subsequent query outside this window reliably succeeds in practice.

Also makes `SerialPort.SendCommand` return an explicit timeout error instead of `("", nil)` on timeout, which was the source of the confusing `"unexpected version response: \"\""` log line (the caller couldn't distinguish "no reply" from "malformed reply").

Caught in the field on Digits 1 this afternoon: firmware was flashed to 1.2.0 twice via the web-UI update trigger, both flashes actually succeeded (verified by querying `VERSION` over the UART socket directly), but the daemon kept reporting 1.1.0.

## Test plan

- [x] `go build ./...` in `pi/digitsd/`
- [x] `go test ./...` in `pi/digitsd/`
- [x] `golangci-lint run ./...` in `pi/digitsd/`
- [ ] Deploy to Digits 1, trigger an update that re-flashes firmware, confirm web UI picks up the new version without a manual `systemctl restart digitsd`