### PR TITLE
docs: correct mic capture channel in architecture overview

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -94,7 +94,7 @@ Digits uses WebRTC for media transport. DTLS-SRTP provides end-to-end encryption
 
 ### Audio Pipeline
 
-- **Capture:** ALSA `plughw:CARD=Zero,DEV=0` at 48kHz stereo -- right channel extracted (external mic on TRS jack)
+- **Capture:** ALSA `plughw:CARD=Zero,DEV=0` at 48kHz stereo -- left channel extracted (external mic on TRS jack, routed by mixer to Mixin Left -> Left ADC)
 - **Processing:** Optional RNNoise ML denoiser for background noise suppression
 - **Encode:** Opus 48kHz mono, 24kbps, VoIP mode, in-band FEC, 20ms frames
 - **Transport:** RTP/SRTP via Pion WebRTC


### PR DESCRIPTION
## Summary
- Overview claimed the right channel was extracted for mic capture, but the codec mixer routes Mic 1 to Mixin Left on both Digits 1 and 2, and digitsd reads channel 0.
- Updated the line to say left channel and noted the routing for clarity.

## Test plan
- [ ] `arecord -D plughw:CARD=Zero,DEV=0 -c 2 -f S16_LE -r 48000 -d 2 /tmp/mic.wav` on a phone and verify mic audio appears on channel 0, not channel 1
- [ ] `grep MicChannel pi/digitsd/internal/audio/pipeline.go` returns `MicChannel: 0`