### PR TITLE
feat(firmware): add Docker-based firmware build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,12 @@ make test
 
 Firmware (from repo root):
 ```
-PICO_SDK_PATH=/path/to/pico-sdk ./scripts/build.sh
-./scripts/flash.sh  # copies UF2 to mounted Pico
+make firmware         # builds in Docker, no host toolchain needed
+make firmware-local   # builds on host (requires arm-none-eabi-gcc + Pico SDK)
+./scripts/flash.sh    # copies UF2 to mounted Pico
 ```
+
+`make firmware-local` runs `./scripts/build.sh`, which auto-detects `PICO_SDK_PATH` from common locations (`/usr/share/pico-sdk`, `~/pico-sdk`, etc.). Only set `PICO_SDK_PATH` explicitly if the SDK is installed somewhere non-standard.
 
 ## Linting
 

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,5 @@ test: server-test pi-test ## Run all tests
 clean: ## Clean build artifacts
 	$(MAKE) -C server clean
 	$(MAKE) -C pi/digitsd clean
-	rm -rf tools/build/ firmware/build/
+	$(MAKE) -C firmware clean
+	rm -rf tools/build/

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ pi-test: ## Run digitsd tests (host architecture)
 
 # ── Firmware ─────────────────────────────────────────────────────────────────
 
-firmware: ## Build Pico firmware (requires arm-none-eabi-gcc + Pico SDK)
-	./scripts/build.sh
+firmware: ## Build Pico firmware (Docker, no host toolchain needed)
+	$(MAKE) -C firmware build
+
+firmware-local: ## Build Pico firmware on host (requires arm-none-eabi-gcc + Pico SDK)
+	$(MAKE) -C firmware build-local
 
 # ── Pi SD Card Image ─────────────────────────────────────────────────────────
 

--- a/firmware/Dockerfile.builder
+++ b/firmware/Dockerfile.builder
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+# build-essential is required: picotool is built during firmware compilation
+# and needs a native (not cross) C/C++ compiler.
 RUN apt-get update -qq \
     && apt-get install -y -qq --no-install-recommends \
        build-essential \
@@ -12,7 +14,8 @@ RUN apt-get update -qq \
        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \
+ARG PICO_SDK_VERSION=2.2.0
+RUN git clone --depth 1 --branch ${PICO_SDK_VERSION} https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \
     && cd /opt/pico-sdk \
     && git submodule update --init --depth 1
 

--- a/firmware/Dockerfile.builder
+++ b/firmware/Dockerfile.builder
@@ -1,0 +1,21 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends \
+       build-essential \
+       gcc-arm-none-eabi \
+       libnewlib-arm-none-eabi \
+       libstdc++-arm-none-eabi-newlib \
+       cmake \
+       python3 \
+       git \
+       ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk \
+    && cd /opt/pico-sdk \
+    && git submodule update --init --depth 1
+
+RUN git config --global --add safe.directory /src
+
+ENV PICO_SDK_PATH=/opt/pico-sdk

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,6 +1,10 @@
 BUILDER_IMG = digits-firmware-builder
 REPO_ROOT   = $(shell git rev-parse --show-toplevel)
-BUILD_DIR   = build
+
+# Docker and local builds use separate CMake build directories so that
+# switching between them doesn't poison the cache with stale toolchain
+# and PICO_SDK_PATH values.
+DOCKER_BUILD_DIR = build/docker
 
 .PHONY: build build-local builder clean
 
@@ -12,10 +16,10 @@ build: builder
 		--user $(shell id -u):$(shell id -g) \
 		-v $(REPO_ROOT):/src -w /src/firmware \
 		$(BUILDER_IMG) \
-		sh -c 'mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake .. && make -j$$(nproc)'
+		sh -c 'mkdir -p $(DOCKER_BUILD_DIR) && cd $(DOCKER_BUILD_DIR) && cmake ../.. && make -j$$(nproc)'
 
 build-local:
 	@$(REPO_ROOT)/scripts/build.sh
 
 clean:
