### PR TITLE
fix(ci): install conventional-changelog-conventionalcommits in release workflows

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -50,7 +50,8 @@ jobs:
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
             @semantic-release/exec \
-            @semantic-release/github
+            @semantic-release/github \
+            conventional-changelog-conventionalcommits
 
       - name: Run semantic-release
         run: |

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -71,7 +71,8 @@ jobs:
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
             @semantic-release/exec \
-            @semantic-release/github
+            @semantic-release/github \
+            conventional-changelog-conventionalcommits
 
       - name: Run semantic-release
         run: |

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "20"
 
       - name: Install semantic-release
-        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github
+        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/github conventional-changelog-conventionalcommits
 
       - name: Run semantic-release
         run: |


### PR DESCRIPTION
## Summary

All three release workflows (\`server-release\`, \`pi-release\`, \`fw-release\`) use \`preset: 'conventionalcommits'\` in their releaserc configs, but the workflow install steps don't install \`conventional-changelog-conventionalcommits\`. It used to be a transitive dep of \`@semantic-release/release-notes-generator\`; a recent upstream release unbundled it, and every release run since has been failing in the \`generateNotes\` step with:

\`\`\`
Error: Cannot find module 'conventional-changelog-conventionalcommits'
    ...
  pluginName: '@semantic-release/release-notes-generator'
\`\`\`

This commit adds the package explicitly to the install list in all three workflows.

## How it slipped through

The \`#166\` (voice_style) PR's server release run was the first one to fail — see run [24329856470](https://github.com/justinlindh/digits/actions/runs/24329856470). Previous runs from earlier today (\`#164\`, \`#163\`) passed, which points to an upstream npm package update landing in the window between those runs.

## Related

Note that the \`#166\` squash commit title is \`feat: ...\` without a scope. Even after this workflow fix lands, \`server/.releaserc.cjs\`'s \`{ scope: '!*server*', release: false }\` rule will still prevent a release from being cut for that commit — the voice_style PR will need a manual tag + GitHub release on \`b270ef8\` to be published. Flagging separately so we can do that by hand after this fix merges.

## Test plan

- [x] YAML edits compile (no syntax errors in the install command)
- [ ] Merge this, watch the next release workflow run (or manually trigger one via \`workflow_dispatch\`) to confirm semantic-release reaches the end of its pipeline instead of dying at \`generateNotes\`