### PR TITLE
fix(pi): AP teardown must not self-kill its cgroup

### DIFF
--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -88,16 +88,29 @@ type APController interface {
 
 const apCheckBinary = "/usr/local/bin/digits-ap-check"
 
-// SystemAPController calls `digits-ap-check down` with a bounded timeout so a
-// hung script cannot wedge the captive portal request goroutine.
+// SystemAPController calls `digits-ap-check down` as a detached transient
+// systemd unit via systemd-run --no-block. We cannot invoke digits-ap-check
+// directly as a child process because its do_ap_down routine stops
+// digits-setup.service, which -- under systemd's default
+// KillMode=control-group -- terminates every process in the service's
+// cgroup including a child digits-ap-check. By spawning digits-ap-check in
+// its own transient cgroup, the teardown script survives the death of its
+// caller and runs to completion.
 type SystemAPController struct{}
 
 func (SystemAPController) Down() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, apCheckBinary, "down").CombinedOutput()
+	out, err := exec.CommandContext(
+		ctx,
+		"systemd-run",
+		"--no-block",
+		"--collect",
+		"--unit=digits-ap-teardown",
+		apCheckBinary, "down",
+	).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("digits-ap-check down: %w: %s", err, out)
+		return fmt.Errorf("digits-ap-check down (systemd-run): %w: %s", err, out)
 	}
 	return nil
 }

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -170,7 +170,13 @@ do_ap_up() {
 do_ap_down() {
     log "Tearing down AP mode -- handing wlan0 back to NetworkManager"
 
-    systemctl stop digits-setup.service 2>/dev/null || true
+    # digits-setup.service is stopped LAST. This script is often invoked from
+    # inside its cgroup (the captive portal's /api/configure handler calls
+    # digits-ap-check down via exec). systemd's default KillMode=control-group
+    # means stopping digits-setup.service kills every process in that cgroup,
+    # including this shell. Any commands after that stop will not run.
+    # Stopping hostapd + dnsmasq + starting NetworkManager first ensures the
+    # AP is actually down before we kill ourselves.
     systemctl stop digits-dnsmasq-ap.service 2>/dev/null || true
     systemctl stop digits-ap.service 2>/dev/null || true
 
@@ -180,6 +186,8 @@ do_ap_down() {
     systemctl start NetworkManager
 
     log "AP mode down -- NetworkManager started"
+
+    systemctl stop digits-setup.service 2>/dev/null || true
 }
 
 # restore_from_backup copies every valid backup file into the operational

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -185,7 +185,14 @@ do_ap_down() {
 
     systemctl start NetworkManager
 
-    log "AP mode down -- NetworkManager started"
+    # do_ap_up stops digitsd.service when entering AP mode. Before the
+    # drop-reboot-on-configure change (PR #175), a reboot brought digitsd
+    # back on the next boot; without the reboot, nothing else restarts
+    # it. Start it here so the device is usable immediately after configure.
+    # --no-block so systemctl returns even if digitsd startup is slow.
+    systemctl start --no-block digitsd.service 2>/dev/null || true
+
+    log "AP mode down -- NetworkManager started, digitsd starting"
 
     systemctl stop digits-setup.service 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
- Captive-portal Wi-Fi setup completed successfully (creds saved, `wifi-configured=1`) but the AP kept broadcasting forever. Journal from the device shows `digits-ap-check down` logged its first line and then the script got killed mid-teardown.
- Root cause: `do_ap_down` stopped `digits-setup.service` as its first step. Because `digits-ap-check down` was spawned as a child of `digits-setup.service` (via `exec.Command` from the `/api/configure` handler), it inherited the service's cgroup. systemd's default `KillMode=control-group` on the stop killed the whole cgroup, including the shell running the teardown script. Every subsequent step (stop hostapd, stop dnsmasq, start NetworkManager) never ran.

## Fixes (two, mutually reinforcing)
1. **`digits-ap-check do_ap_down` reordered** so `systemctl stop digits-setup.service` is the last command. If the shell gets killed at that point the AP is already down and NetworkManager is already coming up. Defensive; keeps direct CLI callers working.
2. **`SystemAPController.Down()` now wraps `digits-ap-check down` in `systemd-run --no-block --collect --unit=digits-ap-teardown`**, so the teardown runs in its own transient cgroup and survives the death of the caller. Proper isolation, not a workaround.

## Evidence
From the affected device's journal (timestamps reflect the Pi with no RTC; ordering is what matters):
```
05:40:36 digits-ap-check: Tearing down AP mode ...
05:40:36 Stopping digits-setup.service ...
05:40:36 digits-setup.service: Deactivated successfully.
05:40:36 Stopped digits-setup.service
[NO further teardown lines]
05:43:11 hostapd[1100]: wlan0: STA ... IEEE 802.11: associated
```
The "AP mode down -- NetworkManager started" log line that would follow a successful teardown is absent, and hostapd (pid 1100) is still accepting associations three minutes later.

## Test plan
- [ ] `go test ./pi/digits-setup/...` passes (does already — tests use a mocked APController)
- [ ] Build a fresh dev image, flash, boot into AP mode, submit creds via captive portal. AP SSID should disappear within ~2s of clicking submit, wlan0 should come up on the configured network, `systemctl is-active digits-ap.service` should be `inactive`.
- [ ] Confirm in journal on a successful configure: "AP mode down -- NetworkManager started" log line appears.