### PR TITLE
fix(server): wire firmware versions into /phones table

### DIFF
--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -180,7 +180,7 @@ func (g *GitHubReleases) fetch() (*ReleaseIndex, error) {
 		}
 
 		ci.Releases[version] = r
-		if ci.Latest == "" || compareSemver(version, ci.Latest) > 0 {
+		if ci.Latest == "" || CompareSemver(version, ci.Latest) > 0 {
 			ci.Latest = version
 		}
 	}

--- a/server/internal/updates/store.go
+++ b/server/internal/updates/store.go
@@ -47,14 +47,14 @@ func (idx *ReleaseIndex) SortedReleases(component string) []Release {
 		releases = append(releases, *r)
 	}
 	sort.Slice(releases, func(i, j int) bool {
-		return compareSemver(releases[i].Version, releases[j].Version) > 0
+		return CompareSemver(releases[i].Version, releases[j].Version) > 0
 	})
 	return releases
 }
 
-// compareSemver compares two semver strings "X.Y.Z".
+// CompareSemver compares two semver strings "X.Y.Z".
 // Returns 1 if a > b, -1 if a < b, 0 if equal.
-func compareSemver(a, b string) int {
+func CompareSemver(a, b string) int {
 	partsA := strings.SplitN(a, ".", 3)
 	partsB := strings.SplitN(b, ".", 3)
 	for i := 0; i < 3; i++ {

--- a/server/internal/updates/store_test.go
+++ b/server/internal/updates/store_test.go
@@ -49,9 +49,9 @@ func TestCompareSemver(t *testing.T) {
 		{"0.5.0", "0.4.9", 1},
 	}
 	for _, c := range cases {
-		got := compareSemver(c.a, c.b)
+		got := CompareSemver(c.a, c.b)
 		if got != c.want {
-			t.Errorf("compareSemver(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+			t.Errorf("CompareSemver(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
 		}
 	}
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -619,22 +619,26 @@ func fmtElapsed(d time.Duration) string {
 // ---- Lines (Phones) ----
 
 type linesData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	Lines              []lineRow
-	Error              string
-	PairError          string
-	User               *auth.User
+	Page                  string
+	Version               string
+	CallHistoryEnabled    bool
+	HouseholdName         string
+	Lines                 []lineRow
+	Error                 string
+	PairError             string
+	User                  *auth.User
+	LatestPiVersion       string
+	LatestFirmwareVersion string
 }
 
 type lineRow struct {
-	Line           line.Line
-	Online         bool
-	OnCall         bool
-	OnCallPeerName string
-	OnCallElapsed  string // "mm:ss" for the Dashboard room-card callout
+	Line            line.Line
+	Online          bool
+	OnCall          bool
+	OnCallPeerName  string
+	OnCallElapsed   string // "mm:ss" for the Dashboard room-card callout
+	DeviceInfo      *signaling.DeviceInfoSnapshot
+	UpdateAvailable bool // either Pi or firmware is behind the latest release
 }
 
 func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
@@ -663,11 +667,40 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 	for _, n := range online {
 		onlineSet[n] = true
 	}
+
+	var latestPi, latestFw string
+	if h.Releases != nil {
+		if idx := h.Releases.ReleaseIndex(); idx != nil {
+			latestPi = idx.Pi.Latest
+			latestFw = idx.Firmware.Latest
+		}
+	}
+
 	rows := make([]lineRow, len(lines))
 	for i, l := range lines {
-		rows[i] = lineRow{Line: l, Online: onlineSet[l.Number]}
+		info := h.hub.DeviceInfo(l.Number)
+		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
+		if info != nil {
+			if latestPi != "" && info.PiVersion != "" && info.PiVersion != latestPi {
+				row.UpdateAvailable = true
+			}
+			if latestFw != "" && info.FirmwareVersion != "" && info.FirmwareVersion != latestFw {
+				row.UpdateAvailable = true
+			}
+		}
+		rows[i] = row
 	}
-	return linesData{Page: "phones", Version: version.Version, CallHistoryEnabled: h.callHistoryEnabled(r), HouseholdName: h.householdNameFromContext(r), Lines: rows, Error: errMsg, User: user}
+	return linesData{
+		Page:                  "phones",
+		Version:               version.Version,
+		CallHistoryEnabled:    h.callHistoryEnabled(r),
+		HouseholdName:         h.householdNameFromContext(r),
+		Lines:                 rows,
+		Error:                 errMsg,
+		User:                  user,
+		LatestPiVersion:       latestPi,
+		LatestFirmwareVersion: latestFw,
+	}
 }
 
 func (h *Handler) handlePhonesGet(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -691,7 +691,6 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 			if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
 				row.UpdateAvailable = true
 			}
-			}
 		}
 		rows[i] = row
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -685,11 +685,12 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 		info := h.hub.DeviceInfo(l.Number)
 		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
 		if info != nil {
-			if latestPi != "" && info.PiVersion != "" && info.PiVersion != latestPi {
+			if latestPi != "" && info.PiVersion != "" && updates.CompareSemver(info.PiVersion, latestPi) < 0 {
 				row.UpdateAvailable = true
 			}
-			if latestFw != "" && info.FirmwareVersion != "" && info.FirmwareVersion != latestFw {
+			if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
 				row.UpdateAvailable = true
+			}
 			}
 		}
 		rows[i] = row

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -230,6 +230,7 @@
           <th>Number</th>
           <th>Label</th>
           <th>Status</th>
+          <th>Pi</th>
           <th>Firmware</th>
           <th>Added</th>
           <th class="r">Actions</th>
@@ -247,7 +248,26 @@
               <span class="chip"><span class="chip__dot"></span>offline</span>
             {{end}}
           </td>
-          <td class="muted" style="font-size: 12px;">unknown</td>
+          <td style="font-size: 12px;">
+            {{if and .DeviceInfo .DeviceInfo.PiVersion}}
+              <span class="num">{{.DeviceInfo.PiVersion}}</span>
+              {{if and $.LatestPiVersion (ne .DeviceInfo.PiVersion $.LatestPiVersion)}}
+                <span class="chip chip--warn" style="margin-left: 6px;"><span class="chip__dot"></span>{{$.LatestPiVersion}}</span>
+              {{end}}
+            {{else}}
+              <span class="muted">unknown</span>
+            {{end}}
+          </td>
+          <td style="font-size: 12px;">
+            {{if and .DeviceInfo .DeviceInfo.FirmwareVersion}}
+              <span class="num">{{.DeviceInfo.FirmwareVersion}}</span>
+              {{if and $.LatestFirmwareVersion (ne .DeviceInfo.FirmwareVersion $.LatestFirmwareVersion)}}
+                <span class="chip chip--warn" style="margin-left: 6px;"><span class="chip__dot"></span>{{$.LatestFirmwareVersion}}</span>
+              {{end}}
+            {{else}}
+              <span class="muted">unknown</span>
+            {{end}}
+          </td>
           <td class="num muted">{{.Line.CreatedAt.Format "Jan 2, 2006"}}</td>
           <td class="r">
             <button class="btn btn--quiet btn--sm"
@@ -270,7 +290,11 @@
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
         <span class="lines__name">{{.Line.Name}}</span>
         <span class="lines__num">{{fmtPhone .Line.Number}}</span>
-        <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
+        {{if .UpdateAvailable}}
+          <span class="chip chip--warn"><span class="chip__dot"></span>update</span>
+        {{else}}
+          <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
+        {{end}}
       </a>
     </li>
     {{end}}
@@ -290,7 +314,7 @@
 {{define "phone-edit-row"}}
 <tr>
   <td class="num">{{fmtPhone .Line.Number}}</td>
-  <td colspan="4">
+  <td colspan="5">
     <form hx-post="/phones/{{.Line.Number}}/edit" hx-target="#phones-table" hx-swap="outerHTML"
           class="hstack hstack--wrap">
       <input type="text" name="name" value="{{.Line.Name}}" class="field__input" style="width: 240px;">


### PR DESCRIPTION
## Summary
- Split the single "Firmware" column on `/phones` into two columns, **Pi** and **Firmware**, pulling each from `hub.DeviceInfo` (same source the detail page already uses). Previously the cell was a hardcoded `"unknown"` string.
- When a connected device is behind the latest release, the row shows an ochre "X.Y.Z" chip next to the current version.
- Mobile: the row stays compact. If either component is behind, the trailing online/offline word is replaced by a small "update" chip. Online/offline is still conveyed by the colored status dot on the left, so no information is lost.

## Proof

Fixtures used: Digits 1 on the latest Pi + firmware, Digits 2 behind on Pi (`1.13.0` vs. latest `1.14.0`), Digits 3 offline (no device info).

**Desktop (1280px):**

![desktop](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-221-firmware-column-desktop.png)

**Mobile (390px):**

![mobile](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-221-firmware-column-mobile.png)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit tier)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Rendered via the fixture-backed dev preview harness at 1280px and 390px; verified the three states: up-to-date, update-available, and offline/unknown.