### PR TITLE
fix(server): route dialup users to /connecting after Google OAuth login

### DIFF
--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -152,5 +152,5 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	http.Redirect(w, r, loginRedirectFor(user), http.StatusSeeOther)
 }


### PR DESCRIPTION
## Summary

Follow-up to #210. The magic-link handler routes dialup-theme users to `/connecting` via `loginRedirectFor`, but `google.go`'s `HandleCallback` hardcoded `"/"`. Users who signed in with Google were skipping the modem intro entirely.

Route the Google OAuth callback through `loginRedirectFor` too, so both auth paths redirect identically.

## Test plan

- [x] `go build`, `go test ./internal/auth/`, `go vet ./...` pass
- [ ] After deploy: sign out of prod, sign back in via Google as a dialup-theme user, verify landing on `/connecting`
- [ ] Intercom-theme users still land on `/` as before