### PR TITLE
fix(ci): match multi-scope commits in semantic-release rules

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -5,11 +5,13 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       releaseRules: [
-        { scope: 'firmware', type: 'feat', release: 'minor' },
-        { scope: 'firmware', type: 'fix', release: 'patch' },
-        { scope: 'firmware', type: 'perf', release: 'patch' },
-        { scope: 'firmware', breaking: true, release: 'major' },
-        { scope: '!firmware', release: false },
+        // Scope globs use micromatch substring patterns so multi-scope commits
+        // like fix(digitsd,firmware,server) trigger this release too.
+        { scope: '*firmware*', type: 'feat', release: 'minor' },
+        { scope: '*firmware*', type: 'fix', release: 'patch' },
+        { scope: '*firmware*', type: 'perf', release: 'patch' },
+        { scope: '*firmware*', breaking: true, release: 'major' },
+        { scope: '!*firmware*', release: false },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
@@ -17,8 +19,6 @@ module.exports = {
     }],
     ['@semantic-release/release-notes-generator', {
       parserOpts: {
-        headerPattern: /^(\w*)(?:\((firmware)\))?: (.*)$/,
-        headerCorrespondence: ['type', 'scope', 'subject'],
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -5,17 +5,17 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       releaseRules: [
-        { scope: 'firmware', type: 'feat', release: 'minor' },
-        { scope: 'firmware', type: 'fix', release: 'patch' },
-        { scope: 'firmware', type: 'perf', release: 'patch' },
-        { scope: 'firmware', breaking: true, release: 'major' },
-        { scope: '!firmware', release: false },
+        // Scope globs use micromatch substring patterns so multi-scope commits
+        // like fix(digitsd,firmware,server) trigger this release too.
+        { scope: '*firmware*', type: 'feat', release: 'minor' },
+        { scope: '*firmware*', type: 'fix', release: 'patch' },
+        { scope: '*firmware*', type: 'perf', release: 'patch' },
+        { scope: '*firmware*', breaking: true, release: 'major' },
+        { scope: '!*firmware*', release: false },
       ],
     }],
     ['@semantic-release/release-notes-generator', {
       parserOpts: {
-        headerPattern: /^(\w*)(?:\((firmware)\))?: (.*)$/,
-        headerCorrespondence: ['type', 'scope', 'subject'],
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -5,15 +5,13 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       releaseRules: [
-        { scope: 'pi', type: 'feat', release: 'minor' },
-        { scope: 'pi', type: 'fix', release: 'patch' },
-        { scope: 'pi', type: 'perf', release: 'patch' },
-        { scope: 'pi', breaking: true, release: 'major' },
-        { scope: 'digitsd', type: 'feat', release: 'minor' },
-        { scope: 'digitsd', type: 'fix', release: 'patch' },
-        { scope: 'digitsd', type: 'perf', release: 'patch' },
-        { scope: 'digitsd', breaking: true, release: 'major' },
-        { scope: '!(pi|digitsd)', release: false },
+        // Scope globs use micromatch substring patterns so multi-scope commits
+        // like fix(digitsd,firmware,server) trigger this release too.
+        { scope: '{*pi*,*digitsd*}', type: 'feat', release: 'minor' },
+        { scope: '{*pi*,*digitsd*}', type: 'fix', release: 'patch' },
+        { scope: '{*pi*,*digitsd*}', type: 'perf', release: 'patch' },
+        { scope: '{*pi*,*digitsd*}', breaking: true, release: 'major' },
+        { scope: '!{*pi*,*digitsd*}', release: false },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
@@ -21,8 +19,6 @@ module.exports = {
     }],
     ['@semantic-release/release-notes-generator', {
       parserOpts: {
-        headerPattern: /^(\w*)(?:\((pi|digitsd)\))?: (.*)$/,
-        headerCorrespondence: ['type', 'scope', 'subject'],
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],

--- a/server/.releaserc.cjs
+++ b/server/.releaserc.cjs
@@ -5,11 +5,13 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       releaseRules: [
-        { scope: 'server', type: 'feat', release: 'minor' },
-        { scope: 'server', type: 'fix', release: 'patch' },
-        { scope: 'server', type: 'perf', release: 'patch' },
-        { scope: 'server', breaking: true, release: 'major' },
-        { scope: '!server', release: false },
+        // Scope globs use micromatch substring patterns so multi-scope commits
+        // like fix(digitsd,firmware,server) trigger this release too.
+        { scope: '*server*', type: 'feat', release: 'minor' },
+        { scope: '*server*', type: 'fix', release: 'patch' },
+        { scope: '*server*', type: 'perf', release: 'patch' },
+        { scope: '*server*', breaking: true, release: 'major' },
+        { scope: '!*server*', release: false },
       ],
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
@@ -17,8 +19,6 @@ module.exports = {
     }],
     ['@semantic-release/release-notes-generator', {
       parserOpts: {
-        headerPattern: /^(\w*)(?:\((server)\))?: (.*)$/,
-        headerCorrespondence: ['type', 'scope', 'subject'],
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
     }],


### PR DESCRIPTION
## Problem

When PR #161 (\`fix(digitsd,firmware,server): relay in-call keypad presses and fix FSM + ringback bugs\`) merged to main, none of the three release pipelines produced a release, despite the commit touching firmware, digitsd, and server. All three workflows ran and all three reported \"no release\".

## Root cause

Every \`releaserc\` uses exact-string scope matching in its \`releaseRules\`:

\`\`\`js
{ scope: 'firmware', type: 'fix', release: 'patch' },
{ scope: '!firmware', release: false },
\`\`\`

A commit with scope \`digitsd,firmware,server\` has the literal scope string \`\"digitsd,firmware,server\"\`, which does not equal \`\"firmware\"\`. It also does not equal \`\"digitsd\"\` or \`\"server\"\`, so the negated rule fires for every pipeline and the merge produces no releases anywhere.

Each \`release-notes-generator\` also had a custom \`headerPattern\` regex like \`/^(\\w*)(?:\\((firmware)\\))?: (.*)$/\` which only accepted a single literal scope. Multi-scope commits fail this regex entirely and would render with degraded formatting if they ever did trigger a release.

## Fix

Switch scope matching to micromatch substring globs:

- \`firmware/.releaserc-*.cjs\`: \`*firmware*\` / \`!*firmware*\`
- \`server/.releaserc.cjs\`: \`*server*\` / \`!*server*\`
- \`pi/.releaserc.cjs\`: \`{*pi*,*digitsd*}\` / \`!{*pi*,*digitsd*}\`

This lets \`fix(digitsd,firmware,server)\` trigger all three pipelines while keeping single-scope negation (\`fix(server)\` still produces no firmware release).

Also drop the custom \`headerPattern\` from each \`release-notes-generator\`; the default conventional-commits parser handles multi-scope correctly.

## Test plan

Ran the actual semantic-release commit-analyzer locally against the real #161 commit message and a matrix of representative commits:

\`\`\`
--- firmware ---
multi-scope fix       -> patch   (was: no release)
firmware-only fix     -> patch
server-only fix       -> no release
ci-only fix           -> no release
digitsd+firmware fix  -> patch
--- pi ---
multi-scope fix       -> patch   (was: no release)
digitsd feat          -> minor
firmware-only fix     -> no release
server-only fix       -> no release
--- server ---
multi-scope fix       -> patch   (was: no release)
server-only fix       -> patch
firmware-only fix     -> no release
ci-only fix           -> no release
\`\`\`

- [x] All four configs pass \`node -c\` syntax check
- [x] Commit-analyzer matrix verified against real commit text above
- [x] Negation cases (ci-only, wrong-scope) still correctly produce no release

## Follow-up

Once this merges, all three release workflows will re-run because each triggers on changes under its own module path. They should then analyze commits since their last tags (including the #161 merge) and cut the missing patch releases for firmware, pi, and server.