### PR TITLE
feat(pi): write nmconnection files directly to /etc/NM, drop reboot-on-configure

### DIFF
--- a/pi/digits-setup/cmd/digits-setup/main.go
+++ b/pi/digits-setup/cmd/digits-setup/main.go
@@ -17,8 +17,9 @@ func main() {
 
 	scanner := &wifi.SystemScanner{}
 	configurator := &wifi.SystemConfigurator{}
+	ap := wifi.SystemAPController{}
 
-	mux := portal.NewHandler(scanner, configurator)
+	mux := portal.NewHandler(scanner, configurator, ap)
 
 	log.Printf("digits-setup listening on %s", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {

--- a/pi/digits-setup/internal/portal/handler.go
+++ b/pi/digits-setup/internal/portal/handler.go
@@ -3,9 +3,11 @@ package portal
 import (
 	"embed"
 	"encoding/json"
+	"errors"
 	"io/fs"
 	"log"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/justinlindh/digits/pi/digits-setup/internal/wifi"
@@ -14,9 +16,20 @@ import (
 //go:embed static/*
 var staticFiles embed.FS
 
+// apTeardownDelay defers `digits-ap-check down` after a successful configure
+// so two things can happen in order: (1) the HTTP response bytes leave wlan0
+// before hostapd stops, and (2) the client has a moment to read them before
+// losing AP association.
+const apTeardownDelay = 2 * time.Second
+
 // NewHandler returns the HTTP mux for the captive portal.
 func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.APController) http.Handler {
 	mux := http.NewServeMux()
+
+	// teardownScheduled gates the deferred AP teardown so a duplicate or
+	// retried /api/configure cannot stack multiple `digits-ap-check down`
+	// goroutines.
+	var teardownScheduled atomic.Bool
 
 	// Captive portal detection — redirect to setup page
 	captiveRedirect := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +73,11 @@ func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.AP
 
 		if err := configurator.Configure(req); err != nil {
 			log.Printf("configure error: %v", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			status := http.StatusInternalServerError
+			if errors.Is(err, wifi.ErrInvalidRequest) {
+				status = http.StatusBadRequest
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 
@@ -75,14 +92,14 @@ func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.AP
 			f.Flush()
 		}
 
-		// Defer AP teardown so the response bytes have time to leave wlan0
-		// before hostapd stops and the client loses association.
-		go func() {
-			time.Sleep(2 * time.Second)
-			if err := ap.Down(); err != nil {
-				log.Printf("configure: ap down failed: %v", err)
-			}
-		}()
+		if teardownScheduled.CompareAndSwap(false, true) {
+			go func() {
+				time.Sleep(apTeardownDelay)
+				if err := ap.Down(); err != nil {
+					log.Printf("configure: ap down failed: %v", err)
+				}
+			}()
+		}
 	})
 
 	// Static files (index.html, style.css, app.js)

--- a/pi/digits-setup/internal/portal/handler.go
+++ b/pi/digits-setup/internal/portal/handler.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/justinlindh/digits/pi/digits-setup/internal/wifi"
 )
@@ -14,7 +15,7 @@ import (
 var staticFiles embed.FS
 
 // NewHandler returns the HTTP mux for the captive portal.
-func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator) http.Handler {
+func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.APController) http.Handler {
 	mux := http.NewServeMux()
 
 	// Captive portal detection — redirect to setup page
@@ -66,10 +67,22 @@ func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator) http.Handl
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]string{
 			"status":  "ok",
-			"message": "Configuration saved. Rebooting in 5 seconds...",
+			"message": "Configuration saved. Reconnect to your normal network.",
 		}); err != nil {
 			log.Printf("configure: encode response: %v", err)
 		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// Defer AP teardown so the response bytes have time to leave wlan0
+		// before hostapd stops and the client loses association.
+		go func() {
+			time.Sleep(2 * time.Second)
+			if err := ap.Down(); err != nil {
+				log.Printf("configure: ap down failed: %v", err)
+			}
+		}()
 	})
 
 	// Static files (index.html, style.css, app.js)

--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,10 @@ import (
 	"path/filepath"
 	"time"
 )
+
+// ErrInvalidRequest is returned by ConfigureWithDeps for user-facing validation
+// failures (missing SSID, etc.) so handlers can return 400 vs. 500.
+var ErrInvalidRequest = errors.New("invalid configure request")
 
 // ConfigRequest is the JSON body for POST /api/configure.
 type ConfigRequest struct {
@@ -111,9 +116,9 @@ const (
 	legacyConnFilename = "digits-wifi.nmconnection"
 )
 
-// uuidForSSID returns a stable UUID-shaped string derived from the SSID so
+// uuidForSSID returns a UUID-shaped string derived from the SSID so
 // reconfiguring the same SSID overwrites the previous file rather than
-// creating a duplicate.
+// creating a duplicate. It is a stable identifier, not an RFC 4122 UUID.
 func uuidForSSID(ssid string) string {
 	h := sha256.Sum256([]byte(ssid))
 	s := hex.EncodeToString(h[:16])
@@ -127,7 +132,7 @@ func uuidForSSID(ssid string) string {
 // boot with a half-written config.
 func ConfigureWithDeps(req ConfigRequest, fs FileSystem, mounter Mounter) error {
 	if req.SSID == "" {
-		return fmt.Errorf("ssid is required")
+		return fmt.Errorf("%w: ssid is required", ErrInvalidRequest)
 	}
 
 	safeName := SanitizeSSID(req.SSID)
@@ -182,6 +187,9 @@ method=auto
 		return fmt.Errorf("operational write: %w", err)
 	}
 
+	// The pre-PR-170 scheme produced exactly one file with this hardcoded
+	// name; removing it by name (not by pattern) is deliberate so we don't
+	// accidentally stomp on current digits-wifi-*.nmconnection entries.
 	for _, p := range []string{
 		filepath.Join(backupDir, legacyConnFilename),
 		filepath.Join(operationalDir, legacyConnFilename),
@@ -191,7 +199,7 @@ method=auto
 		}
 	}
 
-	if err := fs.WriteFile(wifiConfiguredFlag, []byte("1\n"), 0644); err != nil {
+	if err := fs.WriteFile(wifiConfiguredFlag, []byte("1\n"), 0600); err != nil {
 		return fmt.Errorf("write flag: %w", err)
 	}
 

--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -1,6 +1,7 @@
 package wifi
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 )
 
 // ConfigRequest is the JSON body for POST /api/configure.
@@ -26,10 +28,8 @@ type Configurator interface {
 type FileSystem interface {
 	MkdirAll(path string, perm os.FileMode) error
 	WriteFile(name string, data []byte, perm os.FileMode) error
-	ReadFile(name string) ([]byte, error)
 	Remove(name string) error
 	Rename(oldpath, newpath string) error
-	Stat(name string) (os.FileInfo, error)
 }
 
 // OSFileSystem is the real filesystem.
@@ -43,20 +43,12 @@ func (OSFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error 
 	return os.WriteFile(name, data, perm)
 }
 
-func (OSFileSystem) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(name)
-}
-
 func (OSFileSystem) Remove(name string) error {
 	return os.Remove(name)
 }
 
 func (OSFileSystem) Rename(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)
-}
-
-func (OSFileSystem) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(name)
 }
 
 // Mounter abstracts remounting the root filesystem.
@@ -89,11 +81,16 @@ type APController interface {
 	Down() error
 }
 
-// SystemAPController calls `digits-ap-check down`.
+const apCheckBinary = "/usr/local/bin/digits-ap-check"
+
+// SystemAPController calls `digits-ap-check down` with a bounded timeout so a
+// hung script cannot wedge the captive portal request goroutine.
 type SystemAPController struct{}
 
 func (SystemAPController) Down() error {
-	out, err := exec.Command("/usr/local/bin/digits-ap-check", "down").CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, apCheckBinary, "down").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("digits-ap-check down: %w: %s", err, out)
 	}
