### PR TITLE
ci: refuse to flash when target isn't a block device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ flash: ## Flash the most recent image to SD card (auto-detects or SD=/dev/sdX)
 		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN,SUBSYSTEMS | awk '/(usb|mmc)/ && /[0-9]+\.?[0-9]*G/ { dev="/dev/"$$1; size=$$2+0; if (size >= 4 && size <= 64) print dev }' | head -1); \
 		if [ -z "$$SD_DEV" ]; then echo "No SD card detected. Specify manually: make flash SD=/dev/sdX"; exit 1; fi; \
 	fi; \
+	if [ ! -e "$$SD_DEV" ]; then echo "ERROR: $$SD_DEV does not exist. Is the card inserted?"; exit 1; fi; \
+	if [ ! -b "$$SD_DEV" ]; then echo "ERROR: $$SD_DEV is not a block device (it is $$(stat -c %F "$$SD_DEV")). Refusing to flash. If a stale regular file is shadowing the device, remove it with 'sudo rm $$SD_DEV' and re-insert the card."; exit 1; fi; \
 	echo "Flashing $$IMAGE -> $$SD_DEV"; \
 	lsblk "$$SD_DEV"; \
 	echo "WARNING: This will overwrite all data on $$SD_DEV."; \


### PR DESCRIPTION
## Summary
- `make flash` ran `lsblk "$SD_DEV"` as a sanity step but did not actually check whether `SD_DEV` existed or was a block device. If the target was a regular file (e.g. a stale file left in `/dev/` from a prior accidental `dd`), lsblk printed a warning, the script kept going, and `dd` wrote the full 8 GB image to that regular file. The flash appeared to succeed; the actual SD card was untouched; the Pi wouldn't boot.
- Add two explicit guards after `SD_DEV` is resolved: path must exist and must be a block device. Fail loud with a message that explains how to recover (including the `sudo rm` command for a shadowing regular file).

## Test plan
- [ ] `make flash SD=/dev/does-not-exist` fails with the "does not exist" message
- [ ] `touch /tmp/fake-sd && make flash SD=/tmp/fake-sd` fails with the "not a block device" message and suggests the recovery command
- [ ] `make flash SD=/dev/sdX` with a real SD card inserted still proceeds normally through the prompt and dd