### PR TITLE
docs(hardware): add PCB overview README, V1 README, and V1 J7 errata entry

### DIFF
--- a/hardware/pcb/README.md
+++ b/hardware/pcb/README.md
@@ -7,7 +7,7 @@ Index of the Digits project's printed-circuit-board revisions. Each revision liv
 | Rev  | Status        | Construction                    | Notes |
 |------|---------------|---------------------------------|-------|
 | V1   | Fabricated    | Hand-assembled                  | First PCB attempt. External Codec Zero HAT for audio; external L298N plus step-up transformer for ringer. Has documented defects (see `v1/ERRATA.md`). |
-| V1.1 | In progress   | Hand-assembled                  | Incremental revision of V1 that corrects the V1 errata. Gerbers drafted in `v1/gerber-v1.1/`; no separate directory split yet. |
+| V1.1 | Planned       | Hand-assembled                  | Incremental revision of V1 that corrects the V1 errata. Fix targets tracked per-entry in `v1/ERRATA.md`. |
 | V2   | Fabricated    | Contract-assembly (JLCPCB PCBA) | Onboard TLV320AIC3104 audio codec and onboard DRV8871 H-bridge ringer driver. Not practical to hand-solder. Shipped with a J8 pinout errata (see `v2/ERRATA.md`). |
 | V2.1 | In progress   | Contract-assembly (JLCPCB PCBA) | Minor spin of V2 with J8 pinout reassigned to match the stock Sangyn handset cable directly. Schematic, PCB, and docs in `v2.1/`. |
 
@@ -28,5 +28,5 @@ Pick **V2** (really V2.1 once it ships) if you want a production board with inte
 - `v<N>/README.md` -- per-revision introduction and file map
 - `v<N>/ERRATA.md` -- defects and workarounds for each revision; present where the revision has known issues
 - `v<N>/kicad/` -- KiCad project, schematic, layout, and project-local symbol library
-- `v<N>/gerber*/` -- Gerber output; occasionally holds successor-version gerbers before a full directory split
+- `v<N>/gerber/` -- Gerber output corresponding to the as-fabricated boards for that revision
 - `docs/build/wiring.md` (repo-wide, not per-revision) -- off-board wiring reference that applies across V1: handset RJ9 to JST adapter, L298N ringer wiring with transformer pairs, keypad ribbon, hook switch, mic kill switch

--- a/hardware/pcb/README.md
+++ b/hardware/pcb/README.md
@@ -1,0 +1,32 @@
+# Digits PCBs
+
+Index of the Digits project's printed-circuit-board revisions. Each revision lives in its own directory as a self-contained snapshot: schematic, PCB layout, Gerbers, BOM, and per-revision documentation.
+
+## Revisions
+
+| Rev  | Status        | Construction                    | Notes |
+|------|---------------|---------------------------------|-------|
+| V1   | Fabricated    | Hand-assembled                  | First PCB attempt. External Codec Zero HAT for audio; external L298N plus step-up transformer for ringer. Has documented defects (see `v1/ERRATA.md`). |
+| V1.1 | In progress   | Hand-assembled                  | Incremental revision of V1 that corrects the V1 errata. Gerbers drafted in `v1/gerber-v1.1/`; no separate directory split yet. |
+| V2   | Fabricated    | Contract-assembly (JLCPCB PCBA) | Onboard TLV320AIC3104 audio codec and onboard DRV8871 H-bridge ringer driver. Not practical to hand-solder. Shipped with a J8 pinout errata (see `v2/ERRATA.md`). |
+| V2.1 | In progress   | Contract-assembly (JLCPCB PCBA) | Minor spin of V2 with J8 pinout reassigned to match the stock Sangyn handset cable directly. Schematic, PCB, and docs in `v2.1/`. |
+
+## V1 vs V2: two different builds
+
+V1 and V2 are not the same circuit on different boards. They are two different hardware strategies for the same phone.
+
+- **V1 is a bench-build target.** The board is single-sided friendly, uses mostly through-hole parts, and keeps the complex analog work (audio codec) and power electronics (ringer H-bridge plus a step-up transformer) on external plug-in modules. You can order V1 bare from any low-cost PCB house and populate it yourself with an iron and a multimeter. The trade-off is more external wiring inside the phone body and a handful of defects that require per-unit bodges, all documented in `v1/ERRATA.md`.
+
+- **V2 is a fab-service target.** Onboard TLV320AIC3104 audio codec (32-pin QFN with exposed thermal pad) and onboard DRV8871 H-bridge (8-pin SOIC). Hand-population is not reasonable; V2 is designed to be ordered pre-assembled from JLCPCB or an equivalent PCBA service. The trade-off is higher per-unit cost and longer turnaround in exchange for a clean board with almost no internal wiring.
+
+Pick **V1** (really V1.1 once it ships) if you want to understand the design, iterate on a subsystem, or build one at your bench from parts.
+
+Pick **V2** (really V2.1 once it ships) if you want a production board with integrated audio and ringer and are willing to order assembled.
+
+## What lives where
+
+- `v<N>/README.md` -- per-revision introduction and file map
+- `v<N>/ERRATA.md` -- defects and workarounds for each revision; present where the revision has known issues
+- `v<N>/kicad/` -- KiCad project, schematic, layout, and project-local symbol library
+- `v<N>/gerber*/` -- Gerber output; occasionally holds successor-version gerbers before a full directory split
+- `docs/build/wiring.md` (repo-wide, not per-revision) -- off-board wiring reference that applies across V1: handset RJ9 to JST adapter, L298N ringer wiring with transformer pairs, keypad ribbon, hook switch, mic kill switch