-	rm -rf $(BUILD_DIR)
+	rm -rf build

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,0 +1,21 @@
+BUILDER_IMG = digits-firmware-builder
+REPO_ROOT   = $(shell git rev-parse --show-toplevel)
+BUILD_DIR   = build
+
+.PHONY: build build-local builder clean
+
+builder:
+	@docker build -q -t $(BUILDER_IMG) -f Dockerfile.builder .
+
+build: builder
+	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
+		-v $(REPO_ROOT):/src -w /src/firmware \
+		$(BUILDER_IMG) \
+		sh -c 'mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake .. && make -j$$(nproc)'
+
+build-local:
+	@$(REPO_ROOT)/scripts/build.sh
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FIRMWARE_DIR="$SCRIPT_DIR/../firmware"
-BUILD_DIR="$FIRMWARE_DIR/build"
+# Local and Docker builds use separate subdirectories so switching between
+# modes doesn't poison CMakeCache.txt with stale toolchain/PICO_SDK_PATH.
+BUILD_DIR="$FIRMWARE_DIR/build/local"
 
 # Auto-find PICO_SDK_PATH if not set
 if [ -z "${PICO_SDK_PATH:-}" ]; then
@@ -33,7 +35,7 @@ echo "  Build dir: $BUILD_DIR"
 
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake .. -DPICO_SDK_PATH="$PICO_SDK_PATH"
+cmake "$FIRMWARE_DIR" -DPICO_SDK_PATH="$PICO_SDK_PATH"
 make -j"$(nproc)"
 
 echo ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-"$SCRIPT_DIR/build.sh" && picotool load -f "$SCRIPT_DIR/../firmware/build/digits.uf2"
+"$SCRIPT_DIR/build.sh" && picotool load -f "$SCRIPT_DIR/../firmware/build/local/digits.uf2"

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -62,11 +62,23 @@ if [ "${1:-}" = "--release" ]; then
 fi
 
 # --- Local mode: copy UF2 to BOOTSEL mount ---
-UF2_FILE="$SCRIPT_DIR/../firmware/build/digits.uf2"
+# Prefer whichever build dir has the newer UF2 (docker vs local).
+LOCAL_UF2="$SCRIPT_DIR/../firmware/build/local/digits.uf2"
+DOCKER_UF2="$SCRIPT_DIR/../firmware/build/docker/digits.uf2"
 
-if [ ! -f "$UF2_FILE" ]; then
-    echo "ERROR: UF2 file not found at $UF2_FILE" >&2
-    echo "Run scripts/build.sh first." >&2
+if [ -f "$LOCAL_UF2" ] && [ -f "$DOCKER_UF2" ]; then
+    if [ "$LOCAL_UF2" -nt "$DOCKER_UF2" ]; then
+        UF2_FILE="$LOCAL_UF2"
+    else
+        UF2_FILE="$DOCKER_UF2"
+    fi
+elif [ -f "$LOCAL_UF2" ]; then
+    UF2_FILE="$LOCAL_UF2"
+elif [ -f "$DOCKER_UF2" ]; then
+    UF2_FILE="$DOCKER_UF2"
+else
+    echo "ERROR: UF2 file not found in firmware/build/local or firmware/build/docker" >&2
+    echo "Run 'make firmware' or 'make firmware-local' first." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Add \`firmware/Dockerfile.builder\` and \`firmware/Makefile\` so the Pico firmware can be cross-compiled without installing \`arm-none-eabi-gcc\` or the Pico SDK on the host. Mirrors the pattern already used for \`pi/digitsd/Dockerfile.builder\`.
- \`make firmware\` (from repo root) now runs the Docker build with no host toolchain required.
- \`make firmware-local\` preserves the existing host build via \`scripts/build.sh\` (which auto-detects \`PICO_SDK_PATH\` at common locations).
- \`docker run\` uses \`--user \$(id -u):\$(id -g)\` so build outputs are owned by the invoking user and \`make clean\` works without sudo.

## Dockerfile contents

- \`debian:bookworm-slim\` base
- \`build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib cmake python3 git\`
- pico-sdk cloned at \`/opt/pico-sdk\` with submodules
- \`PICO_SDK_PATH\` preset

\`build-essential\` is required because picotool (a host tool the Pico SDK builds during firmware compilation) needs a native C/C++ compiler, not just the ARM cross-compiler.

## Test plan

- [x] \`make firmware\` builds \`firmware/build/digits.uf2\` from a clean checkout
- [x] Output files owned by invoking user, not root
- [x] \`make -C firmware clean\` succeeds without sudo
- [x] \`make firmware-local\` still works unchanged
- [ ] Manual flash of resulting UF2 to a Pico for sanity (not required, no code changed)