### PR TITLE
fix(digitsd): code review cleanups around signaling and call lifecycle

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -90,9 +90,7 @@ type daemonCallbacks struct {
 	restartTimer     *time.Timer // timeout for ICE restart attempt
 }
 
-// sendSignal sends a signaling message and logs failures. Signaling send
-// errors were previously silenced with //nolint:errcheck, which made lost
-// call setup, hangup, and ICE messages invisible during debugging.
+// sendSignal sends a signaling message and logs failures.
 func sendSignal(sig *sigclient.Client, msg *sigclient.Message) {
 	if err := sig.Send(msg); err != nil {
 		slog.Warn("signal send failed", "type", msg.Type, "to", msg.To, "error", err)
@@ -100,12 +98,7 @@ func sendSignal(sig *sigclient.Client, msg *sigclient.Message) {
 }
 
 // recoverGoroutine logs a panic with its stack trace so a single bad frame
-// in an audio/WebRTC goroutine doesn't crash the daemon silently. Usage:
-//
-//	go func() {
-//	    defer recoverGoroutine("remote-track")
-//	    ...
-//	}()
+// doesn't crash an audio/WebRTC goroutine silently.
 func recoverGoroutine(name string) {
 	if r := recover(); r != nil {
 		slog.Error("goroutine panic recovered", "goroutine", name, "panic", r, "stack", string(debug.Stack()))
@@ -497,12 +490,9 @@ func (d *daemonCallbacks) setVoiceStyleConfig(style string) error {
 	return d.cfg.Save()
 }
 
-// triggerHangup dispatches a hangup signal to the controller from a fresh
-// goroutine.  Callers that already hold d.mu (e.g. attemptICERestart) must
-// use this indirection: Controller.HandleSignal will eventually call back
-// into HangupCall, which also takes d.mu.  Callers that do NOT hold d.mu
-// still benefit from the goroutine — it isolates them from the potentially
-// long POTS off-hook sequence kicked off by onSignalHangup.
+// triggerHangup dispatches a hangup to the controller from a fresh goroutine.
+// Callers holding d.mu must use this to avoid deadlock: HandleSignal calls
+// back into HangupCall, which also acquires d.mu.
 func (d *daemonCallbacks) triggerHangup() {
 	if d.ctrl == nil {
 		return
@@ -1222,12 +1212,9 @@ func main() {
 	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
 
-	// 8b. Contacts cache — optional dial safelist. The server pushes contact
-	// updates via "contacts"/"contacts_updated" signaling messages, and the
-	// cache is also persisted to disk so the last-known list survives
-	// reboots. When the cache is empty the filter stays disabled (nil
-	// checker) so no-contacts phones allow every call, matching the
-	// previous behavior when contacts weren't wired in at all.
+	// 8b. Contacts cache — optional dial safelist, persisted to disk.
+	// An empty cache leaves the checker nil so no-contacts phones allow
+	// every call (matching the pre-wiring behavior).
 	contactsPath := filepath.Join(filepath.Dir(*configPath), "contacts.json")
 	contactsCache := contacts.NewCache(contactsPath)
 	if err := contactsCache.Load(); err != nil {
@@ -1769,9 +1756,7 @@ func main() {
 
 // requestICEServers asks signald for STUN/TURN server configs.
 func requestICEServers(sig *sigclient.Client) {
-	if err := sig.Send(&sigclient.Message{Type: sigclient.TypeRequestICE}); err != nil {
-		slog.Warn("ice: request failed", "error", err)
-	}
+	sendSignal(sig, &sigclient.Message{Type: sigclient.TypeRequestICE})
 }
 
 func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapable bool) {

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -493,6 +493,9 @@ func (d *daemonCallbacks) setVoiceStyleConfig(style string) error {
 // triggerHangup dispatches a hangup to the controller from a fresh goroutine.
 // Callers holding d.mu must use this to avoid deadlock: HandleSignal calls
 // back into HangupCall, which also acquires d.mu.
+//
+// d.ctrl is assigned once in main() before the event loop starts and is
+// never mutated, so the unsynchronized nil read here is safe.
 func (d *daemonCallbacks) triggerHangup() {
 	if d.ctrl == nil {
 		return

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,6 +25,7 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/bootcount"
 	"github.com/justinlindh/digits/pi/digitsd/internal/codec"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
+	"github.com/justinlindh/digits/pi/digitsd/internal/contacts"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	"github.com/justinlindh/digits/pi/digitsd/internal/updater"
@@ -86,6 +88,28 @@ type daemonCallbacks struct {
 	isCaller         bool     // true if we initiated the current call
 	isRestartingICE  bool     // true while an ICE restart is in progress
 	restartTimer     *time.Timer // timeout for ICE restart attempt
+}
+
+// sendSignal sends a signaling message and logs failures. Signaling send
+// errors were previously silenced with //nolint:errcheck, which made lost
+// call setup, hangup, and ICE messages invisible during debugging.
+func sendSignal(sig *sigclient.Client, msg *sigclient.Message) {
+	if err := sig.Send(msg); err != nil {
+		slog.Warn("signal send failed", "type", msg.Type, "to", msg.To, "error", err)
+	}
+}
+
+// recoverGoroutine logs a panic with its stack trace so a single bad frame
+// in an audio/WebRTC goroutine doesn't crash the daemon silently. Usage:
+//
+//	go func() {
+//	    defer recoverGoroutine("remote-track")
+//	    ...
+//	}()
+func recoverGoroutine(name string) {
+	if r := recover(); r != nil {
+		slog.Error("goroutine panic recovered", "goroutine", name, "panic", r, "stack", string(debug.Stack()))
+	}
 }
 
 // --- phone.Callbacks implementation ---
@@ -154,6 +178,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	// Handle remote audio track
 	d.peerMgr.OnRemoteTrack = func(track *webrtc.TrackRemote) {
 		go func() {
+			defer recoverGoroutine("caller-remote-track")
 			// Live playback — decode and feed into mixer
 			var frameCount int
 			for {
@@ -179,7 +204,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	sdpSent := make(chan struct{})
 	d.peerMgr.OnICECandidate = func(candidate string) {
 		<-sdpSent
-		d.sig.Send(&sigclient.Message{ //nolint:errcheck
+		sendSignal(d.sig, &sigclient.Message{
 			Type:      sigclient.TypeICE,
 			To:        targetNumber,
 			Candidate: candidate,
@@ -195,8 +220,8 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 	}
 
 	// Send call + SDP, then ungate ICE candidates
-	d.sig.Send(&sigclient.Message{Type: sigclient.TypeCall, To: targetNumber}) //nolint:errcheck
-	d.sig.Send(&sigclient.Message{Type: sigclient.TypeSDP, To: targetNumber, SDP: offer}) //nolint:errcheck
+	sendSignal(d.sig, &sigclient.Message{Type: sigclient.TypeCall, To: targetNumber})
+	sendSignal(d.sig, &sigclient.Message{Type: sigclient.TypeSDP, To: targetNumber, SDP: offer})
 	close(sdpSent)
 
 	// Start audio pipeline
@@ -208,6 +233,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) {
 
 	// Encode and send captured audio
 	go func() {
+		defer recoverGoroutine("caller-encode-loop")
 		for frame := range d.pipeline.OutFrames() {
 			encoded, err := d.encoder.Encode(frame)
 			if err != nil {
@@ -264,6 +290,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	// Handle remote audio track — decode and feed into mixer.
 	d.peerMgr.OnRemoteTrack = func(track *webrtc.TrackRemote) {
 		go func() {
+			defer recoverGoroutine("answer-remote-track")
 			var frameCount int
 
 			// Phase 1: Wait for pipeline (user picks up phone).
@@ -342,7 +369,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	sdpSent := make(chan struct{})
 	d.peerMgr.OnICECandidate = func(candidate string) {
 		<-sdpSent
-		d.sig.Send(&sigclient.Message{ //nolint:errcheck
+		sendSignal(d.sig, &sigclient.Message{
 			Type:      sigclient.TypeICE,
 			To:        caller,
 			Candidate: candidate,
@@ -367,7 +394,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	d.pendingICE = nil
 
 	// Send answer SDP back to caller, then ungate ICE candidates
-	d.sig.Send(&sigclient.Message{ //nolint:errcheck
+	sendSignal(d.sig, &sigclient.Message{
 		Type: sigclient.TypeAnswer,
 		To:   caller,
 		SDP:  answerSDP,
@@ -383,6 +410,7 @@ func (d *daemonCallbacks) AnswerCall() {
 
 	// Encode and send captured audio
 	go func() {
+		defer recoverGoroutine("answer-encode-loop")
 		for frame := range d.pipeline.OutFrames() {
 			encoded, err := d.encoder.Encode(frame)
 			if err != nil {
@@ -419,7 +447,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.restartTimer = nil
 	}
 
-	d.sig.Send(&sigclient.Message{Type: sigclient.TypeHangup, To: peer}) //nolint:errcheck
+	sendSignal(d.sig, &sigclient.Message{Type: sigclient.TypeHangup, To: peer})
 
 	if d.pipeline != nil {
 		d.pipeline.Stop()
@@ -469,6 +497,19 @@ func (d *daemonCallbacks) setVoiceStyleConfig(style string) error {
 	return d.cfg.Save()
 }
 
+// triggerHangup dispatches a hangup signal to the controller from a fresh
+// goroutine.  Callers that already hold d.mu (e.g. attemptICERestart) must
+// use this indirection: Controller.HandleSignal will eventually call back
+// into HangupCall, which also takes d.mu.  Callers that do NOT hold d.mu
+// still benefit from the goroutine — it isolates them from the potentially
+// long POTS off-hook sequence kicked off by onSignalHangup.
+func (d *daemonCallbacks) triggerHangup() {
+	if d.ctrl == nil {
+		return
+	}
+	go d.ctrl.HandleSignal("hangup")
+}
+
 // handleConnectionStateChange is called (without d.mu held) from a pion
 // goroutine when the WebRTC peer connection state changes.  On transient
 // failures the original caller attempts a single ICE restart before giving up.
@@ -495,7 +536,7 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 
 		if alreadyRestarting {
 			slog.Warn("webrtc: ICE restart failed, hanging up")
-			go d.ctrl.HandleSignal("hangup")
+			d.triggerHangup()
 			return
 		}
 
@@ -520,7 +561,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 
 	if d.peerMgr == nil {
 		slog.Warn("ice-restart: no peer manager, hanging up")
-		go d.ctrl.HandleSignal("hangup")
+		d.triggerHangup()
 		return
 	}
 
@@ -530,7 +571,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 	if err != nil {
 		slog.Error("ice-restart: create offer failed", "error", err)
 		d.isRestartingICE = false
-		go d.ctrl.HandleSignal("hangup")
+		d.triggerHangup()
 		return
 	}
 
@@ -538,7 +579,7 @@ func (d *daemonCallbacks) attemptICERestart() {
 	d.startRestartTimeout()
 
 	slog.Info("ice-restart: sending restart offer", "peer", peer, "bytes", len(offer))
-	d.sig.Send(&sigclient.Message{ //nolint:errcheck
+	sendSignal(d.sig, &sigclient.Message{
 		Type: sigclient.TypeICERestart,
 		To:   peer,
 		SDP:  offer,
@@ -554,7 +595,7 @@ func (d *daemonCallbacks) startRestartTimeout() {
 		d.mu.Unlock()
 		if restarting {
 			slog.Warn("webrtc: ICE restart timed out, hanging up")
-			d.ctrl.HandleSignal("hangup")
+			d.triggerHangup()
 		}
 	})
 }
@@ -1181,6 +1222,23 @@ func main() {
 	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
 
+	// 8b. Contacts cache — optional dial safelist. The server pushes contact
+	// updates via "contacts"/"contacts_updated" signaling messages, and the
+	// cache is also persisted to disk so the last-known list survives
+	// reboots. When the cache is empty the filter stays disabled (nil
+	// checker) so no-contacts phones allow every call, matching the
+	// previous behavior when contacts weren't wired in at all.
+	contactsPath := filepath.Join(filepath.Dir(*configPath), "contacts.json")
+	contactsCache := contacts.NewCache(contactsPath)
+	if err := contactsCache.Load(); err != nil {
+		slog.Warn("contacts: load failed", "path", contactsPath, "error", err)
+	} else if n := contactsCache.Count(); n > 0 {
+		ctrl.SetContactChecker(contactsCache)
+		slog.Info("contacts: loaded safelist", "path", contactsPath, "count", n)
+	} else {
+		slog.Info("contacts: no local list, filter disabled", "path", contactsPath)
+	}
+
 	// 9. Start socket server (backward compat for debugging + latclient auto-answer)
 	sockSrv, err := phone.NewSocketServer(*socketPath, cb)
 	if err != nil {
@@ -1314,7 +1372,7 @@ func main() {
 					peer := cb.callPeer
 					cb.mu.Unlock()
 					if peer != "" {
-						sig.Send(&sigclient.Message{ //nolint:errcheck
+						sendSignal(sig, &sigclient.Message{
 							Type:  sigclient.TypeDTMF,
 							To:    peer,
 							Digit: key,
@@ -1378,7 +1436,6 @@ func main() {
 			if event == "HOOK:ON" {
 				mixer.StopAll()
 				easterEggs.Reset()
-				svcCodes.Reset()
 				svcCodes.Reset()
 			}
 
@@ -1477,18 +1534,27 @@ func main() {
 				}()
 			case sigclient.TypeSDP:
 				cb.mu.Lock()
-				if cb.peerMgr != nil {
-					if err := cb.peerMgr.SetAnswer(msg.SDP); err != nil {
-						slog.Error("webrtc: set answer failed", "error", err)
-					}
-				} else {
+				switch {
+				case cb.peerMgr == nil:
+					// Incoming call: offer arrived before we've answered.
+					// Stash it for AnswerCall to pick up.
 					cb.pendingOffer = msg.SDP
-					// Also capture caller from SDP message if not already set by ring
 					if cb.pendingCaller == "" && msg.From != "" {
 						cb.pendingCaller = msg.From
 						slog.Info("set pendingCaller from SDP", "from", msg.From)
 					}
 					slog.Info("stored pending SDP offer", "from", msg.From, "bytes", len(msg.SDP))
+				case cb.isRestartingICE:
+					// Mid-call: the only legitimate reason to receive an SDP
+					// with an active peerMgr is the restart-answer we asked
+					// for when we initiated an ICE restart.
+					if err := cb.peerMgr.SetAnswer(msg.SDP); err != nil {
+						slog.Error("webrtc: set restart answer failed", "error", err)
+					} else {
+						slog.Info("webrtc: applied restart answer", "from", msg.From, "bytes", len(msg.SDP))
+					}
+				default:
+					slog.Warn("webrtc: unexpected SDP with active peer, ignoring", "from", msg.From, "bytes", len(msg.SDP))
 				}
 				cb.mu.Unlock()
 			case sigclient.TypeICE:
@@ -1506,7 +1572,7 @@ func main() {
 			case sigclient.TypeUpdateTrigger:
 				slog.Info("signal: received update trigger from server", "target_pi", msg.TargetPiVersion, "target_fw", msg.TargetFWVersion)
 				statusReporter := func(status, detail string) {
-					sig.Send(&sigclient.Message{ //nolint:errcheck
+					sendSignal(sig, &sigclient.Message{
 						Type:         sigclient.TypeUpdateStatus,
 						UpdateStatus: status,
 						UpdateDetail: detail,
@@ -1518,6 +1584,19 @@ func main() {
 			case sigclient.TypeFactoryReset:
 				slog.Info("factory reset: triggered by server")
 				go triggerFactoryReset()
+
+			case sigclient.TypeContacts, sigclient.TypeContactsUpdated:
+				entries := make([]contacts.Entry, 0, len(msg.Contacts))
+				for _, c := range msg.Contacts {
+					entries = append(entries, contacts.Entry{Number: c.Number, Name: c.Name})
+				}
+				contactsCache.Update(entries)
+				if len(entries) > 0 {
+					ctrl.SetContactChecker(contactsCache)
+				} else {
+					ctrl.SetContactChecker(nil)
+				}
+				slog.Info("contacts: updated", "count", len(entries), "type", msg.Type)
 
 			case sigclient.TypeICERestart:
 				cb.mu.Lock()
@@ -1545,7 +1624,7 @@ func main() {
 					peer = msg.From
 				}
 				slog.Info("ice-restart: sending restart answer", "peer", peer, "bytes", len(answerSDP))
-				sig.Send(&sigclient.Message{ //nolint:errcheck
+				sendSignal(sig, &sigclient.Message{
 					Type: sigclient.TypeSDP,
 					To:   peer,
 					SDP:  answerSDP,
@@ -1601,7 +1680,7 @@ func main() {
 				slog.Info("received restart command", "mode", mode)
 				switch mode {
 				case "service":
-					sig.Send(&sigclient.Message{ //nolint:errcheck
+					sendSignal(sig, &sigclient.Message{
 						Type:         sigclient.TypeUpdateStatus,
 						UpdateStatus: "restarting",
 						UpdateDetail: "Service restart requested",
@@ -1612,7 +1691,7 @@ func main() {
 						os.Exit(0)
 					}()
 				case "reboot":
-					sig.Send(&sigclient.Message{ //nolint:errcheck
+					sendSignal(sig, &sigclient.Message{
 						Type:         sigclient.TypeUpdateStatus,
 						UpdateStatus: "rebooting",
 						UpdateDetail: "Device reboot requested",

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -102,6 +102,12 @@ func (m *Mixer) renderLoop(stop chan struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("mixer: render loop panic", "panic", r, "stack", string(debug.Stack()))
+			// Keep running in sync with reality so Stop() doesn't try to
+			// close a dead channel and a later Start() can observe the
+			// halted state accurately.
+			m.mu.Lock()
+			m.running = false
+			m.mu.Unlock()
 		}
 	}()
 	buf := make([]int16, m.period)

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sync"
 )
 
@@ -98,6 +99,11 @@ func (m *Mixer) Stop() {
 // renderLoop is the single goroutine that writes to hardware.
 // It runs at ALSA's pace: snd_pcm_writei blocks ~20ms per period.
 func (m *Mixer) renderLoop(stop chan struct{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("mixer: render loop panic", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
 	buf := make([]int16, m.period)
 	for {
 		select {


### PR DESCRIPTION
## Summary

Seven small fixes surfaced during a code review of `pi/digitsd/`. Nothing here is a big refactor; each item is a narrow, low-risk change aimed at making failures louder or call-lifecycle edge cases safer.

### Changes

1. **Drop a duplicate `svcCodes.Reset()`** on `HOOK:ON`. Pure copy-paste, removed.
2. **Stop silencing `sig.Send()` errors.** A new `sendSignal(sig, msg)` helper wraps every previously `//nolint:errcheck`-tagged send and logs the failure at `warn`. Covers call setup, hangup, ICE, DTMF, ICE restart, update status, and service/reboot acknowledgements.
3. **Consolidate hangup goroutine spawns** (`handleConnectionStateChange`, `attemptICERestart`, `startRestartTimeout`) into a single `triggerHangup()` helper with a nil guard on `d.ctrl`.
4. **Add panic recovery** to the mixer render loop and to the per-call remote-track and encode goroutines (`caller-remote-track`, `caller-encode-loop`, `answer-remote-track`, `answer-encode-loop`). A single bad frame will now be logged with a stack trace instead of killing audio while the daemon still looks "healthy".
5. **Wire up the already-existing contacts cache.** `internal/contacts/Cache` and `Controller.SetContactChecker` existed but were never connected from `main.go`, so the local-contact safelist never ran. Now `main` creates the cache at `<configDir>/contacts.json`, loads it at startup, and handles `TypeContacts` / `TypeContactsUpdated` signaling messages. The `ContactChecker` is only attached when the cache is non-empty, preserving allow-all for phones that have no local list (avoids a deployment foot-gun where an empty cache would reject every call).
6. **Guard mid-call `TypeSDP` handling.** The handler used to call `peerMgr.SetAnswer()` unconditionally whenever `peerMgr != nil`. It now only does so while `isRestartingICE` is true (the one protocol path that legitimately produces a mid-call SDP answer). Unexpected mid-call SDPs are logged and ignored instead of being applied blindly.

### Dropped from original list

One finding from the initial review, adding a `context.Context` to the remote-track reader goroutines, turned out to be unnecessary. Pion's `ReadRTP` already returns once `peerMgr.Close()` runs in `HangupCall`, and the encode loop exits when `pipeline.Stop()` closes `OutFrames()`. No leak, nothing to fix.

## Test plan

- [ ] `go vet ./...` clean
- [x] `go test ./...` passes (all packages)
- [ ] Smoke test on a real Pi: make/receive a call, hang up, verify logs show the new signal-send warning is absent under normal operation
- [ ] Verify contacts filter remains disabled on phones with no `contacts.json` (no server currently sends contact messages, so this should be a no-op)
- [ ] If/when the server starts sending `TypeContacts`, verify the filter activates and non-contacts hit the rejection sequence