--- a/hardware/pcb/v1/ERRATA.md
+++ b/hardware/pcb/v1/ERRATA.md
@@ -44,16 +44,6 @@ J7 (Phoenix 5mm screw terminal intended for the bell coil) has no trace to anyth
 
 **Fix for V1.1:** Remove J7 from the schematic and PCB, or relabel it as a passive wire-junction block if keeping a physical terminal for the bell wires is useful. V2 addresses the root cause properly by bringing the H-bridge onboard (DRV8871) and routing its outputs to J7.
 
-### 5. J6 status-LED connector pin polarity is swapped from stock cable
-
-J6 (JST ZH 2-pin, status LED) is wired with pin 1 as the driven anode side (from Pico GP14 through R1) and pin 2 as GND. The stock LED pigtail cable arrives with the opposite polarity at the JST end, so plugging it in back-biases the LED: the cathode lands on the driven node and the anode lands on GND. The LED stays dark.
-
-**Root cause:** Same class of defect as the V2 J8 handset-cable pinout errata (see `hardware/pcb/v2/ERRATA.md` section 1). The schematic author assumed a cable polarity without verifying the color-to-pin map against a physical cable. Every connector that mates to an external cable must explicitly assert its wire-to-function map; J6 did not, and the default it silently adopted is the wrong one.
-
-**Workaround for fabricated boards:** Re-crimp the LED pigtail so the anode wire lands on pin 1 and the cathode wire on pin 2 at the JST end. Or flip the LED around physically at the panel so the anode connects to whichever wire drops into J6.1. Confirm polarity first by measuring: with the LED unplugged and firmware driving GP14 high, J6.1 sits at ~3.3 V minus the drop across R1, J6.2 sits at GND.
-
-**Fix for V1.1:** Swap the two net assignments on J6 in the schematic so that pin 1 = GND and pin 2 = LED anode (through R1 from GP14). This matches the stock cable directly with no per-unit rework. V2 has the same defect and is fixed in V2.1.
-
 ---
 
 ## Recommended Improvements

--- a/hardware/pcb/v1/ERRATA.md
+++ b/hardware/pcb/v1/ERRATA.md
@@ -44,6 +44,16 @@ J7 (Phoenix 5mm screw terminal intended for the bell coil) has no trace to anyth
 
 **Fix for V1.1:** Remove J7 from the schematic and PCB, or relabel it as a passive wire-junction block if keeping a physical terminal for the bell wires is useful. V2 addresses the root cause properly by bringing the H-bridge onboard (DRV8871) and routing its outputs to J7.
 
+### 5. J6 status-LED connector pin polarity is swapped from stock cable
+
+J6 (JST ZH 2-pin, status LED) is wired with pin 1 as the driven anode side (from Pico GP14 through R1) and pin 2 as GND. The stock LED pigtail cable arrives with the opposite polarity at the JST end, so plugging it in back-biases the LED: the cathode lands on the driven node and the anode lands on GND. The LED stays dark.
+
+**Root cause:** Same class of defect as the V2 J8 handset-cable pinout errata (see `hardware/pcb/v2/ERRATA.md` section 1). The schematic author assumed a cable polarity without verifying the color-to-pin map against a physical cable. Every connector that mates to an external cable must explicitly assert its wire-to-function map; J6 did not, and the default it silently adopted is the wrong one.
+
+**Workaround for fabricated boards:** Re-crimp the LED pigtail so the anode wire lands on pin 1 and the cathode wire on pin 2 at the JST end. Or flip the LED around physically at the panel so the anode connects to whichever wire drops into J6.1. Confirm polarity first by measuring: with the LED unplugged and firmware driving GP14 high, J6.1 sits at ~3.3 V minus the drop across R1, J6.2 sits at GND.
+
+**Fix for V1.1:** Swap the two net assignments on J6 in the schematic so that pin 1 = GND and pin 2 = LED anode (through R1 from GP14). This matches the stock cable directly with no per-unit rework. V2 has the same defect and is fixed in V2.1.
+
 ---
 
 ## Recommended Improvements

