### PR TITLE
fix(digitsd): self-heal corrupted or unwritable device-id

### DIFF
--- a/pi/digitsd/internal/config/deviceid.go
+++ b/pi/digitsd/internal/config/deviceid.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -13,10 +14,14 @@ const deviceIDPath = "/data/digits/device-id"
 // If the file doesn't exist or contains a non-UUID value (legacy 4-char hex),
 // generates a new UUID v4 and persists it.
 func LoadOrCreateDeviceID() (string, error) {
-	data, err := os.ReadFile(deviceIDPath)
+	return loadOrCreateDeviceIDAt(deviceIDPath)
+}
+
+func loadOrCreateDeviceIDAt(path string) (string, error) {
+	data, err := os.ReadFile(path)
 	if err == nil {
-		id := strings.TrimSpace(string(data))
-		if len(id) == 36 {
+		id := strings.Trim(string(data), " \t\r\n\x00")
+		if isUUIDv4Shape(id) {
 			return id, nil
 		}
 	}
@@ -26,14 +31,44 @@ func LoadOrCreateDeviceID() (string, error) {
 		return "", fmt.Errorf("generate device id: %w", err)
 	}
 
-	if err := os.MkdirAll("/data/digits", 0755); err != nil {
-		return "", fmt.Errorf("mkdir /data/digits: %w", err)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
-	if err := os.WriteFile(deviceIDPath, []byte(id+"\n"), 0644); err != nil {
+	// Unlink first so we can replace a file owned by another user
+	// (legacy images provisioned /data/digits/device-id as root while
+	// digitsd runs as the digits user) or a file without write perms.
+	// ENOENT is fine: os.WriteFile will create it below.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("remove stale device id: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0644); err != nil {
 		return "", fmt.Errorf("persist device id: %w", err)
 	}
 
 	return id, nil
+}
+
+func isUUIDv4Shape(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		case 14:
+			if c != '4' {
+				return false
+			}
+		default:
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func generateUUIDv4() (string, error) {

--- a/pi/digitsd/internal/config/deviceid.go
+++ b/pi/digitsd/internal/config/deviceid.go
@@ -10,9 +10,11 @@ import (
 
 const deviceIDPath = "/data/digits/device-id"
 
-// LoadOrCreateDeviceID reads the device ID from /data/digits/device-id.
-// If the file doesn't exist or contains a non-UUID value (legacy 4-char hex),
-// generates a new UUID v4 and persists it.
+// LoadOrCreateDeviceID reads the device ID from /data/digits/device-id,
+// validating that it has UUID v4 shape. If the file is missing, unreadable,
+// or contains anything that isn't a UUID v4 (legacy short ids, NUL-filled
+// post-crash artifacts, stray text), it generates a fresh UUID v4 and
+// atomically writes it in place.
 func LoadOrCreateDeviceID() (string, error) {
 	return loadOrCreateDeviceIDAt(deviceIDPath)
 }
@@ -31,18 +33,38 @@ func loadOrCreateDeviceIDAt(path string) (string, error) {
 		return "", fmt.Errorf("generate device id: %w", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
 	}
-	// Unlink first so we can replace a file owned by another user
-	// (legacy images provisioned /data/digits/device-id as root while
-	// digitsd runs as the digits user) or a file without write perms.
-	// ENOENT is fine: os.WriteFile will create it below.
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-		return "", fmt.Errorf("remove stale device id: %w", err)
+	// Write to a temp file and rename onto the target so the replace is
+	// atomic (no power-loss window where device-id is missing) and so
+	// it works even if the existing file is owned by another user:
+	// rename only needs write permission on the parent directory. Legacy
+	// images provisioned /data/digits/device-id as root while digitsd
+	// runs as the digits user, so plain os.WriteFile would hit EACCES.
+	tmp, err := os.CreateTemp(dir, "device-id.*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temp device id: %w", err)
 	}
-	if err := os.WriteFile(path, []byte(id+"\n"), 0644); err != nil {
-		return "", fmt.Errorf("persist device id: %w", err)
+	tmpPath := tmp.Name()
+	if _, err := tmp.WriteString(id + "\n"); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("write temp device id: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("chmod temp device id: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("close temp device id: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("rename device id into place: %w", err)
 	}
 
 	return id, nil
@@ -52,7 +74,8 @@ func isUUIDv4Shape(s string) bool {
 	if len(s) != 36 {
 		return false
 	}
-	for i, c := range s {
+	for i := 0; i < 36; i++ {
+		c := s[i]
 		switch i {
 		case 8, 13, 18, 23:
 			if c != '-' {
@@ -60,6 +83,11 @@ func isUUIDv4Shape(s string) bool {
 			}
 		case 14:
 			if c != '4' {
+				return false
+			}
+		case 19:
+			// UUID v4 variant: high bits are 10, so the nibble is 8..b.
+			if c != '8' && c != '9' && c != 'a' && c != 'b' && c != 'A' && c != 'B' {
 				return false
 			}
 		default:

--- a/pi/digitsd/internal/config/deviceid_test.go
+++ b/pi/digitsd/internal/config/deviceid_test.go
@@ -82,8 +82,8 @@ func TestLoadOrCreateDeviceID_CorruptedFixedLengthFile(t *testing.T) {
 	if strings.ContainsRune(got, '\x00') {
 		t.Fatalf("expected regenerated UUID, got NUL-containing %q", got)
 	}
-	if len(got) != 36 || got[8] != '-' || got[13] != '-' || got[18] != '-' || got[23] != '-' {
-		t.Fatalf("expected regenerated UUID, got %q", got)
+	if !isUUIDv4Shape(got) {
+		t.Fatalf("expected regenerated UUID v4, got %q", got)
 	}
 	persisted, err := os.ReadFile(path)
 	if err != nil {
@@ -112,8 +112,8 @@ func TestLoadOrCreateDeviceID_UnwritableExistingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 36 {
-		t.Fatalf("expected regenerated UUID, got %q", got)
+	if !isUUIDv4Shape(got) {
+		t.Fatalf("expected regenerated UUID v4, got %q", got)
 	}
 	persisted, err := os.ReadFile(path)
 	if err != nil {
@@ -121,5 +121,41 @@ func TestLoadOrCreateDeviceID_UnwritableExistingFile(t *testing.T) {
 	}
 	if strings.TrimSpace(string(persisted)) != got {
 		t.Fatalf("persisted %q does not match returned %q", persisted, got)
+	}
+	// Regen used a temp file; make sure it was not left behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "device-id" {
+			t.Errorf("stray file left in dir: %s", e.Name())
+		}
+	}
+}
+
+func TestIsUUIDv4Shape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid", "fa224572-e794-4ce5-a88d-788524adfe45", true},
+		{"valid uppercase", "FA224572-E794-4CE5-A88D-788524ADFE45", true},
+		{"too short", "fa224572-e794-4ce5-a88d-788524adfe4", false},
+		{"too long", "fa224572-e794-4ce5-a88d-788524adfe455", false},
+		{"wrong version", "fa224572-e794-5ce5-a88d-788524adfe45", false},
+		{"wrong variant", "fa224572-e794-4ce5-788d-788524adfe45", false},
+		{"non-hex", "fa224572-e794-4ce5-a88d-788524adfeZZ", false},
+		{"missing hyphen", "fa224572e794-4ce5-a88d-788524adfe45a", false},
+		{"all NULs", string(make([]byte, 36)), false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUUIDv4Shape(tc.in); got != tc.want {
+				t.Errorf("isUUIDv4Shape(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/pi/digitsd/internal/config/deviceid_test.go
+++ b/pi/digitsd/internal/config/deviceid_test.go
@@ -29,25 +29,97 @@ func TestGenerateUUIDv4(t *testing.T) {
 	}
 }
 
-func TestLoadOrCreateDeviceID_NewFile(t *testing.T) {
+func TestLoadOrCreateDeviceID_ExistingValidFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "device-id")
-	// Test with a temp path - write a UUID, read it back
-	id, _ := generateUUIDv4()
-	if err := os.WriteFile(path, []byte(id+"\n"), 0644); err != nil {
+	want := "fa224572-e794-4ce5-a88d-788524adfe45"
+	if err := os.WriteFile(path, []byte(want+"\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	data, _ := os.ReadFile(path)
-	got := strings.TrimSpace(string(data))
-	if got != id {
-		t.Fatalf("expected %q, got %q", id, got)
+	got, err := loadOrCreateDeviceIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
 
-func TestLoadOrCreateDeviceID_LegacyUpgrade(t *testing.T) {
-	// A 4-char hex ID should be rejected (too short)
-	id := "a1b2"
-	if len(id) == 36 {
-		t.Fatal("test setup error")
+func TestLoadOrCreateDeviceID_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "device-id")
+	got, err := loadOrCreateDeviceIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 36 {
+		t.Fatalf("expected 36-char UUID, got %q", got)
+	}
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(persisted)) != got {
+		t.Fatalf("persisted %q does not match returned %q", persisted, got)
+	}
+}
+
+// A file of 36 bytes that is not actually a UUID slips past the
+// length-only check and gets returned as the hardware ID. In
+// particular, a post-crash ext4 zero-write artifact can leave a
+// fixed-size file full of NULs on disk; TrimSpace does not strip NULs,
+// so shape validation is required, not just a length check.
+func TestLoadOrCreateDeviceID_CorruptedFixedLengthFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "device-id")
+	if err := os.WriteFile(path, make([]byte, 36), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadOrCreateDeviceIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsRune(got, '\x00') {
+		t.Fatalf("expected regenerated UUID, got NUL-containing %q", got)
+	}
+	if len(got) != 36 || got[8] != '-' || got[13] != '-' || got[18] != '-' || got[23] != '-' {
+		t.Fatalf("expected regenerated UUID, got %q", got)
+	}
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(persisted)) != got {
+		t.Fatalf("persisted %q does not match returned %q", persisted, got)
+	}
+}
+
+// Legacy provisioning created /data/digits/device-id as root:root while
+// digitsd runs as the digits user. When the file contents are invalid
+// and need regeneration, os.WriteFile cannot open the existing file for
+// writing and the whole call fails. Simulate with a read-only file that
+// still lives in a writable directory.
+func TestLoadOrCreateDeviceID_UnwritableExistingFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("file mode permissions do not apply to root")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "device-id")
+	if err := os.WriteFile(path, []byte("not-a-uuid"), 0444); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadOrCreateDeviceIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 36 {
+		t.Fatalf("expected regenerated UUID, got %q", got)
+	}
+	persisted, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(persisted)) != got {
+		t.Fatalf("persisted %q does not match returned %q", persisted, got)
 	}
 }

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
@@ -56,6 +56,7 @@ DEVICE_UUID=$(cat /proc/sys/kernel/random/uuid)
 log "Device UUID: ${DEVICE_UUID}"
 mkdir -p /data/digits
 echo "${DEVICE_UUID}" > /data/digits/device-id
+chown digits:digits /data/digits/device-id
 
 # Keep a short suffix for the AP SSID (last 4 chars of UUID)
 DEVICE_ID="${DEVICE_UUID: -4}"


### PR DESCRIPTION
## Summary

Digits 1 went offline after a reboot today and got stuck in a tight reconnect loop, rejected by the server on every WS register with `hardware_id required`. Root cause: `/data/digits/device-id` was 37 NUL bytes. Two compounding bugs in digitsd let that state both exist and persist across restarts.

**Bug 1 — brittle validation.** `LoadOrCreateDeviceID` accepted any 36-byte content after `strings.TrimSpace`. TrimSpace does not strip NULs, and a raw length check does not verify UUID shape. Fix: `strings.Trim` over `" \t\r\n\x00"` and a proper UUID v4 shape check.

**Bug 2 — self-heal impossible.** The regen path used `os.WriteFile`, which cannot open an existing file owned by another user. `digits-first-boot.sh` runs as root and created `/data/digits/device-id` as root:root, but digitsd runs as the `digits` user, so the regen branch failed with EACCES on every legacy image. Fix: `os.Remove` before `os.WriteFile` (digits user has write perms on the parent directory, so the unlink succeeds). Also chown the file to `digits:digits` at first-boot so new images never need the self-heal path.

Digits 1 was already restored out of band by manually writing the paired UUID from the `devices` table back to `/data/digits/device-id`.

## Test plan

- [x] `go test ./internal/config/...` — new cases cover valid file, missing file, 36-byte NUL-filled file, and unwritable file owned by another user (simulated via 0444)
- [x] `go test ./...` across digitsd — all green
- [x] `go vet ./...`, `golangci-lint run ./...` — clean
- [ ] Deploy to digits 1 and digits 2 and verify both stay online through a reboot