### PR TITLE
docs(hardware): handset audio path errata for V1 and V2

### DIFF
--- a/hardware/pcb/v1/ERRATA.md
+++ b/hardware/pcb/v1/ERRATA.md
@@ -24,6 +24,16 @@ The 2x20 header (J1) is placed on B.Cu with 180-degree rotation. The combination
 
 **Fix for future revisions:** Remove the 180-degree rotation on J1. The B.Cu mirror alone produces correct mating orientation.
 
+### 3. MIC_GND is a floating net -- no connection to board GND
+
+The schematic uses a local label `MIC_GND` for the handset mic return instead of the global `GND` power symbol. The net connects only to C3 pin 2, J8 pin 4 (RJ9 mic return), and J9 pin 3 (kill-switch GND terminal). It does not reach the board's GND pour anywhere. This was verified in both the schematic netlist and the PCB trace list (10 segments on B.Cu, all within the J8/J9/C3 cluster; no via to GND).
+
+**Symptom:** on a build where the handset mic return depends on MIC_GND reaching the codec's ground (i.e., any build where the HAT/codec ground only reaches the handset through a single external wire), capture alone works and playback alone works, but any full-duplex audio (real call, digitsd audio test with denoise off) produces pure noise on the captured stream. The mic capsule's return current shares its single ground wire with the codec's playback current, and ground bounce from the DAC modulates the mic reference. Discovered on Digits 3 on 2026-04-19 after several hours of software debugging.
+
+**Workaround for fabricated boards:** solder a short bodge wire from any MIC_GND-net pad (J8 pin 4 solder side is easiest) to any real GND pad on V1 PCB (e.g., U1 LM2596 pin 3, or a decoupling cap's GND leg, or a grounded mounting hole). 20-22 AWG, short as possible. This makes MIC_GND a proper low-impedance return and the duplex-capture failure goes away.
+
+**Fix for future revisions:** Use the global `GND` power symbol for the RJ9 mic-return pin, not a local label. (V2 already does this correctly -- verified: J8 pin 4 in V2 is on the global GND net, and the whole MIC_GND-style local-label pattern does not recur.)
+
 ---
 
 ## Recommended Improvements

--- a/hardware/pcb/v2/ERRATA.md
+++ b/hardware/pcb/v2/ERRATA.md
@@ -1,0 +1,53 @@
+# PCB V2 Errata and Assembly Notes
+
+Issues discovered after V2 entered fabrication (2026-04-19). These apply to all fabricated V2 boards unless noted otherwise.
+
+---
+
+## Must Fix at Assembly
+
+### 1. J8 pin-to-net assignment collides with stock Sangyn handset cable
+
+The stock Sangyn Retro 2500 handset RJ9 ribbon cable (when terminated into a 4-pin JST ZH via the usual adapter) delivers:
+
+| JST pin | Wire color | Handset function |
+|---|---|---|
+| 1 | Black | Mic + |
+| 2 | Yellow | Mic − |
+| 3 | Red | Earpiece |
+| 4 | Green | Earpiece |
+
+Mic pair is on the inner-left pins (1, 2). Earpiece pair is on the inner-right pins (3, 4).
+
+V2's J8 (JST ZH 4-pin, footprint `JST_ZH_B4B-ZR-SM4-TF`) assigns:
+
+| Pin | Net |
+|---|---|
+| 1 | MIC_HOT |
+| 2 | EAR_P |
+| 3 | EAR_N |
+| 4 | GND |
+
+Assuming mic pair on **outer** pins (1, 4), not inner. With the stock cable plugged in:
+
+- **J8.1**: Black lands on MIC_HOT. ✅
+- **J8.2**: Yellow (Mic−) lands on EAR_P, which routes to the codec's HPLOUT (active driven earpiece output). The mic capsule's return wire is electrically tied to a driven audio signal. When playback is active, the playback signal is injected directly into the mic capsule's ground reference. Mic captures playback + room audio, duplex breaks.
+- **J8.3**: Red lands on EAR_N. One earpiece terminal sees HPLCOM. Single-ended drive results. Earpiece plays audibly but at roughly half the BTL amplitude.
+- **J8.4**: Green lands on GND. The other earpiece terminal is grounded. Completes the single-ended earpiece path.
+
+**Symptom:** mic captures alone (quietly) work; earpiece playback works (reduced volume); full-duplex audio (real calls, audio test) puts playback directly into the mic path, producing noise on capture.
+
+**Root cause:** schematic author assumed mic pair was on the outer pin positions (1, 4) of the handset cable. Actual Sangyn cable puts mic pair on the inner-left pair (1, 2). Not caught by any ERC rule.
+
+**Workaround for fabricated boards:** do not use the stock cable-to-JST adapter as-is. Build the adapter so that pins 2 and 4 at the JST end are swapped relative to the stock handset cable, giving this order:
+
+| JST pin | Wire | V2 J8 signal |
+|---|---|---|
+| 1 | Black (Mic +) | MIC_HOT |
+| 2 | Green (Earpiece) | EAR_P |
+| 3 | Red (Earpiece) | EAR_N |
+| 4 | Yellow (Mic −) | GND |
+
+Easiest form: cut the stock handset cable, strip the four conductors, crimp JST ZH pins, insert into the housing in the order above. One minor per-unit rework.
+
+**Fix for V3:** update J8 pin assignment in the schematic so `pin 1 = MIC_HOT, pin 2 = GND, pin 3 = EAR_P, pin 4 = EAR_N`, matching the stock Sangyn cable directly. Then no per-unit adapter rework is needed. Add a schematic-review checklist item: for every connector that mates to an external cable with a documented wire color code, the schematic must explicitly assert the color-to-function map, not silently adopt a convention.


### PR DESCRIPTION
## Summary
- Documents two hardware issues discovered during the 2026-04-19 Digits 3 mic debug session
- V1 ERRATA #3: `MIC_GND` is a local label isolated from the GND pour; handset mic return shares a single ground wire with the HAT earpiece driver, causing duplex capture noise. Bodge-wire fix per fabricated board.
- V2 ERRATA (new): J8 pin assignment collides with stock Sangyn handset cable. Mic− wire lands on the codec's earpiece output pin, injecting playback into the mic capsule. Per-unit cable rework (swap Yellow and Green in the JST housing) until V3.

## Test plan
- [x] Build and reflash a Digits 3 image with both bodges in place (MIC_GND→GND wire + JST Yellow/Green swap) and verify full-duplex audio (real call)
- [x] Confirm V2 boards need the adapter-side Yellow/Green swap at assembly; otherwise reference `hardware/pcb/v2/ERRATA.md` at build time
- [x] Fix both issues at the schematic level before V2.1 / V3 tape-out