### PR TITLE
fix(server): dialup theme - house icon for Home, rename Mail Center

### DIFF
--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -329,9 +329,6 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   background-repeat: no-repeat;
   background-position: center;
 }
-.dialup-ic-mail {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='3' y='8' width='26' height='18' fill='%23ffcc00' stroke='%23000' stroke-width='1.5'/><path d='M3 8 L16 20 L29 8' fill='none' stroke='%23000' stroke-width='1.5'/><rect x='22' y='4' width='6' height='8' fill='%23c41e16' stroke='%23000' stroke-width='1'/></svg>");
-}
 .dialup-ic-phone {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='6' y='10' width='20' height='18' fill='%23c41e16' stroke='%23000' stroke-width='1.5' rx='2'/><rect x='9' y='14' width='14' height='10' fill='%23a01a12'/><g fill='%23efe5d1' stroke='%23000' stroke-width='0.5'><rect x='10' y='15' width='3' height='2'/><rect x='14.5' y='15' width='3' height='2'/><rect x='19' y='15' width='3' height='2'/><rect x='10' y='18' width='3' height='2'/><rect x='14.5' y='18' width='3' height='2'/><rect x='19' y='18' width='3' height='2'/><rect x='10' y='21' width='3' height='2'/><rect x='14.5' y='21' width='3' height='2'/><rect x='19' y='21' width='3' height='2'/></g><rect x='4' y='6' width='24' height='5' fill='%23d8362c' stroke='%23000' stroke-width='1.5' rx='2.5'/></svg>");
 }

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -31,7 +31,7 @@
     <span class="dialup-menu__item"><u>F</u>ile</span>
     <span class="dialup-menu__item"><u>E</u>dit</span>
     <span class="dialup-menu__item"><u>G</u>o</span>
-    <span class="dialup-menu__item">Mail <u>C</u>enter</span>
+    <span class="dialup-menu__item">Phone <u>C</u>enter</span>
     <span class="dialup-menu__item"><u>M</u>embers</span>
     <span class="dialup-menu__item"><u>W</u>indow</span>
     <span class="dialup-menu__item">Sign O<u>f</u>f</span>
@@ -41,7 +41,7 @@
   <!-- Toolbar -->
   <div class="dialup-toolbar">
     <a href="/" class="dialup-toolbar__btn">
-      <div class="dialup-toolbar__icon dialup-ic-mail" aria-hidden="true"></div>
+      <div class="dialup-toolbar__icon dialup-ic-welcome" aria-hidden="true"></div>
       <span>Home</span>
     </a>
     <a href="/phones" class="dialup-toolbar__btn">

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -32,7 +32,7 @@
     <span class="dialup-menu__item"><u>E</u>dit</span>
     <span class="dialup-menu__item"><u>G</u>o</span>
     <span class="dialup-menu__item">Phone <u>C</u>enter</span>
-    <span class="dialup-menu__item"><u>M</u>embers</span>
+    <span class="dialup-menu__item">Fa<u>m</u>ilies</span>
     <span class="dialup-menu__item"><u>W</u>indow</span>
     <span class="dialup-menu__item">Sign O<u>f</u>f</span>
     <span class="dialup-menu__item dialup-menu__item--right"><u>H</u>elp</span>


### PR DESCRIPTION
## Summary

Two small refinements to the dialup theme:

1. The toolbar **Home** button was using the envelope icon (\`dialup-ic-mail\`), which didn't read as "home" and digits has no mail concept. Swap to the house icon (\`dialup-ic-welcome\`) that the WELCOME channel already uses.
2. The menu bar item **Mail Center** (decorative) renamed to **Phone Center**. "Mail" was misleading.

Drops the now-unused \`.dialup-ic-mail\` CSS rule.

## Screenshot

![dialup home with house icon and Phone Center menu](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-201-dialup-tweaks.png)

## Test plan
- [x] Build + visual preview under dialup theme
- [ ] e2e (CI)