@@ -108,28 +105,15 @@ func (c *SystemConfigurator) Configure(req ConfigRequest) error {
 }
 
 const (
-	// backupDir is the persistent Wi-Fi config store on /data. Survives rootfs
-	// replacement on OTA image upgrades.
-	backupDir = "/data/wifi"
-
-	// operationalDir is where NetworkManager reads connection profiles at
-	// runtime. Lives on the read-only rootfs and requires a remount,rw to
-	// write.
-	operationalDir = "/etc/NetworkManager/system-connections"
-
-	// wifiConfiguredFlag marks the system as provisioned; digits-ap-check
-	// reads this on boot to choose station vs. AP mode.
+	backupDir          = "/data/wifi"
+	operationalDir     = "/etc/NetworkManager/system-connections"
 	wifiConfiguredFlag = "/data/wifi-configured"
-
-	// legacyConnFilename is the pre-multi-network single filename we clean up
-	// in both stores on a successful configure.
 	legacyConnFilename = "digits-wifi.nmconnection"
 )
 
-// uuidForSSID returns a stable UUID-shaped string derived from the SSID.
-// Format: 8-4-4-4-12 hex chars. Not a real UUID, but NetworkManager accepts
-// anything UUID-shaped in this field. Deterministic so reconfiguring the
-// same SSID overwrites the previous file rather than creating a duplicate.
+// uuidForSSID returns a stable UUID-shaped string derived from the SSID so
+// reconfiguring the same SSID overwrites the previous file rather than
+// creating a duplicate.
 func uuidForSSID(ssid string) string {
 	h := sha256.Sum256([]byte(ssid))
 	s := hex.EncodeToString(h[:16])
@@ -137,6 +121,10 @@ func uuidForSSID(ssid string) string {
 }
 
 // ConfigureWithDeps performs configuration with injectable dependencies.
+//
+// The flag at wifiConfiguredFlag is written last so a partial failure during
+// the operational write does not promote the device to station mode on next
+// boot with a half-written config.
 func ConfigureWithDeps(req ConfigRequest, fs FileSystem, mounter Mounter) error {
 	if req.SSID == "" {
 		return fmt.Errorf("ssid is required")
@@ -152,7 +140,7 @@ func ConfigureWithDeps(req ConfigRequest, fs FileSystem, mounter Mounter) error 
 		hiddenLine = "hidden=true\n"
 	}
 
-	nmConn := fmt.Sprintf(`[connection]
+	data := []byte(fmt.Sprintf(`[connection]
 id=%s
 uuid=%s
 type=wifi
@@ -173,55 +161,36 @@ addr-gen-mode=default
 method=auto
 
 [proxy]
-`, connID, uuid, hiddenLine, req.SSID, req.Password)
+`, connID, uuid, hiddenLine, req.SSID, req.Password))
 
-	data := []byte(nmConn)
-
-	// 1. Persistent backup write (always writable).
 	backupPath := filepath.Join(backupDir, filename)
 	if err := writeAtomic(fs, backupPath, data, 0600); err != nil {
 		return fmt.Errorf("backup write: %w", err)
 	}
-	if err := verifyFile(fs, backupPath, data); err != nil {
-		return fmt.Errorf("backup verify: %w", err)
-	}
 
-	// 2. Operational write behind a remount.
 	if err := mounter.RemountRW(); err != nil {
 		return fmt.Errorf("remount rw: %w", err)
 	}
+	defer func() {
+		if err := mounter.RemountRO(); err != nil {
+			log.Printf("configure: remount ro failed: %v", err)
+		}
+	}()
+
 	opPath := filepath.Join(operationalDir, filename)
-	writeErr := writeAtomic(fs, opPath, data, 0600)
-	verifyErr := error(nil)
-	if writeErr == nil {
-		verifyErr = verifyFile(fs, opPath, data)
+	if err := writeAtomic(fs, opPath, data, 0600); err != nil {
+		return fmt.Errorf("operational write: %w", err)
 	}
 
-	// 3. Legacy cleanup in both stores. Best-effort only; never fails the
-	// configure.
-	legacyPaths := []string{
+	for _, p := range []string{
 		filepath.Join(backupDir, legacyConnFilename),
 		filepath.Join(operationalDir, legacyConnFilename),
-	}
-	for _, p := range legacyPaths {
+	} {
 		if err := fs.Remove(p); err != nil && !os.IsNotExist(err) {
 			log.Printf("configure: legacy cleanup of %s failed: %v", p, err)
 		}
 	}
 
-	// 4. Remount ro regardless of write outcome, then return any earlier error.
-	if err := mounter.RemountRO(); err != nil {
-		log.Printf("configure: remount ro failed: %v", err)
-	}
-	if writeErr != nil {
-		return fmt.Errorf("operational write: %w", writeErr)
-	}
-	if verifyErr != nil {
-		return fmt.Errorf("operational verify: %w", verifyErr)
-	}
-
-	// 5. Set the configured flag last so a partial failure above does not
-	// promote the device to station mode on next boot.
 	if err := fs.WriteFile(wifiConfiguredFlag, []byte("1\n"), 0644); err != nil {
 		return fmt.Errorf("write flag: %w", err)
 	}
@@ -229,21 +198,7 @@ method=auto
 	return nil
 }
 
-// verifyFile reads back a file and compares it to the expected bytes.
-func verifyFile(fs FileSystem, path string, want []byte) error {
-	got, err := fs.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("read-back %s: %w", path, err)
-	}
-	if string(got) != string(want) {
-		return fmt.Errorf("read-back mismatch for %s (wrote %d bytes, read %d bytes)", path, len(want), len(got))
-	}
-	return nil
-}
-
 // writeAtomic writes data to path via a sibling temp file and atomic rename.
-// mkdir is called for the parent dir first. On rename failure the temp file
-// is best-effort removed.
 func writeAtomic(fs FileSystem, path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := fs.MkdirAll(dir, 0755); err != nil {

--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 )
 
 // ConfigRequest is the JSON body for POST /api/configure.
@@ -18,7 +17,7 @@ type ConfigRequest struct {
 	Hidden   bool   `json:"hidden"`
 }
 
-// Configurator writes Wi-Fi config and triggers reboot.
+// Configurator writes Wi-Fi config.
 type Configurator interface {
 	Configure(req ConfigRequest) error
 }
@@ -29,11 +28,8 @@ type FileSystem interface {
 	WriteFile(name string, data []byte, perm os.FileMode) error
 	ReadFile(name string) ([]byte, error)
 	Remove(name string) error
-}
-
-// Rebooter abstracts the system reboot.
-type Rebooter interface {
-	ScheduleReboot(delay time.Duration)
+	Rename(oldpath, newpath string) error
+	Stat(name string) (os.FileInfo, error)
 }
 
 // OSFileSystem is the real filesystem.
@@ -55,25 +51,80 @@ func (OSFileSystem) Remove(name string) error {
 	return os.Remove(name)
 }
 
-// SystemRebooter calls `systemctl reboot`.
-type SystemRebooter struct{}
+func (OSFileSystem) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
 
-func (SystemRebooter) ScheduleReboot(delay time.Duration) {
-	go func() {
-		time.Sleep(delay)
-		out, err := exec.Command("systemctl", "reboot").CombinedOutput()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "reboot failed: %v: %s\n", err, out)
-		}
-	}()
+func (OSFileSystem) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// Mounter abstracts remounting the root filesystem.
+type Mounter interface {
+	RemountRW() error
+	RemountRO() error
+}
+
+// SystemMounter calls `mount -o remount,{rw,ro} /`.
+type SystemMounter struct{}
+
+func (SystemMounter) RemountRW() error {
+	out, err := exec.Command("mount", "-o", "remount,rw", "/").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("remount rw: %w: %s", err, out)
+	}
+	return nil
+}
+
+func (SystemMounter) RemountRO() error {
+	out, err := exec.Command("mount", "-o", "remount,ro", "/").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("remount ro: %w: %s", err, out)
+	}
+	return nil
+}
+
+// APController abstracts tearing down the captive-portal AP.
+type APController interface {
+	Down() error
+}
+
+// SystemAPController calls `digits-ap-check down`.
+type SystemAPController struct{}
+
+func (SystemAPController) Down() error {
+	out, err := exec.Command("/usr/local/bin/digits-ap-check", "down").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("digits-ap-check down: %w: %s", err, out)
+	}
+	return nil
 }
 
 // SystemConfigurator is the production configurator.
 type SystemConfigurator struct{}
 
 func (c *SystemConfigurator) Configure(req ConfigRequest) error {
-	return ConfigureWithDeps(req, OSFileSystem{}, SystemRebooter{})
+	return ConfigureWithDeps(req, OSFileSystem{}, SystemMounter{})
 }