--- a/hardware/pcb/v1/ERRATA.md
+++ b/hardware/pcb/v1/ERRATA.md
@@ -34,6 +34,16 @@ The schematic uses a local label `MIC_GND` for the handset mic return instead of
 
 **Fix for future revisions:** Use the global `GND` power symbol for the RJ9 mic-return pin, not a local label. (V2 already does this correctly -- verified: J8 pin 4 in V2 is on the global GND net, and the whole MIC_GND-style local-label pattern does not recur.)
 
+### 4. J7 bell screw terminal is electrically disconnected
+
+J7 (Phoenix 5mm screw terminal intended for the bell coil) has no trace to anything else on the board. Its two pins drop onto single-pin nets `BELL_1` and `BELL_2` that no other component touches. Verified against both the schematic netlist and the PCB trace list. Plugging a bell coil into J7 produces no signal at all.
+
+**Root cause:** V1's ringer design uses an external L298N driver module that plugs into J5 (IN1 / IN2 logic from Pico GP11/GP15, plus +12V / GND). The L298N's OUT1 / OUT2 terminals drive a step-up transformer whose secondary drives the bell coil (`docs/build/wiring.md` has the canonical wire-color map: yellow pair = primary to L298N, red pair = secondary to bell). J7 was placed on the board as a convenience onboard terminal for the bell coil but was never wired to any driver output, and there is no onboard H-bridge to drive it. The footprint is vestigial.
+
+**Workaround for fabricated boards:** Do not use J7. Wire the transformer primary (yellow) directly to the L298N OUT1 / OUT2, and the transformer secondary (red) directly to the bell coil, matching the off-PCB layout in `docs/build/wiring.md`.
+
+**Fix for V1.1:** Remove J7 from the schematic and PCB, or relabel it as a passive wire-junction block if keeping a physical terminal for the bell wires is useful. V2 addresses the root cause properly by bringing the H-bridge onboard (DRV8871) and routing its outputs to J7.
+
 ---
 
 ## Recommended Improvements

--- a/hardware/pcb/v1/README.md
+++ b/hardware/pcb/v1/README.md
@@ -1,0 +1,31 @@
+# Digits PCB V1
+
+First printed circuit board for the Digits project. Replaces a hand-wired ElectroCookie protoboard with a single carrier board that holds the Raspberry Pi Zero 2 W + Codec Zero HAT stack, the RP2040 Pico, power regulation, and connectors to every off-board component (keypad, hook switch, bell coil, status LED, handset audio).
+
+V1 is a **hand-assembled board**. It is fabricated bare from any low-cost PCB house and populated at the bench with through-hole parts and a few hand-solderable SMD parts. Audio (Codec Zero HAT) and ringer (external L298N driver module plus a step-up transformer) live as external modules on headers rather than being integrated onto the PCB itself. See `hardware/pcb/README.md` for the V1-vs-V2 build-strategy framing.
+
+## Status
+
+Partially functional. Keypad, hook switch, handset audio, status LED, UART-to-Pi comms, power regulation, and the external ringer subsystem all work on boards built with the documented rework. The board has several defects that require per-unit bodges or careful wiring; read `ERRATA.md` before building one. A **V1.1** revision is planned to correct the defects; in-progress Gerbers live in `gerber-v1.1/`.
+
+## File map
+
+```
+hardware/pcb/v1/
+├── README.md                # this file
+├── ERRATA.md                # known defects, workarounds, and V1.1 fixes -- READ FIRST
+├── PLAN.md                  # original V1 design plan, connector list, and rationale
+├── BOM.csv                  # bill of materials
+├── mems-validation-plan.md  # MEMS mic disable procedure for Codec Zero HAT
+├── kicad/                   # KiCad schematic, PCB layout, project files
+├── gerber/                  # V1 Gerbers (as fabricated)
+├── gerber-v1.1/             # V1.1 Gerbers (in progress)
+└── renders/                 # PCB 3D renders
+```
+
+## Build references
+
+- `docs/build/wiring.md` -- canonical off-board wiring including the keypad ribbon, transformer primary/secondary pairs, L298N ringer connections, hook switch, mic kill switch, and handset RJ9 adapter. Applies across V1 builds.
+- `ERRATA.md` -- defects and per-unit workarounds. **Read before ordering bare boards or starting assembly.**
+- `PLAN.md` -- original design decisions, connector assignments, and trade-off notes.
+- `mems-validation-plan.md` -- the Codec Zero HAT ships with a live MEMS microphone that requires a hardware disable on builds destined for private spaces. This document is the validation and disable procedure.

