### PR TITLE
fix(pi): disable gain ramping switches in stored mixer state

### DIFF
--- a/pi/digits_mixer.state
+++ b/pi/digits_mixer.state
@@ -475,8 +475,8 @@ state.Zero {
 	control.38 {
 		iface MIXER
 		name 'DAC Gain Ramping Switch'
-		value.0 true
-		value.1 true
+		value.0 false
+		value.1 false
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -486,8 +486,8 @@ state.Zero {
 	control.39 {
 		iface MIXER
 		name 'Headphone Gain Ramping Switch'
-		value.0 true
-		value.1 true
+		value.0 false
+		value.1 false
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -497,7 +497,7 @@ state.Zero {
 	control.40 {
 		iface MIXER
 		name 'Lineout Gain Ramping Switch'
-		value true
+		value false
 		comment {
 			access 'read write'
 			type BOOLEAN


### PR DESCRIPTION
## Summary

The committed `pi/digits_mixer.state` had the three da7213 playback-path gain-ramping switches (`numid=38` DAC, `numid=39` Headphone, `numid=40` Lineout) recorded as `true`, even though `docs/build/wiring.md:205-211` explicitly mandates they be OFF:

> These three MUST be OFF or audio has fade-in latency:
> | numid | Control                       | Required |
> |-------|-------------------------------|----------|
> | 38    | DAC Gain Ramping Switch       | off      |
> | 39    | Headphone Gain Ramping Switch | off      |
> | 40    | Lineout Gain Ramping Switch   | off      |

With ramping on, every sound gets a ~500 ms fade-in. That swallows short tones entirely — DTMF beeps are only 120 ms — and delays dial tone. The state file was presumably captured on a device that hadn't had the switches manually toggled off before `alsactl store`.

The drift was masked for a long time because `digits-mixer.service` itself has been failing on every boot (racing the `da7213` codec probe — see #143/#156/#158), so the state file was never actually applied in practice. The codec was running with whatever defaults the driver chose at probe time. Once the service is fixed and restore starts working, it would have been restoring a broken configuration.

## Verification on Digits 1

Pushed the edited file to `/tmp/digits_mixer.state.new` and ran `sudo alsactl restore Zero -f /tmp/digits_mixer.state.new`:

```
--- BEFORE ---
numid=38: on,on
numid=39: on,on
numid=40: on

--- RESTORE ---
exit=0

--- AFTER ---
numid=38: off,off  ✓
numid=39: off,off  ✓
numid=40: off      ✓

Lineout Volume: unchanged at 50
```

Verified the restore exits 0, the three targeted controls flip to off, and nothing else changes.

## Scope

Only the three switches mandated by the docs are flipped. The other three gain-ramping controls in the file — `numid=35` Aux, `numid=36` Mixin, `numid=37` ADC — are left as-is; the wiring doc doesn't specify a required state for those and they're on non-critical paths.

## Related

Final follow-up from the Digits 1 audio debugging session. Pairs with #156, #158, #159.

## Test plan

- [x] `alsactl restore` against the edited file exits 0 on Digits 1
- [x] numid=38/39/40 flip from on to off after restore
- [x] No collateral changes to Lineout Volume or other controls
- [ ] Merge, cut a `pi/v1.8.5` release (with #158 and #159), OTA to Digits 1, confirm that after `digits-mixer.service` runs, all three switches read off and short tones (DTMF) play without fade-in