### PR TITLE
fix(pi): populate embedded assets in release build

### DIFF
--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -13,23 +13,24 @@ EMBED_DIR   = internal/assets/embed
 OVERLAY_SRC = $(REPO_ROOT)/pi/image/rootfs-overlay
 TONES_SRC   = $(REPO_ROOT)/pi/tones
 
-# Files from rootfs-overlay that are only used by the image builder (not deployed via embed)
-OVERLAY_EXCLUDE = etc/fstab.fragment usr/local/bin/ro-root usr/local/bin/rw-root etc/sudoers.d/digits-updater
-# Directories in rootfs-overlay that are only consumed at image-build time
-# (kernel boot config, device tree fragments). These live on the FAT firmware
-# partition, not the ext4 rootfs, so they must not be extracted at runtime.
-OVERLAY_EXCLUDE_DIRS = boot
+# Paths in rootfs-overlay that are only consumed at image-build time (kernel
+# boot config and device tree fragments live on the FAT firmware partition;
+# the *.fragment files are appended into existing system files by the image
+# builder; ro-root/rw-root are toggled manually on-device). None of these
+# should be extracted at runtime by digitsd.
+OVERLAY_EXCLUDE = boot etc/fstab.fragment usr/local/bin/ro-root usr/local/bin/rw-root etc/sudoers.d/digits-updater
 
 .PHONY: build build-local builder deploy run test clean embed clean-embed
 
 embed: clean-embed
 	@mkdir -p $(EMBED_DIR)/rootfs $(EMBED_DIR)/data
 	@cp -a $(OVERLAY_SRC)/. $(EMBED_DIR)/rootfs/
-	@for f in $(OVERLAY_EXCLUDE); do rm -f $(EMBED_DIR)/rootfs/$$f; done
-	@for d in $(OVERLAY_EXCLUDE_DIRS); do rm -rf $(EMBED_DIR)/rootfs/$$d; done
+	@for x in $(OVERLAY_EXCLUDE); do rm -rf $(EMBED_DIR)/rootfs/$$x; done
 	@find $(EMBED_DIR)/rootfs -type d -empty -delete 2>/dev/null || true
 	@cp -a $(TONES_SRC)/. $(EMBED_DIR)/data/tones/
-	@echo "embed: prepared $$(find $(EMBED_DIR) -type f | wc -l) files"
+	@count=$$(find $(EMBED_DIR) -type f | wc -l); \
+	 echo "embed: prepared $$count files"; \
+	 if [ "$$count" -eq 0 ]; then echo "embed: ERROR: staged tree is empty — rootfs-overlay missing?" >&2; exit 1; fi
 
 clean-embed:
 	@rm -rf $(EMBED_DIR)

--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -14,7 +14,11 @@ OVERLAY_SRC = $(REPO_ROOT)/pi/image/rootfs-overlay
 TONES_SRC   = $(REPO_ROOT)/pi/tones
 
 # Files from rootfs-overlay that are only used by the image builder (not deployed via embed)
-OVERLAY_EXCLUDE = boot/firmware/cmdline-ro.txt.fragment etc/fstab.fragment usr/local/bin/ro-root usr/local/bin/rw-root etc/sudoers.d/digits-updater
+OVERLAY_EXCLUDE = etc/fstab.fragment usr/local/bin/ro-root usr/local/bin/rw-root etc/sudoers.d/digits-updater
+# Directories in rootfs-overlay that are only consumed at image-build time
+# (kernel boot config, device tree fragments). These live on the FAT firmware
+# partition, not the ext4 rootfs, so they must not be extracted at runtime.
+OVERLAY_EXCLUDE_DIRS = boot
 
 .PHONY: build build-local builder deploy run test clean embed clean-embed
 
@@ -22,6 +26,7 @@ embed: clean-embed
 	@mkdir -p $(EMBED_DIR)/rootfs $(EMBED_DIR)/data
 	@cp -a $(OVERLAY_SRC)/. $(EMBED_DIR)/rootfs/
 	@for f in $(OVERLAY_EXCLUDE); do rm -f $(EMBED_DIR)/rootfs/$$f; done
+	@for d in $(OVERLAY_EXCLUDE_DIRS); do rm -rf $(EMBED_DIR)/rootfs/$$d; done
 	@find $(EMBED_DIR)/rootfs -type d -empty -delete 2>/dev/null || true
 	@cp -a $(TONES_SRC)/. $(EMBED_DIR)/data/tones/
 	@echo "embed: prepared $$(find $(EMBED_DIR) -type f | wc -l) files"

--- a/tools/build-pi.sh
+++ b/tools/build-pi.sh
@@ -18,6 +18,13 @@ echo "=== Building digitsd aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
 ARTIFACT="digitsd-${VERSION}-aarch64"
 
 cd "${REPO_DIR}/pi/digitsd"
+
+# Populate the embed tree so the //go:embed directive sees actual files
+# rather than just the committed .gitkeep. Without this, the binary ships
+# with an effectively empty assets FS and digitsd's asset extractor becomes
+# a no-op, leaving stale files on disk after every OTA update.
+make embed
+
 export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build \
     -ldflags "-X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=${VERSION} \


### PR DESCRIPTION
## Summary

Two related bugs that together rendered digitsd's asset extractor a no-op on every released binary. Caught while chasing the "mixer drift" audio outage on Digits 1 this afternoon.

### Bug 1: release build skips `make embed`

