### PR TITLE
fix(image): restore AP-to-recovery escape via boot counter

### DIFF
--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -113,13 +113,6 @@ do_station_up() {
 do_ap_up() {
     log "Wi-Fi not configured -- entering AP mode"
 
-    # Clear boot counter -- reaching AP mode means the device booted
-    # successfully. Without this, power-cycling 3 times during initial
-    # setup (before WiFi is configured and digitsd can clear it) would
-    # trip the recovery threshold.
-    BOOT_COUNTER="/data/digits/boot-counter"
-    echo "0" > "$BOOT_COUNTER" 2>/dev/null || true
-
     # Kill NetworkManager -- it fights hostapd for wlan0 and re-blocks rfkill
     systemctl stop NetworkManager.service 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
- PR #183 cleared the boot counter in both `do_ap_up` and `do_station_up`. The station-side clear is fine; the AP-side clear was overreach -- it removed the only power-cycle path to recovery when AP is stuck.
- Keep the `do_station_up` clear. Drop the `do_ap_up` clear. Users stuck in a broken AP can now power-cycle 3x to drop into recovery, same as before #183.
- Accepts the narrow false-positive for users who power-cycle repeatedly during intentional fresh-flash AP setup. That's arguably the case where recovery is useful anyway.

## Test plan
- [ ] Fresh flash, let device enter AP mode, power-cycle 3 times before completing Wi-Fi setup -> on the 4th boot, device should enter recovery mode (SSID `Digits-Recovery`)
- [ ] Fresh flash, complete Wi-Fi setup normally -> counter resets on reaching station mode, no false recovery trigger
- [ ] Already-configured device -> normal boot clears counter via `do_station_up`