### PR TITLE
fix(ci): filter release notes to only scope-relevant commits

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -18,8 +18,19 @@ module.exports = {
       },
     }],
     ['@semantic-release/release-notes-generator', {
+      preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+      writerOpts: {
+        // Only include commits whose scope is or contains "firmware".
+        // Multi-scope commits like fix(digitsd,firmware,server) are included.
+        transform: (commit) => {
+          if (!commit.scope || !/(^|,)firmware(,|$)/.test(commit.scope)) return;
+          const typeMap = { feat: 'Features', fix: 'Bug Fixes', perf: 'Performance Improvements' };
+          if (!typeMap[commit.type]) return;
+          return { ...commit, type: typeMap[commit.type], shortHash: commit.hash && commit.hash.substring(0, 7) };
+        },
       },
     }],
     ['@semantic-release/exec', {

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -15,8 +15,19 @@ module.exports = {
       ],
     }],
     ['@semantic-release/release-notes-generator', {
+      preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+      writerOpts: {
+        // Only include commits whose scope is or contains "firmware".
+        // Multi-scope commits like fix(digitsd,firmware,server) are included.
+        transform: (commit) => {
+          if (!commit.scope || !/(^|,)firmware(,|$)/.test(commit.scope)) return;
+          const typeMap = { feat: 'Features', fix: 'Bug Fixes', perf: 'Performance Improvements' };
+          if (!typeMap[commit.type]) return;
+          return { ...commit, type: typeMap[commit.type], shortHash: commit.hash && commit.hash.substring(0, 7) };
+        },
       },
     }],
     ['@semantic-release/github', { assets: [], successComment: false, failComment: false }],

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -18,8 +18,19 @@ module.exports = {
       },
     }],
     ['@semantic-release/release-notes-generator', {
+      preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+      writerOpts: {
+        // Only include commits whose scope is or contains "pi" or "digitsd".
+        // Multi-scope commits like fix(digitsd,firmware,server) are included.
+        transform: (commit) => {
+          if (!commit.scope || !/(^|,)(pi|digitsd)(,|$)/.test(commit.scope)) return;
+          const typeMap = { feat: 'Features', fix: 'Bug Fixes', perf: 'Performance Improvements' };
+          if (!typeMap[commit.type]) return;
+          return { ...commit, type: typeMap[commit.type], shortHash: commit.hash && commit.hash.substring(0, 7) };
+        },
       },
     }],
     ['@semantic-release/exec', {

--- a/server/.releaserc.cjs
+++ b/server/.releaserc.cjs
@@ -18,8 +18,19 @@ module.exports = {
       },
     }],
     ['@semantic-release/release-notes-generator', {
+      preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+      },
+      writerOpts: {
+        // Only include commits whose scope is or contains "server".
+        // Multi-scope commits like fix(digitsd,firmware,server) are included.
+        transform: (commit) => {
+          if (!commit.scope || !/(^|,)server(,|$)/.test(commit.scope)) return;
+          const typeMap = { feat: 'Features', fix: 'Bug Fixes', perf: 'Performance Improvements' };
+          if (!typeMap[commit.type]) return;
+          return { ...commit, type: typeMap[commit.type], shortHash: commit.hash && commit.hash.substring(0, 7) };
+        },
       },
     }],
     ['@semantic-release/github', { assets: [], successComment: false, failComment: false }],


### PR DESCRIPTION
## Problem

Every release now fires correctly after #163, but the rendered notes include every commit since the last tag regardless of scope. Example: [fw/v1.2.1](https://github.com/justinlindh/digits/releases/tag/fw%2Fv1.2.1) lists \`ci\`, \`pi\`, \`digitsd\`, \`hardware\`, \`image\`, and \`server\` commits — none of which belong in a firmware release.

## Root cause

My prior PR (#163) dropped the custom \`headerPattern\` regex on every \`release-notes-generator\` config. That regex had been the filter: commits whose parsed scope didn't equal the target (e.g. \`firmware\`) rendered without a recognized scope and fell into an \"other\" bucket that wasn't shown. Removing the regex without replacing the filter means every commit since the last tag now shows up.

## Fix

Add a \`writerOpts.transform\` to each \`release-notes-generator\` config that drops commits whose parsed \`scope\` doesn't contain the pipeline's target token. The regex is anchored on scope boundaries (\`(^|,)firmware(,|\$)\`), so:

- \`firmware\` → included
- \`digitsd,firmware,server\` → included (matches mid-list)
- \`firmware-tool\` → not included (avoids false positive)
- \`server\` alone → not included (in firmware pipeline)

The transform also maps \`feat\` → Features, \`fix\` → Bug Fixes, \`perf\` → Performance Improvements so conventional-changelog-writer's default templates group them correctly.

Switching to \`preset: 'conventionalcommits'\` (from the default \`angular\`) because the built-in templates produce slightly nicer output with issue links.

## Test plan

Ran the actual \`@semantic-release/release-notes-generator\` and \`@semantic-release/commit-analyzer\` locally against a sample commit set:

\`\`\`
fix(digitsd,firmware,server): relay in-call keypad presses ...  (#161)
fix(ci):                       match multi-scope commits         (#163)
fix(image):                    raise mic gain                    (#154)
fix(digitsd):                  harden asset extractor            (#159)
feat(firmware):                add Docker-based firmware build   (#162)
fix(server):                   pass build version                (#146)
\`\`\`

Output:

\`\`\`
=== FIRMWARE (release: minor) ===
### Features
* firmware: add Docker-based firmware build (#162)
### Bug Fixes
* digitsd,firmware,server: relay in-call keypad presses (#161)

=== PI (release: patch) ===
### Bug Fixes
* digitsd,firmware,server: relay in-call keypad presses (#161)
* digitsd: harden asset extractor (#159)

=== SERVER (release: patch) ===
### Bug Fixes
* digitsd,firmware,server: relay in-call keypad presses (#161)
* server: pass build version (#146)
\`\`\`

Each pipeline gets only its own commits plus multi-scope commits that contain its scope name. ci, image, and unrelated-scope commits correctly drop out of all three.

- [x] All four configs pass \`node -c\` syntax check
- [x] End-to-end verified locally with real release-notes-generator + commit-analyzer
- [x] Release decision unaffected (same release rules from #163)