### PR TITLE
fix(digitsd): content-hash marker for asset extraction

### DIFF
--- a/pi/digitsd/internal/assets/assets.go
+++ b/pi/digitsd/internal/assets/assets.go
@@ -1,11 +1,14 @@
 package assets
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -31,13 +34,19 @@ type Extractor struct {
 }
 
 func (e *Extractor) Extract(currentVersion string) error {
+	contentHash, err := e.hashEmbeddedFS()
+	if err != nil {
+		return fmt.Errorf("hash embedded fs: %w", err)
+	}
+	want := currentVersion + ":" + contentHash
+
 	marker, err := os.ReadFile(e.MarkerPath)
-	if err == nil && strings.TrimSpace(string(marker)) == currentVersion {
-		log.Printf("assets: version %s matches, skipping extraction", currentVersion)
+	if err == nil && strings.TrimSpace(string(marker)) == want {
+		log.Printf("assets: marker matches (version=%s hash=%s), skipping extraction", currentVersion, contentHash[:12])
 		return nil
 	}
 
-	log.Printf("assets: extracting assets for version %s", currentVersion)
+	log.Printf("assets: extracting assets for version %s (hash=%s)", currentVersion, contentHash[:12])
 
 	rootfsFiles, err := e.collectFiles("rootfs")
 	if err != nil {
@@ -79,13 +88,56 @@ func (e *Extractor) Extract(currentVersion string) error {
 	if err := os.MkdirAll(filepath.Dir(e.MarkerPath), 0755); err != nil {
 		return fmt.Errorf("create marker dir: %w", err)
 	}
-	if err := os.WriteFile(e.MarkerPath, []byte(currentVersion), 0644); err != nil {
+	if err := os.WriteFile(e.MarkerPath, []byte(want), 0644); err != nil {
 		return fmt.Errorf("write marker: %w", err)
 	}
 
-	log.Printf("assets: extracted %d rootfs + %d data files for version %s",
-		len(rootfsFiles), len(dataFiles), currentVersion)
+	log.Printf("assets: extracted %d rootfs + %d data files for version %s (hash=%s)",
+		len(rootfsFiles), len(dataFiles), currentVersion, contentHash[:12])
 	return nil
+}
+
+// hashEmbeddedFS computes a deterministic SHA-256 over every file in the
+// embedded FS. The marker file stores this hash alongside the version string
+// so that re-extraction happens whenever embedded content changes, even if
+// the human-chosen version string is unchanged (e.g. a hotfix rebuilt under
+// the same version tag).
+func (e *Extractor) hashEmbeddedFS() (string, error) {
+	var entries []struct {
+		path string
+		data []byte
+	}
+	for _, prefix := range []string{"rootfs", "data"} {
+		err := fs.WalkDir(e.FS, prefix, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			data, rerr := fs.ReadFile(e.FS, path)
+			if rerr != nil {
+				return rerr
+			}
+			entries = append(entries, struct {
+				path string
+				data []byte
+			}{path, data})
+			return nil
+		})
+		if err != nil && !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	h := sha256.New()
+	for _, f := range entries {
+		h.Write([]byte(f.path))
+		h.Write([]byte{0})
+		h.Write(f.data)
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 type embeddedFile struct {

--- a/pi/digitsd/internal/assets/assets_test.go
+++ b/pi/digitsd/internal/assets/assets_test.go
@@ -3,6 +3,7 @@ package assets
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -46,31 +47,85 @@ func TestExtract_WritesFilesOnFirstRun(t *testing.T) {
 	}
 
 	marker, _ := os.ReadFile(markerPath)
-	if string(marker) != "1.0.0" {
-		t.Errorf("marker = %q, want %q", marker, "1.0.0")
+	if !strings.HasPrefix(string(marker), "1.0.0:") {
+		t.Errorf("marker = %q, want prefix %q", marker, "1.0.0:")
 	}
 }
 
-func TestExtract_SkipsWhenVersionMatches(t *testing.T) {
+func TestExtract_SkipsWhenMarkerMatches(t *testing.T) {
 	root := t.TempDir()
 	dataDir := t.TempDir()
 	markerPath := filepath.Join(dataDir, "asset-version")
-	_ = os.WriteFile(markerPath, []byte("1.0.0"), 0644)
 
+	embedded := fstest.MapFS{
+		"rootfs/usr/local/bin/flash-pico.sh": &fstest.MapFile{Data: []byte("#!/bin/bash\necho v1")},
+	}
+
+	// First run: populates the marker with the current hash.
+	first := &Extractor{
+		FS:         embedded,
+		RootDir:    root,
+		DataDir:    dataDir,
+		MarkerPath: markerPath,
+		Remount:    func(rw bool) error { return nil },
+	}
+	if err := first.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract (first): %v", err)
+	}
+
+	// Second run with identical embedded content: should short-circuit.
 	remountCalled := false
-	e := &Extractor{
-		FS:         fstest.MapFS{},
+	second := &Extractor{
+		FS:         embedded,
 		RootDir:    root,
 		DataDir:    dataDir,
 		MarkerPath: markerPath,
 		Remount:    func(rw bool) error { remountCalled = true; return nil },
 	}
-
-	if err := e.Extract("1.0.0"); err != nil {
-		t.Fatalf("Extract: %v", err)
+	if err := second.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract (second): %v", err)
 	}
 	if remountCalled {
-		t.Error("remount should not be called when version matches")
+		t.Error("remount should not be called when marker matches")
+	}
+}
+
+// Regression: a rebuild under the same version string but with different
+// embedded content must re-extract. Before the content-hash marker, the
+// extractor skipped because the version string matched, leaving stale
+// files (e.g. an old digits-mixer.service) on disk forever.
+func TestExtract_ReExtractsWhenContentChangesUnderSameVersion(t *testing.T) {
+	root := t.TempDir()
+	dataDir := t.TempDir()
+	markerPath := filepath.Join(dataDir, "asset-version")
+	scriptPath := filepath.Join(root, "usr/local/bin/flash-pico.sh")
+
+	oldFS := fstest.MapFS{
+		"rootfs/usr/local/bin/flash-pico.sh": &fstest.MapFile{Data: []byte("old content")},
+	}
+	newFS := fstest.MapFS{
+		"rootfs/usr/local/bin/flash-pico.sh": &fstest.MapFile{Data: []byte("new content")},
+	}
+
+	old := &Extractor{FS: oldFS, RootDir: root, DataDir: dataDir, MarkerPath: markerPath, Remount: func(rw bool) error { return nil }}
+	if err := old.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract (old): %v", err)
+	}
+	if got, _ := os.ReadFile(scriptPath); string(got) != "old content" {
+		t.Fatalf("after old extract: got %q", got)
+	}
+
+	// Same version, different embedded content. Must re-extract.
+	fresh := &Extractor{FS: newFS, RootDir: root, DataDir: dataDir, MarkerPath: markerPath, Remount: func(rw bool) error { return nil }}
+	if err := fresh.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract (new): %v", err)
+	}
+	got, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("read after re-extract: %v", err)
+	}
+	if string(got) != "new content" {
+		t.Errorf("re-extract did not update file: got %q, want %q", got, "new content")
 	}
 }
 


### PR DESCRIPTION
## Summary

The asset extractor at \`pi/digitsd/internal/assets/assets.go:33\` gates re-extraction on \`version.Version\` alone. If a release is rebuilt or hotfixed under the same version tag, devices whose marker already matches that string skip extraction forever and keep stale files on disk.

Caught in the field on Digits 1 today:

- \`/data/digits/asset-version\` said \`1.8.3\`
- \`/etc/systemd/system/digits-mixer.service\` on disk was the **pre-#143** version (no \`ExecStartPre\` wait loop)
- The \`digitsd\` binary running on the device was also \`1.8.3\`, built from commit \`9110e7b\`, which is **after** PR #143 merged — so its embedded overlay had the fix
- On every boot, the extractor saw marker == version == \`1.8.3\`, logged \`assets: version 1.8.3 matches, skipping extraction\`, and left the broken unit file in place
- The broken unit then raced the \`da7213\` codec probe at boot. Whether audio worked was pure luck (whichever defaults the codec came up with before \`alsactl restore Zero\` failed with "Cannot find soundcard 'Zero'")

Compute a SHA-256 over the sorted embedded FS contents and include it in the marker as \`<version>:<hash>\`. Re-extract whenever the hash changes, regardless of version.

## Regression test

Adds \`TestExtract_ReExtractsWhenContentChangesUnderSameVersion\` which reproduces the exact failure: extracts one FS under \`1.0.0\`, then extracts a different FS under the same \`1.0.0\`, and asserts the on-disk file got updated. Would have caught this bug.

Also renames \`TestExtract_SkipsWhenVersionMatches\` → \`TestExtract_SkipsWhenMarkerMatches\` and updates it to reflect the new marker semantics.

## Test plan

- [x] \`go build ./...\` in \`pi/digitsd/\`
- [x] \`go test ./...\` in \`pi/digitsd/\`
- [x] \`golangci-lint run ./...\` in \`pi/digitsd/\`
- [ ] Deploy to Digits 1, confirm the stale \`digits-mixer.service\` on disk gets overwritten with the current embedded version on first boot after upgrade
- [ ] Confirm \`/data/digits/asset-version\` contains a \`<version>:<hash>\` string afterwards