### PR TITLE
fix(digitsd): harden asset extractor against partial failures

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -766,6 +766,9 @@ func main() {
 			}
 			return nil
 		},
+		ReloadSystemd: func() error {
+			return exec.Command("sudo", "systemctl", "daemon-reload").Run()
+		},
 	}
 	if err := extractor.Extract(version.Version); err != nil {
 		slog.Warn("asset extraction failed", "err", err)

--- a/pi/digitsd/internal/assets/assets.go
+++ b/pi/digitsd/internal/assets/assets.go
@@ -25,12 +25,16 @@ var permOverrides = []struct {
 type WriteFunc func(data []byte, dest string, perm os.FileMode) error
 
 type Extractor struct {
-	FS             fs.FS
-	RootDir        string
-	DataDir        string
-	MarkerPath     string
-	Remount        func(rw bool) error
+	FS              fs.FS
+	RootDir         string
+	DataDir         string
+	MarkerPath      string
+	Remount         func(rw bool) error
 	RootfsWriteFile WriteFunc // privileged writer for rootfs files (nil = use os.WriteFile)
+	// ReloadSystemd, if set, is called after any rootfs files are written so
+	// that systemd picks up rewritten unit files without requiring a reboot.
+	// Typically wired to `sudo systemctl daemon-reload`.
+	ReloadSystemd func() error
 }
 
 func (e *Extractor) Extract(currentVersion string) error {
@@ -53,6 +57,8 @@ func (e *Extractor) Extract(currentVersion string) error {
 		return fmt.Errorf("collect rootfs files: %w", err)
 	}
 
+	var failures []string
+	rootfsWritten := 0
 	if len(rootfsFiles) > 0 {
 		if err := e.Remount(true); err != nil {
 			return fmt.Errorf("remount rw: %w", err)
@@ -64,12 +70,23 @@ func (e *Extractor) Extract(currentVersion string) error {
 		for _, f := range rootfsFiles {
 			dest := filepath.Join(e.RootDir, f.relPath)
 			if err := e.writeFileWith(f, dest, rootfsWriter); err != nil {
-				_ = e.Remount(false)
-				return fmt.Errorf("write rootfs %s: %w", f.relPath, err)
+				log.Printf("assets: WARNING: write rootfs %s failed: %v", f.relPath, err)
+				failures = append(failures, "rootfs/"+f.relPath)
+				continue
 			}
+			rootfsWritten++
 		}
 		if err := e.Remount(false); err != nil {
 			log.Printf("assets: WARNING: remount ro failed: %v", err)
+		}
+		// Rewritten systemd units won't take effect until systemd re-reads
+		// its unit files, so tell it to reload if we touched anything on
+		// the rootfs. Cheap and idempotent, so no need to gate on whether
+		// any of the written paths were actually under /etc/systemd.
+		if rootfsWritten > 0 && e.ReloadSystemd != nil {
+			if err := e.ReloadSystemd(); err != nil {
+				log.Printf("assets: WARNING: systemd daemon-reload failed: %v", err)
+			}
 		}
 	}
 
@@ -78,11 +95,26 @@ func (e *Extractor) Extract(currentVersion string) error {
 		return fmt.Errorf("collect data files: %w", err)
 	}
 
+	dataWritten := 0
 	for _, f := range dataFiles {
 		dest := filepath.Join(e.DataDir, f.relPath)
 		if err := e.writeFileWith(f, dest, defaultWriteFile); err != nil {
-			return fmt.Errorf("write data %s: %w", f.relPath, err)
+			log.Printf("assets: WARNING: write data %s failed: %v", f.relPath, err)
+			failures = append(failures, "data/"+f.relPath)
+			continue
 		}
+		dataWritten++
+	}
+
+	log.Printf("assets: extracted %d/%d rootfs + %d/%d data files for version %s (hash=%s)",
+		rootfsWritten, len(rootfsFiles), dataWritten, len(dataFiles), currentVersion, contentHash[:12])
+
+	// Only commit the marker on a fully successful run. A partial success
+	// must retry on the next boot so that whatever was blocking the failed
+	// file (e.g. a stale ownership issue) gets another chance after the
+	// user resolves it.
+	if len(failures) > 0 {
+		return fmt.Errorf("asset extraction incomplete: %d file(s) failed: %s", len(failures), strings.Join(failures, ", "))
 	}
 
 	if err := os.MkdirAll(filepath.Dir(e.MarkerPath), 0755); err != nil {
@@ -91,9 +123,6 @@ func (e *Extractor) Extract(currentVersion string) error {
 	if err := os.WriteFile(e.MarkerPath, []byte(want), 0644); err != nil {
 		return fmt.Errorf("write marker: %w", err)
 	}
-
-	log.Printf("assets: extracted %d rootfs + %d data files for version %s (hash=%s)",
-		len(rootfsFiles), len(dataFiles), currentVersion, contentHash[:12])
 	return nil
 }
 

--- a/pi/digitsd/internal/assets/assets_test.go
+++ b/pi/digitsd/internal/assets/assets_test.go
@@ -129,6 +129,110 @@ func TestExtract_ReExtractsWhenContentChangesUnderSameVersion(t *testing.T) {
 	}
 }
 
+// Regression: one bad file should not abort the whole extract. Before,
+// the extractor returned on the first write error, skipping every later
+// file AND skipping the data/* pass AND skipping the marker — so a single
+// inaccessible file would roll back an entire update. Now: log-and-continue,
+// write every file we can, return an error at the end, withhold the marker
+// so the next boot retries.
+func TestExtract_ContinuesPastFileErrors(t *testing.T) {
+	root := t.TempDir()
+	dataDir := t.TempDir()
+	markerPath := filepath.Join(dataDir, "asset-version")
+
+	fsys := fstest.MapFS{
+		"rootfs/etc/systemd/system/a.service": &fstest.MapFile{Data: []byte("a")},
+		"rootfs/etc/systemd/system/b.service": &fstest.MapFile{Data: []byte("b")},
+		"rootfs/etc/systemd/system/c.service": &fstest.MapFile{Data: []byte("c")},
+		"data/tones/dial.wav":                 &fstest.MapFile{Data: []byte("wav")},
+	}
+
+	e := &Extractor{
+		FS:         fsys,
+		RootDir:    root,
+		DataDir:    dataDir,
+		MarkerPath: markerPath,
+		Remount:    func(rw bool) error { return nil },
+		RootfsWriteFile: func(data []byte, dest string, perm os.FileMode) error {
+			if filepath.Base(dest) == "b.service" {
+				return os.ErrPermission
+			}
+			return defaultWriteFile(data, dest, perm)
+		},
+	}
+
+	err := e.Extract("1.0.0")
+	if err == nil {
+		t.Fatal("expected error for partial failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "b.service") {
+		t.Errorf("error should mention failing file: %v", err)
+	}
+
+	// Other rootfs files landed despite the one failure.
+	for _, name := range []string{"a.service", "c.service"} {
+		if _, err := os.Stat(filepath.Join(root, "etc/systemd/system", name)); err != nil {
+			t.Errorf("expected %s on disk after partial extract, got %v", name, err)
+		}
+	}
+	// Data files still ran.
+	if _, err := os.Stat(filepath.Join(dataDir, "tones/dial.wav")); err != nil {
+		t.Errorf("data file missing after partial extract: %v", err)
+	}
+	// Marker withheld so the next boot retries.
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("marker should not exist on partial failure, err=%v", err)
+	}
+}
+
+func TestExtract_CallsReloadSystemdAfterRootfsWrites(t *testing.T) {
+	root := t.TempDir()
+	dataDir := t.TempDir()
+	markerPath := filepath.Join(dataDir, "asset-version")
+
+	reloadCalls := 0
+	e := &Extractor{
+		FS: fstest.MapFS{
+			"rootfs/etc/systemd/system/x.service": &fstest.MapFile{Data: []byte("unit")},
+		},
+		RootDir:       root,
+		DataDir:       dataDir,
+		MarkerPath:    markerPath,
+		Remount:       func(rw bool) error { return nil },
+		ReloadSystemd: func() error { reloadCalls++; return nil },
+	}
+	if err := e.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if reloadCalls != 1 {
+		t.Errorf("ReloadSystemd called %d times, want 1", reloadCalls)
+	}
+}
+
+func TestExtract_SkipsReloadWhenNoRootfsFiles(t *testing.T) {
+	root := t.TempDir()
+	dataDir := t.TempDir()
+	markerPath := filepath.Join(dataDir, "asset-version")
+
+	reloadCalls := 0
+	e := &Extractor{
+		FS: fstest.MapFS{
+			"data/tones/dial.wav": &fstest.MapFile{Data: []byte("wav")},
+		},
+		RootDir:       root,
+		DataDir:       dataDir,
+		MarkerPath:    markerPath,
+		Remount:       func(rw bool) error { return nil },
+		ReloadSystemd: func() error { reloadCalls++; return nil },
+	}
+	if err := e.Extract("1.0.0"); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if reloadCalls != 0 {
+		t.Errorf("ReloadSystemd called %d times, want 0 (no rootfs writes)", reloadCalls)
+	}
+}
+
 func TestExtract_SetsPermissionsForScripts(t *testing.T) {
 	root := t.TempDir()
 	dataDir := t.TempDir()


### PR DESCRIPTION
## Summary

Two robustness improvements to `internal/assets/Extractor`, both driven by failure modes I hit while chasing the audio regression on Digits 1 earlier today:

### 1. Log-and-continue past individual file errors

Before, the extractor returned on the first `writeFileWith` error. One bad file would:

- Skip every later rootfs file
- Skip the entire data/* pass
- Skip the marker write
- Mask the partial success in a single error return

This bit me when testing PR #158: `/data/digits/tones/pairing/*` was owned by `pi:pi` from an older install, digitsd runs as `digits`, so `os.WriteFile` got `EACCES` on the first pairing file and the whole extract bailed. Everything earlier in the walk (including the newly-fixed `digits-mixer.service`) had been written, but the marker wasn't, so the next boot would try again and hit the same wall.

Now: log each failure, continue the walk, return an aggregated error at the end. Marker is still withheld on any failure so the next boot gets another chance to retry — important because persistent failures (like the ownership issue) need a human to unblock them, and we don't want to silently declare success.

### 2. `systemctl daemon-reload` after rootfs writes

Even when extraction succeeds, systemd doesn't notice that unit files under `/etc/systemd/system/` changed until it re-reads them. So a rewritten `digits-mixer.service` would sit on disk without actually taking effect until the next reboot. I hit this during Digits 1 testing — had to manually `daemon-reload` + `start digits-mixer.service` after the new binary wrote the fixed unit.

Plumbed as a new `ReloadSystemd func() error` callback on the `Extractor` struct so the package stays free of `exec` and `sudo` concerns. `cmd/digitsd/main.go` wires it to `exec.Command("sudo", "systemctl", "daemon-reload")`. The callback fires unconditionally whenever any rootfs file was written (not gated on whether the path was under `/etc/systemd/system/`): daemon-reload is idempotent and ~100 ms, so path detection adds complexity without meaningful benefit.

## Tests

Three new tests in `assets_test.go`:

- `TestExtract_ContinuesPastFileErrors`: injects a WriteFunc that fails on exactly one rootfs file, asserts the other rootfs files AND all data files still get written, asserts the error mentions the failing file, asserts the marker was withheld.
- `TestExtract_CallsReloadSystemdAfterRootfsWrites`: asserts the callback fires exactly once when a rootfs file is extracted.
- `TestExtract_SkipsReloadWhenNoRootfsFiles`: asserts the callback does not fire when the embedded FS contains only `data/*`.

Existing tests still pass unmodified.

## Related

- #156 (content-hash marker) — merged in pi/v1.8.4
- #158 (populate embedded assets in release build) — open

This completes the extractor hardening items I flagged as follow-ups in #158.

## Test plan

- [x] `go vet ./...`, `go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean in `pi/digitsd/`
- [ ] Merge and cut a new `pi/v1.8.5` (which should also carry #158 once that lands). OTA to Digits 1 and confirm:
  - extractor runs without manual intervention
  - `digits-mixer.service` gets reloaded and runs to completion during the same boot (not the reboot after)