### PR TITLE
feat(server): local dev environment with seeded dialup user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ pi/rnnoise/rnnoise_loop
 # Secrets / env
 server/.env
 server/.env.*
+# ...but keep committed example files; real .env and .env.dev stay ignored.
+!server/.env.example
+!server/.env.dev.example
 server/certs/
 
 # Media / images

--- a/server/.env.dev.example
+++ b/server/.env.dev.example
@@ -1,0 +1,36 @@
+# Digits Server — Local Dev Environment
+#
+# Copy this file to .env.dev (which is gitignored) to override any of the
+# defaults below. The Makefile's `dev-up` target will source .env.dev if it
+# exists.
+#
+# These values are safe dev defaults. Do NOT use them in production.
+
+# Port the host-native signald listens on for the browser.
+SIGNALD_ADDR=:8080
+
+# Base URL the server uses when rendering absolute links (magic links, etc.).
+BASE_URL=http://localhost:8080
+
+# DEV_MODE=true enables the /auth/dev-session endpoint and logs magic-link
+# URLs to stdout instead of requiring real SMTP.
+DEV_MODE=true
+
+# Any non-empty value works; signald requires ADMIN_SECRET to be set.
+ADMIN_SECRET=dev
+
+# Structured logs off by default so tailing `make dev-up` stays readable.
+LOG_FORMAT=text
+
+# Host port the user-db container publishes on loopback. Change if 5433 is
+# already taken on your machine; the docker-compose.yml user-db service reads
+# DEV_DB_PORT from the environment.
+DEV_DB_PORT=5433
+
+# Connection string for host-native signald, pointing at the user-db container
+# via its published loopback port.
+DATABASE_URL=postgres://digits:digits@127.0.0.1:5433/digits?sslmode=disable
+
+# Seed user email. `make dev-seed` will create this user (idempotently) with
+# theme='dialup' and a household so the dashboard renders on first hit.
+DEV_SEED_EMAIL=dev@digits.local

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-dev run test e2e e2e-ci clean deploy css
+.PHONY: build build-dev run test e2e e2e-ci clean deploy css dev-up dev-down dev-seed dev-logs
 
 # Version resolution: VERSION file > git describe > "dev"
 VERSION ?= $(shell cat VERSION 2>/dev/null || git describe --tags --match 'server/v*' --abbrev=0 2>/dev/null | sed 's|^server/v||' || echo dev)
@@ -47,6 +47,53 @@ e2e-ci:
 	cd e2e && npm install --silent && \
 	npx playwright install --with-deps chromium && \
 	npx playwright test
+
+# ── Local dev environment ────────────────────────────────────────────────
+# Brings up a disposable Postgres in Docker, seeds a dialup-themed user,
+# and runs host-native signald against it. See server/README.md for details.
+#
+# Config lives in server/.env.dev (copy .env.dev.example to .env.dev to
+# customize). Each dev target sources .env.dev if it exists, otherwise
+# falls back to .env.dev.example defaults.
+
+DEV_ENV_FILE   ?= .env.dev
+DEV_DB_SERVICE ?= user-db
+DEV_COMPOSE     = docker compose -p digits-dev -f docker-compose.yml
+
+# Shell snippet (no trailing semicolon) that sources .env.dev or .env.dev.example
+# into the current shell and exports all assigned vars.
+DEV_ENV_SRC = set -a; if [ -f $(DEV_ENV_FILE) ]; then . ./$(DEV_ENV_FILE); else . ./.env.dev.example; fi; set +a
+
+dev-up:
+	@if [ ! -f $(DEV_ENV_FILE) ]; then \
+		echo "note: $(DEV_ENV_FILE) not found, using defaults from .env.dev.example"; \
+	fi
+	$(DEV_ENV_SRC); \
+	$(DEV_COMPOSE) up -d $(DEV_DB_SERVICE); \
+	echo "waiting for $(DEV_DB_SERVICE) to be healthy..."; \
+	for i in $$(seq 1 30); do \
+		status=$$($(DEV_COMPOSE) ps --format '{{.Health}}' $(DEV_DB_SERVICE) 2>/dev/null | head -n1); \
+		[ "$$status" = "healthy" ] && break; \
+		sleep 1; \
+	done; \
+	[ "$$status" = "healthy" ] || { echo "$(DEV_DB_SERVICE) failed to become healthy"; exit 1; }; \
+	echo "seeding dev user..."; \
+	go run ./cmd/devseed/; \
+	echo ""; \
+	echo "starting signald on $$SIGNALD_ADDR (Ctrl+C to stop; run 'make dev-down' to clean up)"; \
+	go build -o bin/signald ./cmd/signald/; \
+	./bin/signald
+
+dev-seed:
+	$(DEV_ENV_SRC); \
+	go run ./cmd/devseed/
+
+dev-down:
+	$(DEV_ENV_SRC); \
+	$(DEV_COMPOSE) down -v
+
+dev-logs:
+	$(DEV_COMPOSE) logs -f $(DEV_DB_SERVICE)
 
 clean:
 	rm -rf bin/

