### PR TITLE
fix(server): clear stale host-scoped session cookies too

### DIFF
--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -196,11 +196,6 @@ func (h *Handlers) HandleLogout(w http.ResponseWriter, r *http.Request) {
 			slog.Error("failed to delete session", "err", err)
 		}
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name:   CookieName,
-		Domain: h.cookieDomain,
-		MaxAge: -1,
-		Path:   "/",
-	})
+	clearSessionCookie(w, h.cookieDomain)
 	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 }

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -26,13 +26,7 @@ func (s *Store) RequireAuth(next http.Handler) http.Handler {
 		}
 		sess, err := s.ValidateSession(cookie.Value)
 		if err != nil {
-			// Clear invalid cookie
-			http.SetCookie(w, &http.Cookie{
-				Name:   CookieName,
-				Domain: s.CookieDomain,
-				MaxAge: -1,
-				Path:   "/",
-			})
+			clearSessionCookie(w, s.CookieDomain)
 			http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 			return
 		}
@@ -55,4 +49,26 @@ func (s *Store) RequireAuth(next http.Handler) http.Handler {
 func UserFromContext(ctx context.Context) *User {
 	u, _ := ctx.Value(UserContextKey).(*User)
 	return u
+}
+
+// clearSessionCookie emits expiring Set-Cookie headers for both the
+// domain-scoped cookie (current config) and the host-scoped cookie (no Domain
+// attribute). Early sessions set without an explicit Domain stick around under
+// the origin host and are invisible to a domain-scoped clear, so after a
+// COOKIE_DOMAIN change they can persist and keep failing validation forever.
+// Writing both variants mops up either form.
+func clearSessionCookie(w http.ResponseWriter, domain string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:   CookieName,
+		Domain: domain,
+		MaxAge: -1,
+		Path:   "/",
+	})
+	if domain != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:   CookieName,
+			MaxAge: -1,
+			Path:   "/",
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Users who signed in before the `COOKIE_DOMAIN=.digits.family` env var was added had their session cookies stored host-scoped (implicit `Domain=app.digits.family`). After the COOKIE_DOMAIN config kicked in, those host-scoped cookies stuck around forever:

- The browser preferred the host-scoped cookie (more specific) when sending requests to /
- It failed session validation
- The invalidate path in middleware.go only emitted `Set-Cookie: ...; Domain=.digits.family; Max-Age=-1` — which does not match a host-scoped cookie
- So the stale cookie was never cleared and the user got bounced to /auth/login in a loop, even immediately after a successful Google OAuth callback wrote a new (domain-scoped) cookie

Root-caused live on prod today after the 1.15.1 deploy; confirmed by clearing cookies manually in the browser — at which point Google sign-in worked again.

## Fix

`clearSessionCookie(w, domain)` emits two `Set-Cookie` deletes: one with the configured Domain, and one with no Domain attribute (host-scoped). Either stale form gets mopped up on the next redirect through middleware or on explicit logout.

## Test plan
- [x] Build + unit + vet clean locally
- [ ] After merge + deploy: sign in with Google on prod without first clearing cookies, confirm it sticks