### PR TITLE
ci(pi): add PR test workflow for digitsd and digits-setup

### DIFF
--- a/.github/workflows/pi-ci.yml
+++ b/.github/workflows/pi-ci.yml
@@ -1,0 +1,55 @@
+name: Pi CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pi/digitsd/**'
+      - 'pi/digits-setup/**'
+      - '.github/workflows/pi-ci.yml'
+  pull_request:
+    paths:
+      - 'pi/digitsd/**'
+      - 'pi/digits-setup/**'
+      - '.github/workflows/pi-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-digitsd:
+    name: test-digitsd
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.1'
+          cache-dependency-path: pi/digitsd/go.sum
+      - name: Install C dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev libopusfile-dev
+      - name: Build digitsd
+        working-directory: pi/digitsd
+        run: go build ./...
+      - name: Test digitsd
+        working-directory: pi/digitsd
+        run: go test ./...
+      - name: Race test wififallback supervisor
+        working-directory: pi/digitsd
+        run: go test -race ./internal/wififallback/...
+
+  test-digits-setup:
+    name: test-digits-setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.1'
+          cache-dependency-path: pi/digits-setup/go.sum
+      - name: Build digits-setup
+        working-directory: pi/digits-setup
+        run: go build ./...
+      - name: Test digits-setup
+        working-directory: pi/digits-setup
+        run: go test ./...


### PR DESCRIPTION
Closes #173.

## Summary
- New `.github/workflows/pi-ci.yml` runs `go build` + `go test ./...` for `pi/digitsd` and `pi/digits-setup` on PRs touching those paths.
- `test-digitsd` installs the same C deps as `lint-digitsd` (libasound2-dev, libopus-dev, libopusfile-dev) and ends with `go test -race ./internal/wififallback/...` for supervisor race coverage.
- Go 1.26.1 pinned to match `pi-release.yml` and `golangci-lint.yml`; per-module `go.sum` caching.
- Cross-compile and hardware integration intentionally excluded per the issue's out-of-scope section.

## Test plan
- [x] `go build ./... && go test ./...` in `pi/digitsd`
- [x] `go test -race ./internal/wififallback/...`
- [x] `go build ./... && go test ./...` in `pi/digits-setup`
- [ ] CI green on this PR
- [ ] Add `test-digitsd` and `test-digits-setup` to required status checks for `main` after merge