### PR TITLE
fix(image): clear boot counter in AP mode to prevent false recovery

### DIFF
--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -94,6 +94,12 @@ reset_wifi_config() {
 do_station_up() {
     log "Wi-Fi configured -- starting normal boot"
 
+    # Clear boot counter -- we reached userspace successfully. digitsd
+    # will clear it again later, but doing it here covers the window
+    # between boot and digitsd startup.
+    BOOT_COUNTER="/data/digits/boot-counter"
+    echo "0" > "$BOOT_COUNTER" 2>/dev/null || true
+
     # Stop AP services
     systemctl stop digits-ap.service digits-dnsmasq-ap.service digits-setup.service 2>/dev/null || true
 
@@ -106,6 +112,13 @@ do_station_up() {
 
 do_ap_up() {
     log "Wi-Fi not configured -- entering AP mode"
+
+    # Clear boot counter -- reaching AP mode means the device booted
+    # successfully. Without this, power-cycling 3 times during initial
+    # setup (before WiFi is configured and digitsd can clear it) would
+    # trip the recovery threshold.
+    BOOT_COUNTER="/data/digits/boot-counter"
+    echo "0" > "$BOOT_COUNTER" 2>/dev/null || true
 
     # Kill NetworkManager -- it fights hostapd for wlan0 and re-blocks rfkill
     systemctl stop NetworkManager.service 2>/dev/null || true


### PR DESCRIPTION
## Summary

- The initramfs boot counter was only cleared by `digitsd`, which is stopped during AP mode. On a fresh flash, power-cycling 3 times before configuring WiFi would trip the recovery threshold.
- Clear the boot counter in `digits-ap-check` for both `do_ap_up()` and `do_station_up()` -- if the device reached that service, the boot was successful.

## Test plan

- [ ] Flash a fresh image, verify AP mode starts
- [ ] Power-cycle 3+ times without configuring WiFi, verify AP mode still starts (not recovery)
- [ ] Configure WiFi, reboot, verify station mode works normally