### PR TITLE
fix(digitsd): include peer in hangup message so ringing stops

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -407,6 +407,7 @@ func (d *daemonCallbacks) HangupCall() {
 	d.pendingOffer = ""
 	d.pendingCaller = ""
 	d.pendingICE = nil
+	peer := d.callPeer
 	d.callPeer = ""
 	d.isCaller = false
 	d.isRestartingICE = false
@@ -415,7 +416,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.restartTimer = nil
 	}
 
-	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup}) //nolint:errcheck
+	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup, To: peer}) //nolint:errcheck
 
 	if d.pipeline != nil {
 		d.pipeline.Stop()


### PR DESCRIPTION
## Summary
- Regression from #112 accidentally reverted the digitsd half of #97
- `HangupCall()` cleared `callPeer` before sending `TypeHangup`, so the message went out with empty `To`
- When Digits 2 calls Digits 1 and hangs up while Digits 1 is ringing, Digits 1 keeps ringing forever
- Restores the capture-before-clear so hangup carries the peer number

The server-side `PeerOf` fallback in #97 is still present as defense in depth, but it relies on an entry existing in the in-memory tracker, which fails silently if `OnCallInitiated`'s DB insert errors. Sending `To` from the client is the reliable path.

## Test plan
- [ ] Deploy updated `digitsd` to Digits 1 and Digits 2
- [ ] Call Digits 1 from Digits 2, hang up Digits 2 while Digits 1 is still ringing, confirm Digits 1 stops ringing
- [ ] Reverse direction and confirm
- [ ] Normal call flow still works (answer, hang up after connect)