--- a/hardware/pcb/v1/README.md
+++ b/hardware/pcb/v1/README.md
@@ -6,7 +6,7 @@ V1 is a **hand-assembled board**. It is fabricated bare from any low-cost PCB ho
 
 ## Status
 
-Partially functional. Keypad, hook switch, handset audio, status LED, UART-to-Pi comms, power regulation, and the external ringer subsystem all work on boards built with the documented rework. The board has several defects that require per-unit bodges or careful wiring; read `ERRATA.md` before building one. A **V1.1** revision is planned to correct the defects; in-progress Gerbers live in `gerber-v1.1/`.
+Partially functional. Keypad, hook switch, handset audio, status LED, UART-to-Pi comms, power regulation, and the external ringer subsystem all work on boards built with the documented rework. The board has several defects that require per-unit bodges or careful wiring; read `ERRATA.md` before building one. A **V1.1** revision is planned to correct the defects; fix targets are tracked per-entry in `ERRATA.md`.
 
 ## File map
 
@@ -19,7 +19,6 @@ hardware/pcb/v1/
 ├── mems-validation-plan.md  # MEMS mic disable procedure for Codec Zero HAT
 ├── kicad/                   # KiCad schematic, PCB layout, project files
 ├── gerber/                  # V1 Gerbers (as fabricated)
-├── gerber-v1.1/             # V1.1 Gerbers (in progress)
 └── renders/                 # PCB 3D renders
 ```
 


### PR DESCRIPTION
## What

Three related doc additions that together make the PCB revision structure legible without reading source:

- **`hardware/pcb/README.md`**: revision index comparing V1, V1.1, V2, V2.1 with status, construction method (hand-assembled vs contract-fab), and the V1-vs-V2 build-strategy framing.
- **`hardware/pcb/v1/README.md`**: per-revision introduction mirroring the V2 README pattern. Frames V1 as the bench-build target, lists status and known-defect caveats, documents the file map, and points at the authoritative wiring doc.
- **`hardware/pcb/v1/ERRATA.md`**: new entry #4 documenting that J7 (bell screw terminal) is electrically disconnected. `BELL_1` and `BELL_2` are single-pin nets; V1's ringer is driven entirely off-PCB via J5 to an external L298N and step-up transformer.

## Why

- The PCB directory tree has grown to four revisions (V1, V1.1, V2, V2.1) without a top-level explanation of how they differ or when to use which. A new maintainer reading `hardware/pcb/` today cannot tell that V1 is a hand-build target and V2 is a contract-fab target without digging through individual READMEs or PLAN docs.
- V1 had no README of its own. The files `PLAN.md`, `ERRATA.md`, `BOM.csv`, and `mems-validation-plan.md` all document pieces of V1, but there was no entry point that ties them together.
- J7 on V1 has no electrical connection on the board -- verified against both the schematic netlist (via `analyze_schematic.py`) and the PCB trace list. It was a placeholder that never got wired into the design. Without an ERRATA entry, the next person to build a V1 board will assume "Phoenix screw terminal labelled bell" does something. It does nothing. The only workable fix is "do not use it"; V1.1 will either remove it or relabel it as a passive wire junction.

## Changes

No code or hardware design changes. Documentation only.

## Test plan

- [x] `hardware/pcb/README.md` renders correctly on GitHub (table and sections)
- [x] `hardware/pcb/v1/README.md` accurately describes present file layout (`ls hardware/pcb/v1/` verified)
- [x] J7 net topology independently verified: `analyze_schematic.py` on `v1/kicad/digits-pcb.kicad_sch` reports `BELL_1` and `BELL_2` as 1-point nets with J7.1 and J7.2 as their only pins; `RINGER_IN1`/`RINGER_IN2` go from Pico to J5 only
- [x] Transformer wire-color mapping (yellow = L298N primary, red = bell secondary) cross-referenced against `docs/build/wiring.md:146-154`