### PR TITLE
fix(image): disable Wi-Fi power-save on Pi Zero 2 W

### DIFF
--- a/pi/image/rootfs-overlay/etc/NetworkManager/conf.d/wifi-powersave.conf
+++ b/pi/image/rootfs-overlay/etc/NetworkManager/conf.d/wifi-powersave.conf
@@ -1,0 +1,18 @@
+# Disable Wi-Fi power-save on Pi Zero 2 W.
+#
+# The BCM43430 / brcmfmac driver on Pi Zero 2 W is notoriously flaky when
+# power-save is enabled under sustained bursty traffic (WebRTC audio is a
+# pathological case -- small packets at a steady 50 pps with ICE keepalives).
+# Symptoms range from packet loss to the driver wedging the SoC until a
+# cold boot. Disabling power-save trades a small idle draw for link
+# stability.
+#
+# NetworkManager powersave values:
+#   0 = use the default
+#   1 = ignore (don't touch the setting)
+#   2 = disable
+#   3 = enable
+#
+# Reference: https://wiki.archlinux.org/title/Power_management/Wakeup_triggers#NetworkManager
+[connection]
+wifi.powersave = 2


### PR DESCRIPTION
## Summary

Adds a NetworkManager `conf.d` fragment that disables Wi-Fi power-save on the shipped Pi image. The BCM43430 / brcmfmac combination on Pi Zero 2 W is known to stall or wedge the SoC under sustained bursty traffic when power-save is on — WebRTC audio (50 pps + ICE keepalives) is a pathological case.

## Why

- All three field phones run the baseline image config (power-save enabled, CLM blob missing). D1 and D2 have been stable; D3 has been rebooting intermittently with **no cause visible** in dmesg or journal (no OOM, no panic, no under-voltage flag, no thermal, no scheduled reboot).
- The reboots look like cold-start hard resets — either a power-supply brownout or a Wi-Fi driver panic severe enough to take the SoC. Hardware swap is the primary hypothesis, but this config is universally worth hardening while we're here.
- Change is image-only, fragment-based, and reversible — if a future build needs power-save on it's one file to remove.

## Scope

- One file: `pi/image/rootfs-overlay/etc/NetworkManager/conf.d/wifi-powersave.conf` with `wifi.powersave = 2`.
- Does **not** address the missing CLM blob (`brcmfmac43430-sdio.clm_blob`) — that's a packaging change and a separate concern.
- Does **not** apply to already-deployed phones automatically. Operators can drop the same file into `/etc/NetworkManager/conf.d/` and `systemctl reload NetworkManager`, or reflash the image.

## Test plan

- [ ] Build a fresh image from this branch via the Docker image builder.
- [ ] Flash to a phone; verify `/etc/NetworkManager/conf.d/wifi-powersave.conf` is present.
- [ ] After boot, `iw dev wlan0 get power_save` reports `off`.
- [ ] Normal 2-party call sustains audio without Wi-Fi hitches.