### PR TITLE
feat(server): move voice_style control to phone detail page

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -723,13 +723,18 @@ func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
+	raw := strings.TrimSpace(r.FormValue("voice_style"))
+	if raw == "" {
+		http.Error(w, "missing voice_style", http.StatusBadRequest)
+		return
+	}
 	ln, err := h.lineStore.GetByNumber(number)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	next := ln.Settings
-	next.VoiceStyle = strings.TrimSpace(r.FormValue("voice_style"))
+	next.VoiceStyle = raw
 	next = next.Normalize()
 	if next.VoiceStyle != ln.Settings.VoiceStyle {
 		if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -204,6 +204,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /phones/{number}", h.handlePhoneDetail)
 	protected.HandleFunc("GET /phones/{number}/edit", h.handlePhoneEditGet)
 	protected.HandleFunc("POST /phones/{number}/edit", h.handlePhoneEditPost)
+	protected.HandleFunc("POST /phones/{number}/voice-style", h.handlePhoneVoiceStylePost)
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)
 	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
@@ -696,7 +697,6 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
-	voiceStyle := strings.TrimSpace(r.FormValue("voice_style"))
 
 	ln, err := h.lineStore.GetByNumber(number)
 	if err != nil {
@@ -709,29 +709,45 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if voiceStyle != "" {
-		next := ln.Settings
-		next.VoiceStyle = voiceStyle
-		next = next.Normalize()
-		if next.VoiceStyle != ln.Settings.VoiceStyle {
-			if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			// Push to the device if it is currently connected so the change
-			// takes effect live without waiting for the next reconnect.
-			if err := h.pushLineSettings(number, next); err != nil {
-				slog.Warn("push line settings failed", "number", number, "err", err)
-			}
-		}
-	}
-
 	data := h.buildLinesData(r, "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, "phones-table", data)
 		return
 	}
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
+}
+
+func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	ln, err := h.lineStore.GetByNumber(number)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	next := ln.Settings
+	next.VoiceStyle = strings.TrimSpace(r.FormValue("voice_style"))
+	next = next.Normalize()
+	if next.VoiceStyle != ln.Settings.VoiceStyle {
+		if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := h.pushLineSettings(number, next); err != nil {
+			slog.Warn("push line settings failed", "number", number, "err", err)
+		}
+		ln.Settings = next
+	}
+	if isHTMX(r) {
+		renderWith(w, h.tmplPhoneDetail, "voice-style-section", struct {
+			Line line.Line
+		}{Line: *ln})
+		return
+	}
+	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
 }
 
 // pushLineSettings sends the updated settings to the device currently

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -472,6 +472,209 @@ func TestPhoneOnlineStatus(t *testing.T) {
 	}
 }
 
