### PR TITLE
fix(server): play dialup welcome greeting on first user interaction

### DIFF
--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -136,21 +136,40 @@
      successful sign-in. The sound only exists in this layout, so it is
      naturally gated to the dial-up theme. preload="none" keeps the file
      off the wire on every navigation; the browser only fetches it when
-     play() is called below (i.e. once, right after login). The inline JS
-     also strips the query param so a page reload doesn't replay it. */}}
+     play() is called below. The inline JS also strips the query param
+     so a page reload doesn't replay it.
+
+     Browsers block audio autoplay unless the page has an active user
+     gesture. The sign-in click happens on /auth/login, but the redirect
+     chain through Google's OAuth domain severs the gesture by the time
+     the user lands here, so the initial play() usually rejects. Fall
+     back to playing on the user's next interaction with the page. */}}
 <audio id="dialup-welcome" src="/static/audio/welcome.mp3" preload="none"></audio>
 <script>
 (function () {
   var params = new URLSearchParams(window.location.search);
   if (params.get('welcome') !== '1') return;
   var audio = document.getElementById('dialup-welcome');
-  if (audio) {
-    audio.play().catch(function () { /* browser blocked autoplay; silent */ });
-  }
+  if (!audio) return;
+
+  // Strip the query param immediately so a reload doesn't re-arm the greeting.
   params.delete('welcome');
   var q = params.toString();
   var clean = window.location.pathname + (q ? '?' + q : '') + window.location.hash;
   window.history.replaceState({}, '', clean);
+
+  var events = ['click', 'keydown', 'touchstart', 'pointerdown'];
+  var onInteraction = function () {
+    audio.play().catch(function () {});
+    events.forEach(function (ev) { document.removeEventListener(ev, onInteraction); });
+  };
+
+  var p = audio.play();
+  if (p && p.catch) {
+    p.catch(function () {
+      events.forEach(function (ev) { document.addEventListener(ev, onInteraction); });
+    });
+  }
 })();
 </script>
 


### PR DESCRIPTION
## Summary

The post-login welcome sound wasn't playing for dialup-theme users. Browser autoplay policy blocks \`audio.play()\` unless the page has an active user gesture, and the sign-in click on \`/auth/login\` doesn't carry across the cross-origin redirect through Google's OAuth domain. By the time the user lands on \`/?welcome=1\`, the gesture chain is broken and \`.play()\` rejects with \`NotAllowedError\` — which we were swallowing silently.

## Fix

If the immediate \`.play()\` rejects, install one-shot \`click\`/\`keydown\`/\`touchstart\`/\`pointerdown\` listeners on document. The first one to fire plays the audio and removes the rest. The user will click something on the dashboard within a few seconds, so the greeting still lands at a natural session moment instead of never.

If the user never interacts before navigating away, the greeting doesn't fire — fine, it's a small easter egg, not load-bearing.

## Test plan
- [x] Build clean
- [ ] After deploy: sign in as a dialup-theme user; confirm the greeting plays either immediately (if MEI allows) or on the first click