### PR TITLE
feat: per-line voice_style setting with live hot-reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ node_modules/
 
 # Superpowers
 .superpowers/
+docs/superpowers/
 
 # Claude Code
 .claude/

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -199,9 +199,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	close(sdpSent)
 
 	// Start audio pipeline
-	pipCfg := audio.DefaultPipelineConfig()
-	pipCfg.Character = d.cfg.VoiceStyleOrDefault() == config.VoiceStyleCopper
-	d.pipeline = audio.NewPipeline(pipCfg)
+	d.pipeline = d.newPipeline()
 	if err := d.pipeline.Start(); err != nil {
 		slog.Error("audio pipeline start failed", "error", err)
 		return
@@ -376,9 +374,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	close(sdpSent)
 
 	// Start audio pipeline (capture only — playback goes through mixer)
-	pipCfg := audio.DefaultPipelineConfig()
-	pipCfg.Character = d.cfg.VoiceStyleOrDefault() == config.VoiceStyleCopper
-	d.pipeline = audio.NewPipeline(pipCfg)
+	d.pipeline = d.newPipeline()
 	if err := d.pipeline.Start(); err != nil {
 		slog.Error("audio pipeline (answer) start failed", "error", err)
 		return
@@ -438,11 +434,19 @@ func (d *daemonCallbacks) HangupCall() {
 	slog.Info("call ended")
 }
 
-// applyVoiceStyleLive forwards a voice style change to the active audio
-// pipeline if one is running. Called from the signal inbox handler when a
-// line_settings update arrives; safe to call with no active pipeline (it
-// becomes a no-op, and the config cache still gets persisted so the next
-// call picks up the style at construction time).
+// newPipeline constructs a fresh capture pipeline with per-line config
+// applied (voice style, etc). The returned pipeline is not yet started.
+// Must be called with d.mu held (reads d.cfg without acquiring the lock).
+func (d *daemonCallbacks) newPipeline() *audio.Pipeline {
+	cfg := audio.DefaultPipelineConfig()
+	cfg.Character = d.cfg.VoiceStyleOrDefault() == config.VoiceStyleCopper
+	return audio.NewPipeline(cfg)
+}
+
+// applyVoiceStyleLive forwards a voice style change to the active pipeline
+// if one is running. Safe to call with no active pipeline: it becomes a
+// no-op, and the config cache save in setVoiceStyleConfig still persists
+// the style for the next call to pick up at construction time.
 func (d *daemonCallbacks) applyVoiceStyleLive(style string) {
 	d.mu.Lock()
 	pip := d.pipeline
@@ -1617,16 +1621,18 @@ func main() {
 				if style == "" {
 					style = config.VoiceStyleCopper
 				}
+
+				cb.mu.Lock()
+				current := cb.cfg.VoiceStyle
+				cb.mu.Unlock()
+				if style == current {
+					// No change — skip the live apply and the config save so
+					// reconnect-triggered pushes don't fsync on every connect.
+					break
+				}
+
 				slog.Info("line_settings applied", "voice_style", style)
-
-				// Apply to any live pipeline so a mid-call change is heard immediately.
-				// If no pipeline is currently running, the next one constructed (at
-				// call start) will pick the style up from the config cache we save
-				// below.
 				cb.applyVoiceStyleLive(style)
-
-				// Persist the new style locally so the next cold start or in-flight
-				// call construction reads the correct value.
 				if err := cb.setVoiceStyleConfig(style); err != nil {
 					slog.Warn("line_settings: config save failed", "err", err)
 				}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1054,7 +1054,32 @@ func main() {
 		} else {
 			slog.Info("audio test: wav dumped", "path", dumpPath)
 		}
+
+		// A/B comparison scaffolding (temporary, for tuning the POTS voice
+		// character filter): play back the raw captured signal first, then
+		// the same signal processed through NewPOTSCharacterChain so the
+		// user can hear the "copper wire" color effect back-to-back on a
+		// real device. Strip this block before merging.
+		slog.Info("audio test A/B: playing RAW (RNNoise only)")
 		mixer.PlayOnceSamples(recorded)
+		time.Sleep(100 * time.Millisecond)
+		for mixer.OncePlaying() {
+			time.Sleep(100 * time.Millisecond)
+		}
+		doubleBeep()
+		for mixer.OncePlaying() {
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		character := audio.NewPOTSCharacterChain(sampleRate).Process(recorded)
+		const characterDumpPath = "/tmp/audiotest_character.wav"
+		if err := writePCMWav(characterDumpPath, character, sampleRate); err != nil {
+			slog.Warn("audio test: character wav dump failed", "path", characterDumpPath, "error", err)
+		} else {
+			slog.Info("audio test: character wav dumped", "path", characterDumpPath)
+		}
+		slog.Info("audio test A/B: playing COPPER (RNNoise + POTS character)")
+		mixer.PlayOnceSamples(character)
 		time.Sleep(100 * time.Millisecond)
 		for mixer.OncePlaying() {
 			time.Sleep(100 * time.Millisecond)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -438,6 +438,21 @@ func (d *daemonCallbacks) HangupCall() {
 	slog.Info("call ended")
 }
 
+// applyVoiceStyleLive forwards a voice style change to the active audio
+// pipeline if one is running. Called from the signal inbox handler when a
+// line_settings update arrives; safe to call with no active pipeline (it
+// becomes a no-op, and the config cache still gets persisted so the next
+// call picks up the style at construction time).
+func (d *daemonCallbacks) applyVoiceStyleLive(style string) {
+	d.mu.Lock()
+	pip := d.pipeline
+	d.mu.Unlock()
+	if pip == nil {
+		return
+	}
+	pip.SetVoiceStyle(style)
+}
+
 // handleConnectionStateChange is called (without d.mu held) from a pion
 // goroutine when the WebRTC peer connection state changes.  On transient
 // failures the original caller attempts a single ICE restart before giving up.
@@ -1580,6 +1595,30 @@ func main() {
 					}()
 				default:
 					slog.Warn("unknown restart mode", "mode", mode)
+				}
+
+			case sigclient.TypeLineSettings:
+				if msg.LineSettings == nil {
+					slog.Warn("line_settings message missing payload", "from", msg.From)
+					break
+				}
+				style := msg.LineSettings.VoiceStyle
+				if style == "" {
+					style = config.VoiceStyleCopper
+				}
+				slog.Info("line_settings applied", "voice_style", style)
+
+				// Apply to any live pipeline so a mid-call change is heard immediately.
+				// If no pipeline is currently running, the next one constructed (at
+				// call start) will pick the style up from the config cache we save
+				// below.
+				cb.applyVoiceStyleLive(style)
+
+				// Persist the new style locally so the next cold start or in-flight
+				// call construction reads the correct value.
+				cb.cfg.VoiceStyle = style
+				if err := cb.cfg.Save(); err != nil {
+					slog.Warn("line_settings: config save failed", "err", err)
 				}
 
 			default:

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1054,32 +1054,7 @@ func main() {
 		} else {
 			slog.Info("audio test: wav dumped", "path", dumpPath)
 		}
-
-		// A/B comparison scaffolding (temporary, for tuning the POTS voice
-		// character filter): play back the raw captured signal first, then
-		// the same signal processed through NewPOTSCharacterChain so the
-		// user can hear the "copper wire" color effect back-to-back on a
-		// real device. Strip this block before merging.
-		slog.Info("audio test A/B: playing RAW (RNNoise only)")
 		mixer.PlayOnceSamples(recorded)
-		time.Sleep(100 * time.Millisecond)
-		for mixer.OncePlaying() {
-			time.Sleep(100 * time.Millisecond)
-		}
-		doubleBeep()
-		for mixer.OncePlaying() {
-			time.Sleep(50 * time.Millisecond)
-		}
-
-		character := audio.NewPOTSCharacterChain(sampleRate).Process(recorded)
-		const characterDumpPath = "/tmp/audiotest_character.wav"
-		if err := writePCMWav(characterDumpPath, character, sampleRate); err != nil {
-			slog.Warn("audio test: character wav dump failed", "path", characterDumpPath, "error", err)
-		} else {
-			slog.Info("audio test: character wav dumped", "path", characterDumpPath)
-		}
-		slog.Info("audio test A/B: playing COPPER (RNNoise + POTS character)")
-		mixer.PlayOnceSamples(character)
 		time.Sleep(100 * time.Millisecond)
 		for mixer.OncePlaying() {
 			time.Sleep(100 * time.Millisecond)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -199,7 +199,9 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	close(sdpSent)
 
 	// Start audio pipeline
-	d.pipeline = audio.NewPipeline(audio.DefaultPipelineConfig())
+	pipCfg := audio.DefaultPipelineConfig()
+	pipCfg.Character = d.cfg.VoiceStyleOrDefault() == config.VoiceStyleCopper
+	d.pipeline = audio.NewPipeline(pipCfg)
 	if err := d.pipeline.Start(); err != nil {
 		slog.Error("audio pipeline start failed", "error", err)
 		return
@@ -374,7 +376,9 @@ func (d *daemonCallbacks) AnswerCall() {
 	close(sdpSent)
 
 	// Start audio pipeline (capture only — playback goes through mixer)
-	d.pipeline = audio.NewPipeline(audio.DefaultPipelineConfig())
+	pipCfg := audio.DefaultPipelineConfig()
+	pipCfg.Character = d.cfg.VoiceStyleOrDefault() == config.VoiceStyleCopper
+	d.pipeline = audio.NewPipeline(pipCfg)
 	if err := d.pipeline.Start(); err != nil {
 		slog.Error("audio pipeline (answer) start failed", "error", err)
 		return

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -453,6 +453,17 @@ func (d *daemonCallbacks) applyVoiceStyleLive(style string) {
 	pip.SetVoiceStyle(style)
 }
 
+// setVoiceStyleConfig writes the new voice style to the local config cache
+// under d.mu (serializing with the call-setup paths that read
+// d.cfg.VoiceStyle) and then persists it to disk outside the lock so the
+// atomic tmp+rename write doesn't block call setup.
+func (d *daemonCallbacks) setVoiceStyleConfig(style string) error {
+	d.mu.Lock()
+	d.cfg.VoiceStyle = style
+	d.mu.Unlock()
+	return d.cfg.Save()
+}
+
 // handleConnectionStateChange is called (without d.mu held) from a pion
 // goroutine when the WebRTC peer connection state changes.  On transient
 // failures the original caller attempts a single ICE restart before giving up.
@@ -1616,8 +1627,7 @@ func main() {
 
 				// Persist the new style locally so the next cold start or in-flight
 				// call construction reads the correct value.
-				cb.cfg.VoiceStyle = style
-				if err := cb.cfg.Save(); err != nil {
+				if err := cb.setVoiceStyleConfig(style); err != nil {
 					slog.Warn("line_settings: config save failed", "err", err)
 				}
 

--- a/pi/digitsd/internal/audio/filters.go
+++ b/pi/digitsd/internal/audio/filters.go
@@ -148,3 +148,23 @@ func NewPOTSChain(sampleRate int) *BiquadChain {
 	}
 	return NewBiquadChain(stages...)
 }
+
+// NewPOTSCharacterChain builds a pure 300-3400 Hz telephony bandpass with no
+// notch comb, intended as a cosmetic voice-color filter that makes speech
+// sound like a legacy copper-wire phone call.
+//
+// Unlike NewPOTSChain this does NOT try to remove mains hum. It assumes its
+// input is already clean (noise removed upstream by RNNoise or similar) and
+// therefore skips the harmonic notches entirely, which preserves voice
+// formants perfectly between the corners. The only effect is band-limiting,
+// which is exactly the POTS sound.
+//
+// Pipeline order matters: run this AFTER the denoiser, not before. Filtering
+// before denoise would narrow the spectrum RNNoise operates on and reduce
+// how well it can separate voice from noise.
+func NewPOTSCharacterChain(sampleRate int) *BiquadChain {
+	return NewBiquadChain(
+		NewHPF(sampleRate, 300), NewHPF(sampleRate, 300),
+		NewLPF(sampleRate, 3400), NewLPF(sampleRate, 3400),
+	)
+}

--- a/pi/digitsd/internal/audio/filters_test.go
+++ b/pi/digitsd/internal/audio/filters_test.go
@@ -134,6 +134,40 @@ func TestPOTSChainKillsHumAndHissPreservesVoice(t *testing.T) {
 	}
 }
 
+func TestPOTSCharacterChainShapesBand(t *testing.T) {
+	// POTS-character chain: pure 300-3400 Hz bandpass, no notch comb.
+	// It is meant to run AFTER RNNoise as a cosmetic voice color, so the
+	// test checks the 4th-order HPF + 4th-order LPF envelope rather than
+	// noise rejection.
+	ch := NewPOTSCharacterChain(48000)
+
+	// Well below the 300 Hz HPF corner: should be deeply attenuated.
+	if loss := attenuationDB(t, ch, 80); loss < 30 {
+		t.Errorf("80Hz attenuation (well below HPF corner): got %.1f dB, want >=30 dB", loss)
+	}
+	ch.Reset()
+	if loss := attenuationDB(t, ch, 150); loss < 12 {
+		t.Errorf("150Hz attenuation (below HPF corner): got %.1f dB, want >=12 dB", loss)
+	}
+	// Well above the 3400 Hz LPF corner.
+	ch.Reset()
+	if loss := attenuationDB(t, ch, 6000); loss < 20 {
+		t.Errorf("6kHz attenuation (above LPF corner): got %.1f dB, want >=20 dB", loss)
+	}
+
+	// Voice passband (safely inside both corners, with margin for the
+	// cascaded 2nd-order sections that push the effective -6 dB point
+	// slightly inside the stated corner). No notch comb means no harmonic
+	// teeth to worry about, so passband loss is smooth and monotonic.
+	for _, f := range []float64{800, 1200, 1500, 1800} {
+		ch.Reset()
+		loss := attenuationDB(t, ch, f)
+		if math.Abs(loss) > 1.0 {
+			t.Errorf("%gHz voice preserve: got %.2f dB, want within +-1 dB", f, loss)
+		}
+	}
+}
+
 func TestBiquadChainNilIsNoOp(t *testing.T) {
 	var ch *BiquadChain
 	in := sine(60, 48000, 10000, 1000)

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -77,13 +77,6 @@ func (p *Pipeline) OutFrames() <-chan []int16 {
 	return p.outPCM
 }
 
-// Voice style identifiers accepted by SetVoiceStyle. Kept here rather than in
-// the signal package so the audio package has no upstream dependency.
-const (
-	VoiceStyleCopper = "copper"
-	VoiceStyleModern = "modern"
-)
-
 // SetVoiceStyle swaps the post-denoise character filter atomically. Safe to
 // call from any goroutine at any time, including mid-call: captureLoop reads
 // the pointer each frame so the next frame after the swap picks up the new
@@ -91,7 +84,7 @@ const (
 // silently disable the effect.
 func (p *Pipeline) SetVoiceStyle(style string) {
 	switch style {
-	case VoiceStyleModern:
+	case "modern":
 		p.character.Store(nil)
 	default:
 		p.character.Store(NewPOTSCharacterChain(p.cfg.SampleRate))

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -13,8 +13,13 @@ type PipelineConfig struct {
 	MicChannel  int  // 0=left, 1=right. Both codecs route mic to left channel.
 	Denoise     bool
 	// Bandpass enables the POTS telephony bandpass + mains notch comb on
-	// the capture path. See NewPOTSChain for the exact filter topology.
+	// the capture path, applied BEFORE the denoiser. See NewPOTSChain for
+	// the exact filter topology.
 	Bandpass bool
+	// Character enables a pure 300-3400 Hz POTS bandpass applied AFTER the
+	// denoiser as a cosmetic voice-color effect that makes calls sound like
+	// a legacy copper-wire phone. See NewPOTSCharacterChain.
+	Character bool
 }
 
 // DefaultPipelineConfig returns sensible defaults for both codec types.
@@ -38,13 +43,14 @@ func DefaultPipelineConfig() PipelineConfig {
 // Pipeline ties ALSA capture → RNNoise denoising → outPCM channel.
 // Capture-only: playback is handled by the Mixer.
 type Pipeline struct {
-	cfg      PipelineConfig
-	capture  *Capture
-	filters  *BiquadChain
-	denoiser *Denoiser
-	outPCM   chan []int16 // denoised mono 20ms frames for WebRTC to encode
-	stop     chan struct{}
-	wg       sync.WaitGroup
+	cfg       PipelineConfig
+	capture   *Capture
+	filters   *BiquadChain // pre-denoise bandpass (optional)
+	character *BiquadChain // post-denoise POTS character shaping (optional)
+	denoiser  *Denoiser
+	outPCM    chan []int16 // denoised mono 20ms frames for WebRTC to encode
+	stop      chan struct{}
+	wg        sync.WaitGroup
 }
 
 // NewPipeline creates a Pipeline with the given config. Call Start() to open
@@ -72,6 +78,9 @@ func (p *Pipeline) Start() error {
 
 	if p.cfg.Bandpass {
 		p.filters = NewPOTSChain(p.cfg.SampleRate)
+	}
+	if p.cfg.Character {
+		p.character = NewPOTSCharacterChain(p.cfg.SampleRate)
 	}
 
 	if p.cfg.Denoise {
@@ -128,6 +137,8 @@ func (p *Pipeline) captureLoop() {
 		if p.denoiser != nil {
 			mono = p.denoiser.Process(mono)
 		}
+
+		mono = p.character.Process(mono)
 
 		// Non-blocking send — drop frame if consumer is slow.
 		select {

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"log/slog"
 	"sync"
+	"sync/atomic"
 )
 
 // PipelineConfig holds configuration for the audio pipeline.
@@ -37,6 +38,10 @@ func DefaultPipelineConfig() PipelineConfig {
 		// place so it can be re-enabled for testing or for a future codec
 		// without RNNoise.
 		Bandpass: false,
+		// Character defaults to true (copper voice) because the physical Digits
+		// phones are vintage handsets and the POTS color matches their aesthetic.
+		// Web UI toggles per line.
+		Character: true,
 	}
 }
 
@@ -46,7 +51,7 @@ type Pipeline struct {
 	cfg       PipelineConfig
 	capture   *Capture
 	filters   *BiquadChain // pre-denoise bandpass (optional)
-	character *BiquadChain // post-denoise POTS character shaping (optional)
+	character atomic.Pointer[BiquadChain] // post-denoise POTS character, swappable live
 	denoiser  *Denoiser
 	outPCM    chan []int16 // denoised mono 20ms frames for WebRTC to encode
 	stop      chan struct{}
@@ -56,16 +61,47 @@ type Pipeline struct {
 // NewPipeline creates a Pipeline with the given config. Call Start() to open
 // ALSA devices and begin streaming.
 func NewPipeline(cfg PipelineConfig) *Pipeline {
-	return &Pipeline{
+	p := &Pipeline{
 		cfg:    cfg,
 		outPCM: make(chan []int16, 8),
 		stop:   make(chan struct{}),
 	}
+	if cfg.Character {
+		p.character.Store(NewPOTSCharacterChain(cfg.SampleRate))
+	}
+	return p
 }
 
 // OutFrames returns the read-only channel of captured+denoised mono PCM frames.
 func (p *Pipeline) OutFrames() <-chan []int16 {
 	return p.outPCM
+}
+
+// Voice style identifiers accepted by SetVoiceStyle. Kept here rather than in
+// the signal package so the audio package has no upstream dependency.
+const (
+	VoiceStyleCopper = "copper"
+	VoiceStyleModern = "modern"
+)
+
+// SetVoiceStyle swaps the post-denoise character filter atomically. Safe to
+// call from any goroutine at any time, including mid-call: captureLoop reads
+// the pointer each frame so the next frame after the swap picks up the new
+// chain. Unknown style values fall back to copper so garbage config can't
+// silently disable the effect.
+func (p *Pipeline) SetVoiceStyle(style string) {
+	switch style {
+	case VoiceStyleModern:
+		p.character.Store(nil)
+	default:
+		p.character.Store(NewPOTSCharacterChain(p.cfg.SampleRate))
+	}
+}
+
+// loadCharacter is a test helper. Returns the current character chain (may
+// be nil).
+func (p *Pipeline) loadCharacter() *BiquadChain {
+	return p.character.Load()
 }
 
 // Start opens the ALSA capture device and begins the capture goroutine.
@@ -78,9 +114,6 @@ func (p *Pipeline) Start() error {
 
 	if p.cfg.Bandpass {
 		p.filters = NewPOTSChain(p.cfg.SampleRate)
-	}
-	if p.cfg.Character {
-		p.character = NewPOTSCharacterChain(p.cfg.SampleRate)
 	}
 
 	if p.cfg.Denoise {
@@ -138,7 +171,9 @@ func (p *Pipeline) captureLoop() {
 			mono = p.denoiser.Process(mono)
 		}
 
-		mono = p.character.Process(mono)
+		if ch := p.character.Load(); ch != nil {
+			mono = ch.Process(mono)
+		}
 
 		// Non-blocking send — drop frame if consumer is slow.
 		select {

--- a/pi/digitsd/internal/audio/pipeline_live_test.go
+++ b/pi/digitsd/internal/audio/pipeline_live_test.go
@@ -12,12 +12,12 @@ func TestSetVoiceStyleTogglesCharacterChain(t *testing.T) {
 		t.Fatal("default pipeline: character chain should be non-nil (copper)")
 	}
 
-	p.SetVoiceStyle(VoiceStyleModern)
+	p.SetVoiceStyle("modern")
 	if p.loadCharacter() != nil {
 		t.Errorf("after modern: character chain should be nil, got non-nil")
 	}
 
-	p.SetVoiceStyle(VoiceStyleCopper)
+	p.SetVoiceStyle("copper")
 	if p.loadCharacter() == nil {
 		t.Errorf("after copper: character chain should be non-nil")
 	}
@@ -25,7 +25,7 @@ func TestSetVoiceStyleTogglesCharacterChain(t *testing.T) {
 
 func TestSetVoiceStyleUnknownFallsBackToCopper(t *testing.T) {
 	p := NewPipeline(DefaultPipelineConfig())
-	p.SetVoiceStyle(VoiceStyleModern)
+	p.SetVoiceStyle("modern")
 	p.SetVoiceStyle("bogus")
 	if p.loadCharacter() == nil {
 		t.Errorf("unknown style: should fall back to copper (non-nil), got nil")

--- a/pi/digitsd/internal/audio/pipeline_live_test.go
+++ b/pi/digitsd/internal/audio/pipeline_live_test.go
@@ -1,0 +1,33 @@
+package audio
+
+import (
+	"testing"
+)
+
+func TestSetVoiceStyleTogglesCharacterChain(t *testing.T) {
+	p := NewPipeline(DefaultPipelineConfig())
+
+	// Default should be copper (character filter present).
+	if p.loadCharacter() == nil {
+		t.Fatal("default pipeline: character chain should be non-nil (copper)")
+	}
+
+	p.SetVoiceStyle(VoiceStyleModern)
+	if p.loadCharacter() != nil {
+		t.Errorf("after modern: character chain should be nil, got non-nil")
+	}
+
+	p.SetVoiceStyle(VoiceStyleCopper)
+	if p.loadCharacter() == nil {
+		t.Errorf("after copper: character chain should be non-nil")
+	}
+}
+
+func TestSetVoiceStyleUnknownFallsBackToCopper(t *testing.T) {
+	p := NewPipeline(DefaultPipelineConfig())
+	p.SetVoiceStyle(VoiceStyleModern)
+	p.SetVoiceStyle("bogus")
+	if p.loadCharacter() == nil {
+		t.Errorf("unknown style: should fall back to copper (non-nil), got nil")
+	}
+}

--- a/pi/digitsd/internal/audio/pipeline_test.go
+++ b/pi/digitsd/internal/audio/pipeline_test.go
@@ -22,8 +22,8 @@ func TestPipelineConfig(t *testing.T) {
 	if cfg.Bandpass {
 		t.Error("Bandpass: got true, want false (RNNoise handles hum)")
 	}
-	if cfg.Character {
-		t.Error("Character: got true, want false (opt-in cosmetic effect)")
+	if !cfg.Character {
+		t.Error("Character: got false, want true (copper default)")
 	}
 }
 

--- a/pi/digitsd/internal/audio/pipeline_test.go
+++ b/pi/digitsd/internal/audio/pipeline_test.go
@@ -22,6 +22,9 @@ func TestPipelineConfig(t *testing.T) {
 	if cfg.Bandpass {
 		t.Error("Bandpass: got true, want false (RNNoise handles hum)")
 	}
+	if cfg.Character {
+		t.Error("Character: got true, want false (opt-in cosmetic effect)")
+	}
 }
 
 func TestNewPipeline(t *testing.T) {

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -13,6 +13,12 @@ import (
 	"path/filepath"
 )
 
+// Voice style identifiers persisted in Config and on the wire.
+const (
+	VoiceStyleCopper = "copper"
+	VoiceStyleModern = "modern"
+)
+
 // Config holds digitsd runtime configuration loaded from a JSON file.
 // CLI flags always override values loaded from the file.
 type Config struct {
@@ -38,6 +44,11 @@ type Config struct {
 	// (LOW = off-hook). Leave false for protoboard builds with V-153-1C25
 	// microswitch (HIGH = off-hook).
 	HookInverted bool `json:"hook_inverted,omitempty"`
+
+	// VoiceStyle is the per-line audio character ("copper" or "modern").
+	// Set by the server on registration and on each web-UI change, cached
+	// locally so the device can start up with the correct style offline.
+	VoiceStyle string `json:"voice_style,omitempty"`
 
 	// path is the file the config was loaded from; used by Save.
 	path string
@@ -126,6 +137,17 @@ func isCorrupt(data []byte) bool {
 		}
 	}
 	return false
+}
+
+// VoiceStyleOrDefault returns the configured voice style, falling back to
+// VoiceStyleCopper when the field is empty. Kept separate from the raw field
+// so the empty-string case (never set, or explicitly cleared) doesn't have
+// to be special-cased at every call site.
+func (c *Config) VoiceStyleOrDefault() string {
+	if c == nil || c.VoiceStyle == "" {
+		return VoiceStyleCopper
+	}
+	return c.VoiceStyle
 }
 
 // Save writes the config back to the file it was loaded from.

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -350,3 +350,32 @@ func TestCLIOverride(t *testing.T) {
 		t.Errorf("CLI override for phone_number failed: got %q", effectiveNumber)
 	}
 }
+
+func TestConfigVoiceStyleDefaultCopper(t *testing.T) {
+	c := &Config{}
+	if got := c.VoiceStyleOrDefault(); got != "copper" {
+		t.Errorf("empty config: got %q, want %q", got, "copper")
+	}
+}
+
+func TestConfigVoiceStyleCustomPreserved(t *testing.T) {
+	c := &Config{VoiceStyle: "modern"}
+	if got := c.VoiceStyleOrDefault(); got != "modern" {
+		t.Errorf("custom value: got %q, want %q", got, "modern")
+	}
+}
+
+func TestConfigLoadPreservesVoiceStyle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"voice_style":"modern"}`), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.VoiceStyle != "modern" {
+		t.Errorf("loaded voice_style: got %q, want %q", c.VoiceStyle, "modern")
+	}
+}

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -47,12 +47,24 @@ const (
 
 	// TypeRestart is sent by the server to restart the service or reboot the device.
 	TypeRestart = "restart"
+
+	// TypeLineSettings is sent by the server to push an updated Settings blob
+	// for the line this device is registered as. Applied live.
+	TypeLineSettings = "line_settings"
 )
 
 // ContactEntry represents a single contact in a sync payload.
 type ContactEntry struct {
 	Number string `json:"number"`
 	Name   string `json:"name"`
+}
+
+// LineSettings is the wire-format copy of server/internal/line.Settings used
+// in signaling messages. Kept as a separate struct (not imported directly
+// from internal/line) so the signaling package stays a leaf with no upstream
+// dependency on the line store.
+type LineSettings struct {
+	VoiceStyle string `json:"voice_style,omitempty"`
 }
 
 // ICEServer represents a STUN or TURN server configuration.
@@ -97,6 +109,9 @@ type Message struct {
 
 	// Restart fields (restart messages)
 	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"
+
+	// Per-line settings updates (line_settings messages)
+	LineSettings *LineSettings `json:"line_settings,omitempty"`
 }
 
 // ParseMessage deserializes a JSON-encoded signaling message.

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -59,10 +59,13 @@ type ContactEntry struct {
 	Name   string `json:"name"`
 }
 
-// LineSettings is the wire-format copy of server/internal/line.Settings used
-// in signaling messages. Kept as a separate struct (not imported directly
-// from internal/line) so the signaling package stays a leaf with no upstream
-// dependency on the line store.
+// LineSettings is the wire-format copy of server-side line.Settings used in
+// signaling messages. Mirrors the server definition so digitsd doesn't need
+// to import any server code.
+//
+// Valid VoiceStyle values are defined canonically in internal/config as
+// VoiceStyleCopper and VoiceStyleModern. Any new voice style must be added
+// there, in server/internal/line, and in server/internal/signaling.
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 }

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -55,7 +55,7 @@ func main() {
 	// Link store
 	linkStore := household.NewLinkStore(database.DB)
 
-	relay := signaling.NewRelay(hub, tracker, line.NewAuthorizer(database))
+	relay := signaling.NewRelay(hub, tracker, line.NewAuthorizer(database), signaling.NewLineStoreAdapter(lineStore))
 
 	// Configure TURN credential generation if enabled
 	if cfg.TURNEnabled {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -216,6 +216,8 @@ BEGIN
         INSERT INTO schema_version (version) VALUES (10);
     END IF;
 END $$;`,
+		// v11: per-line settings JSONB column (voice_style, etc.)
+		`ALTER TABLE lines ADD COLUMN IF NOT EXISTS settings JSONB NOT NULL DEFAULT '{}'::jsonb`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -1,0 +1,43 @@
+package line
+
+// Voice style identifiers persisted in line.Settings and on the wire.
+const (
+	VoiceStyleCopper = "copper"
+	VoiceStyleModern = "modern"
+)
+
+// Settings holds per-line configuration that a household owner can change in
+// the web UI. Stored as a single JSONB column on the lines table so new
+// fields can be added without schema changes.
+type Settings struct {
+	VoiceStyle string `json:"voice_style,omitempty"`
+}
+
+// DefaultSettings returns the settings a newly created line starts with.
+// Copper is the default voice style because Digits' physical form (vintage
+// handsets) pairs better with POTS-colored audio than raw HD.
+func DefaultSettings() Settings {
+	return Settings{VoiceStyle: VoiceStyleCopper}
+}
+
+// Merge layers a patch on top of s, overwriting only the fields the patch
+// actually sets. This is how we apply a DB-loaded settings JSON on top of
+// the defaults: missing fields keep their default value.
+func (s Settings) Merge(patch Settings) Settings {
+	if patch.VoiceStyle != "" {
+		s.VoiceStyle = patch.VoiceStyle
+	}
+	return s
+}
+
+// Normalize rewrites any fields that hold an unknown value to their default.
+// Use this after unmarshaling untrusted input to avoid propagating garbage.
+func (s Settings) Normalize() Settings {
+	switch s.VoiceStyle {
+	case VoiceStyleCopper, VoiceStyleModern:
+		// ok
+	default:
+		s.VoiceStyle = VoiceStyleCopper
+	}
+	return s
+}

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -1,0 +1,72 @@
+package line
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDefaultSettingsVoiceStyleCopper(t *testing.T) {
+	s := DefaultSettings()
+	if s.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("VoiceStyle: got %q, want %q", s.VoiceStyle, VoiceStyleCopper)
+	}
+}
+
+func TestSettingsMergePreservesUnset(t *testing.T) {
+	base := DefaultSettings()
+	patch := Settings{} // empty JSON from DB
+	merged := base.Merge(patch)
+	if merged.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("empty merge should keep default, got %q", merged.VoiceStyle)
+	}
+}
+
+func TestSettingsMergeOverwrites(t *testing.T) {
+	base := DefaultSettings()
+	patch := Settings{VoiceStyle: VoiceStyleModern}
+	merged := base.Merge(patch)
+	if merged.VoiceStyle != VoiceStyleModern {
+		t.Errorf("merge did not overwrite, got %q", merged.VoiceStyle)
+	}
+}
+
+func TestSettingsJSONRoundTrip(t *testing.T) {
+	in := Settings{VoiceStyle: VoiceStyleModern}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Settings
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Errorf("round trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestSettingsUnmarshalEmptyJSONIsZeroValue(t *testing.T) {
+	var s Settings
+	if err := json.Unmarshal([]byte(`{}`), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.VoiceStyle != "" {
+		t.Errorf("empty JSON: got VoiceStyle %q, want empty string", s.VoiceStyle)
+	}
+}
+
+func TestSettingsNormalizeAcceptsKnownValues(t *testing.T) {
+	for _, v := range []string{VoiceStyleCopper, VoiceStyleModern} {
+		s := Settings{VoiceStyle: v}
+		if got := s.Normalize().VoiceStyle; got != v {
+			t.Errorf("Normalize(%q).VoiceStyle = %q", v, got)
+		}
+	}
+}
+
+func TestSettingsNormalizeCoercesUnknown(t *testing.T) {
+	s := Settings{VoiceStyle: "bogus"}
+	if got := s.Normalize().VoiceStyle; got != VoiceStyleCopper {
+		t.Errorf("unknown value should fall back to copper, got %q", got)
+	}
+}

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -2,6 +2,7 @@ package line
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -20,6 +21,19 @@ var ErrNotFound = errors.New("line not found")
 var ErrNumberTaken = errors.New("line number is already in use")
 
 var numberRegex = regexp.MustCompile(`^\d{3}-?\d{4}$`)
+
+// scanSettings parses the settings JSONB value returned by Postgres into a
+// Settings struct, layering the result on top of DefaultSettings so any
+// field not present in the DB falls through to its default.
+func scanSettings(raw []byte) (Settings, error) {
+	patch := Settings{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &patch); err != nil {
+			return Settings{}, fmt.Errorf("settings: %w", err)
+		}
+	}
+	return DefaultSettings().Merge(patch).Normalize(), nil
+}
 
 // ValidateNumber checks that num is exactly 7 digits, optionally formatted as NNN-NNNN.
 func ValidateNumber(num string) error {
@@ -49,6 +63,7 @@ type Line struct {
 	Number      string
 	Name        string
 	HouseholdID string
+	Settings    Settings
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -66,14 +81,18 @@ func NewStore(database *db.Database) *Store {
 // Add inserts a new line for the given household and returns it.
 func (s *Store) Add(number, name, householdID string) (*Line, error) {
 	l := &Line{}
+	var settingsRaw []byte
 	err := s.db.QueryRow(
 		`INSERT INTO lines (number, name, household_id)
 		 VALUES ($1, $2, $3)
-		 RETURNING id, number, name, household_id, created_at, updated_at`,
+		 RETURNING id, number, name, household_id, settings, created_at, updated_at`,
 		number, name, householdID,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt)
+	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("add line: %w", err)
+	}
+	if l.Settings, err = scanSettings(settingsRaw); err != nil {
+		return nil, err
 	}
 	return l, nil
 }
@@ -81,16 +100,20 @@ func (s *Store) Add(number, name, householdID string) (*Line, error) {
 // GetByID retrieves a line by its integer ID.
 func (s *Store) GetByID(id int64) (*Line, error) {
 	l := &Line{}
+	var settingsRaw []byte
 	err := s.db.QueryRow(
-		`SELECT id, number, name, household_id, created_at, updated_at
+		`SELECT id, number, name, household_id, settings, created_at, updated_at
 		 FROM lines WHERE id = $1`,
 		id,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt)
+	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get line by id %d: %w", id, err)
+	}
+	if l.Settings, err = scanSettings(settingsRaw); err != nil {
+		return nil, err
 	}
 	return l, nil
 }
@@ -98,16 +121,20 @@ func (s *Store) GetByID(id int64) (*Line, error) {
 // GetByNumber retrieves a line by its phone number.
 func (s *Store) GetByNumber(number string) (*Line, error) {
 	l := &Line{}
+	var settingsRaw []byte
 	err := s.db.QueryRow(
-		`SELECT id, number, name, household_id, created_at, updated_at
+		`SELECT id, number, name, household_id, settings, created_at, updated_at
 		 FROM lines WHERE number = $1`,
 		number,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt)
+	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get line by number %s: %w", number, err)
+	}
+	if l.Settings, err = scanSettings(settingsRaw); err != nil {
+		return nil, err
 	}
 	return l, nil
 }
@@ -115,7 +142,7 @@ func (s *Store) GetByNumber(number string) (*Line, error) {
 // List returns all lines ordered by number.
 func (s *Store) List() ([]Line, error) {
 	rows, err := s.db.Query(
-		`SELECT id, number, name, household_id, created_at, updated_at
+		`SELECT id, number, name, household_id, settings, created_at, updated_at
 		 FROM lines ORDER BY number`,
 	)
 	if err != nil {
@@ -126,8 +153,12 @@ func (s *Store) List() ([]Line, error) {
 	var lines []Line
 	for rows.Next() {
 		var l Line
-		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		var settingsRaw []byte
+		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan line: %w", err)
+		}
+		if l.Settings, err = scanSettings(settingsRaw); err != nil {
+			return nil, err
 		}
 		lines = append(lines, l)
 	}
@@ -137,7 +168,7 @@ func (s *Store) List() ([]Line, error) {
 // ListByHousehold returns all lines belonging to the given household, ordered by number.
 func (s *Store) ListByHousehold(householdID string) ([]Line, error) {
 	rows, err := s.db.Query(
-		`SELECT id, number, name, household_id, created_at, updated_at
+		`SELECT id, number, name, household_id, settings, created_at, updated_at
 		 FROM lines WHERE household_id = $1 ORDER BY number`,
 		householdID,
 	)
@@ -149,8 +180,12 @@ func (s *Store) ListByHousehold(householdID string) ([]Line, error) {
 	var lines []Line
 	for rows.Next() {
 		var l Line
-		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		var settingsRaw []byte
+		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan line: %w", err)
+		}
+		if l.Settings, err = scanSettings(settingsRaw); err != nil {
+			return nil, err
 		}
 		lines = append(lines, l)
 	}
@@ -164,7 +199,7 @@ func (s *Store) ListByHouseholds(householdIDs []string) (map[string][]Line, erro
 		return nil, nil
 	}
 	rows, err := s.db.Query(
-		`SELECT id, number, name, household_id, created_at, updated_at
+		`SELECT id, number, name, household_id, settings, created_at, updated_at
 		 FROM lines WHERE household_id = ANY($1) ORDER BY number`,
 		pq.Array(householdIDs),
 	)
@@ -176,8 +211,12 @@ func (s *Store) ListByHouseholds(householdIDs []string) (map[string][]Line, erro
 	result := make(map[string][]Line, len(householdIDs))
 	for rows.Next() {
 		var l Line
-		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		var settingsRaw []byte
+		if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan line: %w", err)
+		}
+		if l.Settings, err = scanSettings(settingsRaw); err != nil {
+			return nil, err
 		}
 		result[l.HouseholdID] = append(result[l.HouseholdID], l)
 	}
@@ -237,6 +276,26 @@ func (s *Store) NumberExistsExcluding(number string, excludeID int64) (bool, err
 		return false, fmt.Errorf("number exists excluding: %w", err)
 	}
 	return count > 0, nil
+}
+
+// UpdateSettings replaces the settings JSONB for the line with the given ID.
+func (s *Store) UpdateSettings(id int64, settings Settings) error {
+	raw, err := json.Marshal(settings.Normalize())
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	res, err := s.db.Exec(
+		`UPDATE lines SET settings = $1, updated_at = NOW() WHERE id = $2`,
+		raw, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update settings: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("line %d not found", id)
+	}
+	return nil
 }
 
 // GetHouseholdIDByNumber returns the household UUID for the given phone number.

--- a/server/internal/line/store_test.go
+++ b/server/internal/line/store_test.go
@@ -1,6 +1,7 @@
 package line
 
 import (
+	"database/sql"
 	"os"
 	"testing"
 
@@ -279,6 +280,72 @@ func TestValidateNumber(t *testing.T) {
 		if (err != nil) != tt.wantErr {
 			t.Errorf("ValidateNumber(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 		}
+	}
+}
+
+// testStoreWithHousehold bundles a Store, the raw *sql.DB, and a pre-created
+// household ID for tests that need all three.
+type testStoreWithHousehold struct {
+	store       *Store
+	rawDB       interface {
+		Exec(query string, args ...any) (sql.Result, error)
+	}
+	householdID string
+}
+
+// newTestStoreWithHousehold creates a testStoreWithHousehold using the same
+// skip-if-no-DB pattern as testStore.
+func newTestStoreWithHousehold(t *testing.T) (*testStoreWithHousehold, func()) {
+	t.Helper()
+	s, database := testStore(t)
+	householdID := createTestHousehold(t, database)
+	return &testStoreWithHousehold{
+		store:       s,
+		rawDB:       database.DB,
+		householdID: householdID,
+	}, func() {}
+}
+
+func TestStoreSettingsDefaultAndUpdate(t *testing.T) {
+	store, cleanup := newTestStoreWithHousehold(t)
+	defer cleanup()
+
+	ln, err := store.store.Add("555-0101", "Test", store.householdID)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Newly created line should come back with default-filled settings.
+	got, err := store.store.GetByID(ln.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Settings.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("new line default VoiceStyle: got %q, want %q", got.Settings.VoiceStyle, VoiceStyleCopper)
+	}
+
+	// Update the setting.
+	if err := store.store.UpdateSettings(ln.ID, Settings{VoiceStyle: VoiceStyleModern}); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+	got, err = store.store.GetByID(ln.ID)
+	if err != nil {
+		t.Fatalf("reget: %v", err)
+	}
+	if got.Settings.VoiceStyle != VoiceStyleModern {
+		t.Errorf("after update: got %q, want %q", got.Settings.VoiceStyle, VoiceStyleModern)
+	}
+
+	// Empty settings in DB should still return default after load.
+	if _, err := store.rawDB.Exec(`UPDATE lines SET settings = '{}' WHERE id = $1`, ln.ID); err != nil {
+		t.Fatalf("reset settings: %v", err)
+	}
+	got, err = store.store.GetByID(ln.ID)
+	if err != nil {
+		t.Fatalf("reget after reset: %v", err)
+	}
+	if got.Settings.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("empty json should fall through to default, got %q", got.Settings.VoiceStyle)
 	}
 }
 

--- a/server/internal/line/store_test.go
+++ b/server/internal/line/store_test.go
@@ -287,9 +287,7 @@ func TestValidateNumber(t *testing.T) {
 // household ID for tests that need all three.
 type testStoreWithHousehold struct {
 	store       *Store
-	rawDB       interface {
-		Exec(query string, args ...any) (sql.Result, error)
-	}
+	rawDB       *sql.DB
 	householdID string
 }
 

--- a/server/internal/signaling/linesettings_test.go
+++ b/server/internal/signaling/linesettings_test.go
@@ -1,0 +1,28 @@
+package signaling
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLineSettingsMessageJSONRoundTrip(t *testing.T) {
+	in := &Message{
+		Type:         TypeLineSettings,
+		To:           "5550101",
+		LineSettings: &LineSettings{VoiceStyle: "copper"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := ParseMessage(b)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Type != TypeLineSettings {
+		t.Errorf("Type: got %q, want %q", got.Type, TypeLineSettings)
+	}
+	if got.LineSettings == nil || got.LineSettings.VoiceStyle != "copper" {
+		t.Errorf("LineSettings: got %+v", got.LineSettings)
+	}
+}

--- a/server/internal/signaling/linestore.go
+++ b/server/internal/signaling/linestore.go
@@ -1,0 +1,9 @@
+package signaling
+
+// LineStore is the subset of line.Store the signaling layer needs to fetch
+// per-line settings. Kept as a small interface here so the signaling package
+// does not import the real internal/line package and stays a leaf in the
+// dependency graph.
+type LineStore interface {
+	LineSettingsByNumber(number string) (*LineSettings, error)
+}

--- a/server/internal/signaling/linestore.go
+++ b/server/internal/signaling/linestore.go
@@ -1,9 +1,9 @@
 package signaling
 
 // LineStore is the subset of line.Store the signaling layer needs to fetch
-// per-line settings. Kept as a small interface here so the signaling package
-// does not import the real internal/line package and stays a leaf in the
-// dependency graph.
+// per-line settings. Kept as a small interface here so the dependency on
+// internal/line is isolated to a single adapter file (linestore_adapter.go)
+// rather than threaded through the whole signaling package.
 type LineStore interface {
 	LineSettingsByNumber(number string) (*LineSettings, error)
 }

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -1,0 +1,23 @@
+package signaling
+
+import "github.com/justinlindh/digits/server/internal/line"
+
+// lineStoreAdapter wraps a real *line.Store so the signaling package can
+// consume it through the LineStore interface without importing internal/line
+// into its type system elsewhere.
+type lineStoreAdapter struct {
+	inner *line.Store
+}
+
+// NewLineStoreAdapter returns a signaling.LineStore backed by a real line.Store.
+func NewLineStoreAdapter(s *line.Store) LineStore {
+	return &lineStoreAdapter{inner: s}
+}
+
+func (a *lineStoreAdapter) LineSettingsByNumber(number string) (*LineSettings, error) {
+	ln, err := a.inner.GetByNumber(number)
+	if err != nil {
+		return nil, err
+	}
+	return &LineSettings{VoiceStyle: ln.Settings.VoiceStyle}, nil
+}

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -24,7 +24,16 @@ const (
 	TypeICERestart      = "ice_restart"       // Bidirectional: ICE restart offer with new credentials
 	TypeFactoryReset    = "factory_reset"    // Server → Phone: trigger factory reset
 	TypeRestart         = "restart"            // Server → Phone: restart service or reboot
+	TypeLineSettings    = "line_settings"      // Server → Phone: per-line config update
 )
+
+// LineSettings is the wire-format copy of server/internal/line.Settings used
+// in signaling messages. Kept as a separate struct (not imported directly
+// from internal/line) so the signaling package stays a leaf with no upstream
+// dependency on the line store.
+type LineSettings struct {
+	VoiceStyle string `json:"voice_style,omitempty"`
+}
 
 // ICEServer represents a STUN or TURN server configuration.
 type ICEServer struct {
@@ -66,6 +75,9 @@ type Message struct {
 
 	// Restart fields (restart messages)
 	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"
+
+	// Per-line settings updates (line_settings messages)
+	LineSettings *LineSettings `json:"line_settings,omitempty"`
 }
 
 func ParseMessage(data []byte) (*Message, error) {

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -29,8 +29,12 @@ const (
 
 // LineSettings is the wire-format copy of server/internal/line.Settings used
 // in signaling messages. Kept as a separate struct (not imported directly
-// from internal/line) so the signaling package stays a leaf with no upstream
-// dependency on the line store.
+// from internal/line) so the dependency on internal/line is isolated to
+// linestore_adapter.go.
+//
+// Valid VoiceStyle values are defined canonically in server/internal/line
+// as VoiceStyleCopper and VoiceStyleModern. Any new voice style must be
+// added there, in pi/digitsd/internal/config, and in pi/digitsd/internal/signal.
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -23,18 +23,20 @@ type CallAuthorizer interface {
 }
 
 type Relay struct {
-	Hub          *Hub
-	Tracker      CallTracker
-	TURNGen      *turn.CredentialGenerator
-	TURNDomain   string
+	Hub            *Hub
+	Tracker        CallTracker
+	TURNGen        *turn.CredentialGenerator
+	TURNDomain     string
 	CallAuthorizer CallAuthorizer
+	LineStore      LineStore
 }
 
-func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer) *Relay {
+func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer, lineStore LineStore) *Relay {
 	return &Relay{
 		Hub:            hub,
 		Tracker:        tracker,
 		CallAuthorizer: authorizer,
+		LineStore:      lineStore,
 	}
 }
 
@@ -178,6 +180,31 @@ func (r *Relay) handleRequestICE(from string, _ *Message) {
 
 	if err := r.Hub.SendTo(from, resp); err != nil {
 		slog.Error("send ice-servers failed", "to", from, "err", err)
+	}
+}
+
+// OnRegistered is called immediately after a device successfully registers.
+// It pushes the current line settings to the device so it boots with the
+// right voice style. Best-effort: unknown lines (unpaired) or send failures
+// are logged and skipped -- the device keeps its locally-cached last setting.
+func (r *Relay) OnRegistered(number string) {
+	if r.LineStore == nil {
+		return
+	}
+	settings, err := r.LineStore.LineSettingsByNumber(number)
+	if err != nil {
+		slog.Debug("line settings lookup on register skipped", "number", number, "err", err)
+		return
+	}
+	if settings == nil {
+		return
+	}
+	if err := r.Hub.SendTo(number, &Message{
+		Type:         TypeLineSettings,
+		To:           number,
+		LineSettings: settings,
+	}); err != nil {
+		slog.Warn("push line settings on register failed", "number", number, "err", err)
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -86,7 +86,7 @@ func (m *errorCallAuthorizer) CanCall(fromNumber, toNumber string) (bool, error)
 func TestRelayCallFlow(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	// Register two mock connections
 	conn1 := &Conn{Send: make(chan []byte, 10)}
@@ -115,7 +115,7 @@ func TestRelayCallFlow(t *testing.T) {
 
 func TestRelayCallToOfflinePhone(t *testing.T) {
 	hub := NewHub()
-	relay := NewRelay(hub, nil, nil)
+	relay := NewRelay(hub, nil, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	hub.Register("3140001", conn1)
@@ -146,7 +146,7 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 		},
 	}
 
-	relay := NewRelay(hub, tracker, authorizer)
+	relay := NewRelay(hub, tracker, authorizer, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -229,7 +229,7 @@ func TestRelayCallDeniedOnAuthorizerError(t *testing.T) {
 	tracker := newMockTracker()
 
 	authorizer := &errorCallAuthorizer{err: errors.New("db connection failed")}
-	relay := NewRelay(hub, tracker, authorizer)
+	relay := NewRelay(hub, tracker, authorizer, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -264,7 +264,7 @@ func TestRelayCallDeniedOnAuthorizerError(t *testing.T) {
 func TestRelayBusySignal(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -322,7 +322,7 @@ func TestRelayBusySignal(t *testing.T) {
 func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -366,7 +366,7 @@ func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
 func TestRelayICERestartForwarded(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -407,7 +407,7 @@ func TestRelayICERestartForwarded(t *testing.T) {
 func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -451,7 +451,7 @@ func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
 func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	relay := NewRelay(hub, tracker, nil)
+	relay := NewRelay(hub, tracker, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -512,7 +512,7 @@ func TestHubOnlineNumbers(t *testing.T) {
 
 func TestRelayRestartMessageNotPanics(t *testing.T) {
 	hub := NewHub()
-	relay := NewRelay(hub, nil, nil)
+	relay := NewRelay(hub, nil, nil, nil)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
 	hub.Register("3140001", conn)

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -51,7 +51,7 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 
 	hub := signaling.NewHub()
 	tracker := calls.New(nil) // nil DB — no DB calls expected in these tests
-	relay := signaling.NewRelay(hub, tracker, nil)
+	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	h, err := NewHandler(nil, nil, hub, tracker, relay, HandlerConfig{
 		Addr:        ":0",

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -38,7 +38,7 @@ func setupCallsTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.S
 	deviceStore := device.NewStore(database)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
-	relay := signaling.NewRelay(hub, tracker, nil)
+	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	authStore := auth.NewStoreFromDB(database.DB)
 	householdStore := household.NewStore(database.DB)

--- a/server/internal/web/e2e_test.go
+++ b/server/internal/web/e2e_test.go
@@ -39,7 +39,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *line.Store, *calls.Tracke
 	deviceStore := device.NewStore(database)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
-	relay := signaling.NewRelay(hub, tracker, nil)
+	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	authStore := auth.NewStoreFromDB(database.DB)
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -696,6 +696,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
+	voiceStyle := strings.TrimSpace(r.FormValue("voice_style"))
 
 	ln, err := h.lineStore.GetByNumber(number)
 	if err != nil {
@@ -708,12 +709,34 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if voiceStyle != "" && voiceStyle != ln.Settings.VoiceStyle {
+		next := ln.Settings
+		next.VoiceStyle = voiceStyle
+		if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Push to the device if it is currently connected so the change
+		// takes effect live without waiting for the next reconnect.
+		if err := h.pushLineSettings(number, next); err != nil {
+			slog.Warn("push line settings failed", "number", number, "err", err)
+		}
+	}
+
 	data := h.buildLinesData(r, "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, "phones-table", data)
 		return
 	}
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
+}
+
+// pushLineSettings is implemented in Task 7 once the signaling message
+// type exists. Present here as a stub so handler code compiles in isolation.
+func (h *Handler) pushLineSettings(number string, settings line.Settings) error {
+	_ = number
+	_ = settings
+	return nil
 }
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -709,17 +709,20 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if voiceStyle != "" && voiceStyle != ln.Settings.VoiceStyle {
+	if voiceStyle != "" {
 		next := ln.Settings
 		next.VoiceStyle = voiceStyle
-		if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		// Push to the device if it is currently connected so the change
-		// takes effect live without waiting for the next reconnect.
-		if err := h.pushLineSettings(number, next); err != nil {
-			slog.Warn("push line settings failed", "number", number, "err", err)
+		next = next.Normalize()
+		if next.VoiceStyle != ln.Settings.VoiceStyle {
+			if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			// Push to the device if it is currently connected so the change
+			// takes effect live without waiting for the next reconnect.
+			if err := h.pushLineSettings(number, next); err != nil {
+				slog.Warn("push line settings failed", "number", number, "err", err)
+			}
 		}
 	}
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -731,12 +731,21 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
 }
 
-// pushLineSettings is implemented in Task 7 once the signaling message
-// type exists. Present here as a stub so handler code compiles in isolation.
+// pushLineSettings sends the updated settings to the device currently
+// registered as the given number, if any. A missing device is not an error;
+// the next time that device reconnects it will receive the latest settings
+// via the registration push in relay.OnRegistered.
 func (h *Handler) pushLineSettings(number string, settings line.Settings) error {
-	_ = number
-	_ = settings
-	return nil
+	if h.hub.Get(number) == nil {
+		return nil
+	}
+	return h.hub.SendTo(number, &signaling.Message{
+		Type: signaling.TypeLineSettings,
+		To:   number,
+		LineSettings: &signaling.LineSettings{
+			VoiceStyle: settings.VoiceStyle,
+		},
+	})
 }
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1447,6 +1447,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		LastSeen:   time.Now(),
 	}
 	h.hub.Register(msg.Number, conn)
+	h.relay.OnRegistered(msg.Number)
 	number := msg.Number
 
 	// Configure pong handler to extend read deadline on each pong

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -38,7 +38,7 @@ func setupHandler(t *testing.T) (*Handler, *db.Database, *auth.Store) {
 	deviceStore := device.NewStore(database)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
-	relay := signaling.NewRelay(hub, tracker, nil)
+	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	authStore := auth.NewStoreFromDB(database.DB)
 	householdStore := household.NewStore(database.DB)

--- a/server/internal/web/ratelimit_test.go
+++ b/server/internal/web/ratelimit_test.go
@@ -33,7 +33,7 @@ func setupRateLimitTestServer(t *testing.T) *httptest.Server {
 	deviceStore := device.NewStore(database)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
-	relay := signaling.NewRelay(hub, tracker, nil)
+	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	authStore := auth.NewStoreFromDB(database.DB)
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -231,11 +231,19 @@
     <form hx-post="/phones/{{.Line.Number}}/edit"
           hx-target="#phones-table"
           hx-swap="outerHTML"
-          class="flex gap-2">
+          class="flex flex-wrap items-center gap-2">
       <input type="text"
              name="name"
              value="{{.Line.Name}}"
              class="bg-[#0d1117] border border-[#58a6ff] rounded px-2 py-1 text-sm text-[#e6edf3] focus:outline-none w-48">
+      <label class="flex items-center gap-1 text-xs text-[#8b949e]">
+        Voice
+        <select name="voice_style"
+                class="bg-[#0d1117] border border-[#30363d] rounded px-2 py-1 text-sm text-[#e6edf3]">
+          <option value="copper" {{if eq .Line.Settings.VoiceStyle "copper"}}selected{{end}}>Copper wire</option>
+          <option value="modern" {{if eq .Line.Settings.VoiceStyle "modern"}}selected{{end}}>Modern HD</option>
+        </select>
+      </label>
       <button type="submit" class="text-xs px-3 py-1 bg-[#238636] hover:bg-[#2ea043] text-white rounded transition-colors">Save</button>
       <a href="/phones" class="text-xs px-3 py-1 bg-[#21262d] hover:bg-[#2d333b] text-[#c9d1d9] rounded transition-colors">Cancel</a>
     </form>


### PR DESCRIPTION
## Summary

Adds a per-line `voice_style` setting (`copper` | `modern`) editable in the web UI, persisted in the server DB as a JSONB column, pushed to each digitsd device over its existing signaling WebSocket, and applied live on the audio pipeline via an atomic chain swap without restarting the daemon or dropping the call.

- **Default is `copper`** (POTS-colored audio via a 300-3400 Hz 4th-order bandpass applied after RNNoise). Rationale: Digits runs inside gutted vintage desk phones, and POTS voice coloring matches the physical aesthetic.
- **Editable per line** via a new dropdown in the existing `phone-edit-row` form on `/phones`. Inline for now; refactor to a dedicated settings panel when a second per-line setting lands.
- **Authoritative server, caching device.** Settings live in `lines.settings` JSONB; digitsd caches them in `/data/digits/config.json` so cold boots without the server pick up the last-known value, and the server pushes the fresh state on every reconnect so drift is impossible.
- **Hot-reload mechanism**: `Pipeline.character` is now an `atomic.Pointer[BiquadChain]`, and `SetVoiceStyle(string)` atomically swaps it. `captureLoop` does a per-frame `Load()`, so mid-call toggles take effect on the next audio frame without dropping or glitching the call. The old chain is GC'd once the current frame finishes processing.

## Architecture

```
web UI (dropdown)
   │
   ▼
POST /phones/<num>/edit
   │
   ├─ line.Store.UpdateSettings  (DB: JSONB column on lines)
   │
   └─ Hub.SendTo(TypeLineSettings)  (WebSocket, best-effort)
           │
           ▼
   digitsd signal inbox
           │
           ├─ Pipeline.SetVoiceStyle  (atomic.Pointer swap on live pipeline)
           │
           └─ Config.Save  (atomic tmp+rename to /data/digits/config.json)
```

Server also pushes `TypeLineSettings` immediately after every successful `Hub.Register`, so reconnects always pull fresh authoritative state.

## Notable design choices

- **JSONB column over a separate settings table.** First per-line setting of what will be many; JSONB means no schema migration per new setting, and the Go layer layers `DefaultSettings().Merge(patch).Normalize()` to turn empty DB rows into default-filled values.
- **`signaling.LineStore` interface + `lineStoreAdapter`.** Keeps the signaling package a leaf — only the adapter file imports `internal/line`, matching how `CallAuthorizer` is handled.
- **Three copies of the `"copper"` / `"modern"` constants** across `config`, `line`, and `signaling` packages (the `audio` package's copies were removed during simplify cleanup). This is intentional: each package at a different boundary needs its own vocabulary, and there's no shared leaf package worth creating for two strings.
- **`newPipeline()` helper** on `daemonCallbacks` DRYs the two call-setup sites (`InitiateCall`, `AnswerCall`) so adding a second config field that controls the pipeline only touches one place.
- **Idempotent `TypeLineSettings` handler** skips the config save when the incoming style already matches the cached value, avoiding SD-card fsync on every reconnect.

## Commits (17 total, squash-merges cleanly)

12 plan-driven feature commits (`9a73ccb` → `7bb44b8`), three post-review fix commits (`7e1fb66` race fix, `4a08351` normalization, `19583dc` simplify cleanups), and three branch-tail commits from earlier session work on the POTS character filter primitive (`54281e6` + add/revert pair) that introduce the filter this PR toggles.

## Test plan

- [x] `go build`, `go vet`, `golangci-lint run`, `go test` — all clean on both `server/` and `pi/digitsd/` modules
- [x] TDD for all new types: `line.Settings` (defaults, merge, normalize, JSON round-trip), `Pipeline.SetVoiceStyle` (toggle, unknown-fallback), `config.VoiceStyleOrDefault`, `line.Store` round-trip with empty-JSON fallback to default
- [x] Signaling wire format: `TestLineSettingsMessageJSONRoundTrip` exercises the full Message round trip
- [x] Web handler: test fixtures updated, existing tests pass
- [ ] **Manual on-device verification** (to run after merge or before depending on your appetite):
  - [ ] Deploy new digitsd to both phones, deploy new signald to prod
  - [ ] Verify migration v11 ran: `\d lines` shows `settings | jsonb`
  - [ ] Confirm both phones log \`line_settings applied voice_style=copper\` on reconnect
  - [ ] Dial \`*#8378#\` on digits 2, confirm copper sound
  - [ ] Flip digits 2 to modern via web UI, dial \`*#8378#\` again, confirm modern sound
  - [ ] Reboot digits 2, confirm setting survived (cached in config.json)
  - [ ] Flip digits 2 back to copper

## Known out-of-scope issues

- Pre-existing unsynchronized writes to `Config.DeviceToken` and `Config.PairingCode` in the `TypePaired` handler. Same unsafe pattern as the race this PR fixed for `VoiceStyle`, but not a regression; should be addressed in a small follow-up that unifies the three.