### PR TITLE
fix(digitsd): play POTS off-hook treatment after dial-tone timeout

### DIFF
--- a/.github/workflows/pi-ci.yml
+++ b/.github/workflows/pi-ci.yml
@@ -36,12 +36,9 @@ jobs:
       - name: Build digitsd
         working-directory: pi/digitsd
         run: go build ./...
-      - name: Test digitsd
+      - name: Test digitsd (with race detector)
         working-directory: pi/digitsd
-        run: go test ./...
-      - name: Race test wififallback supervisor
-        working-directory: pi/digitsd
-        run: go test -race ./internal/wififallback/...
+        run: go test -race ./...
 
   test-digits-setup:
     name: test-digits-setup

--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -15,8 +15,8 @@
 #include "pico/time.h"
 
 #define DIAL_DIGITS_REQUIRED 7
-#define DIAL_TIMEOUT_MS 30000  // 30s for bench testing (restore to 5000 for real phone)
-#define DIAL_TONE_TIMEOUT_MS 30000  // 30s of dial tone before off-hook timeout → busy
+#define DIAL_TIMEOUT_MS 15000        // 15s between digits before partial dial → off-hook timeout
+#define DIAL_TONE_TIMEOUT_MS 15000   // 15s of dial tone with no keys → off-hook timeout (Bellcore GR-506-CORE)
 
 static phone_state_t s_state = PHONE_STATE_IDLE;
 static char s_digits[DIAL_DIGITS_REQUIRED + 1];

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -110,21 +110,21 @@ func recoverGoroutine(name string) {
 func (d *daemonCallbacks) SendTone(name string) {
 	// Map controller tone names to WAV file names.
 	switch strings.ToUpper(name) {
-	case "DIAL":
+	case phone.ToneDial:
 		d.mixer.PlayLoop("tone_dial")
-	case "RINGBACK":
+	case phone.ToneRingback:
 		d.mixer.PlayLoop("tone_ringback")
-	case "BUSY":
+	case phone.ToneBusy:
 		d.mixer.PlayLoop("tone_busy")
-	case "REORDER":
+	case phone.ToneReorder:
 		d.mixer.PlayLoop("tone_reorder")
-	case "HOWLER":
+	case phone.ToneHowler:
 		d.mixer.PlayLoop("tone_howler")
-	case "INTERCEPT":
+	case phone.ToneIntercept:
 		d.mixer.PlayOnce("intercept")
-	case "STOP":
+	case phone.ToneStop:
 		d.mixer.StopTone()
-	case "STOPALL":
+	case phone.ToneStopAll:
 		d.mixer.StopAll()
 	default:
 		slog.Warn("tone: unknown", "name", name)
@@ -614,13 +614,13 @@ func (d *daemonCallbacks) HandleSocketCommand(cmd string) string {
 	if strings.HasPrefix(cmd, "TONE:") {
 		tone := cmd[5:]
 		switch tone {
-		case "STOP":
+		case phone.ToneStop:
 			d.mixer.StopTone()
-		case "DIAL":
+		case phone.ToneDial:
 			d.mixer.PlayLoop("tone_dial")
-		case "RINGBACK":
+		case phone.ToneRingback:
 			d.mixer.PlayLoop("tone_ringback")
-		case "BUSY":
+		case phone.ToneBusy:
 			d.mixer.PlayLoop("tone_busy")
 		}
 		return "OK"
@@ -1312,6 +1312,7 @@ func main() {
 		select {
 		case <-quit:
 			slog.Info("digitsd shutting down")
+			ctrl.Close()
 			mixer.Stop()
 			if err := sig.Close(); err != nil {
 				slog.Warn("sig close failed", "error", err)

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -38,6 +38,7 @@ type Mixer struct {
 
 	mu      sync.Mutex
 	stopCh  chan struct{}
+	doneCh  chan struct{} // closed by renderLoop on exit; Stop blocks on it
 	running bool
 
 	// Loop source: loops named tone until StopTone is called.
@@ -77,28 +78,33 @@ func (m *Mixer) Start() {
 	}
 	m.running = true
 	m.stopCh = make(chan struct{})
-	go m.renderLoop(m.stopCh)
+	m.doneCh = make(chan struct{})
+	go m.renderLoop(m.stopCh, m.doneCh)
 	slog.Info("mixer: render loop started")
 }
 
-// Stop halts the render loop. Blocks until the goroutine has exited.
+// Stop halts the render loop. Blocks until the goroutine has exited so callers
+// can safely observe everything the loop wrote.
 func (m *Mixer) Stop() {
 	m.mu.Lock()
 	if !m.running {
 		m.mu.Unlock()
 		return
 	}
-	ch := m.stopCh
-	close(ch)
+	close(m.stopCh)
 	m.running = false
+	done := m.doneCh
 	m.mu.Unlock()
-	// Wait for render loop to drain — it exits on next select check
+	<-done
 	slog.Info("mixer: render loop stopped")
 }
 
 // renderLoop is the single goroutine that writes to hardware.
 // It runs at ALSA's pace: snd_pcm_writei blocks ~20ms per period.
-func (m *Mixer) renderLoop(stop chan struct{}) {
+func (m *Mixer) renderLoop(stop, done chan struct{}) {
+	// Defers run LIFO: close(done) is registered first so it runs LAST,
+	// guaranteeing Stop() unblocks even if the loop panics.
+	defer close(done)
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("mixer: render loop panic", "panic", r, "stack", string(debug.Stack()))

--- a/pi/digitsd/internal/audio/mixer_test.go
+++ b/pi/digitsd/internal/audio/mixer_test.go
@@ -105,8 +105,11 @@ func TestMixerPlayLoopOutputsToneSamples(t *testing.T) {
 	}
 	mx.LoadTone("test_tone", tone)
 
-	mx.Start()
+	// Queue the loop BEFORE Start so the first rendered period is deterministic.
+	// (If queued after Start, the render loop may have already written one or
+	// more silence periods before PlayLoop returns, making periods[0] a race.)
 	mx.PlayLoop("test_tone")
+	mx.Start()
 	time.Sleep(50 * time.Millisecond)
 	mx.StopTone()
 	mx.Stop()
@@ -185,8 +188,10 @@ func TestMixerPlayOnce(t *testing.T) {
 	}
 	mx.LoadTone("beep", tone)
 
-	mx.Start()
+	// Queue the one-shot BEFORE Start so the first rendered period is the tone.
+	// Otherwise the render loop may emit a silence period before PlayOnce queues.
 	mx.PlayOnce("beep")
+	mx.Start()
 	time.Sleep(50 * time.Millisecond)
 	mx.Stop()
 

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -10,18 +10,31 @@ import (
 type State string
 
 const (
-	StateIDLE           State = "IDLE"
-	StateDIALTONE       State = "DIAL_TONE"
-	StateDIALING        State = "DIALING"
-	StateCALLING        State = "CALLING"
-	StateRINGING        State = "RINGING"
-	StateCONNECTED      State = "CONNECTED"
-	StateREMOTE_HANGUP  State = "REMOTE_HANGUP" // Far end hung up; handset still off-hook
+	StateIDLE            State = "IDLE"
+	StateDIALTONE        State = "DIAL_TONE"
+	StateDIALING         State = "DIALING"
+	StateCALLING         State = "CALLING"
+	StateRINGING         State = "RINGING"
+	StateCONNECTED       State = "CONNECTED"
+	StateREMOTE_HANGUP   State = "REMOTE_HANGUP"   // Far end hung up; handset still off-hook
+	StateOFFHOOK_TIMEOUT State = "OFFHOOK_TIMEOUT" // Off-hook with no dialing; CO permanent-signal treatment
+)
+
+// Tone names passed to Callbacks.SendTone. Mixer/daemon dispatch on these.
+const (
+	ToneDial      = "DIAL"
+	ToneRingback  = "RINGBACK"
+	ToneBusy      = "BUSY"
+	ToneReorder   = "REORDER"
+	ToneHowler    = "HOWLER"
+	ToneIntercept = "INTERCEPT"
+	ToneStop      = "STOP"
+	ToneStopAll   = "STOPALL"
 )
 
 // Callbacks is the interface the controller uses to drive hardware and network.
 type Callbacks interface {
-	SendTone(name string)       // Play a tone: DIAL, RINGBACK, BUSY, REORDER, HOWLER, INTERCEPT, STOP, STOPALL
+	SendTone(name string)       // Play a tone (use one of the Tone* constants)
 	OncePlaying() bool          // Reports whether a one-shot tone (e.g. intercept) is still playing
 	SendRing(start bool)        // Send RING:START or RING:STOP
 	SendLED(mode string)        // Send LED:<mode>
@@ -44,6 +57,15 @@ type Controller struct {
 	digits         string
 	ownNumber      string
 	contactChecker ContactChecker
+	// treatmentGen is incremented each time runPermanentSignalTreatment starts.
+	// The spawned goroutine captures the value and aborts on mismatch, so a
+	// hook-flap that re-enters off-hook treatment within ~4 min won't let the
+	// previous goroutine step the new session forward.
+	treatmentGen uint64
+	// done is closed by Close(); long-lived goroutines (off-hook treatment) abort
+	// their sleeps when it fires so daemon shutdown isn't blocked.
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewController creates a new Controller starting in StateIDLE.
@@ -53,6 +75,24 @@ func NewController(cb Callbacks, ownNumber string) *Controller {
 		state:     StateIDLE,
 		cb:        cb,
 		ownNumber: ownNumber,
+		done:      make(chan struct{}),
+	}
+}
+
+// Close signals long-lived background goroutines (off-hook treatment) to exit
+// their sleep loops promptly. Safe to call multiple times.
+func (c *Controller) Close() {
+	c.closeOnce.Do(func() { close(c.done) })
+}
+
+// sleepOrDone blocks for d, returning false if Close was called during the
+// wait (so the caller can short-circuit its sequence).
+func (c *Controller) sleepOrDone(d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return true
+	case <-c.done:
+		return false
 	}
 }
 
@@ -111,6 +151,8 @@ func (c *Controller) HandleEvent(event string) {
 		c.onKey(evVal)
 	case evType == "DIAL":
 		c.onDial(evVal)
+	case evType == "TIMEOUT" && evVal == "DIAL_TONE":
+		c.onTimeoutDialTone()
 	case evType == "RING" && (evVal == "ACK" || evVal == "DONE"):
 		// Informational — ring ack/done from Pico, no action needed
 	case event == "PONG":
@@ -147,13 +189,13 @@ func (c *Controller) onHookOff() {
 		// Outgoing: pick up → dial tone
 		c.state = StateDIALTONE
 		c.digits = ""
-		c.cb.SendTone("DIAL")
+		c.cb.SendTone(ToneDial)
 		c.cb.SendLED("ON")
 	case StateRINGING:
 		// Incoming: answer the call
 		c.state = StateCONNECTED
 		c.cb.SendRing(false)
-		c.cb.SendTone("STOP")
+		c.cb.SendTone(ToneStop)
 		c.cb.SendLED("ON")
 		c.cb.AnswerCall()
 	default:
@@ -168,13 +210,13 @@ func (c *Controller) onHookOn() {
 	wasConnectedOrCalling := c.state == StateCONNECTED || c.state == StateCALLING
 	c.state = StateIDLE
 	c.digits = ""
-	c.cb.SendTone("STOP")
+	c.cb.SendTone(ToneStop)
 	c.cb.SendRing(false)
 	c.cb.SendLED("OFF")
 	if wasConnectedOrCalling {
 		c.cb.HangupCall()
 	}
-	// REMOTE_HANGUP: call already torn down, just clean up tones/LED (done above)
+	// REMOTE_HANGUP / OFFHOOK_TIMEOUT: nothing to tear down, tones/LED cleaned up above.
 }
 
 func (c *Controller) onKey(digit string) {
@@ -186,7 +228,7 @@ func (c *Controller) onKey(digit string) {
 		// First key: stop dial tone, start collecting digits
 		c.state = StateDIALING
 		c.digits = digit
-		c.cb.SendTone("STOP")
+		c.cb.SendTone(ToneStop)
 	case StateDIALING:
 		c.digits += digit
 		// Service codes (*#*N) are handled by ServiceCodeHandler.
@@ -214,7 +256,7 @@ func (c *Controller) onDial(number string) {
 	if c.ownNumber != "" && number == c.ownNumber {
 		slog.Info("phone: self-call detected, busy tone")
 		c.state = StateCALLING
-		c.cb.SendTone("BUSY")
+		c.cb.SendTone(ToneBusy)
 		return
 	}
 
@@ -223,7 +265,7 @@ func (c *Controller) onDial(number string) {
 	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
 		slog.Info("phone: number not in contacts, rejecting", "number", number)
 		c.state = StateCALLING
-		c.cb.SendTone("RINGBACK")
+		c.cb.SendTone(ToneRingback)
 		// Rejection sequence runs async (same as server-side "not connected" error)
 		go func() {
 			checkState := func() bool {
@@ -238,8 +280,8 @@ func (c *Controller) onDial(number string) {
 			}
 
 			// SIT + disconnected announcement
-			c.cb.SendTone("STOP")
-			c.cb.SendTone("INTERCEPT")
+			c.cb.SendTone(ToneStop)
+			c.cb.SendTone(ToneIntercept)
 			deadline := time.Now().Add(15 * time.Second)
 			for c.cb.OncePlaying() {
 				time.Sleep(200 * time.Millisecond)
@@ -256,7 +298,7 @@ func (c *Controller) onDial(number string) {
 			if !checkState() {
 				return
 			}
-			c.cb.SendTone("BUSY")
+			c.cb.SendTone(ToneBusy)
 		}()
 		return
 	}
@@ -271,7 +313,7 @@ func (c *Controller) onDial(number string) {
 		if c.state != StateCALLING {
 			return
 		}
-		c.cb.SendTone("RINGBACK")
+		c.cb.SendTone(ToneRingback)
 		c.cb.InitiateCall(number)
 	}()
 }
@@ -292,7 +334,7 @@ func (c *Controller) onSignalAnswer() {
 		return
 	}
 	c.state = StateCONNECTED
-	c.cb.SendTone("STOP")
+	c.cb.SendTone(ToneStop)
 	c.cb.NotifyCallConnected()
 }
 
@@ -309,48 +351,64 @@ func (c *Controller) onSignalHangup() {
 		slog.Info("phone: hangup signal ignored (not CONNECTED)", "state", c.state)
 		return
 	}
-	// POTS remote-hangup sequence (Bellcore GR-506-CORE permanent signal treatment):
-	//   1. Tear down call, brief silence (~1s, CO processing delay)
-	//   2. Reorder tone (fast busy, 480+620 Hz) for ~45s
-	//   3. Howler/ROH tone (loud multi-freq) for ~3 min
-	//   4. Line lockout (silence until user hangs up)
 	c.state = StateREMOTE_HANGUP
 	c.cb.HangupCall()
-	c.cb.SendTone("STOPALL")
-	slog.Info("phone: remote hangup -- starting POTS off-hook sequence")
+	c.cb.SendTone(ToneStopAll)
+	c.runPermanentSignalTreatment(StateREMOTE_HANGUP, "remote hangup")
+}
+
+// onTimeoutDialTone handles the Pico's TIMEOUT:DIAL_TONE event: the user picked
+// up the handset but never dialed. Same CO treatment as a remote hangup with
+// the handset still off-hook.
+func (c *Controller) onTimeoutDialTone() {
+	if c.state != StateDIALTONE {
+		slog.Info("phone: TIMEOUT:DIAL_TONE ignored", "state", c.state)
+		return
+	}
+	c.state = StateOFFHOOK_TIMEOUT
+	c.cb.SendTone(ToneStopAll)
+	c.runPermanentSignalTreatment(StateOFFHOOK_TIMEOUT, "dial-tone timeout")
+}
+
+// runPermanentSignalTreatment plays the 90s POTS off-hook sequence
+// (Bellcore GR-506-CORE permanent signal treatment) in a goroutine:
+//   1. Brief silence (~1s CO processing delay)
+//   2. Reorder tone (fast busy, 480+620 Hz) for ~45s
+//   3. Howler/ROH tone (loud multi-freq) for ~3 min
+//   4. Line lockout (silence until user hangs up)
+//
+// The sequence aborts at any step if the controller leaves treatmentState or
+// if a newer treatment run has started (tracked via treatmentGen). Caller must
+// hold c.mu and have already set c.state = treatmentState.
+func (c *Controller) runPermanentSignalTreatment(treatmentState State, reason string) {
+	c.treatmentGen++
+	gen := c.treatmentGen
+	slog.Info("phone: starting POTS off-hook sequence", "reason", reason)
 	go func() {
-		// Helper to check we're still in REMOTE_HANGUP state
-		stillOffHook := func() bool {
+		stillInTreatment := func() bool {
 			c.mu.Lock()
 			defer c.mu.Unlock()
-			return c.state == StateREMOTE_HANGUP
+			return c.state == treatmentState && c.treatmentGen == gen
 		}
 
-		// 1. Brief silence (~1s CO processing delay)
-		time.Sleep(1 * time.Second)
-		if !stillOffHook() {
+		if !c.sleepOrDone(1 * time.Second) || !stillInTreatment() {
 			return
 		}
 
-		// 2. Reorder tone for ~45 seconds
-		slog.Info("phone: remote hangup -- reorder tone")
-		c.cb.SendTone("REORDER")
-		time.Sleep(45 * time.Second)
-		if !stillOffHook() {
+		slog.Info("phone: off-hook sequence -- reorder tone", "reason", reason)
+		c.cb.SendTone(ToneReorder)
+		if !c.sleepOrDone(45 * time.Second) || !stillInTreatment() {
 			return
 		}
 
-		// 3. Howler tone for ~3 minutes
-		slog.Info("phone: remote hangup -- howler tone")
-		c.cb.SendTone("HOWLER")
-		time.Sleep(3 * time.Minute)
-		if !stillOffHook() {
+		slog.Info("phone: off-hook sequence -- howler tone", "reason", reason)
+		c.cb.SendTone(ToneHowler)
+		if !c.sleepOrDone(3 * time.Minute) || !stillInTreatment() {
 			return
 		}
 
-		// 4. Line lockout -- silence until hang-up
-		slog.Info("phone: remote hangup -- line lockout")
-		c.cb.SendTone("STOP")
+		slog.Info("phone: off-hook sequence -- line lockout", "reason", reason)
+		c.cb.SendTone(ToneStop)
 	}()
 }
 
@@ -360,6 +418,6 @@ func (c *Controller) onSignalBusy() {
 		return
 	}
 	slog.Info("phone: busy signal received -- call rejected")
-	c.cb.SendTone("BUSY")
+	c.cb.SendTone(ToneBusy)
 	// Stay in CALLING -- caller should hang up
 }

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -1,11 +1,17 @@
 package phone
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
 
+// mockCallbacks captures controller side-effects for assertions. All methods
+// are safe to call from controller-spawned goroutines; tests must read state
+// through the accessor methods (Tones, Calls, ...) so reads are synchronized
+// against the writers.
 type mockCallbacks struct {
+	mu                 sync.Mutex
 	tones              []string
 	rings              []bool
 	leds               []string
@@ -15,36 +21,103 @@ type mockCallbacks struct {
 	callConnectedCalls int
 }
 
-func (m *mockCallbacks) SendTone(name string)       { m.tones = append(m.tones, name) }
-func (m *mockCallbacks) OncePlaying() bool          { return false }
-func (m *mockCallbacks) SendRing(start bool)        { m.rings = append(m.rings, start) }
-func (m *mockCallbacks) SendLED(mode string)        { m.leds = append(m.leds, mode) }
-func (m *mockCallbacks) InitiateCall(number string) { m.calls = append(m.calls, number) }
-func (m *mockCallbacks) AnswerCall()                { m.answers++ }
-func (m *mockCallbacks) HangupCall()                { m.hangups++ }
-func (m *mockCallbacks) NotifyCallConnected()       { m.callConnectedCalls++ }
+func (m *mockCallbacks) SendTone(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tones = append(m.tones, name)
+}
+func (m *mockCallbacks) OncePlaying() bool { return false }
+func (m *mockCallbacks) SendRing(start bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rings = append(m.rings, start)
+}
+func (m *mockCallbacks) SendLED(mode string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.leds = append(m.leds, mode)
+}
+func (m *mockCallbacks) InitiateCall(number string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, number)
+}
+func (m *mockCallbacks) AnswerCall() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.answers++
+}
+func (m *mockCallbacks) HangupCall() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hangups++
+}
+func (m *mockCallbacks) NotifyCallConnected() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callConnectedCalls++
+}
 
-// 1. Full outgoing call flow: HOOK:OFF → keys → DIAL:5551234 → answer → HOOK:ON
+// Snapshot accessors — return copies under lock so test assertions are
+// race-free against goroutines started by the controller.
+func (m *mockCallbacks) Tones() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.tones...)
+}
+func (m *mockCallbacks) Rings() []bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]bool(nil), m.rings...)
+}
+func (m *mockCallbacks) LEDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.leds...)
+}
+func (m *mockCallbacks) Calls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.calls...)
+}
+func (m *mockCallbacks) Hangups() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.hangups
+}
+func (m *mockCallbacks) Answers() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.answers
+}
+func (m *mockCallbacks) CallConnectedCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callConnectedCalls
+}
+
 // waitForCall waits up to 2s for a call to be initiated (async after dial delay).
 func waitForCall(cb *mockCallbacks) {
 	for i := 0; i < 20; i++ {
-		if len(cb.calls) > 0 {
+		if len(cb.Calls()) > 0 {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 }
 
-// waitForTone waits up to 2s for a specific tone to appear.
-func waitForTone(cb *mockCallbacks, tone string) {
+// waitForTone waits up to 2s for a specific tone to appear. Returns true if
+// found, false on timeout.
+func waitForTone(cb *mockCallbacks, tone string) bool {
 	for i := 0; i < 20; i++ {
-		for _, t := range cb.tones {
+		for _, t := range cb.Tones() {
 			if t == tone {
-				return
+				return true
 			}
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	return false
 }
 
 func TestController_OutgoingCallFlow(t *testing.T) {
@@ -56,10 +129,10 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 	if c.State() != StateDIALTONE {
 		t.Fatalf("expected DIAL_TONE, got %s", c.State())
 	}
-	if len(cb.tones) == 0 || cb.tones[len(cb.tones)-1] != "DIAL" {
+	if len(cb.Tones()) == 0 || cb.Tones()[len(cb.Tones())-1] != "DIAL" {
 		t.Error("expected SendTone(DIAL) on HOOK:OFF")
 	}
-	if len(cb.leds) == 0 || cb.leds[len(cb.leds)-1] != "ON" {
+	if len(cb.LEDs()) == 0 || cb.LEDs()[len(cb.LEDs())-1] != "ON" {
 		t.Error("expected SendLED(ON) on HOOK:OFF")
 	}
 
@@ -68,8 +141,8 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 	if c.State() != StateDIALING {
 		t.Fatalf("expected DIALING after first key, got %s", c.State())
 	}
-	tonesSoFar := len(cb.tones)
-	if cb.tones[tonesSoFar-1] != "STOP" {
+	tonesSoFar := len(cb.Tones())
+	if cb.Tones()[tonesSoFar-1] != "STOP" {
 		t.Error("expected SendTone(STOP) on first key")
 	}
 
@@ -87,11 +160,11 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 		t.Fatalf("expected CALLING after DIAL, got %s", c.State())
 	}
 	waitForCall(cb)
-	if len(cb.calls) == 0 || cb.calls[0] != "5551234" {
-		t.Errorf("expected InitiateCall(5551234), got %v", cb.calls)
+	if len(cb.Calls()) == 0 || cb.Calls()[0] != "5551234" {
+		t.Errorf("expected InitiateCall(5551234), got %v", cb.Calls())
 	}
 	waitForTone(cb, "RINGBACK")
-	lastTone := cb.tones[len(cb.tones)-1]
+	lastTone := cb.Tones()[len(cb.Tones())-1]
 	if lastTone != "RINGBACK" {
 		t.Errorf("expected SendTone(RINGBACK), got %s", lastTone)
 	}
@@ -101,7 +174,7 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 	if c.State() != StateCONNECTED {
 		t.Fatalf("expected CONNECTED after answer signal, got %s", c.State())
 	}
-	lastTone = cb.tones[len(cb.tones)-1]
+	lastTone = cb.Tones()[len(cb.Tones())-1]
 	if lastTone != "STOP" {
 		t.Errorf("expected SendTone(STOP) on answer, got %s", lastTone)
 	}
@@ -111,10 +184,10 @@ func TestController_OutgoingCallFlow(t *testing.T) {
 	if c.State() != StateIDLE {
 		t.Fatalf("expected IDLE after HOOK:ON, got %s", c.State())
 	}
-	if cb.hangups != 1 {
-		t.Errorf("expected 1 HangupCall, got %d", cb.hangups)
+	if cb.Hangups() != 1 {
+		t.Errorf("expected 1 HangupCall, got %d", cb.Hangups())
 	}
-	lastLED := cb.leds[len(cb.leds)-1]
+	lastLED := cb.LEDs()[len(cb.LEDs())-1]
 	if lastLED != "OFF" {
 		t.Errorf("expected SendLED(OFF) on hang up, got %s", lastLED)
 	}
@@ -130,10 +203,10 @@ func TestController_IncomingCallFlow(t *testing.T) {
 	if c.State() != StateRINGING {
 		t.Fatalf("expected RINGING, got %s", c.State())
 	}
-	if len(cb.rings) == 0 || cb.rings[0] != true {
+	if len(cb.Rings()) == 0 || cb.Rings()[0] != true {
 		t.Error("expected SendRing(true)")
 	}
-	if len(cb.leds) == 0 || cb.leds[0] != "BLINK" {
+	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
 		t.Error("expected SendLED(BLINK)")
 	}
 
@@ -142,11 +215,11 @@ func TestController_IncomingCallFlow(t *testing.T) {
 	if c.State() != StateCONNECTED {
 		t.Fatalf("expected CONNECTED after HOOK:OFF during RINGING, got %s", c.State())
 	}
-	if cb.answers != 1 {
-		t.Errorf("expected 1 AnswerCall, got %d", cb.answers)
+	if cb.Answers() != 1 {
+		t.Errorf("expected 1 AnswerCall, got %d", cb.Answers())
 	}
 	// Ring should have been stopped
-	lastRing := cb.rings[len(cb.rings)-1]
+	lastRing := cb.Rings()[len(cb.Rings())-1]
 	if lastRing != false {
 		t.Error("expected SendRing(false) when answering")
 	}
@@ -157,8 +230,8 @@ func TestController_IncomingCallFlow(t *testing.T) {
 		t.Fatalf("expected REMOTE_HANGUP after hangup signal, got %s", c.State())
 	}
 	// Verify call was torn down
-	if cb.hangups != 1 {
-		t.Errorf("expected 1 HangupCall, got %d", cb.hangups)
+	if cb.Hangups() != 1 {
+		t.Errorf("expected 1 HangupCall, got %d", cb.Hangups())
 	}
 
 	// User hangs up (on-hook) → IDLE
@@ -166,7 +239,7 @@ func TestController_IncomingCallFlow(t *testing.T) {
 	if c.State() != StateIDLE {
 		t.Fatalf("expected IDLE after HOOK:ON in REMOTE_HANGUP, got %s", c.State())
 	}
-	lastLED := cb.leds[len(cb.leds)-1]
+	lastLED := cb.LEDs()[len(cb.LEDs())-1]
 	if lastLED != "OFF" {
 		t.Errorf("expected SendLED(OFF) after local hangup, got %s", lastLED)
 	}
@@ -182,7 +255,7 @@ func TestController_IgnoreKeyInIdle(t *testing.T) {
 	if c.State() != StateIDLE {
 		t.Errorf("expected IDLE, got %s", c.State())
 	}
-	if len(cb.tones) != 0 || len(cb.leds) != 0 || len(cb.calls) != 0 {
+	if len(cb.Tones()) != 0 || len(cb.LEDs()) != 0 || len(cb.Calls()) != 0 {
 		t.Error("expected no callbacks for KEY in IDLE")
 	}
 }
@@ -199,8 +272,8 @@ func TestController_HangupDuringDialing(t *testing.T) {
 	if c.State() != StateIDLE {
 		t.Errorf("expected IDLE, got %s", c.State())
 	}
-	if cb.hangups != 0 {
-		t.Errorf("expected 0 HangupCall during DIALING, got %d", cb.hangups)
+	if cb.Hangups() != 0 {
+		t.Errorf("expected 0 HangupCall during DIALING, got %d", cb.Hangups())
 	}
 }
 
@@ -217,8 +290,8 @@ func TestController_HangupDuringCalling(t *testing.T) {
 	if c.State() != StateIDLE {
 		t.Errorf("expected IDLE, got %s", c.State())
 	}
-	if cb.hangups != 1 {
-		t.Errorf("expected 1 HangupCall during CALLING, got %d", cb.hangups)
+	if cb.Hangups() != 1 {
+		t.Errorf("expected 1 HangupCall during CALLING, got %d", cb.Hangups())
 	}
 }
 
@@ -235,20 +308,20 @@ func TestController_BusySignal(t *testing.T) {
 		t.Fatalf("expected CALLING, got %s", c.State())
 	}
 
-	tonesBefore := len(cb.tones)
+	tonesBefore := len(cb.Tones())
 	c.HandleSignal("busy")
 
 	// SendTone("STOP") should have been called
-	if len(cb.tones) <= tonesBefore {
+	if len(cb.Tones()) <= tonesBefore {
 		t.Error("expected SendTone to be called on busy")
 	}
-	lastTone := cb.tones[len(cb.tones)-1]
+	lastTone := cb.Tones()[len(cb.Tones())-1]
 	if lastTone != "BUSY" {
 		t.Errorf("expected SendTone(BUSY) on busy, got %s", lastTone)
 	}
 	// No hangup call triggered by signal
-	if cb.hangups != 0 {
-		t.Errorf("expected 0 HangupCall on busy signal, got %d", cb.hangups)
+	if cb.Hangups() != 0 {
+		t.Errorf("expected 0 HangupCall on busy signal, got %d", cb.Hangups())
 	}
 }
 
@@ -275,8 +348,8 @@ func TestController_DialAllowedContact(t *testing.T) {
 		t.Fatalf("expected CALLING, got %s", c.State())
 	}
 	waitForCall(cb)
-	if len(cb.calls) != 1 || cb.calls[0] != "5551234" {
-		t.Errorf("expected InitiateCall(5551234), got %v", cb.calls)
+	if len(cb.Calls()) != 1 || cb.Calls()[0] != "5551234" {
+		t.Errorf("expected InitiateCall(5551234), got %v", cb.Calls())
 	}
 }
 
@@ -293,19 +366,19 @@ func TestController_DialBlockedContact(t *testing.T) {
 	if c.State() != StateCALLING {
 		t.Fatalf("expected CALLING (rejection sequence), got %s", c.State())
 	}
-	if len(cb.calls) != 0 {
-		t.Errorf("expected NO InitiateCall for blocked number, got %v", cb.calls)
+	if len(cb.Calls()) != 0 {
+		t.Errorf("expected NO InitiateCall for blocked number, got %v", cb.Calls())
 	}
 	// Should have sent RINGBACK tone (rejection mimics unreachable number)
 	found := false
-	for _, tone := range cb.tones {
+	for _, tone := range cb.Tones() {
 		if tone == "RINGBACK" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected RINGBACK tone for blocked number, got tones: %v", cb.tones)
+		t.Errorf("expected RINGBACK tone for blocked number, got tones: %v", cb.Tones())
 	}
 }
 
@@ -323,8 +396,8 @@ func TestController_NoContactChecker_AllowsAll(t *testing.T) {
 		t.Fatalf("expected CALLING, got %s", c.State())
 	}
 	waitForCall(cb)
-	if len(cb.calls) != 1 {
-		t.Errorf("expected call to proceed with no checker, got %v", cb.calls)
+	if len(cb.Calls()) != 1 {
+		t.Errorf("expected call to proceed with no checker, got %v", cb.Calls())
 	}
 }
 
@@ -340,10 +413,10 @@ func TestController_SelfDial(t *testing.T) {
 	if c.State() != StateCALLING {
 		t.Fatalf("expected CALLING, got %s", c.State())
 	}
-	if len(cb.calls) != 0 {
-		t.Errorf("expected no InitiateCall for self-dial, got %v", cb.calls)
+	if len(cb.Calls()) != 0 {
+		t.Errorf("expected no InitiateCall for self-dial, got %v", cb.Calls())
 	}
-	lastTone := cb.tones[len(cb.tones)-1]
+	lastTone := cb.Tones()[len(cb.Tones())-1]
 	if lastTone != "BUSY" {
 		t.Errorf("expected BUSY tone for self-dial, got %s", lastTone)
 	}
@@ -364,17 +437,17 @@ func TestController_CallerHangupDuringRing(t *testing.T) {
 		t.Fatalf("expected IDLE after caller hangup during ring, got %s", c.State())
 	}
 	// Ring must have been stopped
-	lastRing := cb.rings[len(cb.rings)-1]
+	lastRing := cb.Rings()[len(cb.Rings())-1]
 	if lastRing != false {
 		t.Error("expected SendRing(false) when caller hangs up during ring")
 	}
-	lastLED := cb.leds[len(cb.leds)-1]
+	lastLED := cb.LEDs()[len(cb.LEDs())-1]
 	if lastLED != "OFF" {
 		t.Error("expected SendLED(OFF) when caller hangs up during ring")
 	}
 	// No HangupCall — there was no active WebRTC session
-	if cb.hangups != 0 {
-		t.Errorf("expected 0 HangupCall (no active call), got %d", cb.hangups)
+	if cb.Hangups() != 0 {
+		t.Errorf("expected 0 HangupCall (no active call), got %d", cb.Hangups())
 	}
 }
 
@@ -395,8 +468,8 @@ func TestOnSignalAnswerNotifiesCallConnected(t *testing.T) {
 		t.Fatalf("expected StateCALLING, got %s", c.State())
 	}
 
-	if cb.callConnectedCalls != 0 {
-		t.Errorf("NotifyCallConnected should not be called before answer, got %d", cb.callConnectedCalls)
+	if cb.CallConnectedCalls() != 0 {
+		t.Errorf("NotifyCallConnected should not be called before answer, got %d", cb.CallConnectedCalls())
 	}
 
 	c.HandleSignal("answer")
@@ -404,8 +477,8 @@ func TestOnSignalAnswerNotifiesCallConnected(t *testing.T) {
 	if c.State() != StateCONNECTED {
 		t.Errorf("expected StateCONNECTED after answer, got %s", c.State())
 	}
-	if cb.callConnectedCalls != 1 {
-		t.Errorf("expected NotifyCallConnected to be called once, got %d", cb.callConnectedCalls)
+	if cb.CallConnectedCalls() != 1 {
+		t.Errorf("expected NotifyCallConnected to be called once, got %d", cb.CallConnectedCalls())
 	}
 }
 
@@ -424,11 +497,11 @@ func TestRingbackMustPlayUntilAnswer(t *testing.T) {
 	// The last tone recorded must still be RINGBACK: no STOP should have been
 	// sent between RINGBACK and now.
 	lastTone := ""
-	if len(cb.tones) > 0 {
-		lastTone = cb.tones[len(cb.tones)-1]
+	if len(cb.Tones()) > 0 {
+		lastTone = cb.Tones()[len(cb.Tones())-1]
 	}
 	if lastTone != "RINGBACK" {
-		t.Errorf("expected last tone to be RINGBACK (ringback should still be playing), got %q; full sequence: %v", lastTone, cb.tones)
+		t.Errorf("expected last tone to be RINGBACK (ringback should still be playing), got %q; full sequence: %v", lastTone, cb.Tones())
 	}
 }
 
@@ -448,7 +521,7 @@ func TestController_IncomingWhileBusy(t *testing.T) {
 		t.Fatalf("expected CONNECTED, got %s", c.State())
 	}
 
-	ringsBefore := len(cb.rings)
+	ringsBefore := len(cb.Rings())
 	c.HandleSignal("ring")
 
 	// State should still be CONNECTED
@@ -456,8 +529,97 @@ func TestController_IncomingWhileBusy(t *testing.T) {
 		t.Errorf("expected CONNECTED after ring signal during active call, got %s", c.State())
 	}
 	// No new ring callbacks
-	if len(cb.rings) != ringsBefore {
+	if len(cb.Rings()) != ringsBefore {
 		t.Error("expected no SendRing call when ring arrives during CONNECTED")
+	}
+}
+
+// 10. Dial-tone timeout (Pico fired TIMEOUT:DIAL_TONE) → POTS off-hook treatment.
+// Caller leaves handset off-hook with no digits dialed: state transitions out of
+// DIALTONE, reorder tone starts after the brief CO silence, keys are silently
+// ignored, and going on-hook restores IDLE.
+func TestController_DialToneTimeout(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	c.HandleEvent("HOOK:OFF")
+	if c.State() != StateDIALTONE {
+		t.Fatalf("expected DIALTONE, got %s", c.State())
+	}
+
+	c.HandleEvent("TIMEOUT:DIAL_TONE")
+	if c.State() != StateOFFHOOK_TIMEOUT {
+		t.Fatalf("expected OFFHOOK_TIMEOUT after TIMEOUT:DIAL_TONE, got %s", c.State())
+	}
+
+	// Dial tone must be cut and reorder tone must start (after brief silence).
+	if !waitForTone(cb, "REORDER") {
+		t.Errorf("expected REORDER tone after dial-tone timeout, got tones: %v", cb.Tones())
+	}
+
+	// Keypresses during off-hook treatment must be silently ignored.
+	stateBefore := c.State()
+	callsBefore := len(cb.Calls())
+	c.HandleEvent("KEY:5")
+	c.HandleEvent("KEY:5")
+	c.HandleEvent("KEY:5")
+	if c.State() != stateBefore {
+		t.Errorf("expected state to stay %s after keys, got %s", stateBefore, c.State())
+	}
+	if len(cb.Calls()) != callsBefore {
+		t.Errorf("expected no call attempts during off-hook treatment, got %v", cb.Calls())
+	}
+
+	// Hook-on returns to IDLE; nothing to hang up.
+	hangupsBefore := cb.Hangups()
+	c.HandleEvent("HOOK:ON")
+	if c.State() != StateIDLE {
+		t.Fatalf("expected IDLE after HOOK:ON, got %s", c.State())
+	}
+	if cb.Hangups() != hangupsBefore {
+		t.Errorf("expected no HangupCall on off-hook timeout recovery, got %d new", cb.Hangups()-hangupsBefore)
+	}
+}
+
+// Close() aborts a running off-hook treatment goroutine so daemon shutdown
+// isn't blocked waiting for the 4-minute sequence to drain. The pre-REORDER
+// silence is 1s; if Close is honored, REORDER must never fire.
+func TestController_CloseAbortsOffHookTreatment(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("TIMEOUT:DIAL_TONE")
+	c.Close()
+
+	time.Sleep(1500 * time.Millisecond)
+	for _, tone := range cb.Tones() {
+		if tone == ToneReorder {
+			t.Errorf("REORDER fired despite Close(); tones=%v", cb.Tones())
+		}
+	}
+}
+
+// 11. TIMEOUT:DIAL_TONE outside DIALTONE state is ignored (defensive).
+func TestController_DialToneTimeout_IgnoredOutsideDialTone(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	// Idle: no off-hook → timeout makes no sense
+	c.HandleEvent("TIMEOUT:DIAL_TONE")
+	if c.State() != StateIDLE {
+		t.Errorf("expected IDLE (timeout ignored), got %s", c.State())
+	}
+
+	// Mid-dial: user already pressed keys, don't slam them into off-hook treatment
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:5")
+	if c.State() != StateDIALING {
+		t.Fatalf("expected DIALING, got %s", c.State())
+	}
+	c.HandleEvent("TIMEOUT:DIAL_TONE")
+	if c.State() != StateDIALING {
+		t.Errorf("expected DIALING (timeout ignored mid-dial), got %s", c.State())
 	}
 }
 
@@ -474,6 +636,7 @@ func TestIsCallActive(t *testing.T) {
 		{"ringing", StateRINGING, true},
 		{"connected", StateCONNECTED, true},
 		{"remote hangup", StateREMOTE_HANGUP, false},
+		{"offhook timeout", StateOFFHOOK_TIMEOUT, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pi/digitsd/internal/phone/eastereggs_test.go
+++ b/pi/digitsd/internal/phone/eastereggs_test.go
@@ -5,11 +5,24 @@ import (
 	"time"
 )
 
+// waitForClip receives the next clip name played from the easter-egg detector
+// (which fires its callback in a goroutine), or fails the test on timeout.
+func waitForClip(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case clip := <-ch:
+		return clip
+	case <-time.After(time.Second):
+		t.Fatal("easter-egg callback never fired")
+		return ""
+	}
+}
+
 func TestEasterEggFunkyTown(t *testing.T) {
-	var played string
+	played := make(chan string, 1)
 	d := NewEasterEggDetector([]EasterEgg{
 		{Name: "Funky Town", Trigger: "5542", Clip: "funkytown"},
-	}, func(clip string) { played = clip })
+	}, func(clip string) { played <- clip })
 	d.MinGap = 0
 
 	for _, k := range "554" {
@@ -20,17 +33,16 @@ func TestEasterEggFunkyTown(t *testing.T) {
 	if !d.AddKey("2") {
 		t.Error("5542 should trigger")
 	}
-	time.Sleep(10 * time.Millisecond)
-	if played != "funkytown" {
-		t.Errorf("expected 'funkytown', got %q", played)
+	if got := waitForClip(t, played); got != "funkytown" {
+		t.Errorf("expected 'funkytown', got %q", got)
 	}
 }
 
 func TestEasterEggRickRoll(t *testing.T) {
-	var played string
+	played := make(chan string, 1)
 	d := NewEasterEggDetector([]EasterEgg{
 		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
-	}, func(clip string) { played = clip })
+	}, func(clip string) { played <- clip })
 	d.MinGap = 0
 
 	for _, k := range "000" {
@@ -39,38 +51,34 @@ func TestEasterEggRickRoll(t *testing.T) {
 	if !d.AddKey("0") {
 		t.Error("0000 should trigger")
 	}
-	time.Sleep(10 * time.Millisecond)
-	if played != "rickroll" {
-		t.Errorf("expected 'rickroll', got %q", played)
+	if got := waitForClip(t, played); got != "rickroll" {
+		t.Errorf("expected 'rickroll', got %q", got)
 	}
 }
 
 func TestEasterEggMultiple(t *testing.T) {
-	var played string
+	played := make(chan string, 2)
 	eggs := []EasterEgg{
 		{Name: "Funky Town", Trigger: "5542", Clip: "funkytown"},
 		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
 	}
-	d := NewEasterEggDetector(eggs, func(clip string) { played = clip })
+	d := NewEasterEggDetector(eggs, func(clip string) { played <- clip })
 	d.MinGap = 0
 
 	// Trigger funky town
 	for _, k := range "5542" {
 		d.AddKey(string(k))
 	}
-	time.Sleep(10 * time.Millisecond)
-	if played != "funkytown" {
-		t.Errorf("expected 'funkytown', got %q", played)
+	if got := waitForClip(t, played); got != "funkytown" {
+		t.Errorf("expected 'funkytown', got %q", got)
 	}
 
 	// Then trigger rick roll
-	played = ""
 	for _, k := range "0000" {
 		d.AddKey(string(k))
 	}
-	time.Sleep(10 * time.Millisecond)
-	if played != "rickroll" {
-		t.Errorf("expected 'rickroll', got %q", played)
+	if got := waitForClip(t, played); got != "rickroll" {
+		t.Errorf("expected 'rickroll', got %q", got)
 	}
 }
 
@@ -118,10 +126,10 @@ func TestEasterEggNoFalsePositive(t *testing.T) {
 }
 
 func TestEasterEggAfterOtherDigits(t *testing.T) {
-	var played string
+	played := make(chan string, 1)
 	d := NewEasterEggDetector([]EasterEgg{
 		{Name: "Funky Town", Trigger: "5542", Clip: "funkytown"},
-	}, func(clip string) { played = clip })
+	}, func(clip string) { played <- clip })
 	d.MinGap = 0
 
 	for _, k := range "123" {
@@ -130,9 +138,8 @@ func TestEasterEggAfterOtherDigits(t *testing.T) {
 	for _, k := range "5542" {
 		d.AddKey(string(k))
 	}
-	time.Sleep(10 * time.Millisecond)
-	if played != "funkytown" {
-		t.Errorf("expected 'funkytown' after prefix, got %q", played)
+	if got := waitForClip(t, played); got != "funkytown" {
+		t.Errorf("expected 'funkytown' after prefix, got %q", got)
 	}
 }
 

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -2,6 +2,7 @@ package phone
 
 import (
 	"testing"
+	"time"
 )
 
 func TestServiceCodeShutdown(t *testing.T) {
@@ -125,9 +126,9 @@ func TestServiceCodeReset(t *testing.T) {
 
 // TestServiceCodeSetup verifies that *#73887# triggers the setup callback.
 func TestServiceCodeSetup(t *testing.T) {
-	called := false
+	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetSetupCallback(func() { called = true })
+	h.SetSetupCallback(func() { called <- struct{}{} })
 
 	code := "*#73887#"
 	var triggered bool
@@ -143,8 +144,11 @@ func TestServiceCodeSetup(t *testing.T) {
 	if !triggered {
 		t.Error("*#73887# should trigger setup code")
 	}
-	// The goroutine may not have run yet; we just verify the trigger happened.
-	_ = called
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Error("setup callback never fired")
+	}
 }
 
 // TestServiceCodeSetupNotTriggeredByPrefix verifies that partial sequences
@@ -199,9 +203,9 @@ func TestServiceCodeSetupRegistered(t *testing.T) {
 }
 
 func TestServiceCodeRepair(t *testing.T) {
-	called := false
+	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetRepairCallback(func() { called = true })
+	h.SetRepairCallback(func() { called <- struct{}{} })
 
 	code := "*#0*"
 	var triggered bool
@@ -214,13 +218,17 @@ func TestServiceCodeRepair(t *testing.T) {
 	if !triggered {
 		t.Error("*#0* should trigger repair")
 	}
-	_ = called
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Error("repair callback never fired")
+	}
 }
 
 func TestServiceCodeFactoryReset(t *testing.T) {
-	called := false
+	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetFactoryResetCallback(func() { called = true })
+	h.SetFactoryResetCallback(func() { called <- struct{}{} })
 
 	code := "*#00000#"
 	var triggered bool
@@ -233,7 +241,11 @@ func TestServiceCodeFactoryReset(t *testing.T) {
 	if !triggered {
 		t.Error("*#00000# should trigger factory reset")
 	}
-	_ = called
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Error("factory-reset callback never fired")
+	}
 }
 
 func TestServiceCodeRepairDoesNotTriggerShutdown(t *testing.T) {


### PR DESCRIPTION
## What

When the user picks up the handset and lets dial tone play past the firmware's dial-tone timeout, the Pico FSM transitions to BUSY and silently drops keypresses. The Pi never learns about the timeout (\`TIMEOUT:DIAL_TONE\` was unhandled), keeps streaming dial tone audio, and the keypad appears dead until the user cycles the hook.

This PR wires the Pi controller to handle \`TIMEOUT:DIAL_TONE\` by running the same 90s POTS off-hook permanent-signal treatment (Bellcore GR-506-CORE) the codebase already implements for remote hangup: 1s silence → 45s reorder → 3min howler → lockout silence. Also restores the bench-test 30s timeout to a production-accurate 15s, and ships a pile of code-review fallout from auditing the change.

## Why

The keypad-dead-after-timeout symptom is the visible bug. Underneath, the firmware's BUSY state was meant to signal "off-hook, no longer accepting input" but the Pi never received that signal, so the user got no audible cue (dial tone kept playing) and no functional cue (keys stopped working). 90s POTS networks handled this with the permanent-signal treatment escalation, which is the behavior we want this private phone network to mimic.

## What's in the diff

**Bug fix proper:**
- \`controller.go\`: new \`StateOFFHOOK_TIMEOUT\`, new \`onTimeoutDialTone\` handler, shared \`runPermanentSignalTreatment\` helper extracted from \`onSignalHangup\`.
- Generation counter (\`treatmentGen\`) so a stale goroutine from a previous session can't step a fresh session forward across rapid hook-flap.
- \`Controller.Close()\` cancels in-flight sleeps so SIGTERM doesn't leave a 4-minute goroutine running.
- \`firmware/src/phone_fsm.c\`: \`DIAL_TIMEOUT_MS\` and \`DIAL_TONE_TIMEOUT_MS\` 30s → 15s.

**Surrounding cleanup (caught by review):**
- Tone names hoisted to \`phone.Tone*\` constants; \`main.go\` dispatch and the legacy socket \`TONE:\` handler now use them.
- \`mockCallbacks\` gained a mutex + snapshot accessors so tests are race-free against the controller's goroutines.
- Service-code and easter-egg tests had a dead \`_ = called\` line hiding both a race and a missing assertion; replaced with channel-based sync that actually verifies the callback fired.
- \`mixer.Stop()\` now waits for the render loop to exit (\`doneCh\` closed in renderLoop's defer) instead of returning while the goroutine may still be mid-\`WriteFrame\`. The old behavior was a real production correctness bug, not just a test issue.
- Fixed two flaky mixer tests that asserted on \`periods[0]\` after \`Start → PlayLoop/PlayOnce\` whose ordering wasn't deterministic; queue the tone before \`Start\` instead.
- \`pi-ci\` now runs the full digitsd module under \`-race\`, replacing the two narrow per-package invocations.

## Test plan

- [x] \`go test ./...\` passes (all 13 packages)
- [x] \`go test -race ./...\` passes (full module, was previously failing on \`internal/audio\` and \`internal/phone\`)
- [x] \`go vet ./...\` clean
- [x] Firmware builds (\`make firmware\`)
- [x] New \`TestController_DialToneTimeout\` covers state transition, REORDER tone, key-ignored, hook-on recovery
- [x] New \`TestController_DialToneTimeout_IgnoredOutsideDialTone\` covers defensive-no-op cases
- [x] New \`TestController_CloseAbortsOffHookTreatment\` verifies Close stops the sequence before REORDER fires
- [ ] Manual: pick up phone, wait 15s, confirm reorder tone starts; press digits, confirm they're ignored; hang up, confirm IDLE returns