+
+const (
+	// backupDir is the persistent Wi-Fi config store on /data. Survives rootfs
+	// replacement on OTA image upgrades.
+	backupDir = "/data/wifi"
+
+	// operationalDir is where NetworkManager reads connection profiles at
+	// runtime. Lives on the read-only rootfs and requires a remount,rw to
+	// write.
+	operationalDir = "/etc/NetworkManager/system-connections"
+
+	// wifiConfiguredFlag marks the system as provisioned; digits-ap-check
+	// reads this on boot to choose station vs. AP mode.
+	wifiConfiguredFlag = "/data/wifi-configured"
+
+	// legacyConnFilename is the pre-multi-network single filename we clean up
+	// in both stores on a successful configure.
+	legacyConnFilename = "digits-wifi.nmconnection"
+)
 
 // uuidForSSID returns a stable UUID-shaped string derived from the SSID.
 // Format: 8-4-4-4-12 hex chars. Not a real UUID, but NetworkManager accepts
@@ -86,26 +137,21 @@ func uuidForSSID(ssid string) string {
 }
 
 // ConfigureWithDeps performs configuration with injectable dependencies.
-func ConfigureWithDeps(req ConfigRequest, fs FileSystem, rebooter Rebooter) error {
+func ConfigureWithDeps(req ConfigRequest, fs FileSystem, mounter Mounter) error {
 	if req.SSID == "" {
 		return fmt.Errorf("ssid is required")
-	}
-	// Write wpa_supplicant.conf
-	wpaDir := "/data/wifi"
-	if err := fs.MkdirAll(wpaDir, 0755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", wpaDir, err)
 	}
 
 	safeName := SanitizeSSID(req.SSID)
 	uuid := uuidForSSID(req.SSID)
 	connID := "digits-wifi-" + safeName + "-" + uuid[:6]
+	filename := connID + ".nmconnection"
 
 	hiddenLine := ""
 	if req.Hidden {
 		hiddenLine = "hidden=true\n"
 	}
 
-	// Write NetworkManager connection file (NM manages wlan0 on the working Pi)
 	nmConn := fmt.Sprintf(`[connection]
 id=%s
 uuid=%s
@@ -129,38 +175,87 @@ method=auto
 [proxy]
 `, connID, uuid, hiddenLine, req.SSID, req.Password)
 
-	nmPath := filepath.Join(wpaDir, "digits-wifi-"+safeName+"-"+uuid[:6]+".nmconnection")
-	if err := fs.WriteFile(nmPath, []byte(nmConn), 0600); err != nil {
-		return fmt.Errorf("write nmconnection: %w", err)
+	data := []byte(nmConn)
+
+	// 1. Persistent backup write (always writable).
+	backupPath := filepath.Join(backupDir, filename)
+	if err := writeAtomic(fs, backupPath, data, 0600); err != nil {
+		return fmt.Errorf("backup write: %w", err)
+	}
+	if err := verifyFile(fs, backupPath, data); err != nil {
+		return fmt.Errorf("backup verify: %w", err)
 	}
 
-	// Read back and verify the file was written correctly
-	readBack, err := fs.ReadFile(nmPath)
-	if err != nil {
-		return fmt.Errorf("verify nmconnection: read-back failed: %w", err)
+	// 2. Operational write behind a remount.
+	if err := mounter.RemountRW(); err != nil {
+		return fmt.Errorf("remount rw: %w", err)
 	}
-	if string(readBack) != nmConn {
-		return fmt.Errorf("verify nmconnection: read-back mismatch (wrote %d bytes, read %d bytes)", len(nmConn), len(readBack))
-	}
-
-	// Best-effort cleanup: remove the legacy single-file nmconnection left over
-	// from pre-multi-network devices so NetworkManager doesn't load a stale
-	// profile alongside the new per-SSID file.
-	legacyPath := filepath.Join(wpaDir, "digits-wifi.nmconnection")
-	if err := fs.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
-		// Log but do not fail the configure; a failure here should not block
-		// the user's provisioning attempt.
-		log.Printf("configure: legacy cleanup of %s failed: %v", legacyPath, err)
+	opPath := filepath.Join(operationalDir, filename)
+	writeErr := writeAtomic(fs, opPath, data, 0600)
+	verifyErr := error(nil)
+	if writeErr == nil {
+		verifyErr = verifyFile(fs, opPath, data)
 	}
 
-	// Set wifi-configured flag
-	flagPath := "/data/wifi-configured"
-	if err := fs.WriteFile(flagPath, []byte("1\n"), 0644); err != nil {
+	// 3. Legacy cleanup in both stores. Best-effort only; never fails the
+	// configure.
+	legacyPaths := []string{
+		filepath.Join(backupDir, legacyConnFilename),
+		filepath.Join(operationalDir, legacyConnFilename),
+	}
+	for _, p := range legacyPaths {
+		if err := fs.Remove(p); err != nil && !os.IsNotExist(err) {
+			log.Printf("configure: legacy cleanup of %s failed: %v", p, err)
+		}
+	}
+
+	// 4. Remount ro regardless of write outcome, then return any earlier error.
+	if err := mounter.RemountRO(); err != nil {
+		log.Printf("configure: remount ro failed: %v", err)
+	}
+	if writeErr != nil {
+		return fmt.Errorf("operational write: %w", writeErr)
+	}
+	if verifyErr != nil {
+		return fmt.Errorf("operational verify: %w", verifyErr)
+	}
+
+	// 5. Set the configured flag last so a partial failure above does not
+	// promote the device to station mode on next boot.
+	if err := fs.WriteFile(wifiConfiguredFlag, []byte("1\n"), 0644); err != nil {
 		return fmt.Errorf("write flag: %w", err)
 	}
 
-	// Schedule reboot
-	rebooter.ScheduleReboot(5 * time.Second)
+	return nil
+}
 
+// verifyFile reads back a file and compares it to the expected bytes.
+func verifyFile(fs FileSystem, path string, want []byte) error {
+	got, err := fs.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read-back %s: %w", path, err)
+	}
+	if string(got) != string(want) {
+		return fmt.Errorf("read-back mismatch for %s (wrote %d bytes, read %d bytes)", path, len(want), len(got))
+	}
+	return nil
+}
+
+// writeAtomic writes data to path via a sibling temp file and atomic rename.
+// mkdir is called for the parent dir first. On rename failure the temp file
+// is best-effort removed.
+func writeAtomic(fs FileSystem, path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	if err := fs.WriteFile(tmp, data, perm); err != nil {
+		return fmt.Errorf("write temp %s: %w", tmp, err)
+	}
+	if err := fs.Rename(tmp, path); err != nil {
+		_ = fs.Remove(tmp)
+		return fmt.Errorf("rename %s -> %s: %w", tmp, path, err)
+	}
 	return nil
 }

--- a/pi/digits-setup/internal/wifi/configure_test.go
+++ b/pi/digits-setup/internal/wifi/configure_test.go
@@ -1,6 +1,7 @@
 package wifi
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -228,6 +229,52 @@ func TestConfigureRemountRWFailureAbortsWithoutFlag(t *testing.T) {
 	}
 	if mounter.roCalls != 0 {
 		t.Error("remount ro must not be called when remount rw failed")
+	}
+}
+
+// failOpWriteFS fails WriteFile once, for the operational path only. Used to
+// verify that a failed operational write leaves the backup present and does
+// NOT set the wifi-configured flag (the "half-written config never promotes
+// to station" invariant from ConfigureWithDeps' doc comment).
+type failOpWriteFS struct {
+	*mockFS
+}
+
+func (f *failOpWriteFS) WriteFile(name string, data []byte, perm os.FileMode) error {
+	if strings.HasPrefix(name, "/etc/NetworkManager/system-connections/") {
+		return fmt.Errorf("simulated operational write failure")
+	}
+	return f.mockFS.WriteFile(name, data, perm)
+}
+
+func TestConfigureMissingSSIDIsInvalidRequest(t *testing.T) {
+	err := ConfigureWithDeps(ConfigRequest{Password: "pw"}, newMockFS(), &mockMounter{})
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("err = %v, want ErrInvalidRequest", err)
+	}
+}
+
+func TestConfigureOperationalWriteFailureKeepsBackupOmitsFlag(t *testing.T) {
+	base := newMockFS()
+	fs := &failOpWriteFS{mockFS: base}
+	mounter := &mockMounter{}
+
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	err := ConfigureWithDeps(req, fs, mounter)
+	if err == nil {
+		t.Fatal("expected error from failing operational write")
+	}
+
+	filename := "digits-wifi-Net-" + uuidForSSID("Net")[:6] + ".nmconnection"
+	backupPath := filepath.Join("/data/wifi", filename)
+	if _, ok := base.files[backupPath]; !ok {
+		t.Error("backup must remain when operational write fails")
+	}
+	if _, ok := base.files["/data/wifi-configured"]; ok {
+		t.Error("flag must not be set when operational write fails")
+	}
+	if mounter.roCalls != 1 {
+		t.Errorf("remount ro should run via defer, got roCalls=%d", mounter.roCalls)
 	}
 }
 

--- a/pi/digits-setup/internal/wifi/configure_test.go
+++ b/pi/digits-setup/internal/wifi/configure_test.go
@@ -1,11 +1,11 @@
 package wifi
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // mockFS records all file operations.
@@ -52,49 +52,97 @@ func (m *mockFS) Remove(name string) error {
 	return nil
 }
 
-// mockRebooter records if reboot was scheduled.
-type mockRebooter struct {
-	called bool
-	delay  time.Duration
+func (m *mockFS) Rename(oldpath, newpath string) error {
+	f, ok := m.files[oldpath]
+	if !ok {
+		return os.ErrNotExist
+	}
+	delete(m.files, oldpath)
+	m.files[newpath] = f
+	return nil
 }
 
-func (m *mockRebooter) ScheduleReboot(delay time.Duration) {
-	m.called = true
-	m.delay = delay
+func (m *mockFS) Stat(name string) (os.FileInfo, error) {
+	if _, ok := m.files[name]; !ok {
+		return nil, os.ErrNotExist
+	}
+	return nil, nil
+}
+
+// mockMounter records remount calls.
+type mockMounter struct {
+	rwCalls int
+	roCalls int
+	failRW  bool
+	failRO  bool
+}
+
+func (m *mockMounter) RemountRW() error {
+	m.rwCalls++
+	if m.failRW {
+		return fmt.Errorf("simulated remount rw failure")
+	}
+	return nil
+}
+
+func (m *mockMounter) RemountRO() error {
+	m.roCalls++
+	if m.failRO {
+		return fmt.Errorf("simulated remount ro failure")
+	}
+	return nil
 }
 
 func TestConfigureSuccess(t *testing.T) {
 	fs := newMockFS()
-	rebooter := &mockRebooter{}
+	mounter := &mockMounter{}
 
 	req := ConfigRequest{
 		SSID:     "MyNetwork",
 		Password: "secret123",
 	}
 
-	err := ConfigureWithDeps(req, fs, rebooter)
-	if err != nil {
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Check wpa_supplicant.conf with hash suffix
-	wantPath := filepath.Join("/data/wifi", "digits-wifi-MyNetwork-"+uuidForSSID("MyNetwork")[:6]+".nmconnection")
-	nm, ok := fs.files[wantPath]
+	filename := "digits-wifi-MyNetwork-" + uuidForSSID("MyNetwork")[:6] + ".nmconnection"
+	backupPath := filepath.Join("/data/wifi", filename)
+	opPath := filepath.Join("/etc/NetworkManager/system-connections", filename)
+
+	backup, ok := fs.files[backupPath]
 	if !ok {
-		t.Fatalf("nmconnection not written to %s", wantPath)
+		t.Fatalf("backup not written to %s", backupPath)
 	}
-	if nm.perm != 0600 {
-		t.Errorf("nm perm = %o, want 0600", nm.perm)
+	op, ok := fs.files[opPath]
+	if !ok {
+		t.Fatalf("operational not written to %s", opPath)
 	}
-	nmStr := string(nm.data)
-	if !strings.Contains(nmStr, "ssid=MyNetwork") {
-		t.Errorf("nm missing ssid, got: %s", nmStr)
+	if string(backup.data) != string(op.data) {
+		t.Errorf("backup and operational content differ")
 	}
-	if !strings.Contains(nmStr, "psk=secret123") {
-		t.Errorf("nm missing psk, got: %s", nmStr)
+	if backup.perm != 0600 || op.perm != 0600 {
+		t.Errorf("perms backup=%o op=%o, want 0600/0600", backup.perm, op.perm)
+	}
+	if !strings.Contains(string(backup.data), "ssid=MyNetwork") {
+		t.Errorf("missing ssid, got: %s", backup.data)
+	}
+	if !strings.Contains(string(backup.data), "psk=secret123") {
+		t.Errorf("missing psk, got: %s", backup.data)
+	}
+	if _, ok := fs.files[backupPath+".tmp"]; ok {
+		t.Error("backup temp file was not renamed away")
+	}
+	if _, ok := fs.files[opPath+".tmp"]; ok {
+		t.Error("operational temp file was not renamed away")
+	}
+	if mounter.rwCalls != 1 {
+		t.Errorf("remount rw calls = %d, want 1", mounter.rwCalls)
+	}
+	if mounter.roCalls != 1 {
+		t.Errorf("remount ro calls = %d, want 1", mounter.roCalls)
 	}
 
-	// Check flag
 	flag, ok := fs.files["/data/wifi-configured"]
 	if !ok {
 		t.Fatal("wifi-configured flag not written")
@@ -102,201 +150,197 @@ func TestConfigureSuccess(t *testing.T) {
 	if string(flag.data) != "1\n" {
 		t.Errorf("flag = %q, want '1\\n'", string(flag.data))
 	}
-
-	// Check reboot
-	if !rebooter.called {
-		t.Error("reboot not scheduled")
-	}
-	if rebooter.delay != 5*time.Second {
-		t.Errorf("reboot delay = %v, want 5s", rebooter.delay)
-	}
 }
 
 func TestConfigureMissingSSID(t *testing.T) {
 	fs := newMockFS()
-	rebooter := &mockRebooter{}
+	mounter := &mockMounter{}
 
-	req := ConfigRequest{
-		Password: "secret",
-	}
-
-	err := ConfigureWithDeps(req, fs, rebooter)
+	err := ConfigureWithDeps(ConfigRequest{Password: "secret"}, fs, mounter)
 	if err == nil {
 		t.Fatal("expected error for missing SSID")
 	}
 	if !strings.Contains(err.Error(), "ssid") {
 		t.Errorf("error = %q, want mention of ssid", err.Error())
 	}
-	if rebooter.called {
-		t.Error("reboot should not be scheduled on error")
+	if mounter.rwCalls != 0 {
+		t.Error("remount must not be called on validation error")
+	}
+	if _, ok := fs.files["/data/wifi-configured"]; ok {
+		t.Error("flag must not be set on error")
 	}
 }
 
 func TestConfigureHiddenNetwork(t *testing.T) {
 	fs := newMockFS()
-	rebooter := &mockRebooter{}
+	mounter := &mockMounter{}
 
-	req := ConfigRequest{
-		SSID:     "SecretNet",
-		Password: "pass123",
-		Hidden:   true,
-	}
-
-	err := ConfigureWithDeps(req, fs, rebooter)
-	if err != nil {
+	req := ConfigRequest{SSID: "SecretNet", Password: "pass123", Hidden: true}
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantPath := filepath.Join("/data/wifi", "digits-wifi-SecretNet-"+uuidForSSID("SecretNet")[:6]+".nmconnection")
-	nm, ok := fs.files[wantPath]
+	filename := "digits-wifi-SecretNet-" + uuidForSSID("SecretNet")[:6] + ".nmconnection"
+	opPath := filepath.Join("/etc/NetworkManager/system-connections", filename)
+	f, ok := fs.files[opPath]
 	if !ok {
-		t.Fatalf("nmconnection not written to %s", wantPath)
+		t.Fatalf("nmconnection not written to %s", opPath)
 	}
-	nmStr := string(nm.data)
-	if !strings.Contains(nmStr, "hidden=true") {
-		t.Errorf("hidden network should have hidden=true, got: %s", nmStr)
+	if !strings.Contains(string(f.data), "hidden=true") {
+		t.Errorf("hidden network should have hidden=true, got: %s", f.data)
 	}
 }
 
 func TestConfigureVisibleNetworkNoScanSSID(t *testing.T) {
 	fs := newMockFS()
-	rebooter := &mockRebooter{}
+	mounter := &mockMounter{}
 
-	req := ConfigRequest{
-		SSID:     "VisibleNet",
-		Password: "pass123",
-		Hidden:   false,
-	}
-
-	err := ConfigureWithDeps(req, fs, rebooter)
-	if err != nil {
+	req := ConfigRequest{SSID: "VisibleNet", Password: "pass123"}
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	wantPath := filepath.Join("/data/wifi", "digits-wifi-VisibleNet-"+uuidForSSID("VisibleNet")[:6]+".nmconnection")
-	nm, ok := fs.files[wantPath]
+	filename := "digits-wifi-VisibleNet-" + uuidForSSID("VisibleNet")[:6] + ".nmconnection"
+	opPath := filepath.Join("/etc/NetworkManager/system-connections", filename)
+	f, ok := fs.files[opPath]
 	if !ok {
-		t.Fatalf("nmconnection not written to %s", wantPath)
+		t.Fatalf("nmconnection not written to %s", opPath)
 	}
-	nmStr := string(nm.data)
-	if strings.Contains(nmStr, "hidden=") {
-		t.Errorf("visible network should not have hidden=, got: %s", nmStr)
+	if strings.Contains(string(f.data), "hidden=") {
+		t.Errorf("visible network should not have hidden=, got: %s", f.data)
 	}
 }
 
-// corruptingFS writes null bytes instead of actual data, simulating filesystem corruption.
+// corruptingFS writes null bytes instead of actual data for paths matching a prefix.
 type corruptingFS struct {
 	mockFS
+	corruptPrefix string
 }
 
 func (c *corruptingFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	corrupt := make([]byte, len(data))
-	c.files[name] = mockFile{data: corrupt, perm: perm}
+	if c.corruptPrefix != "" && strings.HasPrefix(name, c.corruptPrefix) {
+		c.files[name] = mockFile{data: make([]byte, len(data)), perm: perm}
+		return nil
+	}
+	c.files[name] = mockFile{data: data, perm: perm}
 	return nil
 }
 
 func TestConfigureCorruptWrite(t *testing.T) {
-	fs := &corruptingFS{mockFS: *newMockFS()}
-	rebooter := &mockRebooter{}
+	fs := &corruptingFS{mockFS: *newMockFS(), corruptPrefix: "/etc/NetworkManager/"}
+	mounter := &mockMounter{}
 
-	req := ConfigRequest{
-		SSID:     "MyNetwork",
-		Password: "secret123",
-	}
-
-	err := ConfigureWithDeps(req, fs, rebooter)
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	err := ConfigureWithDeps(req, fs, mounter)
 	if err == nil {
-		t.Fatal("expected error for corrupt write")
+		t.Fatal("expected verify error from corrupt write")
 	}
-	if !strings.Contains(err.Error(), "read-back mismatch") {
-		t.Errorf("error = %q, want read-back mismatch", err.Error())
+	if !strings.Contains(err.Error(), "verify") {
+		t.Errorf("error = %q, want mention of verify", err.Error())
 	}
-	if rebooter.called {
-		t.Error("reboot should not be scheduled on corrupt write")
+	if _, ok := fs.files["/data/wifi-configured"]; ok {
+		t.Error("flag must not be set on verify failure")
 	}
-}
-
-func TestConfigureLegacyFileCleanup(t *testing.T) {
-	fs := newMockFS()
-	rebooter := &mockRebooter{}
-
-	// Pre-populate the legacy file
-	legacyPath := "/data/wifi/digits-wifi.nmconnection"
-	fs.files[legacyPath] = mockFile{data: []byte("old config"), perm: 0600}
-
-	req := ConfigRequest{
-		SSID:     "NewNetwork",
-		Password: "secret123",
-	}
-
-	err := ConfigureWithDeps(req, fs, rebooter)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Verify legacy file was removed
-	if _, exists := fs.files[legacyPath]; exists {
-		t.Error("legacy nmconnection file should have been removed")
-	}
-
-	// Verify new per-SSID file was written
-	wantPath := filepath.Join("/data/wifi", "digits-wifi-NewNetwork-"+uuidForSSID("NewNetwork")[:6]+".nmconnection")
-	if _, exists := fs.files[wantPath]; !exists {
-		t.Fatalf("new per-SSID nmconnection not written to %s", wantPath)
-	}
-
-	// Verify reboot was scheduled
-	if !rebooter.called {
-		t.Error("reboot should have been scheduled")
+	if mounter.roCalls != 1 {
+		t.Error("remount ro must run even on write failure to restore rootfs")
 	}
 }
 
 func TestConfigureFilenameCollisionPrevention(t *testing.T) {
 	fs := newMockFS()
-	rebooter1 := &mockRebooter{}
-	rebooter2 := &mockRebooter{}
+	mounter1 := &mockMounter{}
+	mounter2 := &mockMounter{}
 
-	// Two SSIDs that sanitize to the same base name
-	// "Network 1" and "Network-1" both become "Network-1"
-	req1 := ConfigRequest{
-		SSID:     "Network 1",
-		Password: "pass1",
-	}
-	req2 := ConfigRequest{
-		SSID:     "Network-1",
-		Password: "pass2",
-	}
+	// Two SSIDs that sanitize to the same base name.
+	req1 := ConfigRequest{SSID: "Network 1", Password: "pass1"}
+	req2 := ConfigRequest{SSID: "Network-1", Password: "pass2"}
 
-	// Configure first SSID
-	err := ConfigureWithDeps(req1, fs, rebooter1)
-	if err != nil {
+	if err := ConfigureWithDeps(req1, fs, mounter1); err != nil {
 		t.Fatalf("first configure failed: %v", err)
 	}
-
 	path1 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network 1")[:6]+".nmconnection")
 	if _, exists := fs.files[path1]; !exists {
 		t.Fatalf("first network file not written to %s", path1)
 	}
 
-	// Configure second SSID with different UUID
-	err = ConfigureWithDeps(req2, fs, rebooter2)
-	if err != nil {
+	if err := ConfigureWithDeps(req2, fs, mounter2); err != nil {
 		t.Fatalf("second configure failed: %v", err)
 	}
-
 	path2 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network-1")[:6]+".nmconnection")
 	if _, exists := fs.files[path2]; !exists {
 		t.Fatalf("second network file not written to %s", path2)
 	}
 
-	// Both files should exist; they should have different hashes in their names
 	if _, exists := fs.files[path1]; !exists {
 		t.Error("first network file was overwritten; hash suffix should prevent collision")
 	}
-
-	// Verify they are different files
 	if path1 == path2 {
 		t.Error("filenames are identical; hash suffix should differentiate them")
+	}
+}
+
+func TestConfigureRemountRWFailureAbortsWithoutFlag(t *testing.T) {
+	fs := newMockFS()
+	mounter := &mockMounter{failRW: true}
+
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	err := ConfigureWithDeps(req, fs, mounter)
+	if err == nil {
+		t.Fatal("expected error from failing remount rw")
+	}
+	if _, ok := fs.files["/data/wifi-configured"]; ok {
+		t.Error("flag must not be set when operational write is skipped")
+	}
+	filename := "digits-wifi-Net-" + uuidForSSID("Net")[:6] + ".nmconnection"
+	backupPath := filepath.Join("/data/wifi", filename)
+	if _, ok := fs.files[backupPath]; !ok {
+		t.Error("backup should be written before remount is attempted")
+	}
+	if mounter.roCalls != 0 {
+		t.Error("remount ro must not be called when remount rw failed")
+	}
+}
+
+func TestConfigureLegacyCleanupBothDirs(t *testing.T) {
+	fs := newMockFS()
+	fs.files["/data/wifi/digits-wifi.nmconnection"] = mockFile{data: []byte("old"), perm: 0600}
+	fs.files["/etc/NetworkManager/system-connections/digits-wifi.nmconnection"] = mockFile{data: []byte("old"), perm: 0600}
+	mounter := &mockMounter{}
+
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := fs.files["/data/wifi/digits-wifi.nmconnection"]; ok {
+		t.Error("legacy backup file should be removed")
+	}
+	if _, ok := fs.files["/etc/NetworkManager/system-connections/digits-wifi.nmconnection"]; ok {
+		t.Error("legacy operational file should be removed")
+	}
+}
+
+func TestConfigureLegacyCleanupMissingIsOK(t *testing.T) {
+	fs := newMockFS()
+	mounter := &mockMounter{}
+
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConfigureAtomicRenameOrder(t *testing.T) {
+	fs := newMockFS()
+	mounter := &mockMounter{}
+
+	req := ConfigRequest{SSID: "Net", Password: "pw"}
+	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for name := range fs.files {
+		if strings.HasSuffix(name, ".tmp") {
+			t.Errorf("stray temp file left behind: %s", name)
+		}
 	}
 }
 
@@ -313,7 +357,7 @@ BSS 77:88:99:aa:bb:cc(on wlan0)
 	SSID: HomeNetwork
 BSS dd:ee:ff:00:11:22(on wlan0)
 	signal: -90.00 dBm
-	SSID: 
+	SSID:
 `
 
 	networks := parseIWScan([]byte(input))

--- a/pi/digits-setup/internal/wifi/configure_test.go
+++ b/pi/digits-setup/internal/wifi/configure_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 )
 
-// mockFS records all file operations.
 type mockFS struct {
 	dirs  map[string]os.FileMode
 	files map[string]mockFile
@@ -36,14 +35,6 @@ func (m *mockFS) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-func (m *mockFS) ReadFile(name string) ([]byte, error) {
-	f, ok := m.files[name]
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-	return f.data, nil
-}
-
 func (m *mockFS) Remove(name string) error {
 	if _, ok := m.files[name]; !ok {
 		return os.ErrNotExist
@@ -62,19 +53,10 @@ func (m *mockFS) Rename(oldpath, newpath string) error {
 	return nil
 }
 
-func (m *mockFS) Stat(name string) (os.FileInfo, error) {
-	if _, ok := m.files[name]; !ok {
-		return nil, os.ErrNotExist
-	}
-	return nil, nil
-}
-
-// mockMounter records remount calls.
 type mockMounter struct {
 	rwCalls int
 	roCalls int
 	failRW  bool
-	failRO  bool
 }
 
 func (m *mockMounter) RemountRW() error {
@@ -87,9 +69,6 @@ func (m *mockMounter) RemountRW() error {
 
 func (m *mockMounter) RemountRO() error {
 	m.roCalls++
-	if m.failRO {
-		return fmt.Errorf("simulated remount ro failure")
-	}
 	return nil
 }
 
@@ -97,11 +76,7 @@ func TestConfigureSuccess(t *testing.T) {
 	fs := newMockFS()
 	mounter := &mockMounter{}
 
-	req := ConfigRequest{
-		SSID:     "MyNetwork",
-		Password: "secret123",
-	}
-
+	req := ConfigRequest{SSID: "MyNetwork", Password: "secret123"}
 	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -130,17 +105,10 @@ func TestConfigureSuccess(t *testing.T) {
 	if !strings.Contains(string(backup.data), "psk=secret123") {
 		t.Errorf("missing psk, got: %s", backup.data)
 	}
-	if _, ok := fs.files[backupPath+".tmp"]; ok {
-		t.Error("backup temp file was not renamed away")
-	}
-	if _, ok := fs.files[opPath+".tmp"]; ok {
-		t.Error("operational temp file was not renamed away")
-	}
-	if mounter.rwCalls != 1 {
-		t.Errorf("remount rw calls = %d, want 1", mounter.rwCalls)
-	}
-	if mounter.roCalls != 1 {
-		t.Errorf("remount ro calls = %d, want 1", mounter.roCalls)
+	for name := range fs.files {
+		if strings.HasSuffix(name, ".tmp") {
+			t.Errorf("stray temp file left behind: %s", name)
+		}
 	}
 
 	flag, ok := fs.files["/data/wifi-configured"]
@@ -211,51 +179,13 @@ func TestConfigureVisibleNetworkNoScanSSID(t *testing.T) {
 	}
 }
 
-// corruptingFS writes null bytes instead of actual data for paths matching a prefix.
-type corruptingFS struct {
-	mockFS
-	corruptPrefix string
-}
-
-func (c *corruptingFS) WriteFile(name string, data []byte, perm os.FileMode) error {
-	if c.corruptPrefix != "" && strings.HasPrefix(name, c.corruptPrefix) {
-		c.files[name] = mockFile{data: make([]byte, len(data)), perm: perm}
-		return nil
-	}
-	c.files[name] = mockFile{data: data, perm: perm}
-	return nil
-}
-
-func TestConfigureCorruptWrite(t *testing.T) {
-	fs := &corruptingFS{mockFS: *newMockFS(), corruptPrefix: "/etc/NetworkManager/"}
-	mounter := &mockMounter{}
-
-	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	err := ConfigureWithDeps(req, fs, mounter)
-	if err == nil {
-		t.Fatal("expected verify error from corrupt write")
-	}
-	if !strings.Contains(err.Error(), "verify") {
-		t.Errorf("error = %q, want mention of verify", err.Error())
-	}
-	if _, ok := fs.files["/data/wifi-configured"]; ok {
-		t.Error("flag must not be set on verify failure")
-	}
-	if mounter.roCalls != 1 {
-		t.Error("remount ro must run even on write failure to restore rootfs")
-	}
-}
-
 func TestConfigureFilenameCollisionPrevention(t *testing.T) {
 	fs := newMockFS()
-	mounter1 := &mockMounter{}
-	mounter2 := &mockMounter{}
 
-	// Two SSIDs that sanitize to the same base name.
 	req1 := ConfigRequest{SSID: "Network 1", Password: "pass1"}
 	req2 := ConfigRequest{SSID: "Network-1", Password: "pass2"}
 
-	if err := ConfigureWithDeps(req1, fs, mounter1); err != nil {
+	if err := ConfigureWithDeps(req1, fs, &mockMounter{}); err != nil {
 		t.Fatalf("first configure failed: %v", err)
 	}
 	path1 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network 1")[:6]+".nmconnection")
@@ -263,7 +193,7 @@ func TestConfigureFilenameCollisionPrevention(t *testing.T) {
 		t.Fatalf("first network file not written to %s", path1)
 	}
 
-	if err := ConfigureWithDeps(req2, fs, mounter2); err != nil {
+	if err := ConfigureWithDeps(req2, fs, &mockMounter{}); err != nil {
 		t.Fatalf("second configure failed: %v", err)
 	}
 	path2 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network-1")[:6]+".nmconnection")
@@ -305,10 +235,9 @@ func TestConfigureLegacyCleanupBothDirs(t *testing.T) {
 	fs := newMockFS()
 	fs.files["/data/wifi/digits-wifi.nmconnection"] = mockFile{data: []byte("old"), perm: 0600}
 	fs.files["/etc/NetworkManager/system-connections/digits-wifi.nmconnection"] = mockFile{data: []byte("old"), perm: 0600}
-	mounter := &mockMounter{}
 
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+	if err := ConfigureWithDeps(req, fs, &mockMounter{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := fs.files["/data/wifi/digits-wifi.nmconnection"]; ok {
@@ -321,26 +250,9 @@ func TestConfigureLegacyCleanupBothDirs(t *testing.T) {
 
 func TestConfigureLegacyCleanupMissingIsOK(t *testing.T) {
 	fs := newMockFS()
-	mounter := &mockMounter{}
-
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+	if err := ConfigureWithDeps(req, fs, &mockMounter{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestConfigureAtomicRenameOrder(t *testing.T) {
-	fs := newMockFS()
-	mounter := &mockMounter{}
-
-	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	for name := range fs.files {
-		if strings.HasSuffix(name, ".tmp") {
-			t.Errorf("stray temp file left behind: %s", name)
-		}
 	}
 }
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -48,23 +48,29 @@ validate_nmconnection() {
     return 0
 }
 
+# has_any <dir>
+# Returns 0 if the directory contains at least one digits-wifi*.nmconnection
+# file. Used on the boot hot path before committing to per-file validation.
+has_any() {
+    local dir="$1"
+    shopt -s nullglob
+    local files=("$dir"/$NM_CONN_PATTERN)
+    shopt -u nullglob
+    [ ${#files[@]} -gt 0 ]
+}
+
 # list_valid <dir>
-# Prints basenames (one per line) of valid digits-wifi*.nmconnection files in
-# the given directory. Uses validate_nmconnection for each candidate.
+# Prints basenames of valid digits-wifi*.nmconnection files in the given
+# directory. Runs validate_nmconnection on each candidate.
 list_valid() {
     local dir="$1"
     shopt -s nullglob
     for f in "$dir"/$NM_CONN_PATTERN; do
         if validate_nmconnection "$f"; then
-            basename "$f"
+            printf '%s\n' "${f##*/}"
         fi
     done
     shopt -u nullglob
-}
-
-# count_valid <dir>
-count_valid() {
-    list_valid "$1" | wc -l
 }
 
 # Clear wifi-configured state so the device falls back to AP mode.
@@ -185,20 +191,24 @@ do_init() {
         return
     fi
 
-    local op_count
-    op_count=$(count_valid "$NM_OPERATIONAL_DIR")
-    if [ "$op_count" -eq 0 ]; then
-        local backup_count
-        backup_count=$(count_valid "$NM_BACKUP_DIR")
-        if [ "$backup_count" -eq 0 ]; then
-            log "WARNING: No valid Wi-Fi config files in $NM_OPERATIONAL_DIR or $NM_BACKUP_DIR -- falling back to AP mode"
-            reset_wifi_config
-            do_ap_up
-            return
-        fi
-        restore_from_backup
+    # Hot path: operational store already has at least one file. Trust it and
+    # let NetworkManager validate; avoid forking grep per file before
+    # network-pre.target.
+    if has_any "$NM_OPERATIONAL_DIR"; then
+        do_station_up
+        return
     fi
 
+    # Cold path: operational store is empty (e.g. after an OTA image upgrade
+    # replaced the rootfs). Fall back to the persistent backup.
+    if ! has_any "$NM_BACKUP_DIR" || [ -z "$(list_valid "$NM_BACKUP_DIR")" ]; then
+        log "WARNING: No valid Wi-Fi config files in $NM_OPERATIONAL_DIR or $NM_BACKUP_DIR -- falling back to AP mode"
+        reset_wifi_config
+        do_ap_up
+        return
+    fi
+
+    restore_from_backup
     do_station_up
 }
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -17,8 +17,11 @@ NM_OPERATIONAL_DIR="/etc/NetworkManager/system-connections"
 NM_CONN_PATTERN="digits-wifi*.nmconnection"
 LOG_TAG="digits-ap-check"
 
+# Log to stderr and /dev/kmsg, never stdout. list_valid captures stdout via
+# command substitution, so any log output here would contaminate its result.
 log() {
-    echo "$LOG_TAG: $*" | tee /dev/kmsg 2>/dev/null || true
+    echo "$LOG_TAG: $*" >&2
+    echo "$LOG_TAG: $*" > /dev/kmsg 2>/dev/null || true
     logger -t "$LOG_TAG" "$*" 2>/dev/null || true
 }
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 WIFI_CONFIGURED_FLAG="/data/wifi-configured"
-NM_CONN_SRC_DIR="/data/wifi"
-NM_CONN_DST_DIR="/etc/NetworkManager/system-connections"
+NM_BACKUP_DIR="/data/wifi"
+NM_OPERATIONAL_DIR="/etc/NetworkManager/system-connections"
 NM_CONN_PATTERN="digits-wifi*.nmconnection"
 LOG_TAG="digits-ap-check"
 
@@ -48,15 +48,23 @@ validate_nmconnection() {
     return 0
 }
 
-# List all configured nmconnection files in the data partition.
-# Sets global array NM_CONN_SOURCES.
-list_nm_sources() {
-    NM_CONN_SOURCES=()
+# list_valid <dir>
+# Prints basenames (one per line) of valid digits-wifi*.nmconnection files in
+# the given directory. Uses validate_nmconnection for each candidate.
+list_valid() {
+    local dir="$1"
     shopt -s nullglob
-    # shellcheck disable=SC2206
-    local files=($NM_CONN_SRC_DIR/$NM_CONN_PATTERN)
+    for f in "$dir"/$NM_CONN_PATTERN; do
+        if validate_nmconnection "$f"; then
+            basename "$f"
+        fi
+    done
     shopt -u nullglob
-    NM_CONN_SOURCES=("${files[@]}")
+}
+
+# count_valid <dir>
+count_valid() {
+    list_valid "$1" | wc -l
 }
 
 # Clear wifi-configured state so the device falls back to AP mode.
@@ -64,8 +72,14 @@ reset_wifi_config() {
     log "Resetting wifi config -- will enter AP mode"
     rm -f "$WIFI_CONFIGURED_FLAG"
     shopt -s nullglob
-    rm -f "$NM_CONN_SRC_DIR"/$NM_CONN_PATTERN
+    rm -f "$NM_BACKUP_DIR"/$NM_CONN_PATTERN
     shopt -u nullglob
+    # Wipe the operational store too. Requires remount,rw.
+    mount -o remount,rw / 2>/dev/null || true
+    shopt -s nullglob
+    rm -f "$NM_OPERATIONAL_DIR"/$NM_CONN_PATTERN
+    shopt -u nullglob
+    mount -o remount,ro / 2>/dev/null || true
 }
 
 do_station_up() {
@@ -77,60 +91,7 @@ do_station_up() {
     # Unblock WiFi radio
     rfkill unblock wifi || true
 
-    # Enumerate valid source files once so we know what the desired destination
-    # set looks like.
-    list_nm_sources
-    local desired_basenames=()
-    for src in "${NM_CONN_SOURCES[@]}"; do
-        if validate_nmconnection "$src"; then
-            desired_basenames+=("$(basename "$src")")
-        fi
-    done
-
-    # Remount rw once, do all filesystem mutations, remount ro.
-    mount -o remount,rw / 2>/dev/null || true
-
-    # Prune stale digits-wifi*.nmconnection files from the NM directory that
-    # don't correspond to a currently-valid source. This prevents accumulation
-    # as the user reconfigures across networks over time.
-    shopt -s nullglob
-    for dst in "$NM_CONN_DST_DIR"/$NM_CONN_PATTERN; do
-        local base
-        base=$(basename "$dst")
-        local keep=0
-        for wanted in "${desired_basenames[@]}"; do
-            if [ "$base" = "$wanted" ]; then
-                keep=1
-                break
-            fi
-        done
-        if [ "$keep" -eq 0 ]; then
-            log "Pruning stale NM connection: $base"
-            rm -f "$dst" 2>/dev/null || true
-        fi
-    done
-    shopt -u nullglob
-
-    # Copy each valid source into the NM connections directory.
-    local copied=0
-    for src in "${NM_CONN_SOURCES[@]}"; do
-        if validate_nmconnection "$src"; then
-            local dst="$NM_CONN_DST_DIR/$(basename "$src")"
-            cp "$src" "$dst" 2>/dev/null || true
-            chmod 600 "$dst" 2>/dev/null || true
-            copied=$((copied + 1))
-        fi
-    done
-
-    mount -o remount,ro / 2>/dev/null || true
-
-    if [ "$copied" -gt 0 ]; then
-        log "Copied $copied NM connection file(s)"
-    else
-        log "WARNING: No valid NM connection files found in $NM_CONN_SRC_DIR"
-    fi
-
-    # Let NetworkManager handle everything
+    # Let NetworkManager handle everything; it reads its own config dir.
     log "Wi-Fi client mode -- NetworkManager will connect"
 }
 
@@ -199,26 +160,46 @@ do_ap_down() {
     log "AP mode down -- NetworkManager started"
 }
 
+# restore_from_backup copies every valid backup file into the operational
+# directory. Used when the operational store is empty (e.g. after an OTA
+# image upgrade that replaced the rootfs).
+restore_from_backup() {
+    log "Restoring NM connections from backup at $NM_BACKUP_DIR"
+    local count=0
+    mount -o remount,rw / 2>/dev/null || true
+    while IFS= read -r base; do
+        [ -z "$base" ] && continue
+        local src="$NM_BACKUP_DIR/$base"
+        local dst="$NM_OPERATIONAL_DIR/$base"
+        cp "$src" "$dst" 2>/dev/null || true
+        chmod 600 "$dst" 2>/dev/null || true
+        count=$((count + 1))
+    done < <(list_valid "$NM_BACKUP_DIR")
+    mount -o remount,ro / 2>/dev/null || true
+    log "Restored $count NM connection file(s) from backup"
+}
+
 do_init() {
-    if [ -f "$WIFI_CONFIGURED_FLAG" ]; then
-        list_nm_sources
-        local valid_count=0
-        for src in "${NM_CONN_SOURCES[@]}"; do
-            if validate_nmconnection "$src"; then
-                valid_count=$((valid_count + 1))
-            fi
-        done
-        if [ "$valid_count" -eq 0 ]; then
-            log "WARNING: No valid Wi-Fi config files found in $NM_CONN_SRC_DIR -- falling back to AP mode"
-            reset_wifi_config
-        fi
+    if [ ! -f "$WIFI_CONFIGURED_FLAG" ]; then
+        do_ap_up
+        return
     fi
 
-    if [ -f "$WIFI_CONFIGURED_FLAG" ]; then
-        do_station_up
-    else
-        do_ap_up
+    local op_count
+    op_count=$(count_valid "$NM_OPERATIONAL_DIR")
+    if [ "$op_count" -eq 0 ]; then
+        local backup_count
+        backup_count=$(count_valid "$NM_BACKUP_DIR")
+        if [ "$backup_count" -eq 0 ]; then
+            log "WARNING: No valid Wi-Fi config files in $NM_OPERATIONAL_DIR or $NM_BACKUP_DIR -- falling back to AP mode"
+            reset_wifi_config
+            do_ap_up
+            return
+        fi
+        restore_from_backup
     fi
+
+    do_station_up
 }
 
 case "${1:-init}" in


### PR DESCRIPTION
## What

Closes #172. `digits-setup` now dual-writes each `.nmconnection` atomically to
`/etc/NetworkManager/system-connections/` (operational store NM reads live)
and `/data/wifi/` (persistent backup that survives rootfs replacement on OTA
image upgrades), then defers an `digits-ap-check down` call by 2s so the
captive portal response flushes to the client before hostapd stops.
`digits-ap-check` stops hot-copying on every boot; `do_init` only restores
from `/data/wifi/` when the operational store is empty (the OTA cold path).

## Why

PR #170 introduced per-SSID `.nmconnection` files but required a reboot after
configure so `digits-ap-check` could stage them into `/etc/NM/...`. Writing
directly removes the reboot, lets users reconfigure Wi-Fi without rebooting,
and deletes the per-boot copy/prune logic. `/data/wifi/` stays as a backup so
OTA image rebuilds do not factory-reset every device's Wi-Fi config.

## Test plan

### Automated
- [x] `cd pi/digits-setup && go build ./... && go vet ./... && go test ./... && golangci-lint run ./...`
- [x] `bash -n pi/image/rootfs-overlay/usr/local/bin/digits-ap-check`
- [x] `cd pi/digitsd && go build ./...`

### Manual (on both phones, post-merge)
- [ ] Fresh AP-mode device: configure via captive portal, verify HTTP 200 reaches the browser before AP drops, device joins station mode without rebooting
- [ ] Already-online device: reconfigure to a different network, verify NM picks it up (if not, follow-up to add `nmcli reload && nmcli up`)
- [ ] Simulated OTA: `rm /etc/NetworkManager/system-connections/digits-wifi*.nmconnection` on a working device, reboot, verify cold-path restore from `/data/wifi/`
- [ ] Inject a null-byte file into `/etc/NM/.../digits-wifi-bad.nmconnection`, reboot, verify fallback
- [ ] Fallback supervisor triggers `reset_wifi_config`, verify both dirs are wiped