### PR TITLE
feat(server): per-phone silent mode toggle (#217)

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -490,6 +490,29 @@ func (d *daemonCallbacks) setVoiceStyleConfig(style string) error {
 	return d.cfg.Save()
 }
 
+// applySilentModeLive forwards a silent-mode change to the phone controller.
+// Safe before the controller is constructed: becomes a no-op, and
+// setSilentModeConfig still persists the flag for the next startup.
+func (d *daemonCallbacks) applySilentModeLive(silent bool) {
+	d.mu.Lock()
+	ctrl := d.ctrl
+	d.mu.Unlock()
+	if ctrl == nil {
+		return
+	}
+	ctrl.SetSilentMode(silent)
+}
+
+// setSilentModeConfig writes the new flag to the local config cache under
+// d.mu (serializing with call-setup paths that read d.cfg) and then persists
+// it to disk outside the lock.
+func (d *daemonCallbacks) setSilentModeConfig(silent bool) error {
+	d.mu.Lock()
+	d.cfg.SilentMode = silent
+	d.mu.Unlock()
+	return d.cfg.Save()
+}
+
 // triggerHangup dispatches a hangup to the controller from a fresh goroutine.
 // Callers holding d.mu must use this to avoid deadlock: HandleSignal calls
 // back into HangupCall, which also acquires d.mu.
@@ -1230,6 +1253,7 @@ func main() {
 	// 8. Create phone Controller
 	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
+	ctrl.SetSilentMode(cfg.SilentModeOrDefault())
 
 	// 8b. Contacts cache — optional dial safelist, persisted to disk.
 	// An empty cache leaves the checker nil so no-contacts phones allow
@@ -1719,24 +1743,33 @@ func main() {
 					slog.Warn("line_settings message missing payload", "from", msg.From)
 					break
 				}
+
+				// Voice style (existing behavior).
 				style := msg.LineSettings.VoiceStyle
 				if style == "" {
 					style = config.VoiceStyleCopper
 				}
-
 				cb.mu.Lock()
-				current := cb.cfg.VoiceStyle
+				currentStyle := cb.cfg.VoiceStyle
+				currentSilent := cb.cfg.SilentMode
 				cb.mu.Unlock()
-				if style == current {
-					// No change — skip the live apply and the config save so
-					// reconnect-triggered pushes don't fsync on every connect.
-					break
+
+				if style != currentStyle {
+					slog.Info("line_settings applied", "voice_style", style)
+					cb.applyVoiceStyleLive(style)
+					if err := cb.setVoiceStyleConfig(style); err != nil {
+						slog.Warn("line_settings: voice-style save failed", "err", err)
+					}
 				}
 
-				slog.Info("line_settings applied", "voice_style", style)
-				cb.applyVoiceStyleLive(style)
-				if err := cb.setVoiceStyleConfig(style); err != nil {
-					slog.Warn("line_settings: config save failed", "err", err)
+				// Silent mode (new).
+				silent := msg.LineSettings.SilentMode
+				if silent != currentSilent {
+					slog.Info("line_settings applied", "silent_mode", silent)
+					cb.applySilentModeLive(silent)
+					if err := cb.setSilentModeConfig(silent); err != nil {
+						slog.Warn("line_settings: silent-mode save failed", "err", err)
+					}
 				}
 
 			default:

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1253,7 +1253,7 @@ func main() {
 	// 8. Create phone Controller
 	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
-	ctrl.SetSilentMode(cfg.SilentModeOrDefault())
+	ctrl.SetSilentMode(cfg.SilentMode)
 
 	// 8b. Contacts cache — optional dial safelist, persisted to disk.
 	// An empty cache leaves the checker nil so no-contacts phones allow
@@ -1744,7 +1744,6 @@ func main() {
 					break
 				}
 
-				// Voice style (existing behavior).
 				style := msg.LineSettings.VoiceStyle
 				if style == "" {
 					style = config.VoiceStyleCopper
@@ -1762,7 +1761,6 @@ func main() {
 					}
 				}
 
-				// Silent mode (new).
 				silent := msg.LineSettings.SilentMode
 				if silent != currentSilent {
 					slog.Info("line_settings applied", "silent_mode", silent)

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -59,6 +59,11 @@ type Config struct {
 	// locally so the device can start up with the correct style offline.
 	VoiceStyle string `json:"voice_style,omitempty"`
 
+	// SilentMode is the per-line ringer-silence flag. When true, the digitsd
+	// phone controller suppresses the bell on incoming rings but still blinks
+	// the LED. Cached locally so the setting survives reboots while offline.
+	SilentMode bool `json:"silent_mode,omitempty"`
+
 	// WiFiFallback configures the WiFi auto-fallback supervisor.
 	WiFiFallback WiFiFallback `json:"wifi_fallback"`
 
@@ -178,6 +183,16 @@ func (c *Config) VoiceStyleOrDefault() string {
 		return VoiceStyleCopper
 	}
 	return c.VoiceStyle
+}
+
+// SilentModeOrDefault returns the configured silent-mode flag, or false if
+// unset. Kept as a method for symmetry with VoiceStyleOrDefault even though
+// the bool zero value already is the default.
+func (c *Config) SilentModeOrDefault() bool {
+	if c == nil {
+		return false
+	}
+	return c.SilentMode
 }
 
 // Save writes the config back to the file it was loaded from.

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -185,16 +185,6 @@ func (c *Config) VoiceStyleOrDefault() string {
 	return c.VoiceStyle
 }
 
-// SilentModeOrDefault returns the configured silent-mode flag, or false if
-// unset. Kept as a method for symmetry with VoiceStyleOrDefault even though
-// the bool zero value already is the default.
-func (c *Config) SilentModeOrDefault() bool {
-	if c == nil {
-		return false
-	}
-	return c.SilentMode
-}
-
 // Save writes the config back to the file it was loaded from.
 // Uses atomic write (tmp + fsync + rename) and keeps a .bak copy.
 func (c *Config) Save() error {

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -452,3 +452,48 @@ func TestLoadWithoutWiFiFallbackSectionUsesDefaults(t *testing.T) {
 		t.Errorf("APNoClientTimeout = %v, want 10m", c.WiFiFallback.APNoClientTimeout)
 	}
 }
+
+func TestConfigSilentModeDefaultFalse(t *testing.T) {
+	c := Default()
+	if c.SilentModeOrDefault() {
+		t.Errorf("SilentMode default: got true, want false")
+	}
+}
+
+func TestConfigSilentModeExplicitTrue(t *testing.T) {
+	c := &Config{SilentMode: true}
+	if !c.SilentModeOrDefault() {
+		t.Errorf("SilentMode explicit true: got false, want true")
+	}
+}
+
+func TestConfigLoadPreservesSilentMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"silent_mode":true}`), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !c.SilentMode {
+		t.Errorf("load did not preserve silent_mode=true")
+	}
+}
+
+func TestConfigSaveRoundTripSilentMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	c := &Config{path: path, SilentMode: true, VoiceStyle: VoiceStyleCopper}
+	if err := c.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !loaded.SilentMode {
+		t.Errorf("round trip did not preserve silent_mode")
+	}
+}

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -453,17 +453,9 @@ func TestLoadWithoutWiFiFallbackSectionUsesDefaults(t *testing.T) {
 	}
 }
 
-func TestConfigSilentModeDefaultFalse(t *testing.T) {
-	c := Default()
-	if c.SilentModeOrDefault() {
-		t.Errorf("SilentMode default: got true, want false")
-	}
-}
-
-func TestConfigSilentModeExplicitTrue(t *testing.T) {
-	c := &Config{SilentMode: true}
-	if !c.SilentModeOrDefault() {
-		t.Errorf("SilentMode explicit true: got false, want true")
+func TestConfigDefaultSilentModeFalse(t *testing.T) {
+	if Default().SilentMode {
+		t.Errorf("Default().SilentMode: got true, want false")
 	}
 }
 

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -57,6 +57,7 @@ type Controller struct {
 	digits         string
 	ownNumber      string
 	contactChecker ContactChecker
+	silentMode     bool // when true, onSignalRing suppresses SendRing(true)
 	// treatmentGen is incremented each time runPermanentSignalTreatment starts.
 	// The spawned goroutine captures the value and aborts on mismatch, so a
 	// hook-flap that re-enters off-hook treatment within ~4 min won't let the
@@ -102,6 +103,23 @@ func (c *Controller) SetContactChecker(cc ContactChecker) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.contactChecker = cc
+}
+
+// SetSilentMode updates the silent-mode flag. When newly true during an
+// active ring, the current bell is stopped (LED keeps blinking). When newly
+// false during an active ring, the bell does NOT start - the user would
+// find a mid-ring bell start jarring, and they can answer if they want
+// audio. Thread-safe.
+func (c *Controller) SetSilentMode(silent bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.silentMode == silent {
+		return
+	}
+	c.silentMode = silent
+	if silent && c.state == StateRINGING {
+		c.cb.SendRing(false)
+	}
 }
 
 // State returns the current FSM state (thread-safe).
@@ -324,7 +342,9 @@ func (c *Controller) onSignalRing() {
 		return
 	}
 	c.state = StateRINGING
-	c.cb.SendRing(true)
+	if !c.silentMode {
+		c.cb.SendRing(true)
+	}
 	c.cb.SendLED("BLINK")
 }
 

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -647,3 +647,43 @@ func TestIsCallActive(t *testing.T) {
 		})
 	}
 }
+
+// Silent mode suppresses the bell but keeps LED + state transition.
+func TestController_IncomingRingSilentModeSuppressesBell(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+	c.SetSilentMode(true) // seeded from config at startup
+
+	c.HandleSignal("ring")
+
+	if c.State() != StateRINGING {
+		t.Fatalf("state: got %s, want RINGING", c.State())
+	}
+	for _, r := range cb.Rings() {
+		if r == true {
+			t.Error("expected no SendRing(true) while silent")
+		}
+	}
+	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
+		t.Errorf("expected SendLED(BLINK), got %v", cb.LEDs())
+	}
+}
+
+// Silent off behaves exactly like today.
+func TestController_IncomingRingSilentOffBehavesNormally(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+	c.SetSilentMode(false)
+
+	c.HandleSignal("ring")
+
+	if c.State() != StateRINGING {
+		t.Fatalf("state: got %s", c.State())
+	}
+	if len(cb.Rings()) == 0 || cb.Rings()[0] != true {
+		t.Errorf("expected SendRing(true), got %v", cb.Rings())
+	}
+	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
+		t.Errorf("expected SendLED(BLINK), got %v", cb.LEDs())
+	}
+}

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -687,3 +687,60 @@ func TestController_IncomingRingSilentOffBehavesNormally(t *testing.T) {
 		t.Errorf("expected SendLED(BLINK), got %v", cb.LEDs())
 	}
 }
+
+// Flipping silent ON mid-ring stops the bell immediately. LED stays on.
+// State stays RINGING so offhook still answers normally.
+func TestController_SetSilentModeOnDuringRingStopsBell(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	c.HandleSignal("ring") // state RINGING, SendRing(true), SendLED("BLINK")
+	if c.State() != StateRINGING {
+		t.Fatalf("precondition: state %s != RINGING", c.State())
+	}
+
+	c.SetSilentMode(true)
+
+	last := cb.Rings()[len(cb.Rings())-1]
+	if last != false {
+		t.Errorf("expected SendRing(false) after silent=true mid-ring, got %v", cb.Rings())
+	}
+	if c.State() != StateRINGING {
+		t.Errorf("state changed unexpectedly: %s (should stay RINGING)", c.State())
+	}
+	lastLED := cb.LEDs()[len(cb.LEDs())-1]
+	if lastLED == "OFF" {
+		t.Errorf("LED turned OFF on silent=true mid-ring; should stay BLINK")
+	}
+}
+
+// Flipping silent OFF mid-ring does NOT start the bell. The asymmetry is
+// intentional: a mid-ring bell start is jarring.
+func TestController_SetSilentModeOffDuringRingDoesNotStartBell(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+	c.SetSilentMode(true)
+
+	c.HandleSignal("ring") // silent: no SendRing(true), only LED:BLINK
+	ringsBefore := len(cb.Rings())
+
+	c.SetSilentMode(false)
+
+	if len(cb.Rings()) != ringsBefore {
+		t.Errorf("unexpected SendRing call on silent=false mid-ring: %v", cb.Rings())
+	}
+}
+
+// Flipping silent while idle changes state with no hardware side-effect.
+func TestController_SetSilentModeIdleIsSideEffectFree(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	c.SetSilentMode(true)
+	c.SetSilentMode(false)
+	c.SetSilentMode(true)
+
+	if len(cb.Rings()) != 0 || len(cb.LEDs()) != 0 {
+		t.Errorf("expected no callbacks while idle, got rings=%v leds=%v", cb.Rings(), cb.LEDs())
+	}
+}

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -68,6 +68,7 @@ type ContactEntry struct {
 // there, in server/internal/line, and in server/internal/signaling.
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
+	SilentMode bool   `json:"silent_mode,omitempty"`
 }
 
 // ICEServer represents a STUN or TURN server configuration.

--- a/server/e2e/tests/09-silent-mode.spec.ts
+++ b/server/e2e/tests/09-silent-mode.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * 09-silent-mode.spec.ts -- Per-phone silent-mode toggle (issue #217).
+ *
+ * Tests:
+ *   - Ringer panel renders on phone detail page
+ *   - Toggling silent on via the checkbox updates the partial inline (htmx swap)
+ *     and persists across reload
+ *   - /phones list shows the silent badge for silent phones, not for others
+ *   - Toggling silent off removes the badge
+ *   - Same flow under the dialup theme
+ *
+ * Skips if the test household has no paired phones.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { isServerUp, setTheme } from './helpers';
+
+test.beforeEach(async ({ page }, testInfo) => {
+  const up = await isServerUp();
+  testInfo.skip(!up, 'Dev server not running');
+});
+
+function isAuthOrOnboard(url: string) {
+  return url.includes('/auth/login') || url.includes('/onboard');
+}
+
+/**
+ * Returns the href of the first phone on the /phones list, or null when the
+ * household has none. The caller should skip in the null case.
+ */
+async function firstPhoneHref(page: Page): Promise<string | null> {
+  await page.goto('/phones');
+  if (isAuthOrOnboard(page.url())) {
+    return null;
+  }
+  const link = page.locator('a[href^="/phones/"]:not([href="/phones"])').first();
+  if ((await link.count()) === 0) {
+    return null;
+  }
+  return await link.getAttribute('href');
+}
+
+/**
+ * Sets the silent-mode flag on the line currently shown by the detail page.
+ * The form auto-submits on change via htmx. Waits for the POST response so the
+ * partial swap is settled before returning.
+ */
+async function setSilentOnDetailPage(page: Page, target: 'on' | 'off') {
+  const checkbox = page.locator('#silent-mode-section input[name="silent_mode"]');
+  await expect(checkbox).toBeVisible();
+  const checked = await checkbox.isChecked();
+  if ((target === 'on' && checked) || (target === 'off' && !checked)) {
+    return; // already in desired state, do not bounce a no-op POST
+  }
+  const wait = page.waitForResponse(
+    (r) => r.url().includes('/silent-mode') && r.request().method() === 'POST',
+  );
+  await checkbox.click();
+  await wait;
+}
+
+test.describe('Silent mode (intercom theme)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setTheme(page.request, 'intercom').catch(() => undefined);
+  });
+
+  test('ringer panel renders on phone detail page', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+
+    await expect(page.locator('h2.panel__title', { hasText: /ringer/i })).toBeVisible();
+    await expect(page.locator('#silent-mode-section')).toBeVisible();
+    await expect(page.locator('#silent-mode-section input[name="silent_mode"]')).toBeVisible();
+    await expect(
+      page.locator('#silent-mode-section', { hasText: /the light still flashes/i }),
+    ).toBeVisible();
+  });
+
+  test('toggling silent on persists and shows the list badge', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+
+    await page.goto(href);
+    await setSilentOnDetailPage(page, 'off'); // baseline
+    await setSilentOnDetailPage(page, 'on');
+
+    // Reload: the swap state must be persisted server-side.
+    await page.goto(href);
+    await expect(
+      page.locator('#silent-mode-section input[name="silent_mode"]'),
+    ).toBeChecked();
+
+    // Badge appears on the list.
+    await page.goto('/phones');
+    const badge = page.locator(`a[href="${href}"]`).locator('..').locator('.phone-silent').first();
+    await expect(badge).toBeVisible();
+
+    // Toggle off and confirm badge disappears.
+    await page.goto(href);
+    await setSilentOnDetailPage(page, 'off');
+    await page.goto('/phones');
+    const offRow = page.locator(`a[href="${href}"]`).locator('..');
+    await expect(offRow.locator('.phone-silent')).toHaveCount(0);
+  });
+
+  test('list badge is absent when silent is off across all rows', async ({ page }) => {
+    // After cleanup from the prior test the line is silent=off. This test
+    // pins the negative case explicitly, so a regression that always emits
+    // the badge is caught.
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+    await setSilentOnDetailPage(page, 'off');
+    await page.goto('/phones');
+    await expect(page.locator('.phone-silent')).toHaveCount(0);
+  });
+});
+
+test.describe('Silent mode (dialup theme)', () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      await setTheme(page.request, 'dialup');
+    } catch (e) {
+      test.skip(true, `setTheme failed: ${(e as Error).message}`);
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    await setTheme(page.request, 'intercom').catch(() => undefined);
+  });
+
+  test('ringer panel and toggle work the same under dialup', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+
+    await page.goto(href);
+    await expect(page.locator('#silent-mode-section')).toBeVisible();
+    await setSilentOnDetailPage(page, 'on');
+
+    await page.goto('/phones');
+    const row = page.locator(`a[href="${href}"]`).locator('..');
+    const badge = row.locator('.phone-silent').first();
+    await expect(badge).toBeVisible();
+    // Dialup shows the SILENT label; intercom hides it via display:none.
+    await expect(row.locator('.phone-silent__text')).toBeVisible();
+
+    // Restore baseline so the next theme block starts clean.
+    await page.goto(href);
+    await setSilentOnDetailPage(page, 'off');
+  });
+});

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -11,6 +11,7 @@ const (
 // fields can be added without schema changes.
 type Settings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
+	SilentMode bool   `json:"silent_mode,omitempty"`
 }
 
 // DefaultSettings returns the settings a newly created line starts with.
@@ -27,6 +28,7 @@ func (s Settings) Merge(patch Settings) Settings {
 	if patch.VoiceStyle != "" {
 		s.VoiceStyle = patch.VoiceStyle
 	}
+	s.SilentMode = patch.SilentMode
 	return s
 }
 

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -2,6 +2,7 @@ package line
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +69,51 @@ func TestSettingsNormalizeCoercesUnknown(t *testing.T) {
 	s := Settings{VoiceStyle: "bogus"}
 	if got := s.Normalize().VoiceStyle; got != VoiceStyleCopper {
 		t.Errorf("unknown value should fall back to copper, got %q", got)
+	}
+}
+
+func TestSettingsSilentModeDefaultFalse(t *testing.T) {
+	s := DefaultSettings()
+	if s.SilentMode {
+		t.Errorf("SilentMode default: got true, want false")
+	}
+}
+
+func TestSettingsJSONRoundTripSilentMode(t *testing.T) {
+	in := Settings{VoiceStyle: VoiceStyleCopper, SilentMode: true}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Settings
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Errorf("round trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestSettingsJSONOmitsSilentModeWhenFalse(t *testing.T) {
+	// omitempty keeps the JSONB payload free of noise when silent is off.
+	s := Settings{VoiceStyle: VoiceStyleCopper, SilentMode: false}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "silent_mode") {
+		t.Errorf("expected silent_mode omitted when false, got %s", b)
+	}
+}
+
+func TestSettingsMergeSilentModeFromPatch(t *testing.T) {
+	base := DefaultSettings()
+	patch := Settings{SilentMode: true}
+	merged := base.Merge(patch)
+	if !merged.SilentMode {
+		t.Errorf("Merge did not take SilentMode from patch")
+	}
+	if merged.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("Merge clobbered VoiceStyle: got %q", merged.VoiceStyle)
 	}
 }

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -1,6 +1,7 @@
 package signaling
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -8,6 +9,12 @@ import (
 
 	"github.com/gorilla/websocket"
 )
+
+// ErrNotConnected is returned by SendTo and SendToHardware when the target
+// device has no active hub connection. Callers that treat "device offline" as
+// expected (e.g., best-effort pushes) can check for it with errors.Is and skip
+// logging.
+var ErrNotConnected = errors.New("not connected")
 
 type Conn struct {
 	WS         *websocket.Conn
@@ -86,7 +93,7 @@ func (h *Hub) Get(number string) *Conn {
 func (h *Hub) SendTo(number string, msg *Message) error {
 	conn := h.Get(number)
 	if conn == nil {
-		return fmt.Errorf("phone %s not connected", number)
+		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
 	}
 	data, err := msg.Marshal()
 	if err != nil {
@@ -105,7 +112,7 @@ func (h *Hub) SendToHardware(hardwareID string, msg *Message) error {
 	conn := h.hwConns[hardwareID]
 	h.mu.RUnlock()
 	if conn == nil {
-		return fmt.Errorf("hardware %s not connected", hardwareID)
+		return fmt.Errorf("hardware %s: %w", hardwareID, ErrNotConnected)
 	}
 	data, err := msg.Marshal()
 	if err != nil {

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -19,5 +19,8 @@ func (a *lineStoreAdapter) LineSettingsByNumber(number string) (*LineSettings, e
 	if err != nil {
 		return nil, err
 	}
-	return &LineSettings{VoiceStyle: ln.Settings.VoiceStyle}, nil
+	return &LineSettings{
+		VoiceStyle: ln.Settings.VoiceStyle,
+		SilentMode: ln.Settings.SilentMode,
+	}, nil
 }

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -37,6 +37,7 @@ const (
 // added there, in pi/digitsd/internal/config, and in pi/digitsd/internal/signal.
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
+	SilentMode bool   `json:"silent_mode,omitempty"`
 }
 
 // ICEServer represents a STUN or TURN server configuration.

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -1,0 +1,106 @@
+package signaling
+
+import (
+	"testing"
+)
+
+// fakeLineStore is an in-memory LineStore for unit tests. It returns whatever
+// LineSettings the caller wires in, keyed by phone number.
+type fakeLineStore struct {
+	settings map[string]*LineSettings
+}
+
+func newFakeLineStore() *fakeLineStore {
+	return &fakeLineStore{settings: make(map[string]*LineSettings)}
+}
+
+func (f *fakeLineStore) set(number string, s *LineSettings) {
+	f.settings[number] = s
+}
+
+func (f *fakeLineStore) LineSettingsByNumber(number string) (*LineSettings, error) {
+	return f.settings[number], nil
+}
+
+// TestOnRegisteredPushesSilentMode verifies that when OnRegistered is called
+// for a number whose stored LineSettings has SilentMode: true, the hub
+// receives a TypeLineSettings message with SilentMode: true and the correct
+// VoiceStyle in the payload.
+func TestOnRegisteredPushesSilentMode(t *testing.T) {
+	hub := NewHub()
+	store := newFakeLineStore()
+	store.set("3140001", &LineSettings{
+		VoiceStyle: "copper",
+		SilentMode: true,
+	})
+	relay := NewRelay(hub, nil, nil, store)
+
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn)
+
+	relay.OnRegistered("3140001")
+
+	select {
+	case data := <-conn.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeLineSettings {
+			t.Errorf("Type: got %q, want %q", msg.Type, TypeLineSettings)
+		}
+		if msg.LineSettings == nil {
+			t.Fatal("LineSettings: got nil, want non-nil")
+		}
+		if !msg.LineSettings.SilentMode {
+			t.Errorf("SilentMode: got false, want true")
+		}
+		if msg.LineSettings.VoiceStyle != "copper" {
+			t.Errorf("VoiceStyle: got %q, want %q", msg.LineSettings.VoiceStyle, "copper")
+		}
+	default:
+		t.Fatal("device did not receive a line_settings push after OnRegistered")
+	}
+}
+
+// TestOnRegisteredPushesSilentModeFalseByDefault verifies that when
+// OnRegistered is called for a number whose stored LineSettings has
+// SilentMode: false, the pushed message also carries SilentMode: false.
+// This pins the wire semantics at the relay boundary so a future refactor
+// cannot silently (pun intended) drop the field.
+func TestOnRegisteredPushesSilentModeFalseByDefault(t *testing.T) {
+	hub := NewHub()
+	store := newFakeLineStore()
+	store.set("3140002", &LineSettings{
+		VoiceStyle: "modern",
+		SilentMode: false,
+	})
+	relay := NewRelay(hub, nil, nil, store)
+
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140002", conn)
+
+	relay.OnRegistered("3140002")
+
+	select {
+	case data := <-conn.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeLineSettings {
+			t.Errorf("Type: got %q, want %q", msg.Type, TypeLineSettings)
+		}
+		if msg.LineSettings == nil {
+			t.Fatal("LineSettings: got nil, want non-nil")
+		}
+		if msg.LineSettings.SilentMode {
+			t.Errorf("SilentMode: got true, want false")
+		}
+		if msg.LineSettings.VoiceStyle != "modern" {
+			t.Errorf("VoiceStyle: got %q, want %q", msg.LineSettings.VoiceStyle, "modern")
+		}
+	default:
+		t.Fatal("device did not receive a line_settings push after OnRegistered")
+	}
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -219,6 +219,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /phones/{number}/edit", h.handlePhoneEditGet)
 	protected.HandleFunc("POST /phones/{number}/edit", h.handlePhoneEditPost)
 	protected.HandleFunc("POST /phones/{number}/voice-style", h.handlePhoneVoiceStylePost)
+	protected.HandleFunc("POST /phones/{number}/silent-mode", h.handlePhoneSilentModePost)
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)
 	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)
@@ -783,6 +784,41 @@ func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Reque
 	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
 }
 
+func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	silent := strings.TrimSpace(r.FormValue("silent_mode")) == "on"
+
+	ln, err := h.lineStore.GetByNumber(number)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	next := ln.Settings
+	next.SilentMode = silent
+	next = next.Normalize()
+	if next.SilentMode != ln.Settings.SilentMode {
+		if err := h.lineStore.UpdateSettings(ln.ID, next); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := h.pushLineSettings(number, next); err != nil {
+			slog.Warn("push line settings failed", "number", number, "err", err)
+		}
+		ln.Settings = next
+	}
+	if isHTMX(r) {
+		renderWith(w, h.tmplPhoneDetail, "silent-mode-section", struct {
+			Line line.Line
+		}{Line: *ln})
+		return
+	}
+	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
+}
+
 // pushLineSettings sends the updated settings to the device currently
 // registered as the given number, if any. A missing device is not an error;
 // the next time that device reconnects it will receive the latest settings
@@ -796,6 +832,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings) error 
 		To:   number,
 		LineSettings: &signaling.LineSettings{
 			VoiceStyle: settings.VoiceStyle,
+			SilentMode: settings.SilentMode,
 		},
 	})
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -824,10 +824,7 @@ func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Reque
 // the next time that device reconnects it will receive the latest settings
 // via the registration push in relay.OnRegistered.
 func (h *Handler) pushLineSettings(number string, settings line.Settings) error {
-	if h.hub.Get(number) == nil {
-		return nil
-	}
-	return h.hub.SendTo(number, &signaling.Message{
+	err := h.hub.SendTo(number, &signaling.Message{
 		Type: signaling.TypeLineSettings,
 		To:   number,
 		LineSettings: &signaling.LineSettings{
@@ -835,6 +832,10 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings) error 
 			SilentMode: settings.SilentMode,
 		},
 	})
+	if errors.Is(err, signaling.ErrNotConnected) {
+		return nil
+	}
+	return err
 }
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -625,6 +625,116 @@ func TestPhoneVoiceStyleUnknownValueNormalizesToCopper(t *testing.T) {
 	}
 }
 
+func readSilentMode(t *testing.T, database *db.Database) bool {
+	t.Helper()
+	var raw bool
+	if err := database.DB.QueryRow(
+		`SELECT COALESCE((settings->>'silent_mode')::bool, false) FROM lines WHERE number = '3140001'`,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read silent_mode: %v", err)
+	}
+	return raw
+}
+
+func postSilentMode(t *testing.T, h *Handler, cookie *http.Cookie, value string, htmx bool) *httptest.ResponseRecorder {
+	t.Helper()
+	form := url.Values{"silent_mode": {value}}
+	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/silent-mode", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	return w
+}
+
+func TestPhoneSilentModeOnPersistsAndRedirects(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postSilentMode(t, h, cookie, "on", false)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != "/phones/3140001" {
+		t.Fatalf("expected redirect to /phones/3140001, got %q", loc)
+	}
+	if !readSilentMode(t, database) {
+		t.Fatal("expected silent_mode=true in db")
+	}
+}
+
+func TestPhoneSilentModeOffPersists(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("setup on: got %d", w.Code)
+	}
+	if !readSilentMode(t, database) {
+		t.Fatal("setup failed: expected silent_mode=true before turning off")
+	}
+	if w := postSilentMode(t, h, cookie, "off", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("off: got %d", w.Code)
+	}
+	if readSilentMode(t, database) {
+		t.Fatal("expected silent_mode=false in db after turning off")
+	}
+}
+
+func TestPhoneSilentModeMissingFieldTreatedAsOff(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("setup on: got %d", w.Code)
+	}
+
+	form := url.Values{}
+	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/silent-mode", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if readSilentMode(t, database) {
+		t.Fatal("expected silent_mode=false when form omits the key")
+	}
+}
+
+func TestPhoneSilentModeHTMXReturnsPartial(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postSilentMode(t, h, cookie, "on", true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `id="silent-mode-section"`) {
+		t.Fatalf("htmx response missing silent-mode-section wrapper:\n%s", body)
+	}
+	if !strings.Contains(body, `name="silent_mode"`) {
+		t.Fatalf("htmx response missing silent_mode input:\n%s", body)
+	}
+	checkboxIdx := strings.Index(body, `name="silent_mode"`)
+	if checkboxIdx < 0 {
+		t.Fatalf("missing checkbox:\n%s", body)
+	}
+	tag := body[checkboxIdx:strings.Index(body[checkboxIdx:], ">")+checkboxIdx]
+	if !strings.Contains(tag, "checked") {
+		t.Errorf("expected checkbox checked after turning on: %q", tag)
+	}
+}
+
 func TestPhoneVoiceStyleMissingLineReturns404(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -735,6 +735,77 @@ func TestPhoneSilentModeHTMXReturnsPartial(t *testing.T) {
 	}
 }
 
+func TestPhoneSilentModeMissingLineReturns404(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	user, err := authStore.GetUserByEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("get test user: %v", err)
+	}
+	hh, err := h.householdStore.Create("Silent Mode Missing", user.ID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM household_members WHERE household_id = $1", hh.ID)
+		_, _ = database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
+	})
+
+	w := postSilentMode(t, h, cookie, "on", false)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing line, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPhoneSilentModePushesToConnectedDevice(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, err := signaling.ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse pushed message: %v", err)
+		}
+		if msg.Type != signaling.TypeLineSettings {
+			t.Fatalf("expected %s push, got %s", signaling.TypeLineSettings, msg.Type)
+		}
+		if msg.LineSettings == nil || !msg.LineSettings.SilentMode {
+			t.Fatalf("expected silent_mode=true line_settings, got %+v", msg.LineSettings)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("device did not receive line_settings push")
+	}
+}
+
+func TestPhoneSilentModeNoOpSkipsPush(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.Hub().Register("3140001", conn)
+
+	// Line defaults to silent_mode=false on insert. Saving false again must be a no-op.
+	if w := postSilentMode(t, h, cookie, "off", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
+	}
+	select {
+	case data := <-conn.Send:
+		t.Fatalf("expected no push on no-op save, got message: %s", string(data))
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no push.
+	}
+}
+
 func TestPhoneVoiceStyleMissingLineReturns404(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -973,3 +973,38 @@ func TestSettingsCRTModePost_Invalid(t *testing.T) {
 		t.Errorf("CRTMode = %q, want %q (unchanged after invalid POST)", got.CRTMode, auth.CRTModeConnecting)
 	}
 }
+
+func TestPhonesListShowsSilentBadgeWhenSilent(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
+		t.Fatalf("setup: got %d", w.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/phones", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /phones: got %d, body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `class="phone-silent"`) {
+		t.Errorf("expected phone-silent badge in /phones HTML, body:\n%s", w.Body.String())
+	}
+}
+
+func TestPhonesListOmitsSilentBadgeWhenNotSilent(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	req := httptest.NewRequest(http.MethodGet, "/phones", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	if strings.Contains(w.Body.String(), `phone-silent`) {
+		t.Errorf("unexpected silent badge in /phones HTML when silent mode off")
+	}
+}

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1332,3 +1332,55 @@ body.crt-all .crt__brand::after {
   body.crt-page .crt__brand,
   body.crt-all .crt__brand { bottom: 8px; font-size: 9px; letter-spacing: 0.3em; }
 }
+
+/* Dialup: the Ringer panel is a Win95 groupbox-style frame. The checkbox
+   uses native rendering with a small inset well for authenticity. */
+body.dialup .toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: "MS Sans Serif", "Chicago", Tahoma, sans-serif;
+  font-size: 13px;
+  cursor: pointer;
+}
+body.dialup .toggle input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: #000080;
+  cursor: pointer;
+}
+body.dialup .toggle__label {
+  color: #000;
+  font-weight: normal;
+}
+
+/* Silent badge in dialup theme: answering-machine amber status lamp with
+   a pixelated feel. The dot glows; the SILENT label sits beside it in
+   tiny system type. Pure CSS, no image assets. */
+body.dialup .phone-silent {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 10px;
+  vertical-align: middle;
+  font-family: "MS Sans Serif", "Chicago", Tahoma, sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: #cc8800;
+  text-shadow: 0 0 1px rgba(255, 170, 0, 0.3);
+}
+body.dialup .phone-silent__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #ffcc33 0%, #ff9900 55%, #cc6600 100%);
+  box-shadow:
+    0 0 4px 1px rgba(255, 170, 0, 0.75),
+    inset 0 0 1px rgba(0, 0, 0, 0.4);
+  border: 1px solid #663300;
+}
+body.dialup .phone-silent__text {
+  display: inline;
+  font-weight: bold;
+}

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1334,8 +1334,8 @@ body.crt-all .crt__brand::after {
 }
 
 /* Dialup: the Ringer panel is a Win95 groupbox-style frame. The checkbox
-   uses native rendering with a small inset well for authenticity. */
-body.dialup .toggle {
+   uses native rendering with the Win95 highlight blue. */
+body.dialup .checkbox-row {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -1343,14 +1343,14 @@ body.dialup .toggle {
   font-size: 13px;
   cursor: pointer;
 }
-body.dialup .toggle input[type="checkbox"] {
+body.dialup .checkbox-row input[type="checkbox"] {
   width: 15px;
   height: 15px;
   margin: 0;
   accent-color: #000080;
   cursor: pointer;
 }
-body.dialup .toggle__label {
+body.dialup .checkbox-row__label {
   color: #000;
   font-weight: normal;
 }

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1185,22 +1185,22 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   .show-sm { display: block; }
 }
 
-/* Ringer panel: checkbox toggle paired with a label. Mirrors .radio-card
-   spacing so the Ringer section visually sits next to Voice style. */
-.toggle {
+/* Ringer panel: checkbox-with-label row. Distinct from the .toggle pill-switch
+   used elsewhere; this is a plain native checkbox paired with text. */
+.checkbox-row {
   display: flex;
   align-items: center;
   gap: 10px;
   cursor: pointer;
   user-select: none;
 }
-.toggle input[type="checkbox"] {
+.checkbox-row input[type="checkbox"] {
   width: 18px;
   height: 18px;
   cursor: pointer;
   accent-color: var(--ink);
 }
-.toggle__label {
+.checkbox-row__label {
   font-size: 14px;
   font-weight: 500;
   color: var(--ink);

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1185,3 +1185,52 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   .show-sm { display: block; }
 }
 
+/* Ringer panel: checkbox toggle paired with a label. Mirrors .radio-card
+   spacing so the Ringer section visually sits next to Voice style. */
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+.toggle input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--ink);
+}
+.toggle__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+}
+
+/* Silent-mode badge in the phones list. Intercom theme uses a muted bell
+   glyph (neutral grey, not alert-red) because silent is a chosen state,
+   not a problem state. The dialup theme overrides this with an amber LED. */
+.phone-silent {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+  color: var(--ink-muted);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.phone-silent__dot {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238a7a63' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9'/><path d='M10 21a2 2 0 0 0 4 0'/><line x1='2' y1='2' x2='22' y2='22'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+/* Intercom hides the SILENT text label (the glyph carries the meaning and the
+   row is already dense). Dialup shows it. */
+.phone-silent__text {
+  display: none;
+}
+

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -81,6 +81,16 @@
         </div>
       </section>
 
+      <!-- Ringer -->
+      <section class="panel">
+        <header class="panel__head">
+          <h2 class="panel__title">Ringer</h2>
+        </header>
+        <div class="panel__body">
+          {{template "silent-mode-section" .}}
+        </div>
+      </section>
+
     </div>
 
     <!-- Right: operator service panel (collapsed by default) -->
@@ -485,6 +495,25 @@
       <p class="radio-card__desc">Full-range clean audio. No coloration, maximum clarity.</p>
     </label>
     <button type="submit" class="btn btn--primary" style="margin-top: 6px;">Save</button>
+  </form>
+</div>
+{{end}}
+
+{{define "silent-mode-section"}}
+<div id="silent-mode-section">
+  <form hx-post="/phones/{{.Line.Number}}/silent-mode"
+        hx-target="#silent-mode-section"
+        hx-swap="outerHTML"
+        class="stack-sm">
+    <label class="toggle">
+      <input type="checkbox" name="silent_mode" value="on"
+             {{if .Line.Settings.SilentMode}}checked{{end}}
+             onchange="this.form.requestSubmit()">
+      <span class="toggle__label">Silent mode</span>
+    </label>
+    <p class="muted" style="font-size: 12px; margin: 4px 0 0;">
+      Incoming calls won't ring. The light still flashes and you can still answer.
+    </p>
   </form>
 </div>
 {{end}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -505,11 +505,11 @@
         hx-target="#silent-mode-section"
         hx-swap="outerHTML"
         class="stack-sm">
-    <label class="toggle">
+    <label class="checkbox-row">
       <input type="checkbox" name="silent_mode" value="on"
              {{if .Line.Settings.SilentMode}}checked{{end}}
              onchange="this.form.requestSubmit()">
-      <span class="toggle__label">Silent mode</span>
+      <span class="checkbox-row__label">Silent mode</span>
     </label>
     <p class="muted" style="font-size: 12px; margin: 4px 0 0;">
       Incoming calls won't ring. The light still flashes and you can still answer.

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -238,7 +238,15 @@
         {{range .Lines}}
         <tr>
           <td class="num"><a href="/phones/{{.Line.Number}}">{{fmtPhone .Line.Number}}</a></td>
-          <td><a href="/phones/{{.Line.Number}}">{{.Line.Name}}</a></td>
+          <td>
+            <a href="/phones/{{.Line.Number}}">{{.Line.Name}}</a>
+            {{if .Line.Settings.SilentMode}}
+            <span class="phone-silent" aria-label="Silent mode on" title="Silent mode on">
+              <span class="phone-silent__dot" aria-hidden="true"></span>
+              <span class="phone-silent__text">SILENT</span>
+            </span>
+            {{end}}
+          </td>
           <td>
             {{if .Online}}
               <span class="chip chip--on"><span class="chip__dot"></span>online</span>
@@ -267,6 +275,12 @@
       <a class="lines__row" href="/phones/{{.Line.Number}}">
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
         <span class="lines__name">{{.Line.Name}}</span>
+        {{if .Line.Settings.SilentMode}}
+        <span class="phone-silent" aria-label="Silent mode on" title="Silent mode on">
+          <span class="phone-silent__dot" aria-hidden="true"></span>
+          <span class="phone-silent__text">SILENT</span>
+        </span>
+        {{end}}
         <span class="lines__num">{{fmtPhone .Line.Number}}</span>
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
       </a>

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -274,13 +274,7 @@
     <li>
       <a class="lines__row" href="/phones/{{.Line.Number}}">
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
-        <span class="lines__name">{{.Line.Name}}</span>
-        {{if .Line.Settings.SilentMode}}
-        <span class="phone-silent" aria-label="Silent mode on" title="Silent mode on">
-          <span class="phone-silent__dot" aria-hidden="true"></span>
-          <span class="phone-silent__text">SILENT</span>
-        </span>
-        {{end}}
+        <span class="lines__name">{{.Line.Name}}{{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}</span>
         <span class="lines__num">{{fmtPhone .Line.Number}}</span>
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
       </a>


### PR DESCRIPTION
## What

Adds a per-phone Silent mode toggle to the web app. When on, incoming calls suppress the bell on that phone but still flash the LED, and offhook still answers. Setting persists server-side and locally on the device, syncs over the existing signaling channel, and survives reboots and disconnects.

## Why

Closes #217. Quiet hours / nighttime scenarios where you want a phone to stop ringing without losing call functionality.

## Key choices

- Silent flag rides on the existing `LineSettings` JSONB blob and `TypeLineSettings` wire message. No schema migration. Mirrors the existing `voice_style` plumbing end to end.
- Gate sits in digitsd's phone controller (`onSignalRing`): skip `SendRing(true)` when silent, still send `SendLED("BLINK")`. Firmware is untouched.
- Asymmetric mid-ring behavior: flipping silent ON during an active ring stops the bell immediately. Flipping OFF mid-ring does NOT start it. (A bell starting mid-ring would be jarring; if you want it, just answer.)
- Same HTML markup in both themes; `digits.css` and `dialup.css` carry all the visual differentiation.

## Screenshots

**Intercom theme**

Detail page with the Ringer panel (silent on):

![intercom detail](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/silent-mode-intercom-detail-on.png)

Lines list with the muted-bell glyph next to Kitchen:

![intercom list](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/silent-mode-intercom-list-table.png)

**Dialup theme**

Detail page with the Win95 checkbox in the Ringer groupbox:

![dialup detail](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/silent-mode-dialup-detail-on.png)

Lines list with the amber answering-machine LED + SILENT label:

![dialup list](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/silent-mode-dialup-list-table.png)

## Test plan

- [x] Unit: `server/internal/line/...` round-trips the bool through JSONB
- [x] Unit: `pi/digitsd/internal/config/...` persists and reloads `silent_mode` from disk
- [x] Unit: `pi/digitsd/internal/phone/...` covers the gate in `onSignalRing`, the mid-ring ON interrupt, the asymmetric mid-ring OFF no-op, idle side-effect-freedom
- [x] Unit: `server/internal/web/handler_test.go` covers form parsing (on / off / missing), 404 on unknown line, push-to-connected-device, no-op skip, and the htmx partial response
- [x] Integration: `server/internal/signaling/relay_linesettings_test.go` verifies the register-time push carries the new flag in both true and false cases
- [x] E2E: `server/e2e/tests/09-silent-mode.spec.ts` exercises the toggle round-trip and badge appear/disappear in both themes (skips cleanly without auth or phones)
- [ ] Hardware: deploy to D1 and walk the seven scenarios (baseline ring, silent ON suppresses bell, mid-ring ON stops bell, mid-ring OFF does not start bell, reboot persists, offline toggle applies on reconnect, `config.json` reflects state). Pending; will run before merge.

## Notes for reviewers

- A pre-existing redundancy in `pushLineSettings` (double `hub.Get` + TOCTOU window) was found by the simplify pass and fixed in this branch. Introduces `signaling.ErrNotConnected` as a typed sentinel.
- The `.toggle` CSS class collision with the existing privacy pill-switch on `/settings` was caught in review and fixed by renaming to `.checkbox-row`.
- The mobile card grid bug (badge becoming a 5th grid child and breaking the row) was caught in review and fixed by nesting the badge inside `.lines__name`.
- After merging main, `handlePhoneSilentModePost` was aligned with PR #220's `requireLineOwnership` pattern so the new endpoint enforces household scoping.