--- a/server/README.md
+++ b/server/README.md
@@ -30,6 +30,50 @@ make clean          # remove build artifacts
 
 Requires Go 1.26+.
 
+## Local development
+
+For iterating on the web UI you can spin up a disposable Postgres in Docker, seed a signed-in dialup-themed user, and run host-native `signald` against it with one command.
+
+```bash
+cd server/
+make dev-up         # start local Postgres, seed dev user, run signald
+make dev-seed       # re-seed the dev user (no-op if already present)
+make dev-down       # stop signald, remove DB container + volume
+make dev-logs       # tail the user-db container logs
+```
+
+`make dev-up` runs `signald` in the foreground. Stop it with Ctrl+C, then run `make dev-down` to remove the Docker volume and wipe state. Running `make dev-up` again gives a clean slate.
+
+When the server prints `server started addr=:8080`, open the URL that `dev-seed` printed in your browser:
+
+```
+http://localhost:8080/auth/dev-session?email=dev@digits.local
+```
+
+That endpoint is only mounted when `DEV_MODE=true`. It sets a session cookie and redirects to the dialup-themed dashboard.
+
+### Config
+
+Defaults live in `.env.dev.example` (committed). To override, copy it to `.env.dev` (gitignored):
+
+```bash
+cp .env.dev.example .env.dev
+```
+
+Common overrides:
+
+| Variable         | Default                                                        | Notes                                          |
+|------------------|----------------------------------------------------------------|------------------------------------------------|
+| `SIGNALD_ADDR`   | `:8080`                                                        | Change if port 8080 is taken on your machine.  |
+| `BASE_URL`       | `http://localhost:8080`                                        | Must match `SIGNALD_ADDR`.                     |
+| `DEV_DB_PORT`    | `5433`                                                         | Host port for the dev Postgres container.      |
+| `DATABASE_URL`   | `postgres://digits:digits@127.0.0.1:5433/digits?sslmode=disable` | Update the port if you changed `DEV_DB_PORT`. |
+| `DEV_SEED_EMAIL` | `dev@digits.local`                                             | Email for the seeded user.                     |
+
+The user-db container exposes `5433` on `127.0.0.1` only, so host-native `signald` can reach it without opening the port to the network.
+
+Prod uses a separate compose file (`docker-compose.prod.yml`) and is unaffected by these dev targets.
+
 ## Run
 
 ```bash

--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -1,0 +1,107 @@
+// devseed creates (or updates) a single dialup-themed user + household in the
+// local dev database so `make dev-up` lands the operator on a rendered
+// dashboard after one click.
+//
+// It is idempotent: running it twice does not create duplicate users or
+// households. It prints a /auth/dev-session URL at the end which the operator
+// can paste into a browser to sign in.
+//
+// This binary is intentionally minimal. It is not meant for production
+// seeding; it has no flags beyond what is needed to bootstrap one dialup user.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/db"
+	"github.com/justinlindh/digits/server/internal/household"
+)
+
+func main() {
+	var (
+		email       = flag.String("email", envOr("DEV_SEED_EMAIL", "dev@digits.local"), "Email address for the seeded dev user")
+		baseURL     = flag.String("base-url", envOr("BASE_URL", "http://localhost:8080"), "Base URL to embed in the printed sign-in link")
+		databaseURL = flag.String("database-url", os.Getenv("DATABASE_URL"), "Postgres connection string (falls back to DATABASE_URL)")
+	)
+	flag.Parse()
+
+	if *databaseURL == "" {
+		log.Fatal("DATABASE_URL (or -database-url) must be set")
+	}
+
+	database, err := db.Open(*databaseURL)
+	if err != nil {
+		log.Fatalf("open database: %v", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	authStore := auth.NewStoreFromDB(database.DB)
+	houseStore := household.NewStore(database.DB)
+
+	user, created, err := upsertUser(authStore, *email)
+	if err != nil {
+		log.Fatalf("upsert user: %v", err)
+	}
+	if err := authStore.SetTheme(user.ID, auth.ThemeDialup); err != nil {
+		log.Fatalf("set theme: %v", err)
+	}
+
+	hh, err := ensureHousehold(houseStore, user.ID)
+	if err != nil {
+		log.Fatalf("ensure household: %v", err)
+	}
+
+	verb := "updated"
+	if created {
+		verb = "created"
+	}
+	fmt.Printf("User %s %s (id=%s, theme=dialup)\n", *email, verb, user.ID)
+	fmt.Printf("Household: %s (id=%s)\n", hh.Name, hh.ID)
+	fmt.Println()
+	fmt.Println("Sign in by opening this URL in your browser:")
+	fmt.Printf("  %s/auth/dev-session?email=%s\n", strings.TrimRight(*baseURL, "/"), url.QueryEscape(*email))
+	fmt.Println()
+	fmt.Println("The server must be running with DEV_MODE=true for the dev-session endpoint to work.")
+}
+
+// upsertUser returns the existing user for email, or creates a new one. The
+// second return value reports whether a new row was inserted.
+func upsertUser(s *auth.Store, email string) (*auth.User, bool, error) {
+	if u, err := s.GetUserByEmail(email); err == nil {
+		return u, false, nil
+	}
+	u, err := s.CreateUser(email, "Dev", nil)
+	if err != nil {
+		return nil, false, err
+	}
+	return u, true, nil
+}
+
+// ensureHousehold returns the user's first household, creating one if they
+// have none. Running again is a no-op — NeedsOnboarding gates creation.
+func ensureHousehold(s *household.Store, userID string) (*household.Household, error) {
+	if !s.NeedsOnboarding(userID) {
+		hs, err := s.GetForUser(userID)
+		if err != nil {
+			return nil, err
+		}
+		if len(hs) == 0 {
+			return nil, fmt.Errorf("user reports not needing onboarding but has no households")
+		}
+		return hs[0], nil
+	}
+	return s.Onboard(userID, "Dev")
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/server/cmd/devseed/main_test.go
+++ b/server/cmd/devseed/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestEnvOr(t *testing.T) {
+	t.Run("env set", func(t *testing.T) {
+		t.Setenv("DEVSEED_TEST_KEY", "from-env")
+		got := envOr("DEVSEED_TEST_KEY", "fallback")
+		if got != "from-env" {
+			t.Fatalf("envOr with set var: got %q, want %q", got, "from-env")
+		}
+	})
+
+	t.Run("env unset", func(t *testing.T) {
+		// Setenv with empty string then delete via Unsetenv would also work,
+		// but t.Setenv("", "") does not exist; use a var that is not set.
+		t.Setenv("DEVSEED_TEST_KEY_UNSET", "")
+		got := envOr("DEVSEED_TEST_KEY_UNSET", "fallback")
+		if got != "fallback" {
+			t.Fatalf("envOr with empty var: got %q, want %q", got, "fallback")
+		}
+	})
+
+	t.Run("env missing", func(t *testing.T) {
+		got := envOr("DEVSEED_DEFINITELY_NOT_SET_XYZ", "fallback")
+		if got != "fallback" {
+			t.Fatalf("envOr with missing var: got %q, want %q", got, "fallback")
+		}
+	})
+}

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -61,6 +61,10 @@ services:
       POSTGRES_DB: digits
       POSTGRES_USER: digits
       POSTGRES_PASSWORD: digits
+    # Expose on loopback only so host-native signald (make dev) can reach it.
+    # Production uses docker-compose.prod.yml and does not publish this port.
+    ports:
+      - "127.0.0.1:${DEV_DB_PORT:-5433}:5432"
     volumes:
       - user_pgdata:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary

Adds a one-command path for running host-native `signald` against a disposable local Postgres with a pre-seeded dialup-themed user, so dialup UI iteration (tracked in #202, #204) does not need a hand-wired DB each time.

- `make dev-up` brings up Postgres in Docker (`-p digits-dev`), waits for health, seeds one dialup user + household via a new `cmd/devseed` Go utility, then runs signald in the foreground.
- `make dev-down` tears down the DB container and wipes its volume; `make dev-seed` re-runs the seeder (idempotent); `make dev-logs` tails the DB.
- Config lives in `.env.dev.example` (committed) with sensible defaults -- `SIGNALD_ADDR=:8080`, `DEV_DB_PORT=5433`, `DEV_SEED_EMAIL=dev@digits.local`. Copy to `.env.dev` (gitignored) to override.
- `docker-compose.yml` now publishes `user-db` on `127.0.0.1:${DEV_DB_PORT:-5433}` so host-native signald can reach it. Prod (`docker-compose.prod.yml`) is unchanged.
- Sign-in uses the existing `/auth/dev-session` endpoint that was already gated on `DEV_MODE=true` and used by the e2e suite.

Screenshot of the resulting dialup dashboard at a 360px viewport:

![dialup home at 360px](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-206-local-dev-dialup-360.png)

## Test plan

- [x] `make dev-down` on a clean checkout succeeds as a no-op
- [x] `make dev-up` from scratch: DB healthy, user + household seeded, signald listens on configured port
- [x] `curl http://localhost:<port>/healthz` returns 200 while the server is up
- [x] Hitting `/auth/dev-session?email=dev@digits.local` sets a session cookie and redirects to `/?welcome=1`
- [x] Authenticated `/` serves the dialup layout (template has `layout-dialup` classes, `dialup.css` stylesheet link)
- [x] `make dev-down` stops and removes container + volume
- [x] Re-running `make dev-up` is idempotent (second run prints "updated" for seed)
- [x] `make dev-seed` reruns without duplicating rows
- [x] `go test ./...` and `golangci-lint run ./...` pass
- [x] `make -n e2e-ci` parses and is unchanged from main