### PR TITLE
fix(server): drop layout-dependent 'below' from pair-flow hint

### DIFF
--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -30,7 +30,7 @@
             <div class="pin__slot"></div>
             <div class="pin__slot"></div>
           </div>
-          <p class="center muted" style="font-size: 12px; margin: 0 0 14px;">Tap the keypad, or type the code below.</p>
+          <p class="center muted" style="font-size: 12px; margin: 0 0 14px;">Tap the keypad or type it in.</p>
 
           <div class="keypad-wrap">
             <div class="keypad" role="group" aria-label="Pairing keypad">


### PR DESCRIPTION
## What

Small copy fix on /phones missed by PR #218: the hint under the pin display reads "Tap the keypad, or type the code below." The text input is only "below" on mobile. On desktop the form is beside the keypad.

Change:

> Tap the keypad, or type the code below.

becomes:

> Tap the keypad or type it in.

## Why

Directional language that's only correct on one breakpoint reads wrong on the other. Neutral phrasing works on both.

## Test plan

- [x] Manual smoke on /phones in intercom theme, desktop viewport -- reads correctly alongside the keypad+form.
- [x] Mobile breakpoint check (form stacks below the keypad) -- still reads correctly.