### PR TITLE
fix(server): dialup theme mobile layout

### DIFF
--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1087,10 +1087,68 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
 /* --------- Responsive helpers --------- */
 
 .show-sm { display: none; }
+
 @media (max-width: 720px) {
   .hide-sm { display: none !important; }
   .show-sm { display: block; }
-  .dialup-body { flex-direction: column; }
-  .dialup-channels { width: auto; flex-direction: row; flex-wrap: wrap; }
-  .dialup-channel { flex: 1 1 120px; }
+
+  /* Reduce the teal desktop padding so every pixel counts. */
+  body.dialup { padding: 4px; }
+
+  /* Hide decorative chrome: title bar, menu bar, keyword bar. */
+  .dialup-title,
+  .dialup-menu,
+  .dialup-keyword { display: none; }
+
+  /* Toolbar collapses to a thin strip: hide the 32px icon buttons and
+     the separator; keep the welcome text + Sign Off button aligned right. */
+  .dialup-toolbar { padding: 3px 6px; gap: 6px; }
+  .dialup-toolbar__btn:not(.dialup-toolbar__btn--link) { display: none; }
+  .dialup-toolbar__sep { display: none; }
+  .dialup-toolbar__btn--link {
+    min-width: 0;
+    flex-direction: row;
+    gap: 4px;
+    padding: 3px 8px;
+  }
+  .dialup-toolbar__btn--link .dialup-toolbar__icon {
+    width: 16px;
+    height: 16px;
+  }
+  .dialup-toolbar__welcome {
+    margin-left: auto;
+    font-size: 11px;
+  }
+
+  /* Channels move from left sidebar to a horizontal scrolling strip. */
+  .dialup-body { flex-direction: column; min-height: 0; }
+  .dialup-channels {
+    width: auto;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 4px;
+    padding: 4px;
+    -webkit-overflow-scrolling: touch;
+  }
+  .dialup-channels__header { display: none; }
+  .dialup-channel {
+    flex: 0 0 auto;
+    padding: 5px 10px;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+  .dialup-channel__icon { width: 16px; height: 16px; }
+
+  /* Main content no longer fights the sidebar for width. */
+  .dialup-main { padding: 8px; }
+
+  /* Status bar drops everything except the dot, bps, and version. */
+  .dialup-status { font-size: 10px; gap: 4px; padding: 2px 4px; }
+  .dialup-status__sep,
+  .dialup-status span:not(.num):not(.dialup-status__dot):not(.dialup-status__spacer) {
+    display: none;
+  }
+  .dialup-status > .num:first-of-type { display: inline; }
 }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1130,7 +1130,6 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
     overflow-y: hidden;
     gap: 4px;
     padding: 4px;
-    -webkit-overflow-scrolling: touch;
   }
   .dialup-channels__header { display: none; }
   .dialup-channel {
@@ -1150,5 +1149,4 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   .dialup-status span:not(.num):not(.dialup-status__dot):not(.dialup-status__spacer) {
     display: none;
   }
-  .dialup-status > .num:first-of-type { display: inline; }
 }

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=1024">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{block "title" .}}Digits{{end}} — Digits</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="stylesheet" href="/static/dialup.css">


### PR DESCRIPTION
## Summary

The `dialup` webapp theme forced a `width=1024` viewport, making mobile browsers render it at desktop width with everything zoomed out. This PR makes the theme usable on a phone.

- Replace hardcoded viewport with `width=device-width, initial-scale=1` (matches `layout-v2.html`)
- Collapse chrome below 720px: hide title/menu/keyword bars, strip toolbar to welcome text + Sign Off, turn channels sidebar into a horizontal scroll strip, compress status bar to dot + `56000 bps` + version
- Walk every interior page at 360x640 via agent-browser; no interior-page regressions found (the existing responsive defaults handle it)

Closes #202.

## Screenshots at 360px

| Dashboard | Phones (pair + keypad) |
|-----------|-----------------------|
| ![dashboard at 360px](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-209-dialup-mobile-dashboard.png) | ![phones at 360px](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-209-dialup-mobile-phones.png) |

## Test plan

- [x] Build + Go tests green (`make build`, `go test ./...`, `go vet ./...`)
- [x] Walked dashboard, phones, phone-detail, settings, links, calls, onboard, login at 360px using the new `make dev-up` flow from #206
- [x] Verified long household names + long emails still wrap rather than overflow
- [ ] After deploy: smoke-test on a real iPhone / Android browser
- [ ] Verify desktop layout unchanged at >=721px viewports