### PR TITLE
ci: add concurrency cancellation and per-job timeouts

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,10 +20,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-server:
     name: lint-server
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -38,6 +43,7 @@ jobs:
   lint-digitsd:
     name: lint-digitsd
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -54,6 +60,7 @@ jobs:
   lint-digits-setup:
     name: lint-digits-setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/pi-ci.yml
+++ b/.github/workflows/pi-ci.yml
@@ -16,10 +16,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-digitsd:
     name: test-digitsd
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -41,6 +46,7 @@ jobs:
   test-digits-setup:
     name: test-digits-setup
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [main, 'feature/**']
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/server-e2e.yml
+++ b/.github/workflows/server-e2e.yml
@@ -9,9 +9,14 @@ on:
       - '.github/workflows/server-e2e.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:16


### PR DESCRIPTION
Follow-up to PR #174 review.

## Summary
- Workflow-level `concurrency` group keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress` only on PR refs, so rapid PR pushes drop stale runs without ever cancelling a main-branch run.
- `timeout-minutes` on every job (10 for lint/light, 15 for unit/test, 25 for e2e) as cheap insurance against hung tests.
- Applied to `pi-ci.yml`, `golangci-lint.yml`, `server-ci.yml`, `server-e2e.yml`. Release workflows (`*-release.yml`) intentionally untouched — cancelling release runs mid-flight is not desired.

## Test plan
- [ ] CI green on this PR (also exercises the new concurrency block by definition)

Also done out-of-band: added `test-digitsd` and `test-digits-setup` to the `main-protection` ruleset's required status checks (alongside existing `unit` and `integration`).