`tools/build-pi.sh` (used by the `pi-release` workflow via semantic-release) runs `go build` directly from a fresh checkout without first running `make embed`. The embed directory is gitignored — `pi/digitsd/.gitignore` ignores `internal/assets/embed/*` except `.gitkeep` — so in a clean tree the only file under `embed/` is `.gitkeep`. The `//go:embed embed/*` directive in `pi/digitsd/internal/assets/embed.go` therefore produces an almost-empty FS.

When the extractor runs on device:

- `hashEmbeddedFS` walks `"rootfs"` and `"data"` in the embedded FS. Both paths don't exist. `fs.WalkDir` returns a not-exist error which is silently ignored. The hash ends up being SHA-256 of empty input (`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`).
- `collectFiles("rootfs")` and `collectFiles("data")` do the same walk and also silently return zero files.
- Extract "succeeds", logs `assets: extracted 0 rootfs + 0 data files`, and writes the empty-hash marker.

Every OTA update since this path was introduced has been updating the `digitsd` binary but leaving stale rootfs files on disk. Devices only ever got correct rootfs/data from the initial SD image flash (which uses the image builder, not the embed path), never from OTA. This is how Digits 1 ended up running `digitsd 1.8.3 (9110e7b)` — built from a commit that contained the `digits-mixer.service` wait-loop fix (#143) — while still having the pre-#143 broken unit file on disk.

### Bug 2: boot firmware files break extraction once it's actually running

Even if the build had embedded the right files, `make embed` copies `pi/image/rootfs-overlay/` wholesale, including:

- `boot/firmware/cmdline-ro.txt.fragment`
- `boot/firmware/config-codec.txt.fragment`
- `boot/firmware/overlays/digits-codec.dts`

These are only consumed at image-build time and live on the FAT firmware partition at runtime. The current `OVERLAY_EXCLUDE` list in `pi/digitsd/Makefile` only excludes one of those (`cmdline-ro.txt.fragment`) — the two codec files were added later without being added to the exclude list.

When the extractor tried to `cp` them to `/boot/firmware/` on the device, `cp` failed (exit 1) and the whole extraction aborted on the first error — before reaching the systemd units or tones. This was masked until now because the empty-FS case (Bug 1) never got as far as trying to write anything.

## Fix

**`tools/build-pi.sh`**: run `make embed` at the top of the build, matching what `make build` already does for the local Docker path. One-liner.

**`pi/digitsd/Makefile`**: split the exclude list. Keep `OVERLAY_EXCLUDE` for individual files and add a new `OVERLAY_EXCLUDE_DIRS` for directories that must be stripped with `rm -rf`. Put `boot` in the directory list. The image builder still reads `pi/image/rootfs-overlay/` directly, so image builds are unchanged.

## Verification on Digits 1

1. Built a test binary with these fixes using `VERSION=1.8.4-test-embed make build` (Docker cross-compile).
2. Pushed it to `/usr/local/bin/digitsd` and cleared `/data/digits/asset-version`.
3. Restarted digitsd.
4. Watched the extractor run:
   ```
   assets: extracting assets for version 1.8.4-test-embed (hash=fa0c64e19da0)
   assets: wrote /etc/systemd/system/digits-mixer.service (405 bytes, 644)
   ...
   assets: extracted 15 rootfs + 38 data files for version 1.8.4-test-embed (hash=fa0c64e19da0)
   ```
5. Confirmed the on-disk `digits-mixer.service` SHA-256 changed from `8a273e58…` (pre-#143) to `000a2a12…` (post-#143, matches the overlay source).
6. `systemctl daemon-reload && systemctl start digits-mixer.service` → **active** (had been `failed` on every boot since forever, racing the da7213 codec probe).
7. `Lineout Volume` back to 50 after the service ran `alsactl restore`.

## Related

This is the missing piece that makes #156's content-hash marker actually do its job. Without this PR, #156 correctly detects that the embedded content has changed across rebuilds — but the embedded content in released binaries is still empty, so nothing gets written regardless.

## Out of scope (follow-ups I'll flag)

- The stored mixer state file `/data/digits_mixer.state` has the three gain-ramping switches (`numid=38/39/40`) recorded as TRUE, but per `docs/build/wiring.md:205` they should be OFF. The mixer service now successfully restores that wrong state. Separate PR.
- The extractor aborts on the first file error instead of logging-and-continuing. When I hit a dead-ownership data file during testing on Digits 1 (`/data/digits/tones/pairing/*` was owned by `pi:pi` from an older install), the whole extraction bailed and no marker was written. Consider making it log-and-continue for data files, or making it write a partial-success marker. Separate PR.
- The extractor doesn't call `systemctl daemon-reload` after rewriting files under `/etc/systemd/system/`. Without that, the running systemd still sees the old unit definition until the next reboot. Low priority since the rewrite only happens on upgrades which usually come with a reboot, but worth fixing.

## Test plan

- [x] Local `make build` from clean worktree — produces non-empty embed, ships binary with actual assets
- [x] `go test ./...` in `pi/digitsd/`
- [x] `golangci-lint run ./...` in `pi/digitsd/`
- [x] Deployed to Digits 1, verified extractor wrote 15 rootfs + 38 data files and the stale `digits-mixer.service` got replaced
- [ ] Merge, cut a new `pi/v1.8.5` release, confirm the release binary contains embedded assets (check with `strings bin/digitsd | grep digits-mixer.service`)
- [ ] OTA that release to Digits 1 from the currently-stale 1.8.4, confirm the extractor runs and rewrites the unit file again