### PR TITLE
fix(firmware): compute DIGITS_VERSION on host for Docker builds

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -10,6 +10,13 @@ DOCKER_BUILD_DIR = build/docker
 # Override on the command line: `make build HARDWARE_REV=2`.
 HARDWARE_REV ?= 1
 
+# Git describe runs on the host so worktrees resolve correctly. Inside the
+# Docker container, .git is a pointer file to a gitdir outside the mount,
+# and `git describe` would fail silently -- which would leave FIRMWARE_VERSION
+# as "unknown". Compute it here and pass through.
+DIGITS_VERSION ?= $(shell git describe --tags --always --dirty --match 'fw/v*' 2>/dev/null | sed 's|^fw/v||')
+DIGITS_COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
 .PHONY: build build-local builder clean
 
 builder:
@@ -20,8 +27,10 @@ build: builder
 		--user $(shell id -u):$(shell id -g) \
 		-v $(REPO_ROOT):/src -w /src/firmware \
 		-e HARDWARE_REV=$(HARDWARE_REV) \
+		-e DIGITS_VERSION=$(DIGITS_VERSION) \
+		-e DIGITS_COMMIT=$(DIGITS_COMMIT) \
 		$(BUILDER_IMG) \
-		sh -c 'mkdir -p $(DOCKER_BUILD_DIR) && cd $(DOCKER_BUILD_DIR) && cmake -DHARDWARE_REV=$$HARDWARE_REV ../.. && make -j$$(nproc)'
+		sh -c 'mkdir -p $(DOCKER_BUILD_DIR) && cd $(DOCKER_BUILD_DIR) && cmake -DHARDWARE_REV=$$HARDWARE_REV -DDIGITS_VERSION=$$DIGITS_VERSION -DDIGITS_COMMIT=$$DIGITS_COMMIT ../.. && make -j$$(nproc)'
 
 build-local:
 	@HARDWARE_REV=$(HARDWARE_REV) $(REPO_ROOT)/scripts/build.sh


### PR DESCRIPTION
## What

Computes `DIGITS_VERSION` and `DIGITS_COMMIT` on the host before launching the firmware Docker build, passes them through as `-e` env vars + `-D` cmake flags. Fallback for CI-style overrides (`?=`) is preserved.

## Why

Docker firmware builds from a git worktree silently produced `FIRMWARE_VERSION="unknown"` binaries because worktrees use a `.git` pointer file whose target lives outside the Docker mount. The in-container `git describe` failed without any error surface; CMake fell back to `"unknown"`. Pushed firmware on all three dev phones would have kept reporting `fw_version=unknown` until this was fixed.

Discovered while deploying the party-line feature (#198): `digitsd`'s version-gated HOOK:FLASH forwarding never activated because it saw `"unknown"` and compared against the `v1.5.0` minimum as invalid semver.

Non-worktree primary clones are unaffected -- the host-side `git describe` produces the same answer that used to come from inside the container.

## Test plan

- [x] `make firmware` from a worktree produces an ELF with correct `FIRMWARE_VERSION` baked in (`grep 'FIRMWARE_VERSION' firmware/build/docker/CMakeFiles/digits.dir/flags.make` shows the real version, not `"unknown"`)
- [x] `make firmware` from the primary clone still works
- [x] `DIGITS_VERSION=1.2.3 make firmware` still overrides (CI contract preserved)