+// setupVoiceStyleLine creates the test user's household, inserts a line with
+// the default voice_style, and registers cleanup. Returns a function that
+// reads the current voice_style straight from the DB so tests can assert
+// final state without reaching into the line store abstraction.
+func setupVoiceStyleLine(t *testing.T, h *Handler, database *db.Database, authStore *auth.Store) (readVoiceStyle func() string) {
+	t.Helper()
+	user, err := authStore.GetUserByEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("get test user: %v", err)
+	}
+	hh, err := h.householdStore.Create("Voice Style Test", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	lineStore := line.NewStore(database)
+	if _, err := lineStore.Add("3140001", "Test Phone", hh.ID); err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+		_, _ = database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+	return func() string {
+		var raw string
+		// COALESCE to match the server-side default: an absent voice_style
+		// key (fresh line, never edited) reads back as copper.
+		if err := database.DB.QueryRow(`SELECT COALESCE(settings->>'voice_style', 'copper') FROM lines WHERE number = '3140001'`).Scan(&raw); err != nil {
+			t.Fatalf("read voice_style: %v", err)
+		}
+		return raw
+	}
+}
+
+func postVoiceStyle(t *testing.T, h *Handler, cookie *http.Cookie, value string, htmx bool) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"voice_style": {value}}
+	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/voice-style", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	return w
+}
+
+func TestPhoneVoiceStyleEmptyReturns400(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	read := setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postVoiceStyle(t, h, cookie, "", false)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty voice_style, got %d: %s", w.Code, w.Body.String())
+	}
+	// Must not have written anything — default is copper on insert.
+	if got := read(); got != "copper" {
+		t.Fatalf("expected voice_style untouched (copper), got %q", got)
+	}
+}
+
+func TestPhoneVoiceStyleUpdatePersistsAndRedirects(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	read := setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postVoiceStyle(t, h, cookie, "modern", false)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/phones/3140001" {
+		t.Fatalf("expected redirect to /phones/3140001, got %q", loc)
+	}
+	if got := read(); got != "modern" {
+		t.Fatalf("expected voice_style=modern in db, got %q", got)
+	}
+}
+
+func TestPhoneVoiceStyleHTMXReturnsPartialWithSelection(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postVoiceStyle(t, h, cookie, "modern", true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `id="voice-style-section"`) {
+		t.Fatalf("htmx response missing voice-style-section wrapper:\n%s", body)
+	}
+	// The newly-selected radio must carry `checked`, the other must not.
+	modernIdx := strings.Index(body, `value="modern"`)
+	copperIdx := strings.Index(body, `value="copper"`)
+	if modernIdx < 0 || copperIdx < 0 {
+		t.Fatalf("htmx response missing radios:\n%s", body)
+	}
+	// Walk forward from each input to the end of its tag to check for `checked`.
+	modernTag := body[modernIdx:strings.Index(body[modernIdx:], ">")+modernIdx]
+	copperTag := body[copperIdx:strings.Index(body[copperIdx:], ">")+copperIdx]
+	if !strings.Contains(modernTag, "checked") {
+		t.Errorf("modern radio not marked checked after save: %q", modernTag)
+	}
+	if strings.Contains(copperTag, "checked") {
+		t.Errorf("copper radio still marked checked after switching to modern: %q", copperTag)
+	}
+}
+
+func TestPhoneVoiceStyleUnknownValueNormalizesToCopper(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	read := setupVoiceStyleLine(t, h, database, authStore)
+
+	// First move the line away from the default so we can observe the coercion.
+	if w := postVoiceStyle(t, h, cookie, "modern", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("seed modern failed: %d %s", w.Code, w.Body.String())
+	}
+	if got := read(); got != "modern" {
+		t.Fatalf("seed expected modern, got %q", got)
+	}
+
+	w := postVoiceStyle(t, h, cookie, "disco", false)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 for unknown value (normalized), got %d: %s", w.Code, w.Body.String())
+	}
+	if got := read(); got != "copper" {
+		t.Fatalf("expected unknown value to normalize to copper, got %q", got)
+	}
+}
+
+func TestPhoneVoiceStyleMissingLineReturns404(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	user, err := authStore.GetUserByEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("get test user: %v", err)
+	}
+	hh, err := h.householdStore.Create("Voice Style Missing", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+
+	w := postVoiceStyle(t, h, cookie, "modern", false)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing line, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPhoneVoiceStylePushesToConnectedDevice(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	if w := postVoiceStyle(t, h, cookie, "modern", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, err := signaling.ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse pushed message: %v", err)
+		}
+		if msg.Type != signaling.TypeLineSettings {
+			t.Fatalf("expected %s push, got %s", signaling.TypeLineSettings, msg.Type)
+		}
+		if msg.LineSettings == nil || msg.LineSettings.VoiceStyle != "modern" {
+			t.Fatalf("expected modern line_settings, got %+v", msg.LineSettings)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("device did not receive line_settings push")
+	}
+}
+
+func TestPhoneVoiceStyleNoOpSkipsPush(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	// Line defaults to copper on insert — saving copper again must be a no-op.
+	if w := postVoiceStyle(t, h, cookie, "copper", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
+	}
+	select {
+	case data := <-conn.Send:
+		t.Fatalf("expected no push on no-op save, got message: %s", string(data))
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no push.
+	}
+}
+
 func TestWSRegister_MissingHardwareID(t *testing.T) {
 	h, _, _ := setupHandler(t)
 	srv := httptest.NewServer(h.Router())

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -61,6 +61,7 @@
           <span class="text-sm text-[#c9d1d9]">{{len .Devices}} paired</span>
         </div>
         {{end}}
+        {{template "voice-style-section" .}}
         <div class="mt-4">
           <form method="POST" action="/phones/{{.Line.Number}}/delete"
                 onsubmit="return confirm('Delete line {{.Line.Name}} ({{fmtPhone .Line.Number}})? This cannot be undone.')">
@@ -635,6 +636,29 @@
   }
   </script>
   {{end}}
+</div>
+{{end}}
+
+{{define "voice-style-section"}}
+<div id="voice-style-section">
+  <label for="voice-style" class="block text-xs text-[#8b949e] mb-1">Voice Style</label>
+  <form hx-post="/phones/{{.Line.Number}}/voice-style"
+        hx-target="#voice-style-section"
+        hx-swap="outerHTML"
+        class="flex flex-col md:flex-row gap-3 md:items-end">
+    <div class="flex-1">
+      <select id="voice-style" name="voice_style"
+        class="w-full px-3 py-2 rounded-md bg-[#0d1117] border border-[#21262d] text-[#e6edf3] text-sm focus:outline-none focus:ring-2 focus:ring-[#58a6ff]/50 focus:border-[#58a6ff]">
+        <option value="copper" {{if eq .Line.Settings.VoiceStyle "copper"}}selected{{end}}>Copper wire</option>
+        <option value="modern" {{if eq .Line.Settings.VoiceStyle "modern"}}selected{{end}}>Modern HD</option>
+      </select>
+    </div>
+    <button type="submit"
+      class="w-full md:w-auto px-4 py-2 rounded-md bg-[#238636] text-white text-sm font-medium hover:bg-[#2ea043] transition-colors">
+      Save
+    </button>
+  </form>
+  <p class="text-xs text-[#8b949e] mt-2">POTS bandpass for warm vintage sound, or full-range HD audio.</p>
 </div>
 {{end}}
 

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -61,7 +61,6 @@
           <span class="text-sm text-[#c9d1d9]">{{len .Devices}} paired</span>
         </div>
         {{end}}
-        {{template "voice-style-section" .}}
         <div class="mt-4">
           <form method="POST" action="/phones/{{.Line.Number}}/delete"
                 onsubmit="return confirm('Delete line {{.Line.Name}} ({{fmtPhone .Line.Number}})? This cannot be undone.')">
@@ -473,6 +472,16 @@
       </div>
     </div>
 
+    <!-- Options card -->
+    <div class="bg-[#161b22] border border-[#21262d] rounded-lg">
+      <div class="px-4 py-3 border-b border-[#21262d]">
+        <h2 class="text-sm font-medium text-[#e6edf3]">Options</h2>
+      </div>
+      <div class="p-4">
+        {{template "voice-style-section" .}}
+      </div>
+    </div>
+
   </div>
 
   {{if .Online}}
@@ -641,24 +650,32 @@
 
 {{define "voice-style-section"}}
 <div id="voice-style-section">
-  <label for="voice-style" class="block text-xs text-[#8b949e] mb-1">Voice Style</label>
+  <label class="block text-xs text-[#8b949e] mb-2">Voice Style</label>
   <form hx-post="/phones/{{.Line.Number}}/voice-style"
         hx-target="#voice-style-section"
         hx-swap="outerHTML"
-        class="flex flex-col md:flex-row gap-3 md:items-end">
-    <div class="flex-1">
-      <select id="voice-style" name="voice_style"
-        class="w-full px-3 py-2 rounded-md bg-[#0d1117] border border-[#21262d] text-[#e6edf3] text-sm focus:outline-none focus:ring-2 focus:ring-[#58a6ff]/50 focus:border-[#58a6ff]">
-        <option value="copper" {{if eq .Line.Settings.VoiceStyle "copper"}}selected{{end}}>Copper wire</option>
-        <option value="modern" {{if eq .Line.Settings.VoiceStyle "modern"}}selected{{end}}>Modern HD</option>
-      </select>
-    </div>
+        class="space-y-2">
+    <label class="flex items-start gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border {{if eq .Line.Settings.VoiceStyle "copper"}}border-[#1f6feb] bg-[#1f6feb]/10{{else}}border-transparent{{end}}">
+      <input type="radio" name="voice_style" value="copper" class="mt-0.5 accent-[#1f6feb]"
+             {{if eq .Line.Settings.VoiceStyle "copper"}}checked{{end}}>
+      <span class="flex-1">
+        <span class="block text-sm text-[#e6edf3]">Copper wire</span>
+        <span class="block text-xs text-[#8b949e] mt-0.5">Warm vintage POTS sound. Narrow 300–3400 Hz band, like the old phone network.</span>
+      </span>
+    </label>
+    <label class="flex items-start gap-3 px-3 py-2 rounded cursor-pointer transition-colors hover:bg-[#21262d] border {{if eq .Line.Settings.VoiceStyle "modern"}}border-[#1f6feb] bg-[#1f6feb]/10{{else}}border-transparent{{end}}">
+      <input type="radio" name="voice_style" value="modern" class="mt-0.5 accent-[#1f6feb]"
+             {{if eq .Line.Settings.VoiceStyle "modern"}}checked{{end}}>
+      <span class="flex-1">
+        <span class="block text-sm text-[#e6edf3]">Modern HD</span>
+        <span class="block text-xs text-[#8b949e] mt-0.5">Full-range clean audio. No coloration, maximum clarity.</span>
+      </span>
+    </label>
     <button type="submit"
-      class="w-full md:w-auto px-4 py-2 rounded-md bg-[#238636] text-white text-sm font-medium hover:bg-[#2ea043] transition-colors">
+      class="w-full md:w-auto mt-2 px-4 py-2 rounded-md bg-[#238636] text-white text-sm font-medium hover:bg-[#2ea043] transition-colors">
       Save
     </button>
   </form>
-  <p class="text-xs text-[#8b949e] mt-2">POTS bandpass for warm vintage sound, or full-range HD audio.</p>
 </div>
 {{end}}
 

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -236,14 +236,6 @@
              name="name"
              value="{{.Line.Name}}"
              class="bg-[#0d1117] border border-[#58a6ff] rounded px-2 py-1 text-sm text-[#e6edf3] focus:outline-none w-48">
-      <label class="flex items-center gap-1 text-xs text-[#8b949e]">
-        Voice
-        <select name="voice_style"
-                class="bg-[#0d1117] border border-[#30363d] rounded px-2 py-1 text-sm text-[#e6edf3]">
-          <option value="copper" {{if eq .Line.Settings.VoiceStyle "copper"}}selected{{end}}>Copper wire</option>
-          <option value="modern" {{if eq .Line.Settings.VoiceStyle "modern"}}selected{{end}}>Modern HD</option>
-        </select>
-      </label>
       <button type="submit" class="text-xs px-3 py-1 bg-[#238636] hover:bg-[#2ea043] text-white rounded transition-colors">Save</button>
       <a href="/phones" class="text-xs px-3 py-1 bg-[#21262d] hover:bg-[#2d333b] text-[#c9d1d9] rounded transition-colors">Cancel</a>
     </form>


### PR DESCRIPTION
## Summary
- Removes the Voice dropdown from the /phones list inline edit row
- Adds a Voice Style section to the /phones/{number} detail page's Details card, styled to match the existing settings page selects (native control, matching focus ring and button)
- New POST /phones/{number}/voice-style handler updates line settings, pushes live to the connected device, and htmx-swaps just the voice-style section on success

## Test plan
- [x] Verified in prod via agent-browser: switch Copper wire → Modern HD → save → DB reflects \`{"voice_style": "modern"}\`, section re-renders with Modern HD selected
- [x] Revert to Copper wire round-trip works the same
- [x] go vet + go test ./internal/web/... pass