### PR TITLE
fix(server): drop webapp Tailwind step from Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,11 +4,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-# Build Tailwind CSS (download standalone CLI if not vendored)
+# Build Tailwind CSS for admin (webapp uses hand-rolled CSS, no Tailwind)
 RUN set -e; \
     TWCSS=/tmp/tailwindcss; \
     curl -fsSL https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.2/tailwindcss-linux-x64 -o $TWCSS && chmod +x $TWCSS; \
-    $TWCSS --input internal/web/static/input.css --output internal/web/static/tailwind.css --content 'internal/web/templates/*.html' --minify; \
     $TWCSS --input internal/admin/static/input.css --output internal/admin/static/tailwind.css --content 'internal/admin/templates/*.html' --minify
 
 ARG VERSION=dev


### PR DESCRIPTION
## Summary

The webapp redesign in #196 dropped Tailwind on the webapp side (hand-rolled `digits.css` ships instead), but the Dockerfile's build step still references the deleted `internal/web/static/input.css`. This breaks the prod Docker build:

\`\`\`
Specified input file \`./internal/web/static/input.css\` does not exist.
\`\`\`

Admin still uses Tailwind, so keep that step.

Caught trying to deploy #196 — the fix unblocks the v1.15.0 rollout.

## Test plan
- [x] \`docker compose -f docker-compose.prod.yml build --no-cache signald\` succeeds locally
- [x] Admin CSS still built correctly