### PR TITLE
feat(server): dialup theme port of intercom redesign + CRT scroll fix + dev conveniences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,25 @@ make firmware-local   # builds on host (requires arm-none-eabi-gcc + Pico SDK)
 
 `make firmware-local` runs `./scripts/build.sh`, which auto-detects `PICO_SDK_PATH` from common locations (`/usr/share/pico-sdk`, `~/pico-sdk`, etc.). Only set `PICO_SDK_PATH` explicitly if the SDK is installed somewhere non-standard.
 
+## Local dev server
+
+For running the webapp against a disposable local Postgres with a pre-seeded dialup-themed user (so UI work does not need a hand-wired DB):
+
+```
+make dev-up      # brings up user-db in Docker, seeds dev@digits.local + household, runs host-native signald (foreground)
+make dev-down    # stops and wipes the DB container + volume
+make dev-seed    # re-runs the idempotent seeder only
+make dev-logs    # tails the DB container
+```
+
+All from `server/`. Defaults in `.env.dev.example` (committed); override by copying to `.env.dev` (gitignored) -- e.g. change `SIGNALD_ADDR` if `:8080` is taken on your machine.
+
+Sign in by visiting `http://localhost:<SIGNALD_ADDR port>/auth/dev-session?email=dev@digits.local` -- the primary seeded user has `theme='dialup'` and is preloaded with three lines (Kitchen / Living room / Garage), two linked families (Grandma Lindh, The Coopers) each with their own lines, and one outstanding pending invite so every surface on `/`, `/links`, `/phones`, `/calls`, `/settings` renders with real data.
+
+`make dev-seed` is idempotent -- re-running never duplicates. `make dev-down && make dev-up` does a full reset. Pass `-minimal` to `go run ./cmd/devseed/` directly if you only want the primary user with no lines or links (e.g. for testing onboarding flows).
+
+Prefer this over hand-running `go run ./cmd/signald/` with a local DB; `dev-up` handles the Postgres container, migrations, and seeding as one command.
+
 ## Linting
 
 golangci-lint v2 with `standard` defaults. Config is in `.golangci.yml` at repo root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ Sign in by visiting `http://localhost:<SIGNALD_ADDR port>/auth/dev-session?email
 
 `make dev-seed` is idempotent -- re-running never duplicates. `make dev-down && make dev-up` does a full reset. Pass `-minimal` to `go run ./cmd/devseed/` directly if you only want the primary user with no lines or links (e.g. for testing onboarding flows).
 
+When `DEV_MODE=true`, signald serves `/static/*` from disk (`internal/web/static/` relative to its CWD) instead of the embedded FS, so CSS and JS edits are visible on reload without a rebuild. Template edits still require restart (they are parsed at startup). Production builds always use the embedded FS.
+
 Prefer this over hand-running `go run ./cmd/signald/` with a local DB; `dev-up` handles the Postgres container, migrations, and seeding as one command.
 
 ## Linting

--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -1,13 +1,17 @@
-// devseed creates (or updates) a single dialup-themed user + household in the
-// local dev database so `make dev-up` lands the operator on a rendered
-// dashboard after one click.
+// devseed populates the local dev database with a comprehensive scenario
+// for iterating on UI: a primary dialup user plus additional households
+// linked to them, each with multiple phone lines, plus one outstanding
+// pending invite. This means `make dev-up` lands on a rendered dashboard
+// AND /links hub / Today panel / pending-invite row are all populated
+// without hand-wiring fixtures per session.
 //
-// It is idempotent: running it twice does not create duplicate users or
-// households. It prints a /auth/dev-session URL at the end which the operator
-// can paste into a browser to sign in.
+// The seeder is idempotent: every entity is checked before being created.
+// Running twice does not duplicate users, households, lines, links, or
+// invites. Running against a partially-seeded DB fills in whatever is
+// missing.
 //
-// This binary is intentionally minimal. It is not meant for production
-// seeding; it has no flags beyond what is needed to bootstrap one dialup user.
+// Minimal mode (single primary user, no extras) is available via the
+// -minimal flag for callers that want the old behavior.
 package main
 
 import (
@@ -22,13 +26,74 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/household"
+	"github.com/justinlindh/digits/server/internal/line"
 )
+
+// seededUser describes one user's full state after seeding.
+type seededUser struct {
+	Email         string
+	DisplayName   string
+	HouseholdName string
+	Theme         auth.Theme
+	Lines         []seededLine
+	LinkToPrimary bool // when true, the seeder wires an accepted link to the primary household
+}
+
+type seededLine struct {
+	Number string
+	Name   string
+}
+
+var (
+	primary = seededUser{
+		Email:         "dev@digits.local",
+		DisplayName:   "Dev",
+		HouseholdName: "Lindh Family",
+		Theme:         auth.ThemeDialup,
+		Lines: []seededLine{
+			{"2480001", "Kitchen"},
+			{"2480002", "Living room"},
+			{"2480003", "Garage"},
+		},
+	}
+
+	others = []seededUser{
+		{
+			Email:         "grandma@digits.local",
+			DisplayName:   "Grandma",
+			HouseholdName: "Grandma Lindh",
+			Theme:         auth.ThemeIntercom,
+			Lines: []seededLine{
+				{"5550001", "Bedroom"},
+			},
+			LinkToPrimary: true,
+		},
+		{
+			Email:         "coopers@digits.local",
+			DisplayName:   "Cooper",
+			HouseholdName: "The Coopers",
+			Theme:         auth.ThemeIntercom,
+			Lines: []seededLine{
+				{"3120001", "Kitchen"},
+				{"3120002", "Studio"},
+			},
+			LinkToPrimary: true,
+		},
+	}
+)
+
+type stores struct {
+	auth  *auth.Store
+	house *household.Store
+	link  *household.LinkStore
+	line  *line.Store
+}
 
 func main() {
 	var (
-		email       = flag.String("email", envOr("DEV_SEED_EMAIL", "dev@digits.local"), "Email address for the seeded dev user")
 		baseURL     = flag.String("base-url", envOr("BASE_URL", "http://localhost:8080"), "Base URL to embed in the printed sign-in link")
 		databaseURL = flag.String("database-url", os.Getenv("DATABASE_URL"), "Postgres connection string (falls back to DATABASE_URL)")
+		minimal     = flag.Bool("minimal", false, "Seed only the primary dialup user with no lines, links, or pending invites")
 	)
 	flag.Parse()
 
@@ -42,56 +107,96 @@ func main() {
 	}
 	defer func() { _ = database.Close() }()
 
-	authStore := auth.NewStoreFromDB(database.DB)
-	houseStore := household.NewStore(database.DB)
+	s := &stores{
+		auth:  auth.NewStoreFromDB(database.DB),
+		house: household.NewStore(database.DB),
+		link:  household.NewLinkStore(database.DB),
+		line:  line.NewStore(database),
+	}
 
-	user, created, err := upsertUser(authStore, *email)
+	primaryUser, primaryHH, err := ensureUser(s, primary, *minimal)
 	if err != nil {
-		log.Fatalf("upsert user: %v", err)
-	}
-	if err := authStore.SetTheme(user.ID, auth.ThemeDialup); err != nil {
-		log.Fatalf("set theme: %v", err)
+		log.Fatalf("seed primary: %v", err)
 	}
 
-	hh, err := ensureHousehold(houseStore, user.ID)
-	if err != nil {
-		log.Fatalf("ensure household: %v", err)
+	if *minimal {
+		printSummary(*baseURL, []string{primary.Email}, primary.Email)
+		return
 	}
 
-	verb := "updated"
-	if created {
-		verb = "created"
+	if err := s.house.SetCallHistoryEnabled(primaryHH.ID, true); err != nil {
+		log.Fatalf("enable call history on primary: %v", err)
 	}
-	fmt.Printf("User %s %s (id=%s, theme=dialup)\n", *email, verb, user.ID)
-	fmt.Printf("Household: %s (id=%s)\n", hh.Name, hh.ID)
-	fmt.Println()
-	fmt.Println("Sign in by opening this URL in your browser:")
-	fmt.Printf("  %s/auth/dev-session?email=%s\n", strings.TrimRight(*baseURL, "/"), url.QueryEscape(*email))
-	fmt.Println()
-	fmt.Println("The server must be running with DEV_MODE=true for the dev-session endpoint to work.")
+
+	seededEmails := []string{primary.Email}
+	for _, o := range others {
+		otherUser, otherHH, err := ensureUser(s, o, false)
+		if err != nil {
+			log.Fatalf("seed %s: %v", o.Email, err)
+		}
+		seededEmails = append(seededEmails, o.Email)
+		if o.LinkToPrimary {
+			if err := ensureAcceptedLink(s.link, primaryHH.ID, primaryUser.ID, otherHH.ID, otherUser.ID); err != nil {
+				log.Fatalf("link %s to primary: %v", o.Email, err)
+			}
+		}
+	}
+
+	if err := ensurePendingInvite(s.link, primaryHH.ID, primaryUser.ID); err != nil {
+		log.Fatalf("ensure pending invite on primary: %v", err)
+	}
+
+	printSummary(*baseURL, seededEmails, primary.Email)
 }
 
-// upsertUser returns the existing user for email, or creates a new one. The
-// second return value reports whether a new row was inserted.
-func upsertUser(s *auth.Store, email string) (*auth.User, bool, error) {
+// ensureUser guarantees the user, their household, their theme, and their
+// lines are in the configured state. If minimal is true, only the user + an
+// empty household are ensured (no lines).
+func ensureUser(s *stores, spec seededUser, minimal bool) (*auth.User, *household.Household, error) {
+	u, err := upsertUser(s.auth, spec.Email, spec.DisplayName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("upsert user: %w", err)
+	}
+	if err := s.auth.SetTheme(u.ID, spec.Theme); err != nil {
+		return nil, nil, fmt.Errorf("set theme: %w", err)
+	}
+	hh, err := ensureHousehold(s.house, u.ID, spec.HouseholdName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ensure household: %w", err)
+	}
+	if hh.Name != spec.HouseholdName {
+		if err := s.house.UpdateName(hh.ID, spec.HouseholdName); err != nil {
+			return nil, nil, fmt.Errorf("rename household: %w", err)
+		}
+		hh.Name = spec.HouseholdName
+	}
+	if !minimal {
+		for _, l := range spec.Lines {
+			if err := ensureLine(s.line, l.Number, l.Name, hh.ID); err != nil {
+				return nil, nil, fmt.Errorf("ensure line %s: %w", l.Number, err)
+			}
+		}
+	}
+	return u, hh, nil
+}
+
+// upsertUser returns the existing user for email, or creates one with the
+// given display name. The display name is only used on first insert.
+func upsertUser(s *auth.Store, email, displayName string) (*auth.User, error) {
 	u, err := s.GetUserByEmail(email)
 	switch {
 	case err == nil:
-		return u, false, nil
+		return u, nil
 	case errors.Is(err, auth.ErrUserNotFound):
-		created, err := s.CreateUser(email, "Dev", nil)
-		if err != nil {
-			return nil, false, err
-		}
-		return created, true, nil
+		return s.CreateUser(email, displayName, nil)
 	default:
-		return nil, false, fmt.Errorf("lookup user: %w", err)
+		return nil, fmt.Errorf("lookup user: %w", err)
 	}
 }
 
-// ensureHousehold returns the user's first household, creating one if they
-// have none. Running again is a no-op — NeedsOnboarding gates creation.
-func ensureHousehold(s *household.Store, userID string) (*household.Household, error) {
+// ensureHousehold returns the user's first household, creating one with the
+// desired name if the user has none.
+func ensureHousehold(s *household.Store, userID, name string) (*household.Household, error) {
 	if !s.NeedsOnboarding(userID) {
 		hs, err := s.GetForUser(userID)
 		if err != nil {
@@ -102,7 +207,77 @@ func ensureHousehold(s *household.Store, userID string) (*household.Household, e
 		}
 		return hs[0], nil
 	}
-	return s.Onboard(userID, "Dev")
+	return s.Create(name, userID)
+}
+
+// ensureLine creates a phone line only if none exists with that number.
+// Phone numbers are globally unique, so GetByNumber is the natural key.
+func ensureLine(s *line.Store, number, name, householdID string) error {
+	existing, err := s.GetByNumber(number)
+	if err == nil && existing != nil {
+		return nil
+	}
+	if err != nil && !errors.Is(err, line.ErrNotFound) {
+		return err
+	}
+	if _, err := s.Add(number, name, householdID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureAcceptedLink wires an accepted link between two households if one
+// does not already exist. Uses the production invite/accept flow so the
+// seeded link is indistinguishable from a user-created one.
+func ensureAcceptedLink(s *household.LinkStore, primaryHHID, primaryUserID, otherHHID, otherUserID string) error {
+	linked, err := s.AreLinked(primaryHHID, otherHHID)
+	if err != nil {
+		return fmt.Errorf("check link: %w", err)
+	}
+	if linked {
+		return nil
+	}
+	invite, err := s.CreateInvite(primaryHHID, primaryUserID)
+	if err != nil {
+		return fmt.Errorf("create invite: %w", err)
+	}
+	if _, err := s.AcceptInvite(invite.InviteCode, otherUserID, otherHHID); err != nil {
+		return fmt.Errorf("accept invite: %w", err)
+	}
+	return nil
+}
+
+// ensurePendingInvite makes sure the primary household has exactly one
+// pending-invite code outstanding so the Families page renders its
+// "Pending invites sent" row. Does nothing if one already exists.
+func ensurePendingInvite(s *household.LinkStore, householdID, userID string) error {
+	pending, err := s.GetPendingForHousehold(householdID)
+	if err != nil {
+		return fmt.Errorf("get pending: %w", err)
+	}
+	if len(pending) > 0 {
+		return nil
+	}
+	if _, err := s.CreateInvite(householdID, userID); err != nil {
+		return fmt.Errorf("create pending invite: %w", err)
+	}
+	return nil
+}
+
+func printSummary(baseURL string, emails []string, primaryEmail string) {
+	fmt.Println()
+	fmt.Println("Seeded users:")
+	for _, e := range emails {
+		fmt.Printf("  - %s\n", e)
+	}
+	fmt.Println()
+	fmt.Println("Sign in as the primary dialup user:")
+	fmt.Printf("  %s/auth/dev-session?email=%s\n",
+		strings.TrimRight(baseURL, "/"),
+		url.QueryEscape(primaryEmail),
+	)
+	fmt.Println()
+	fmt.Println("The server must be running with DEV_MODE=true for the dev-session endpoint to work.")
 }
 
 func envOr(key, fallback string) string {

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -113,7 +113,8 @@ func main() {
 
 	// Create web handler
 	handler, err := web.NewHandler(lineStore, deviceStore, hub, tracker, relay, web.HandlerConfig{
-		Addr: cfg.Addr,
+		Addr:    cfg.Addr,
+		DevMode: cfg.DevMode,
 	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, cfg.BaseURL, cfg.AdminSecret)
 	if err != nil {
 		log.Fatalf("create handler: %v", err)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
@@ -36,6 +37,37 @@ var staticFS embed.FS
 // TemplateFS returns the embedded template filesystem for external template parsing.
 func TemplateFS() embed.FS {
 	return templateFS
+}
+
+// devStaticDirDefault is the disk path (relative to the process CWD) used
+// for /static/ when DevMode is on and no explicit override is supplied.
+// It matches the Makefile's dev-up target, which runs signald with CWD
+// set to the server/ module root.
+const devStaticDirDefault = "internal/web/static"
+
+// staticFileServer returns the handler that serves /static/. In devMode it
+// serves from disk so CSS and JS edits are visible on reload without a
+// rebuild; diskDir falls back to devStaticDirDefault when empty. In
+// production mode it serves the embedded FS, keeping the binary
+// self-contained. Both code paths route /static/dialup.css to the same
+// file content for a given checkout.
+func staticFileServer(devMode bool, diskDir string) http.Handler {
+	if devMode {
+		if diskDir == "" {
+			diskDir = devStaticDirDefault
+		}
+		return http.StripPrefix("/static/", http.FileServer(http.Dir(diskDir)))
+	}
+	// fs.Sub strips the "static" prefix from the embedded FS so request
+	// paths align with the disk-mode handler's StripPrefix treatment.
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		// embed declares the "static" directory above; sub-rooting to it
+		// cannot fail at runtime. A panic here would indicate a programmer
+		// error in the embed declaration.
+		panic(fmt.Errorf("fs.Sub(staticFS, \"static\"): %w", err))
+	}
+	return http.StripPrefix("/static/", http.FileServer(http.FS(sub)))
 }
 
 type Handler struct {
@@ -79,6 +111,16 @@ type Handler struct {
 
 type HandlerConfig struct {
 	Addr string
+	// DevMode enables development-only conveniences. Today that means
+	// serving /static/ from disk instead of the embedded FS, so CSS and
+	// JS edits don't require a signald rebuild. When false, the embedded
+	// FS is used.
+	DevMode bool
+	// DevStaticDir is the disk path served for /static/ when DevMode is
+	// true. Empty falls back to devStaticDirDefault ("internal/web/static"),
+	// which matches the layout the Makefile's dev-up target runs from.
+	// The field exists mainly so tests can point at a temp directory.
+	DevStaticDir string
 }
 
 func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling.Hub, tracker *calls.Tracker, relay *signaling.Relay, cfg HandlerConfig, authStore *auth.Store, authHandlers *auth.Handlers, googleAuth *auth.GoogleAuth, householdStore *household.Store, pairingStore *pairing.Store, linkStore *household.LinkStore, emailSender email.Sender, baseURL string, adminSecret string) (*Handler, error) {
@@ -184,8 +226,10 @@ func (h *Handler) Hub() *signaling.Hub {
 func (h *Handler) Router() http.Handler {
 	mux := http.NewServeMux()
 
-	// Static assets — no auth required
-	mux.Handle("GET /static/", http.FileServer(http.FS(staticFS)))
+	// Static assets — no auth required. In DevMode, serve from disk so
+	// CSS/JS edits don't require a rebuild; otherwise serve the embedded
+	// FS so the production binary is self-contained.
+	mux.Handle("GET /static/", staticFileServer(h.cfg.DevMode, h.cfg.DevStaticDir))
 
 	// Health check — no auth required
 	mux.HandleFunc("GET /healthz", httputil.Healthz())

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -933,9 +933,11 @@ func TestSettingsPage_ThemeSwatches(t *testing.T) {
 		`#f5f1ea`,
 		`#2e231b`,
 		`#c48b3a`,
-		`#0a3a8a`,
-		`#7ab4ff`,
-		`#f0c020`,
+		// Dialup swatches render actual --dialup-chrome-l / --dialup-blue-dark
+		// / --dialup-gold tokens so the preview matches the live theme.
+		`#ece9d8`,
+		`#003da7`,
+		`#ffcc00`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("settings theme section missing %q", want)

--- a/server/internal/web/spec_compliance_test.go
+++ b/server/internal/web/spec_compliance_test.go
@@ -254,14 +254,18 @@ func TestSpecSettings(t *testing.T) {
 		}
 	}
 
-	// Theme cards + every swatch hex value (Spec: explicit palettes).
-	// (Spec: "Intercom palette: #f5f1ea, #2e231b, #c48b3a. Dialup palette:
-	//  #0a3a8a, #7ab4ff, #f0c020.")
+	// Theme cards + every swatch hex value.
+	// Intercom stays on the shipped palette values, which match its
+	// canonical tokens. Dialup's swatches were reconciled to actual
+	// --dialup-chrome-l / --dialup-blue-dark / --dialup-gold so the
+	// preview matches what the theme actually renders (see the
+	// 2026-04-21 dialup-theme-port design: "palette tokens are
+	// canonical").
 	for _, want := range []string{
 		`class="theme-card`,
 		"theme-card__swatch",
 		"#f5f1ea", "#2e231b", "#c48b3a",
-		"#0a3a8a", "#7ab4ff", "#f0c020",
+		"#ece9d8", "#003da7", "#ffcc00",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("Settings theme section missing %q", want)

--- a/server/internal/web/spec_compliance_test.go
+++ b/server/internal/web/spec_compliance_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/justinlindh/digits/server/internal/auth"
 )
 
 // TestSpecDashboard covers the Dashboard section of the spec.
@@ -302,5 +304,40 @@ func TestSpecCallLog(t *testing.T) {
 	h.Router().ServeHTTP(w2, req2)
 	if !strings.Contains(w2.Body.String(), "Call log") {
 		t.Errorf("Settings page missing 'Call log' toggle label")
+	}
+}
+
+// TestSpecDialupHubGlyph asserts the dialup theme renders the new
+// pixel-art house SVG on /links, not the intercom line-drawing.
+// Spec: Option D of the 2026-04-21 dialup-theme-port design.
+// Each family spoke (and the center household) shows a chunky Win98
+// pixel-art house with a roof-mounted antenna and signal arcs.
+func TestSpecDialupHubGlyph(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	user, err := authStore.GetUserByEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("get test user: %v", err)
+	}
+	if err := authStore.SetTheme(user.ID, auth.ThemeDialup); err != nil {
+		t.Fatalf("set dialup theme: %v", err)
+	}
+	seedLinkedFamily(t, h, database, authStore, hh.ID, user.ID, "Grandma Lindh", "2180042", "Grandma")
+
+	req := httptest.NewRequest(http.MethodGet, "/links", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /links: got %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	// The dialup-specific SVG uses <g class="dialup-house__antenna">
+	// which the intercom template never emits. Presence proves the
+	// hub spoke + center switched to the pixel-art glyph for dialup.
+	if !strings.Contains(body, `dialup-house__antenna`) {
+		t.Error("dialup /links should render the dialup house SVG (class=dialup-house__antenna)")
 	}
 }

--- a/server/internal/web/spec_compliance_test.go
+++ b/server/internal/web/spec_compliance_test.go
@@ -152,6 +152,11 @@ func TestSpecFamilies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get test user: %v", err)
 	}
+	// The test user is shared across spec tests; ensure intercom theme
+	// so the postcard branch rendering FAMILY MAIL is exercised here.
+	if err := authStore.SetTheme(user.ID, auth.ThemeIntercom); err != nil {
+		t.Fatalf("reset theme to intercom: %v", err)
+	}
 	seedLinkedFamily(t, h, database, authStore, hh.ID, user.ID, "Grandma Lindh", "2180042", "Grandma")
 
 	// Default view — no postcard yet.
@@ -322,6 +327,9 @@ func TestSpecDialupHubGlyph(t *testing.T) {
 	if err := authStore.SetTheme(user.ID, auth.ThemeDialup); err != nil {
 		t.Fatalf("set dialup theme: %v", err)
 	}
+	// Reset the test user's theme on exit so subsequent tests (which
+	// share this user via setupAuthedHousehold) see the default value.
+	t.Cleanup(func() { _ = authStore.SetTheme(user.ID, auth.ThemeIntercom) })
 	seedLinkedFamily(t, h, database, authStore, hh.ID, user.ID, "Grandma Lindh", "2180042", "Grandma")
 
 	req := httptest.NewRequest(http.MethodGet, "/links", nil)

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1226,16 +1226,109 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
 .theme-card__name { font-weight: bold; font-size: 12px; }
 .theme-card__desc { font-size: 11px; color: var(--dialup-ink-muted); }
 
-/* Neighborhood rows placeholder - see issue #214 for full dialup treatment */
-.neighborhood { display: flex; flex-direction: column; }
-.neighborhood__row { display: grid; grid-template-columns: 200px 1fr; border: 1px solid var(--dialup-bevel-lo); background: #fff; margin-bottom: 4px; }
-.neighborhood__identity { padding: 8px; background: var(--dialup-chrome-l); border-right: 1px solid var(--dialup-bevel-lo); }
-.neighborhood__name { font-weight: bold; display: flex; align-items: center; gap: 6px; }
-.neighborhood__name svg { width: 20px; height: 20px; }
-.neighborhood__meta { font-size: 11px; color: var(--dialup-ink-muted); }
-.neighborhood__lines { padding: 8px; display: grid; grid-template-columns: 1fr 1fr; gap: 4px; }
-.neighborhood__line { display: flex; align-items: center; gap: 6px; font-size: 12px; }
-.neighborhood__line-num { margin-left: auto; font-family: var(--font-mono); }
+/* --------- Families neighborhood rows (two-pane address book) ---------
+   Left identity pane on chrome background with a mini-glyph of the
+   family's household. Right pane is a single-column list of that
+   family's lines, one per row, with the existing green status dot
+   (.lines__dot) on the left and the formatted number right-aligned in
+   monospace. Horizontal rule separates adjacent lines so the layout
+   reads like a period Address Book panel. */
+
+.neighborhood {
+  display: flex;
+  flex-direction: column;
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+  background: #ffffff;
+}
+
+.neighborhood__row {
+  display: grid;
+  grid-template-columns: 210px 1fr;
+  border-bottom: 1px solid var(--dialup-bevel-lo);
+}
+.neighborhood__row:last-child { border-bottom: 0; }
+
+.neighborhood__identity {
+  padding: 10px 12px;
+  background: var(--dialup-chrome-l);
+  border-right: 1px solid var(--dialup-bevel-lo);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.neighborhood__name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: bold;
+  font-size: 13px;
+  color: var(--dialup-ink);
+  font-style: normal;
+}
+.neighborhood__name svg {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  color: var(--dialup-blue-dark);
+}
+
+.neighborhood__meta {
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+  line-height: 1.5;
+}
+
+/* Single-column list: one phone line per row, dotted-leader style
+   connecting the label and the number so the two read as a pair even
+   when the row is wide. */
+.neighborhood__lines {
+  padding: 6px 12px 8px;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+}
+
+.neighborhood__line {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+  font-size: 12px;
+  color: var(--dialup-ink);
+  border-bottom: 1px dotted var(--dialup-chrome-d);
+}
+.neighborhood__line:last-child { border-bottom: 0; }
+
+/* The template emits .lines__dot before the line name — already styled
+   elsewhere. Just ensure it reads as a clear lead-in here. */
+.neighborhood__line .lines__dot { flex-shrink: 0; }
+
+.neighborhood__line-name {
+  font-family: inherit;
+  font-style: normal;
+  font-weight: 400;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.neighborhood__line-num {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+  white-space: nowrap;
+}
+
+@media (max-width: 680px) {
+  .neighborhood__row { grid-template-columns: 1fr; }
+  .neighborhood__identity {
+    border-right: 0;
+    border-bottom: 1px solid var(--dialup-bevel-lo);
+  }
+}
 
 /* Postcard placeholder - see issue #214 for full dialup treatment */
 .postcard { display: grid; grid-template-columns: 1fr 72px; gap: 10px; padding: 8px; background: #fff; border: 2px inset var(--dialup-chrome); margin-bottom: 8px; }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1330,14 +1330,128 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   }
 }
 
-/* Postcard placeholder - see issue #214 for full dialup treatment */
-.postcard { display: grid; grid-template-columns: 1fr 72px; gap: 10px; padding: 8px; background: #fff; border: 2px inset var(--dialup-chrome); margin-bottom: 8px; }
-.postcard__kicker { font-size: 10px; color: var(--dialup-ink-muted); font-family: "Courier New", Courier, monospace; }
-.postcard__code { font-family: var(--font-mono); font-size: 20px; font-weight: bold; letter-spacing: 0.1em; color: var(--dialup-blue); margin: 4px 0; }
-.postcard__message { font-size: 12px; margin: 4px 0 0; }
-.postcard__message code { font-family: var(--font-mono); background: var(--dialup-chrome-l); padding: 0 3px; }
-.postcard__stamp { border: 1px dotted var(--dialup-blue); padding: 4px; text-align: center; font-size: 9px; color: var(--dialup-blue); }
-.postcard__stamp svg { width: 22px; height: 22px; }
+/* --------- Families invite postcard ---------
+   Raised beveled card on dialup cream, reading as a physical
+   postcard that landed on the Families page. Large blue-dark
+   invite code in monospace. Right column holds the postmark
+   stamp (postcard-stamp-dialup template). */
+
+.postcard {
+  display: grid;
+  grid-template-columns: 1fr 96px;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--dialup-cream);
+  border-top: 2px solid var(--dialup-bevel-hi);
+  border-left: 2px solid var(--dialup-bevel-hi);
+  border-right: 2px solid var(--dialup-bevel-ll);
+  border-bottom: 2px solid var(--dialup-bevel-ll);
+  margin-bottom: 10px;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.2);
+}
+
+.postcard__kicker {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 10px;
+  font-weight: bold;
+  letter-spacing: 0.12em;
+  color: var(--dialup-ink-muted);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.postcard__code {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 22px;
+  font-weight: bold;
+  letter-spacing: 0.2em;
+  color: var(--dialup-blue-dark);
+  margin: 6px 0 10px;
+  line-height: 1;
+  user-select: all;
+}
+
+.postcard__greeting {
+  font-style: italic;
+  font-size: 12px;
+  color: var(--dialup-ink);
+  margin: 0 0 4px;
+}
+
+.postcard__message {
+  font-size: 12px;
+  color: var(--dialup-ink);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.postcard__message code {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 11px;
+  background: var(--dialup-chrome-l);
+  border: 1px solid var(--dialup-bevel-lo);
+  padding: 1px 4px;
+}
+
+.postcard__stamp {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+/* Pixel-art postmark stamp (dialup theme only). Gold dashed outer
+   frame around a thin blue-dark inner frame with diagonal paper
+   texture, ink-colored DIGITS/NEIGHBORHOOD text stacked around a
+   center asterisk. Matches the postcard-stamp-dialup template. */
+.postcard__stamp-mark {
+  width: 90px;
+  height: 90px;
+  padding: 4px;
+  border: 2px dashed var(--dialup-gold-dark);
+  background: var(--dialup-cream);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.postcard__stamp-mark-frame {
+  width: 100%;
+  height: 100%;
+  border: 1px solid var(--dialup-blue-dark);
+  padding: 2px 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  background:
+    repeating-linear-gradient(
+      45deg,
+      transparent 0 4px,
+      rgba(0, 61, 167, 0.06) 4px 5px
+    );
+}
+
+.postcard__stamp-mark-line {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 9px;
+  font-weight: bold;
+  color: var(--dialup-blue-dark);
+  letter-spacing: 0.12em;
+  line-height: 1.1;
+  text-align: center;
+}
+.postcard__stamp-mark-line--top {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+}
+
+.postcard__stamp-mark-center {
+  font-size: 16px;
+  color: var(--dialup-gold-dark);
+  line-height: 1;
+  margin: 1px 0;
+}
 
 /* --------- Dashboard rooms grid ---------
    Each room card is a pressed-in beveled panel -- reads as a status

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -84,6 +84,21 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   box-shadow: 2px 2px 0 rgba(0,0,0,0.4);
 }
 
+/* Non-CRT dialup: lock the body + window to the viewport so title
+   bar, menu, toolbar, and Keyword bar stay fixed while content
+   scrolls inside .dialup-main. Mirrors the contained-browser-window
+   feel the CRT bezel provides when CRTMode=all. */
+body.dialup:not(.crt-all) {
+  height: 100vh;
+  overflow: hidden;
+}
+body.dialup:not(.crt-all) .dialup-window {
+  max-height: calc(100vh - 16px);
+}
+/* Flex-item overflow fix: without min-height: 0 a flex child will
+   grow to its content and defeat .dialup-main's overflow: auto. */
+.dialup-main { min-height: 0; }
+
 .dialup-title {
   background: linear-gradient(90deg, var(--dialup-blue-dark) 0%, var(--dialup-blue) 50%, var(--dialup-blue-light) 100%);
   color: #fff;

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1583,6 +1583,10 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   flex-wrap: wrap;
 }
 
+/* Chips are <span> tags -- decorative summary, not navigation. The
+   intercom theme treats them the same (no hover, no press). Default
+   cursor avoids the text-select I-beam that <span> would otherwise
+   get on mouseover. */
 .connected-row__chip {
   display: inline-flex;
   gap: 6px;
@@ -1595,21 +1599,9 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   font-size: 11px;
   font-weight: bold;
   color: var(--dialup-ink);
-  text-decoration: none;
   align-items: center;
   line-height: 1.2;
-}
-
-.connected-row__chip:hover {
-  background: var(--dialup-chrome-l);
-  text-decoration: none;
-}
-
-.connected-row__chip:active {
-  border-top-color: var(--dialup-bevel-lo);
-  border-left-color: var(--dialup-bevel-lo);
-  border-right-color: var(--dialup-bevel-hi);
-  border-bottom-color: var(--dialup-bevel-hi);
+  cursor: default;
 }
 
 .connected-row__chip svg {

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1340,6 +1340,23 @@ body.crt-page .crt__screen { aspect-ratio: 4 / 3; }
   }
 }
 
+/* CRT-all (wrapped app) scroll fix: .dialup-window sets min-height
+   calc(100vh - 16px), which exceeds the bezel's inner screen height
+   (100vh - 120px at desktop) and previously clipped anything below
+   the fold since .crt__screen uses overflow: hidden. Treat the window
+   as a flex child of the screen and let it scroll in place. The
+   screen's ::before/::after overlays remain fixed to the bezel frame
+   (absolute on .crt__screen, unaffected by the child's scrolling). */
+body.crt-all .crt__screen {
+  display: flex;
+  flex-direction: column;
+}
+body.crt-all .crt__screen > .dialup-window {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+
 body.crt-page .crt__screen::before,
 body.crt-all .crt__screen::before {
   content: "";

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1209,12 +1209,87 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   }
 }
 
-/* Settings sticky side-nav placeholder - see issue #214 for full dialup treatment */
-.settings-layout { display: grid; grid-template-columns: 160px 1fr; gap: 12px; }
-.settings-nav { display: flex; flex-direction: column; gap: 2px; padding: 4px; }
-.settings-nav__item { padding: 4px 8px; color: var(--dialup-ink); text-decoration: none; }
-.settings-nav__item.is-active { background: var(--dialup-blue); color: #fff; }
-.settings-sections { display: flex; flex-direction: column; gap: 8px; }
+/* --------- Settings side-nav layout ---------
+   Left column is an inset-beveled well (like a Win98 properties-dialog
+   list) holding vertical section links. Active item is painted with
+   the dialup menu-selection vocabulary: deep blue background, white
+   bold text. Sticky inside .dialup-main so it stays in view as the
+   right-hand section content scrolls. */
+
+.settings-layout {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.settings-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px;
+  background: var(--dialup-chrome);
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+  position: sticky;
+  top: 8px;
+}
+
+.settings-nav__item {
+  padding: 5px 10px;
+  color: var(--dialup-ink);
+  text-decoration: none;
+  font-size: 12px;
+  border: 1px solid transparent;
+  line-height: 1.3;
+}
+
+.settings-nav__item:hover {
+  border-top-color: var(--dialup-bevel-hi);
+  border-left-color: var(--dialup-bevel-hi);
+  border-right-color: var(--dialup-bevel-lo);
+  border-bottom-color: var(--dialup-bevel-lo);
+  background: var(--dialup-chrome-l);
+  text-decoration: none;
+}
+
+.settings-nav__item.is-active {
+  background: var(--dialup-blue);
+  color: #ffffff;
+  font-weight: bold;
+  border-top-color: var(--dialup-bevel-lo);
+  border-left-color: var(--dialup-bevel-lo);
+  border-right-color: var(--dialup-bevel-hi);
+  border-bottom-color: var(--dialup-bevel-hi);
+}
+.settings-nav__item.is-active:hover {
+  background: var(--dialup-blue-mid);
+  color: #ffffff;
+}
+
+.settings-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+@media (max-width: 680px) {
+  .settings-layout { grid-template-columns: 1fr; }
+  .settings-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 2px;
+    position: static;
+  }
+  .settings-nav__item {
+    flex: 1 1 auto;
+    text-align: center;
+    min-width: 80px;
+  }
+}
 
 /* Theme picker cards placeholder - see issue #214 for full dialup treatment */
 .theme-card { display: grid; grid-template-columns: 18px 60px 1fr auto; gap: 8px; padding: 6px; border: 2px inset var(--dialup-chrome); background: var(--dialup-chrome-l); align-items: center; }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1339,17 +1339,165 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
 .postcard__stamp { border: 1px dotted var(--dialup-blue); padding: 4px; text-align: center; font-size: 9px; color: var(--dialup-blue); }
 .postcard__stamp svg { width: 22px; height: 22px; }
 
-/* Dashboard rooms placeholder - see issue #214 for full dialup treatment */
-.rooms { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 6px; margin-bottom: 12px; }
-.rooms__card { padding: 8px; background: #fff; border: 2px inset var(--dialup-chrome); display: flex; flex-direction: column; gap: 4px; text-decoration: none; color: var(--dialup-ink); }
-.rooms__card:hover { background: var(--dialup-chrome-l); }
-.rooms__card--live { border-color: var(--dialup-blue); }
-.rooms__head { display: flex; justify-content: space-between; align-items: center; font-weight: bold; }
-.rooms__num { font-family: var(--font-mono); font-size: 11px; color: var(--dialup-ink-muted); }
-.rooms__callout { margin-top: auto; padding: 4px; border: 1px dotted var(--dialup-blue); background: #e8f0fa; }
-.rooms__callout-kicker { font-size: 9px; color: var(--dialup-ink-muted); }
-.rooms__callout-name { font-weight: bold; font-size: 13px; }
-.rooms__empty { grid-column: 1 / -1; padding: 20px; text-align: center; font-size: 12px; }
+/* --------- Dashboard rooms grid ---------
+   Each room card is a pressed-in beveled panel -- reads as a status
+   readout, not a pushable button. Chips inside .rooms__card get a
+   scoped LED restyle (pixel dot + uppercase caption) that leaves
+   chips in other contexts (phone-detail, call log) unchanged. The
+   ON LINE chip on an active call fades via @keyframes dialup-blink. */
+
+.rooms {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.rooms__card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  min-height: 96px;
+  background: #ffffff;
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+  color: var(--dialup-ink);
+  text-decoration: none;
+}
+
+.rooms__card:hover { background: var(--dialup-chrome-l); text-decoration: none; }
+
+.rooms__card--live {
+  background: #fffdf0;
+  border-top-color: var(--dialup-gold-dark);
+  border-left-color: var(--dialup-gold-dark);
+}
+
+.rooms__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.rooms__name {
+  font-weight: bold;
+  font-size: 13px;
+  color: var(--dialup-ink);
+}
+
+.rooms__num {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+}
+
+.rooms__callout {
+  margin-top: auto;
+  padding: 6px 8px;
+  background: var(--dialup-chrome-l);
+  border-top: 1px solid var(--dialup-bevel-lo);
+  border-left: 1px solid var(--dialup-bevel-lo);
+  border-right: 1px solid var(--dialup-bevel-hi);
+  border-bottom: 1px solid var(--dialup-bevel-hi);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.rooms__callout-kicker {
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dialup-ink-muted);
+}
+
+.rooms__callout-name {
+  font-weight: bold;
+  font-size: 12px;
+  color: var(--dialup-ink);
+}
+
+.rooms__callout-elapsed {
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  margin-left: auto;
+}
+
+.rooms__empty {
+  grid-column: 1 / -1;
+  padding: 22px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--dialup-ink-muted);
+  background: #ffffff;
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+}
+
+/* Scoped chip restyle: inside a room card, chips render as a small
+   square LED + uppercase caption. Chips outside .rooms__card keep
+   their existing dialup treatment. */
+.rooms__card .chip {
+  display: inline-flex;
+  gap: 5px;
+  padding: 1px 6px;
+  background: var(--dialup-chrome-l);
+  border: 1px solid var(--dialup-bevel-lo);
+  border-radius: 0;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dialup-ink-muted);
+  align-items: center;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.rooms__card .chip .chip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 0;
+  background: var(--dialup-chrome-d);
+  border: 1px solid var(--dialup-ink);
+  box-shadow: none;
+}
+
+.rooms__card .chip--on {
+  background: var(--dialup-chrome-l);
+  color: var(--dialup-accent-grn);
+}
+.rooms__card .chip--on .chip__dot {
+  background: var(--dialup-accent-grn);
+  box-shadow: 0 0 2px var(--dialup-accent-grn);
+}
+
+.rooms__card .chip--live {
+  background: var(--dialup-chrome-l);
+  color: var(--dialup-accent-red);
+  animation: dialup-blink 2s ease-in-out infinite;
+}
+.rooms__card .chip--live .chip__dot {
+  background: var(--dialup-accent-red);
+  /* Override the generic .chip--live pulsing-dot animation -- here we
+     blink the whole chip (text + border) as one unit, so the dot
+     doesn't double-pulse. */
+  animation: none;
+}
+
+@keyframes dialup-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
 
 .today-list { list-style: none; margin: 0; padding: 0; }
 .today-list__row { display: grid; grid-template-columns: 60px 14px 1fr auto; gap: 8px; padding: 4px 8px; border-bottom: 1px solid var(--dialup-bevel-lo); font-size: 12px; }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1583,10 +1583,8 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   flex-wrap: wrap;
 }
 
-/* Chips are <span> tags -- decorative summary, not navigation. The
-   intercom theme treats them the same (no hover, no press). Default
-   cursor avoids the text-select I-beam that <span> would otherwise
-   get on mouseover. */
+/* Chips link to the matching family's neighborhood row on /links.
+   Raised by default; hover lightens; :active presses in. */
 .connected-row__chip {
   display: inline-flex;
   gap: 6px;
@@ -1599,9 +1597,21 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   font-size: 11px;
   font-weight: bold;
   color: var(--dialup-ink);
+  text-decoration: none;
   align-items: center;
   line-height: 1.2;
-  cursor: default;
+}
+
+.connected-row__chip:hover {
+  background: var(--dialup-chrome-l);
+  text-decoration: none;
+}
+
+.connected-row__chip:active {
+  border-top-color: var(--dialup-bevel-lo);
+  border-left-color: var(--dialup-bevel-lo);
+  border-right-color: var(--dialup-bevel-hi);
+  border-bottom-color: var(--dialup-bevel-hi);
 }
 
 .connected-row__chip svg {

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -912,33 +912,44 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
 .pin__slot.is-filled { background: var(--dialup-gold); }
 .pin__slot.is-active { border-bottom-color: var(--dialup-accent-red); box-shadow: inset 0 -2px 0 var(--dialup-accent-red); }
 
-/* --------- Hub-and-spoke (Connected Families) --------- */
+/* --------- Hub-and-spoke (Connected Families) - Option D ---------
+   Spoke and center share the same chunky pixel-art house silhouette
+   (see house-icon-dialup-spoke / -center templates). Only window fill
+   distinguishes the center (lit gold) from spokes (dark blue). The
+   dashed gold rail is the "cable" between homes. */
 
 .hub {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 14px 10px;
-  gap: 10px;
-  background: #fff;
+  padding: 16px 10px 18px;
+  gap: 12px;
+  background: var(--dialup-chrome-l);
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
 }
+
 .hub__spokes {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: flex-end;
-  gap: 16px 24px;
+  gap: 18px 28px;
   max-width: 760px;
 }
+
 .hub__spoke {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  padding-bottom: 14px;
+  gap: 4px;
+  padding-bottom: 18px;
   position: relative;
-  max-width: 140px;
+  max-width: 120px;
 }
+
 .hub__spoke::after {
   content: '';
   position: absolute;
@@ -946,10 +957,16 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   left: 50%;
   transform: translateX(-50%);
   width: 0;
-  height: 12px;
+  height: 14px;
   border-left: 2px dashed var(--dialup-gold-dark);
 }
-.hub__house { width: 40px; height: 40px; color: var(--dialup-blue-dark); }
+
+.hub__house {
+  width: 48px;
+  height: 48px;
+  overflow: visible; /* antenna + signal arcs extend above the SVG box */
+}
+
 .hub__label {
   font-family: inherit;
   font-style: normal;
@@ -958,7 +975,15 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   color: var(--dialup-ink);
   text-align: center;
 }
-.hub__since { font-size: 10px; color: var(--dialup-ink-muted); text-transform: uppercase; font-weight: bold; }
+
+.hub__since {
+  font-size: 10px;
+  color: var(--dialup-ink-muted);
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 0.05em;
+}
+
 .hub__rail {
   width: calc(100% - 16px);
   max-width: 560px;
@@ -966,7 +991,16 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   border-top: 2px dashed var(--dialup-gold-dark);
   background: none;
 }
-.hub__center { position: relative; display: flex; flex-direction: column; align-items: center; gap: 2px; margin-top: 12px; }
+
+.hub__center {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-top: 14px;
+}
+
 .hub__center::before {
   content: '';
   position: absolute;
@@ -974,12 +1008,36 @@ button { font: inherit; color: inherit; cursor: pointer; background: var(--dialu
   left: 50%;
   transform: translateX(-50%);
   width: 0;
-  height: 12px;
+  height: 14px;
   border-left: 2px dashed var(--dialup-gold-dark);
 }
-.hub__center-house { width: 60px; height: 60px; color: var(--dialup-blue-dark); }
-.hub__center-name { font-weight: bold; font-size: 13px; color: var(--dialup-ink); font-style: normal; }
-.hub__center-sub { font-size: 10px; color: var(--dialup-ink-muted); text-transform: uppercase; font-weight: bold; }
+
+.hub__center-house {
+  width: 76px;
+  height: 76px;
+  overflow: visible;
+}
+
+.hub__center-name {
+  font-weight: bold;
+  font-size: 14px;
+  color: var(--dialup-ink);
+  font-style: normal;
+}
+
+.hub__center-sub {
+  font-size: 10px;
+  color: var(--dialup-ink-muted);
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: 0.1em;
+}
+
+@media (max-width: 600px) {
+  .hub__spokes { gap: 12px 18px; }
+  .hub__house { width: 40px; height: 40px; }
+  .hub__center-house { width: 64px; height: 64px; }
+}
 
 /* --------- Disclosure (details/summary) --------- */
 

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1499,13 +1499,125 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   50% { opacity: 0.35; }
 }
 
-.today-list { list-style: none; margin: 0; padding: 0; }
-.today-list__row { display: grid; grid-template-columns: 60px 14px 1fr auto; gap: 8px; padding: 4px 8px; border-bottom: 1px solid var(--dialup-bevel-lo); font-size: 12px; }
-.today-list__empty { padding: 16px; text-align: center; }
+/* --------- Dashboard today-list (call log preview) ---------
+   Tabular rows with alternating zebra, monospace time and duration
+   columns, and the direction glyph (in-arrow vs out-arrow) in a
+   dedicated narrow column. Matches the control-panel readout feel
+   of the rooms cards above. */
 
-.connected-row { display: flex; gap: 6px; padding: 8px; align-items: center; flex-wrap: wrap; }
-.connected-row__chip { display: inline-flex; gap: 4px; padding: 2px 8px; background: var(--dialup-chrome-l); border: 1px solid var(--dialup-bevel-lo); font-size: 12px; align-items: center; }
-.connected-row__chip svg { width: 16px; height: 16px; }
+.today-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: #ffffff;
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+}
+
+.today-list__row {
+  display: grid;
+  grid-template-columns: 70px 16px 1fr auto;
+  gap: 10px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--dialup-bevel-lo);
+  font-size: 12px;
+  align-items: center;
+}
+.today-list__row:last-child { border-bottom: 0; }
+.today-list__row:nth-child(even) { background: var(--dialup-chrome-l); }
+
+.today-list__time {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+}
+
+.today-list__dir {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  color: var(--dialup-accent-grn);
+  font-weight: bold;
+  text-align: center;
+}
+.today-list__dir--in { color: var(--dialup-blue); }
+
+.today-list__peer { color: var(--dialup-ink); }
+.today-list__peer .muted { color: var(--dialup-ink-muted); }
+
+.today-list__dur {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+  white-space: nowrap;
+}
+
+.today-list__empty {
+  padding: 20px;
+  text-align: center;
+  color: var(--dialup-ink-muted);
+  font-size: 12px;
+  background: #ffffff;
+  border-top: 2px solid var(--dialup-bevel-lo);
+  border-left: 2px solid var(--dialup-bevel-lo);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+}
+
+/* --------- Dashboard connected-families chip row ---------
+   A strip of raised beveled chips, one per linked family, each with
+   the small dialup-blue house glyph and the family name. Hover
+   lightens; :active presses in. The "Manage ->" link on the right
+   of the panel header uses the existing .panel__action styling. */
+
+.connected-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  background: var(--dialup-chrome-l);
+  border-top: 1px solid var(--dialup-bevel-lo);
+  border-left: 1px solid var(--dialup-bevel-lo);
+  border-right: 1px solid var(--dialup-bevel-hi);
+  border-bottom: 1px solid var(--dialup-bevel-hi);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.connected-row__chip {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px 10px;
+  background: var(--dialup-chrome);
+  border-top: 1px solid var(--dialup-bevel-hi);
+  border-left: 1px solid var(--dialup-bevel-hi);
+  border-right: 1px solid var(--dialup-bevel-lo);
+  border-bottom: 1px solid var(--dialup-bevel-lo);
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--dialup-ink);
+  text-decoration: none;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.connected-row__chip:hover {
+  background: var(--dialup-chrome-l);
+  text-decoration: none;
+}
+
+.connected-row__chip:active {
+  border-top-color: var(--dialup-bevel-lo);
+  border-left-color: var(--dialup-bevel-lo);
+  border-right-color: var(--dialup-bevel-hi);
+  border-bottom-color: var(--dialup-bevel-hi);
+}
+
+.connected-row__chip svg {
+  width: 14px;
+  height: 14px;
+  color: var(--dialup-blue-dark);
+  flex-shrink: 0;
+}
 
 /* =========================================================================
    CRT monitor bezel (used on /connecting and, when CRTMode=all, wrapping

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1306,15 +1306,77 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
   }
 }
 
-/* Theme picker cards placeholder - see issue #214 for full dialup treatment */
-.theme-card { display: grid; grid-template-columns: 18px 60px 1fr auto; gap: 8px; padding: 6px; border: 2px inset var(--dialup-chrome); background: var(--dialup-chrome-l); align-items: center; }
-.theme-card + .theme-card { margin-top: 4px; }
-.theme-card--selected { background: var(--dialup-blue-light); }
-.theme-card__swatch { display: flex; height: 24px; border: 1px solid var(--dialup-bevel-lo); }
-.theme-card__swatch-strip { flex: 1; }
-.theme-card__body { display: flex; flex-direction: column; }
-.theme-card__name { font-weight: bold; font-size: 12px; }
-.theme-card__desc { font-size: 11px; color: var(--dialup-ink-muted); }
+/* --------- Settings theme picker cards ---------
+   Each theme card is a raised outset button (clickable) holding a
+   radio + three color swatches + theme name + description. The
+   currently selected theme card is pressed-in with a pale gold
+   fill, matching the dialup "this is the active selection"
+   vocabulary used elsewhere (e.g. .rooms__card--live). */
+
+.theme-card {
+  display: grid;
+  grid-template-columns: 20px 64px 1fr auto;
+  gap: 10px;
+  padding: 8px 10px;
+  background: var(--dialup-chrome);
+  border-top: 2px solid var(--dialup-bevel-hi);
+  border-left: 2px solid var(--dialup-bevel-hi);
+  border-right: 2px solid var(--dialup-bevel-lo);
+  border-bottom: 2px solid var(--dialup-bevel-lo);
+  align-items: center;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--dialup-ink);
+}
+.theme-card + .theme-card { margin-top: 6px; }
+
+.theme-card:hover { background: var(--dialup-chrome-l); }
+
+.theme-card input[type="radio"] {
+  margin: 0;
+  accent-color: var(--dialup-blue);
+}
+
+.theme-card--selected {
+  background: #fff7d0;
+  border-top-color: var(--dialup-bevel-lo);
+  border-left-color: var(--dialup-bevel-lo);
+  border-right-color: var(--dialup-bevel-hi);
+  border-bottom-color: var(--dialup-bevel-hi);
+}
+
+.theme-card__swatch {
+  display: flex;
+  height: 28px;
+  border-top: 1px solid var(--dialup-bevel-lo);
+  border-left: 1px solid var(--dialup-bevel-lo);
+  border-right: 1px solid var(--dialup-bevel-hi);
+  border-bottom: 1px solid var(--dialup-bevel-hi);
+}
+
+.theme-card__swatch-strip {
+  flex: 1;
+  min-width: 0;
+}
+
+.theme-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.theme-card__name {
+  font-weight: bold;
+  font-size: 12px;
+  color: var(--dialup-ink);
+}
+
+.theme-card__desc {
+  font-size: 11px;
+  color: var(--dialup-ink-muted);
+  line-height: 1.4;
+}
 
 /* --------- Families neighborhood rows (two-pane address book) ---------
    Left identity pane on chrome background with a mini-glyph of the

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2086,9 +2086,106 @@ body.crt-all .crt__brand::after {
   body.crt-all .crt__brand { bottom: 8px; font-size: 9px; letter-spacing: 0.3em; }
 }
 
-/* Confirm dialog placeholder - see issue #214 for full dialup treatment */
-.confirm-dialog { border: 2px outset var(--dialup-chrome); padding: 12px 14px; background: var(--dialup-chrome-l); max-width: 380px; width: 90vw; font-family: var(--dialup-font, Tahoma, sans-serif); }
-.confirm-dialog::backdrop { background: rgba(0,0,0,0.4); }
-.confirm-dialog__title { font-weight: bold; font-size: 14px; margin: 0 0 8px; color: var(--dialup-ink); }
-.confirm-dialog__body { font-size: 12px; color: var(--dialup-ink); margin: 0 0 14px; line-height: 1.5; }
-.confirm-dialog__actions { display: flex; gap: 6px; justify-content: flex-end; }
+/* --------- Confirm dialog (full Win98 modal chrome) ---------
+   Gradient titlebar, warning glyph, chunky bevels, hard shadow.
+   Buttons reuse .btn / .btn--quiet / .btn--danger so focus states
+   and hover already work through the existing dialup button kit. */
+
+.confirm-dialog {
+  padding: 0;
+  background: var(--dialup-chrome);
+  border-top: 2px solid var(--dialup-bevel-hi);
+  border-left: 2px solid var(--dialup-bevel-hi);
+  border-right: 2px solid var(--dialup-bevel-ll);
+  border-bottom: 2px solid var(--dialup-bevel-ll);
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.4);
+  max-width: 420px;
+  width: 92vw;
+  font-family: "Tahoma", "MS Sans Serif", Geneva, sans-serif;
+  color: var(--dialup-ink);
+}
+.confirm-dialog::backdrop { background: rgba(0, 0, 0, 0.4); }
+
+.confirm-dialog__titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(90deg, var(--dialup-blue-dark) 0%, var(--dialup-blue) 55%, var(--dialup-blue-light) 100%);
+  color: #ffffff;
+  padding: 3px 5px;
+  font-weight: bold;
+  font-size: 12px;
+  min-height: 22px;
+}
+.confirm-dialog__titlebar-title { text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3); }
+.confirm-dialog__titlebar-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: var(--dialup-chrome);
+  color: var(--dialup-ink);
+  border-top: 1px solid var(--dialup-bevel-hi);
+  border-left: 1px solid var(--dialup-bevel-hi);
+  border-right: 1px solid var(--dialup-bevel-ll);
+  border-bottom: 1px solid var(--dialup-bevel-ll);
+  font-size: 10px;
+  line-height: 1;
+}
+
+.confirm-dialog__body-wrap {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  grid-template-rows: auto auto;
+  gap: 8px 14px;
+  padding: 14px 16px 12px;
+  margin: 0;
+}
+
+.confirm-dialog__glyph {
+  grid-column: 1;
+  grid-row: 1;
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 28px;
+  line-height: 1;
+  color: var(--dialup-gold-dark);
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.25);
+}
+
+.confirm-dialog__body-col {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.confirm-dialog__title {
+  font-weight: bold;
+  font-size: 13px;
+  margin: 0 0 6px;
+  color: var(--dialup-ink);
+}
+.confirm-dialog__body {
+  font-size: 12px;
+  color: var(--dialup-ink);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.confirm-dialog__actions {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding-top: 8px;
+  margin-top: 4px;
+  border-top: 1px solid var(--dialup-bevel-lo);
+}
+
+.confirm-dialog__actions .btn {
+  min-width: 88px;
+}

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1496,3 +1496,30 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   gap: 8px;
 }
 
+/* Intercom treats the new Win98 titlebar as hidden chrome and laddered
+   the form contents back into the same visual result as before: the
+   warning glyph sits inline to the left of the title + body, then the
+   actions hang at the bottom-right. Keeps the soft-modal appearance
+   the intercom theme shipped in #218. */
+.confirm-dialog__titlebar { display: none; }
+.confirm-dialog__body-wrap {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  grid-template-rows: auto auto;
+  gap: 6px 14px;
+  margin: 0;
+}
+.confirm-dialog__glyph {
+  grid-column: 1;
+  grid-row: 1;
+  font-size: 22px;
+  line-height: 1.1;
+  color: var(--brass);
+}
+.confirm-dialog__body-col { grid-column: 2; grid-row: 1; }
+.confirm-dialog__actions {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  margin-top: 4px;
+}
+

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1457,7 +1457,10 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   font-family: var(--font-display);
   font-style: italic;
   font-size: 13px;
+  color: var(--ink);
+  text-decoration: none;
 }
+.connected-row__chip:hover { background: var(--paper); border-color: var(--brass); }
 .connected-row__chip svg { width: 18px; height: 18px; color: var(--ink-soft); }
 
 /* Confirm dialog (shared pattern; triggers: data-confirm attributes) */

--- a/server/internal/web/static_server_test.go
+++ b/server/internal/web/static_server_test.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Production path: /static/* must be served from the embedded FS so the
+// binary is self-contained on deploy. A response from the embed path
+// carries the dialup.css top comment.
+func TestStaticFileServer_ProductionServesFromEmbed(t *testing.T) {
+	h := staticFileServer(false, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/static/dialup.css", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /static/dialup.css: got %d, want 200", rec.Code)
+	}
+	// dialup.css opens with a comment block naming the theme; match
+	// a stable substring that should not drift without intent.
+	if !strings.Contains(rec.Body.String(), "dial-up online service 1997 theme") {
+		t.Error("embedded dialup.css did not contain expected header comment")
+	}
+}
+
+// Dev path: /static/* must be served from whatever disk directory is
+// passed via HandlerConfig.DevStaticDir so CSS edits don't require a
+// rebuild. Uses a temp directory so the test is independent of CWD.
+func TestStaticFileServer_DevServesFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	marker := []byte("/* dev-mode disk-serve smoke test */\n")
+	if err := os.WriteFile(filepath.Join(dir, "probe.css"), marker, 0o644); err != nil {
+		t.Fatalf("write probe file: %v", err)
+	}
+
+	h := staticFileServer(true, dir)
+	req := httptest.NewRequest(http.MethodGet, "/static/probe.css", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /static/probe.css: got %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "dev-mode disk-serve smoke test") {
+		t.Errorf("dev-mode handler did not serve the on-disk probe content; got body: %q", rec.Body.String())
+	}
+}
+
+// Empty DevStaticDir falls back to the devStaticDirDefault constant so
+// callers that only flip DevMode get the expected behavior.
+func TestStaticFileServer_DevDefaultDirResolves(t *testing.T) {
+	h := staticFileServer(true, "")
+	if h == nil {
+		t.Fatal("staticFileServer(true, \"\") returned nil")
+	}
+	// We don't assert on response content here because CWD may not host
+	// the default directory; the presence of a non-nil handler is enough
+	// to confirm the fallback branch doesn't blow up at construction.
+}

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -121,9 +121,16 @@
      Supports htmx for hx-post triggers via data-confirm-hx="post". */}}
 {{define "confirm-dialog"}}
 <dialog id="confirm-dialog" class="confirm-dialog">
-  <form method="POST" id="confirm-dialog__form">
-    <h3 id="confirm-dialog__title" class="confirm-dialog__title"></h3>
-    <p id="confirm-dialog__body" class="confirm-dialog__body"></p>
+  <div class="confirm-dialog__titlebar" aria-hidden="true">
+    <span class="confirm-dialog__titlebar-title">Confirm action</span>
+    <span class="confirm-dialog__titlebar-x">&#x2715;</span>
+  </div>
+  <form method="POST" id="confirm-dialog__form" class="confirm-dialog__body-wrap">
+    <span class="confirm-dialog__glyph" aria-hidden="true">&#x26A0;</span>
+    <div class="confirm-dialog__body-col">
+      <h3 id="confirm-dialog__title" class="confirm-dialog__title"></h3>
+      <p id="confirm-dialog__body" class="confirm-dialog__body"></p>
+    </div>
     <div class="confirm-dialog__actions">
       <button type="button" id="confirm-dialog__cancel" class="btn btn--quiet">Never mind</button>
       <button type="submit" id="confirm-dialog__submit" class="btn btn--danger"></button>

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -89,6 +89,20 @@
 <line x1="52" y1="50" x2="62" y2="50" stroke="#804f00" stroke-width="0.5"/>
 {{end}}
 
+{{/* postcard-stamp-dialup renders the /links invite-postcard stamp in
+     pixel-art: a gold dashed-border frame holding a blue-inked
+     "DIGITS / NEIGHBORHOOD" postmark. Replaces the soft house-icon
+     stamp that ships with the intercom theme. */}}
+{{define "postcard-stamp-dialup"}}
+<div class="postcard__stamp-mark" aria-hidden="true">
+  <div class="postcard__stamp-mark-frame">
+    <div class="postcard__stamp-mark-line postcard__stamp-mark-line--top">DIGITS</div>
+    <div class="postcard__stamp-mark-center">&#x2605;</div>
+    <div class="postcard__stamp-mark-line">NEIGHBORHOOD</div>
+  </div>
+</div>
+{{end}}
+
 {{/* confirm-dialog is a page-level modal triggered by elements that carry
      data-confirm attributes. Replaces the browser confirm() prompt with
      themed UI. Used for Cancel-pending-invite, Disconnect-family, and any

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -14,6 +14,81 @@
      via CSS. Use viewBox="0 0 80 80", fill="none", stroke="currentColor". */}}
 {{define "house-icon"}}<path d="M10 40 L40 16 L70 40 L70 66 Q70 68 68 68 L12 68 Q10 68 10 66 Z"/><rect x="33" y="50" width="14" height="18" rx="1"/><rect x="18" y="44" width="10" height="10"/><rect x="52" y="44" width="10" height="10"/><path d="M58 12 L58 30" stroke-linecap="round"/><circle cx="58" cy="10" r="2" fill="currentColor"/>{{end}}
 
+{{/* house-icon-dialup-spoke emits a chunky Win98 pixel-art house with
+     a roof-mounted antenna and two gold signal arcs overhead. Each
+     family spoke on /links uses this in the dialup theme. Dark-blue
+     windows. viewBox 0 0 80 80, matches house-icon for CSS parity. */}}
+{{define "house-icon-dialup-spoke"}}
+<g class="dialup-house__antenna">
+<path d="M 12 4 A 10 10 0 0 1 28 4" fill="none" stroke="#d69e00" stroke-width="1.5"/>
+<path d="M 8 1 A 14 14 0 0 1 32 1" fill="none" stroke="#d69e00" stroke-width="1" opacity="0.7"/>
+<line x1="20" y1="6" x2="20" y2="18" stroke="#000" stroke-width="1.5"/>
+<circle cx="20" cy="5" r="2" fill="#000"/>
+</g>
+<rect x="17" y="14" width="6" height="12" fill="#804f00"/>
+<rect x="17" y="14" width="6" height="1" fill="#a67000"/>
+<rect x="22" y="14" width="1" height="12" fill="#402500"/>
+<polygon points="10,36 40,18 70,36" fill="#c41e16"/>
+<polygon points="14,36 40,20 66,36" fill="#e87a0f" opacity="0.35"/>
+<rect x="10" y="36" width="60" height="42" fill="#ece9d8"/>
+<rect x="10" y="36" width="60" height="2" fill="#ffffff"/>
+<rect x="10" y="36" width="2" height="42" fill="#ffffff"/>
+<rect x="68" y="36" width="2" height="42" fill="#808080"/>
+<rect x="10" y="76" width="60" height="2" fill="#808080"/>
+<rect x="35" y="56" width="10" height="22" fill="#804f00"/>
+<rect x="35" y="56" width="10" height="1" fill="#402500"/>
+<rect x="35" y="56" width="1" height="22" fill="#402500"/>
+<rect x="44" y="56" width="1" height="22" fill="#1a0e00"/>
+<circle cx="42" cy="68" r="1.4" fill="#ffcc00"/>
+<rect x="18" y="46" width="10" height="8" fill="#003da7"/>
+<rect x="18" y="46" width="10" height="1" fill="#000000"/>
+<rect x="18" y="46" width="1" height="8" fill="#000000"/>
+<line x1="23" y1="46" x2="23" y2="54" stroke="#7ab4ff" stroke-width="0.5"/>
+<line x1="18" y1="50" x2="28" y2="50" stroke="#7ab4ff" stroke-width="0.5"/>
+<rect x="52" y="46" width="10" height="8" fill="#003da7"/>
+<rect x="52" y="46" width="10" height="1" fill="#000000"/>
+<rect x="52" y="46" width="1" height="8" fill="#000000"/>
+<line x1="57" y1="46" x2="57" y2="54" stroke="#7ab4ff" stroke-width="0.5"/>
+<line x1="52" y1="50" x2="62" y2="50" stroke="#7ab4ff" stroke-width="0.5"/>
+{{end}}
+
+{{/* house-icon-dialup-center is the same silhouette as the spoke but
+     with warm-lit gold windows - "the lights are on" marker for the
+     user's own household at the hub center. */}}
+{{define "house-icon-dialup-center"}}
+<g class="dialup-house__antenna">
+<path d="M 12 4 A 10 10 0 0 1 28 4" fill="none" stroke="#d69e00" stroke-width="1.5"/>
+<path d="M 8 1 A 14 14 0 0 1 32 1" fill="none" stroke="#d69e00" stroke-width="1" opacity="0.7"/>
+<line x1="20" y1="6" x2="20" y2="18" stroke="#000" stroke-width="1.5"/>
+<circle cx="20" cy="5" r="2" fill="#000"/>
+</g>
+<rect x="17" y="14" width="6" height="12" fill="#804f00"/>
+<rect x="17" y="14" width="6" height="1" fill="#a67000"/>
+<rect x="22" y="14" width="1" height="12" fill="#402500"/>
+<polygon points="10,36 40,18 70,36" fill="#c41e16"/>
+<polygon points="14,36 40,20 66,36" fill="#e87a0f" opacity="0.35"/>
+<rect x="10" y="36" width="60" height="42" fill="#fffbf0"/>
+<rect x="10" y="36" width="60" height="2" fill="#ffffff"/>
+<rect x="10" y="36" width="2" height="42" fill="#ffffff"/>
+<rect x="68" y="36" width="2" height="42" fill="#808080"/>
+<rect x="10" y="76" width="60" height="2" fill="#808080"/>
+<rect x="35" y="56" width="10" height="22" fill="#804f00"/>
+<rect x="35" y="56" width="10" height="1" fill="#402500"/>
+<rect x="35" y="56" width="1" height="22" fill="#402500"/>
+<rect x="44" y="56" width="1" height="22" fill="#1a0e00"/>
+<circle cx="42" cy="68" r="1.4" fill="#ffcc00"/>
+<rect x="18" y="46" width="10" height="8" fill="#ffcc00"/>
+<rect x="18" y="46" width="10" height="1" fill="#d69e00"/>
+<rect x="18" y="46" width="1" height="8" fill="#d69e00"/>
+<line x1="23" y1="46" x2="23" y2="54" stroke="#804f00" stroke-width="0.5"/>
+<line x1="18" y1="50" x2="28" y2="50" stroke="#804f00" stroke-width="0.5"/>
+<rect x="52" y="46" width="10" height="8" fill="#ffcc00"/>
+<rect x="52" y="46" width="10" height="1" fill="#d69e00"/>
+<rect x="52" y="46" width="1" height="8" fill="#d69e00"/>
+<line x1="57" y1="46" x2="57" y2="54" stroke="#804f00" stroke-width="0.5"/>
+<line x1="52" y1="50" x2="62" y2="50" stroke="#804f00" stroke-width="0.5"/>
+{{end}}
+
 {{/* confirm-dialog is a page-level modal triggered by elements that carry
      data-confirm attributes. Replaces the browser confirm() prompt with
      themed UI. Used for Cancel-pending-invite, Disconnect-family, and any

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -146,7 +146,11 @@
   var body = document.getElementById('confirm-dialog__body');
   var submit = document.getElementById('confirm-dialog__submit');
   var cancel = document.getElementById('confirm-dialog__cancel');
+  var titlebarX = dialog.querySelector('.confirm-dialog__titlebar-x');
   cancel.addEventListener('click', function () { dialog.close(); });
+  if (titlebarX) {
+    titlebarX.addEventListener('click', function () { dialog.close(); });
+  }
   dialog.addEventListener('click', function (e) {
     if (e.target === dialog) dialog.close();
   });

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -14,11 +14,11 @@
         <div class="rooms__head">
           <span class="rooms__name">{{.Line.Name}}</span>
           {{if .OnCall}}
-            <span class="chip chip--live"><span class="chip__dot"></span>on a call</span>
+            <span class="chip chip--live"><span class="chip__dot"></span>{{if eq $.User.Theme "dialup"}}on line{{else}}on a call{{end}}</span>
           {{else if .Online}}
-            <span class="chip chip--on"><span class="chip__dot"></span>online</span>
+            <span class="chip chip--on"><span class="chip__dot"></span>{{if eq $.User.Theme "dialup"}}ready{{else}}online{{end}}</span>
           {{else}}
-            <span class="chip"><span class="chip__dot"></span>offline</span>
+            <span class="chip"><span class="chip__dot"></span>{{if eq $.User.Theme "dialup"}}asleep{{else}}offline{{end}}</span>
           {{end}}
         </div>
         <div class="rooms__num num">{{fmtPhone .Line.Number}}</div>

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -69,10 +69,10 @@
     </header>
     <div class="connected-row">
       {{range .LinkedFamilies}}
-      <span class="connected-row__chip">
+      <a class="connected-row__chip" href="/links#family-{{.ID}}">
         <svg viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{template "house-icon"}}</svg>
         <span>{{.Name}}</span>
-      </span>
+      </a>
       {{end}}
     </div>
   </section>

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -92,7 +92,7 @@
     <!-- Neighborhood: two-pane address-book rows -->
     <div class="neighborhood panel">
       {{range .LinkedFamilies}}
-      <div class="neighborhood__row">
+      <div class="neighborhood__row" id="family-{{.ID}}">
         <div class="neighborhood__identity">
           <div class="neighborhood__name">
             <svg class="hub__house" viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{template "house-icon"}}</svg>

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -32,8 +32,12 @@
             </p>
           </div>
           <div class="postcard__stamp" aria-hidden="true">
-            <svg viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">{{template "house-icon"}}</svg>
-            <div>FAMILY MAIL</div>
+            {{if eq .User.Theme "dialup"}}
+              {{template "postcard-stamp-dialup"}}
+            {{else}}
+              <svg viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">{{template "house-icon"}}</svg>
+              <div>FAMILY MAIL</div>
+            {{end}}
           </div>
         </div>
         {{end}}

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -74,7 +74,7 @@
         <div class="hub__spokes">
           {{range .LinkedFamilies}}
           <div class="hub__spoke">
-            <svg class="hub__house" viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{template "house-icon"}}</svg>
+            <svg class="hub__house" viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{if eq $.User.Theme "dialup"}}{{template "house-icon-dialup-spoke"}}{{else}}{{template "house-icon"}}{{end}}</svg>
             <div class="hub__label">{{.Name}}</div>
             {{if .AcceptedAt}}<div class="hub__since">Since {{.AcceptedAt.Format "Jan 2, 2006"}}</div>{{end}}
           </div>
@@ -82,7 +82,7 @@
         </div>
         <div class="hub__rail"></div>
         <div class="hub__center">
-          <svg class="hub__center-house" viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{template "house-icon"}}</svg>
+          <svg class="hub__center-house" viewBox="0 0 80 80" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" aria-hidden="true">{{if eq $.User.Theme "dialup"}}{{template "house-icon-dialup-center"}}{{else}}{{template "house-icon"}}{{end}}</svg>
           <div class="hub__center-name">{{if $.HouseholdName}}{{$.HouseholdName}}{{else}}Your household{{end}}</div>
           <div class="hub__center-sub">You</div>
         </div>

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -341,30 +341,32 @@
 
   function update() {
     var m = scrollMetrics();
+    var viewTop = m.scrollTop;
+    var viewBottom = viewTop + m.viewHeight;
 
-    // Bottom-of-page clamp: if the content overflows AND we've
-    // scrolled to the end, the last section is "what you're looking
-    // at" regardless of its top. Guard on pageHeight > viewHeight so
-    // this doesn't latch on a short page where scrollTop is simply
-    // pinned at 0 (false-positive that would always select the last
-    // nav item at rest).
-    if (m.pageHeight > m.viewHeight + 4 && m.scrollTop + m.viewHeight >= m.pageHeight - 4) {
-      setActive(sections[sections.length - 1].id);
-      return;
-    }
-
-    // Walk sections top-down and keep the last one whose top sits
-    // above the focus line (25% from the top of the viewport).
-    var focusLine = m.scrollTop + m.viewHeight * 0.25;
-    var active = sections[0];
+    // Pick the section whose visible area inside the scroller's
+    // viewport is the largest. This naturally handles the edges:
+    //   - At the very top, Account fills the viewport and wins.
+    //   - Mid-scroll, whichever section occupies the most of what
+    //     the user is looking at is the active one.
+    //   - At the bottom, the final short section has the most
+    //     visible area and latches cleanly -- no special-case clamp.
+    // Ties go to the later section (>=), so on exact boundaries the
+    // highlight advances with scroll direction rather than getting
+    // stuck on the earlier section.
+    var bestSec = sections[0];
+    var bestVisible = -1;
     for (var i = 0; i < sections.length; i++) {
-      if (sectionTopRelative(sections[i]) <= focusLine) {
-        active = sections[i];
-      } else {
-        break;
+      var sec = sections[i];
+      var top = sectionTopRelative(sec);
+      var bottom = top + sec.offsetHeight;
+      var visible = Math.max(0, Math.min(bottom, viewBottom) - Math.max(top, viewTop));
+      if (visible >= bestVisible) {
+        bestVisible = visible;
+        bestSec = sec;
       }
     }
-    setActive(active.id);
+    setActive(bestSec.id);
   }
 
   // rAF-throttle so rapid scroll events don't thrash the DOM.

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -306,10 +306,17 @@
     if (byId[id]) byId[id].classList.add('is-active');
   }
 
-  // Resolve the real scroll container. In CRT-all mode the
-  // .dialup-window is the scroller (overflow-y: auto inside the
-  // bezel). Otherwise the page itself scrolls via window.
-  var scroller = document.querySelector('body.crt-all .dialup-window');
+  // Resolve the real scroll container, in priority order:
+  //   1. body.crt-all  -> .dialup-window (scroll lives inside the CRT bezel)
+  //   2. body.dialup   -> .dialup-main   (non-CRT dialup locks the window to viewport)
+  //   3. otherwise     -> window (intercom theme, plain page scroll)
+  var body = document.body;
+  var scroller = null;
+  if (body.classList.contains('crt-all')) {
+    scroller = document.querySelector('.crt__screen > .dialup-window');
+  } else if (body.classList.contains('dialup')) {
+    scroller = document.querySelector('.dialup-main');
+  }
   function scrollMetrics() {
     if (scroller) {
       return {
@@ -337,9 +344,13 @@
   function update() {
     var m = scrollMetrics();
 
-    // Bottom-of-page clamp: if there's no more scroll room, the last
-    // section is "what you're looking at" regardless of its top.
-    if (m.scrollTop + m.viewHeight >= m.pageHeight - 4) {
+    // Bottom-of-page clamp: if the content overflows AND we've
+    // scrolled to the end, the last section is "what you're looking
+    // at" regardless of its top. Guard on pageHeight > viewHeight so
+    // this doesn't latch on a short page where scrollTop is simply
+    // pinned at 0 (false-positive that would always select the last
+    // nav item at rest).
+    if (m.pageHeight > m.viewHeight + 4 && m.scrollTop + m.viewHeight >= m.pageHeight - 4) {
       setActive(sections[sections.length - 1].id);
       return;
     }

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -383,6 +383,14 @@
     setActive(chosen.id);
   }
 
+  // When the user clicks a nav item we want the clicked section to
+  // stay highlighted across the smooth-scroll. Without this, the
+  // scroll animation triggers scroll events -> spy re-runs -> the
+  // section currently under the focus line (typically the NEXT one)
+  // wins, so the highlight jumps away from what the user clicked.
+  // spyLockedUntil suspends the spy until the smooth-scroll settles.
+  var spyLockedUntil = 0;
+
   // rAF-throttle so rapid scroll events don't thrash the DOM.
   var scheduled = false;
   function onScroll() {
@@ -390,6 +398,7 @@
     scheduled = true;
     window.requestAnimationFrame(function () {
       scheduled = false;
+      if (Date.now() < spyLockedUntil) return;
       update();
     });
   }
@@ -410,9 +419,31 @@
   }
 
   links.forEach(function (link) {
-    link.addEventListener('click', function () {
+    link.addEventListener('click', function (e) {
+      // Let modifier-clicks (new tab, new window) keep native behavior.
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
       var hash = link.getAttribute('href') || '';
-      if (hash.charAt(0) === '#') setActive(hash.slice(1));
+      if (hash.charAt(0) !== '#') return;
+      var id = hash.slice(1);
+      var target = document.getElementById(id);
+      if (!target) return;
+
+      e.preventDefault();
+      setActive(id);
+      // Lock spy across the smooth-scroll so the click-chosen item
+      // doesn't get overridden by the scroll events the animation
+      // generates.
+      spyLockedUntil = Date.now() + 800;
+
+      var top = sectionTopRelative(target);
+      if (scroller) {
+        scroller.scrollTo({ top: top, behavior: 'smooth' });
+      } else {
+        window.scrollTo({ top: top, behavior: 'smooth' });
+      }
+
+      // Update the URL hash without triggering a second browser jump.
+      if (history.replaceState) history.replaceState(null, '', hash);
     });
   });
 })();

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -306,17 +306,15 @@
     if (byId[id]) byId[id].classList.add('is-active');
   }
 
-  // Resolve the real scroll container, in priority order:
-  //   1. body.crt-all  -> .dialup-window (scroll lives inside the CRT bezel)
-  //   2. body.dialup   -> .dialup-main   (non-CRT dialup locks the window to viewport)
-  //   3. otherwise     -> window (intercom theme, plain page scroll)
+  // Resolve the real scroll container. For either dialup variant
+  // (CRT-all or non-CRT), the innermost scroll container is
+  // .dialup-main -- both have overflow: auto set on it, and the
+  // window / bezel above just frames it without scrolling. Intercom
+  // falls through to window-level scrolling.
   var body = document.body;
-  var scroller = null;
-  if (body.classList.contains('crt-all')) {
-    scroller = document.querySelector('.crt__screen > .dialup-window');
-  } else if (body.classList.contains('dialup')) {
-    scroller = document.querySelector('.dialup-main');
-  }
+  var scroller = body.classList.contains('dialup')
+    ? document.querySelector('.dialup-main')
+    : null;
   function scrollMetrics() {
     if (scroller) {
       return {

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -344,29 +344,37 @@
     var viewTop = m.scrollTop;
     var viewBottom = viewTop + m.viewHeight;
 
-    // Pick the section whose visible area inside the scroller's
-    // viewport is the largest. This naturally handles the edges:
-    //   - At the very top, Account fills the viewport and wins.
-    //   - Mid-scroll, whichever section occupies the most of what
-    //     the user is looking at is the active one.
-    //   - At the bottom, the final short section has the most
-    //     visible area and latches cleanly -- no special-case clamp.
-    // Ties go to the later section (>=), so on exact boundaries the
-    // highlight advances with scroll direction rather than getting
-    // stuck on the earlier section.
-    var bestSec = sections[0];
-    var bestVisible = -1;
+    // Primary rule: the last section whose top sits above a focus
+    // line ~25% down the viewport is "what you're reading." This
+    // advances the highlight cleanly as you scroll, without a short
+    // early section losing to a tall later one.
+    var focusLine = viewTop + m.viewHeight * 0.25;
+    var chosen = sections[0];
     for (var i = 0; i < sections.length; i++) {
-      var sec = sections[i];
-      var top = sectionTopRelative(sec);
-      var bottom = top + sec.offsetHeight;
-      var visible = Math.max(0, Math.min(bottom, viewBottom) - Math.max(top, viewTop));
-      if (visible >= bestVisible) {
-        bestVisible = visible;
-        bestSec = sec;
-      }
+      if (sectionTopRelative(sections[i]) <= focusLine) chosen = sections[i];
+      else break;
     }
-    setActive(bestSec.id);
+
+    // Bottom-of-page fallback: if that chosen section is entirely
+    // outside the viewport (typical at max scroll, where the focus
+    // line can't reach the last one or two sections), pick whichever
+    // section has the most visible pixels instead. Guarantees the
+    // highlight stays on something the user can actually see.
+    var chosenTop = sectionTopRelative(chosen);
+    var chosenBottom = chosenTop + chosen.offsetHeight;
+    if (chosenBottom <= viewTop || chosenTop >= viewBottom) {
+      var bestSec = chosen;
+      var bestVisible = -1;
+      for (var j = 0; j < sections.length; j++) {
+        var top = sectionTopRelative(sections[j]);
+        var bottom = top + sections[j].offsetHeight;
+        var visible = Math.max(0, Math.min(bottom, viewBottom) - Math.max(top, viewTop));
+        if (visible > bestVisible) { bestVisible = visible; bestSec = sections[j]; }
+      }
+      chosen = bestSec;
+    }
+
+    setActive(chosen.id);
   }
 
   // rAF-throttle so rapid scroll events don't thrash the DOM.

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -275,4 +275,57 @@
   {{template "page-footer" .}}
 
 </div>
+<script>
+(function () {
+  // Settings section scrollspy: highlights the .settings-nav item
+  // whose target section is currently in the middle of the viewport.
+  // Also updates on click so the active state switches instantly,
+  // before the scroll animation has caught up.
+  var nav = document.querySelector('.settings-nav');
+  if (!nav || typeof IntersectionObserver === 'undefined') return;
+  var links = nav.querySelectorAll('.settings-nav__item');
+  if (!links.length) return;
+
+  var byId = {};
+  var sections = [];
+  links.forEach(function (link) {
+    var hash = link.getAttribute('href') || '';
+    if (hash.charAt(0) !== '#') return;
+    var id = hash.slice(1);
+    var sec = document.getElementById(id);
+    if (!sec) return;
+    byId[id] = link;
+    sections.push(sec);
+  });
+  if (!sections.length) return;
+
+  function setActive(id) {
+    links.forEach(function (l) { l.classList.remove('is-active'); });
+    if (byId[id]) byId[id].classList.add('is-active');
+  }
+
+  // rootMargin carves a horizontal band roughly 20-30% from the top of
+  // the viewport; the section crossing that band is the active one.
+  var observer = new IntersectionObserver(function (entries) {
+    var best = null;
+    var bestTop = Infinity;
+    entries.forEach(function (e) {
+      if (e.isIntersecting && e.boundingClientRect.top < bestTop) {
+        best = e.target;
+        bestTop = e.boundingClientRect.top;
+      }
+    });
+    if (best) setActive(best.id);
+  }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+
+  sections.forEach(function (s) { observer.observe(s); });
+
+  links.forEach(function (link) {
+    link.addEventListener('click', function () {
+      var hash = link.getAttribute('href') || '';
+      if (hash.charAt(0) === '#') setActive(hash.slice(1));
+    });
+  });
+})();
+</script>
 {{end}}

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -278,11 +278,13 @@
 <script>
 (function () {
   // Settings section scrollspy: highlights the .settings-nav item
-  // whose target section is currently in the middle of the viewport.
-  // Also updates on click so the active state switches instantly,
-  // before the scroll animation has caught up.
+  // whose target section is currently under a focus line about 25%
+  // down the viewport. When the viewport is at the bottom of the page
+  // (typical for short final sections that can't scroll up to the
+  // focus line), force the last section's link active so the user
+  // can still "reach" it.
   var nav = document.querySelector('.settings-nav');
-  if (!nav || typeof IntersectionObserver === 'undefined') return;
+  if (!nav) return;
   var links = nav.querySelectorAll('.settings-nav__item');
   if (!links.length) return;
 
@@ -304,21 +306,73 @@
     if (byId[id]) byId[id].classList.add('is-active');
   }
 
-  // rootMargin carves a horizontal band roughly 20-30% from the top of
-  // the viewport; the section crossing that band is the active one.
-  var observer = new IntersectionObserver(function (entries) {
-    var best = null;
-    var bestTop = Infinity;
-    entries.forEach(function (e) {
-      if (e.isIntersecting && e.boundingClientRect.top < bestTop) {
-        best = e.target;
-        bestTop = e.boundingClientRect.top;
-      }
-    });
-    if (best) setActive(best.id);
-  }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+  // Resolve the real scroll container. In CRT-all mode the
+  // .dialup-window is the scroller (overflow-y: auto inside the
+  // bezel). Otherwise the page itself scrolls via window.
+  var scroller = document.querySelector('body.crt-all .dialup-window');
+  function scrollMetrics() {
+    if (scroller) {
+      return {
+        scrollTop: scroller.scrollTop,
+        viewHeight: scroller.clientHeight,
+        pageHeight: scroller.scrollHeight,
+      };
+    }
+    var doc = document.documentElement;
+    return {
+      scrollTop: window.scrollY || doc.scrollTop,
+      viewHeight: window.innerHeight || doc.clientHeight,
+      pageHeight: Math.max(doc.scrollHeight, document.body.scrollHeight),
+    };
+  }
 
-  sections.forEach(function (s) { observer.observe(s); });
+  function sectionTopRelative(sec) {
+    // Position of section top within the scroller's coordinate system.
+    if (scroller) {
+      return sec.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop;
+    }
+    return sec.getBoundingClientRect().top + (window.scrollY || document.documentElement.scrollTop);
+  }
+
+  function update() {
+    var m = scrollMetrics();
+
+    // Bottom-of-page clamp: if there's no more scroll room, the last
+    // section is "what you're looking at" regardless of its top.
+    if (m.scrollTop + m.viewHeight >= m.pageHeight - 4) {
+      setActive(sections[sections.length - 1].id);
+      return;
+    }
+
+    // Walk sections top-down and keep the last one whose top sits
+    // above the focus line (25% from the top of the viewport).
+    var focusLine = m.scrollTop + m.viewHeight * 0.25;
+    var active = sections[0];
+    for (var i = 0; i < sections.length; i++) {
+      if (sectionTopRelative(sections[i]) <= focusLine) {
+        active = sections[i];
+      } else {
+        break;
+      }
+    }
+    setActive(active.id);
+  }
+
+  // rAF-throttle so rapid scroll events don't thrash the DOM.
+  var scheduled = false;
+  function onScroll() {
+    if (scheduled) return;
+    scheduled = true;
+    window.requestAnimationFrame(function () {
+      scheduled = false;
+      update();
+    });
+  }
+
+  var scrollTarget = scroller || window;
+  scrollTarget.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll);
+  update();
 
   links.forEach(function (link) {
     link.addEventListener('click', function () {

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -345,14 +345,14 @@
     var viewBottom = viewTop + m.viewHeight;
 
     // Focus line slides with scroll progress so every section can
-    // reach it. At the top it sits at 25% down the viewport (so the
-    // first section wins while the page is at rest); at the bottom
-    // it sits near 85% (so the last section activates before we run
-    // out of scroll room on a short final section). Linear blend
-    // between the two based on progress through the scrollable range.
+    // reach it AND each section gets a wide-enough active window.
+    // Starting lower (0.10) at the top keeps the first section
+    // highlighted until the user has scrolled well past it; ending
+    // higher (0.90) at the bottom lets the last section activate
+    // before we run out of scroll room on a short final section.
     var maxScroll = Math.max(0, m.pageHeight - m.viewHeight);
     var progress = maxScroll > 0 ? Math.min(1, viewTop / maxScroll) : 0;
-    var factor = 0.25 + 0.60 * progress;
+    var factor = 0.10 + 0.80 * progress;
     var focusLine = viewTop + m.viewHeight * factor;
 
     var chosen = sections[0];
@@ -397,7 +397,17 @@
   var scrollTarget = scroller || window;
   scrollTarget.addEventListener('scroll', onScroll, { passive: true });
   window.addEventListener('resize', onScroll);
+
+  // Run once now and again after the page has settled. Section top
+  // positions depend on final layout (font loading, any late-loaded
+  // chrome in the window frame), so the very first call can run
+  // against preliminary geometry -- belt-and-suspenders so the
+  // highlight lands on the right item on first paint.
   update();
+  window.addEventListener('load', update);
+  if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+    document.fonts.ready.then(update);
+  }
 
   links.forEach(function (link) {
     link.addEventListener('click', function () {

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -344,22 +344,28 @@
     var viewTop = m.scrollTop;
     var viewBottom = viewTop + m.viewHeight;
 
-    // Primary rule: the last section whose top sits above a focus
-    // line ~25% down the viewport is "what you're reading." This
-    // advances the highlight cleanly as you scroll, without a short
-    // early section losing to a tall later one.
-    var focusLine = viewTop + m.viewHeight * 0.25;
+    // Focus line slides with scroll progress so every section can
+    // reach it. At the top it sits at 25% down the viewport (so the
+    // first section wins while the page is at rest); at the bottom
+    // it sits near 85% (so the last section activates before we run
+    // out of scroll room on a short final section). Linear blend
+    // between the two based on progress through the scrollable range.
+    var maxScroll = Math.max(0, m.pageHeight - m.viewHeight);
+    var progress = maxScroll > 0 ? Math.min(1, viewTop / maxScroll) : 0;
+    var factor = 0.25 + 0.60 * progress;
+    var focusLine = viewTop + m.viewHeight * factor;
+
     var chosen = sections[0];
     for (var i = 0; i < sections.length; i++) {
       if (sectionTopRelative(sections[i]) <= focusLine) chosen = sections[i];
       else break;
     }
 
-    // Bottom-of-page fallback: if that chosen section is entirely
-    // outside the viewport (typical at max scroll, where the focus
-    // line can't reach the last one or two sections), pick whichever
-    // section has the most visible pixels instead. Guarantees the
-    // highlight stays on something the user can actually see.
+    // Safety net: if the chosen section is entirely outside the
+    // viewport (e.g., because the final section is smaller than
+    // what remains of the page between it and the focus line), fall
+    // back to whichever section has the most visible pixels. Keeps
+    // the highlight on something the user can actually see.
     var chosenTop = sectionTopRelative(chosen);
     var chosenBottom = chosenTop + chosen.offsetHeight;
     if (chosenBottom <= viewTop || chosenTop >= viewBottom) {

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -178,9 +178,9 @@
         <label class="theme-card {{if eq .User.Theme "dialup"}}theme-card--selected{{end}}">
           <input type="radio" name="theme" value="dialup" {{if eq .User.Theme "dialup"}}checked{{end}}>
           <span class="theme-card__swatch">
-            <span class="theme-card__swatch-strip" style="background: #0a3a8a;"></span>
-            <span class="theme-card__swatch-strip" style="background: #7ab4ff;"></span>
-            <span class="theme-card__swatch-strip" style="background: #f0c020;"></span>
+            <span class="theme-card__swatch-strip" style="background: #ece9d8;"></span>
+            <span class="theme-card__swatch-strip" style="background: #003da7;"></span>
+            <span class="theme-card__swatch-strip" style="background: #ffcc00;"></span>
           </span>
           <span class="theme-card__body">
             <span class="theme-card__name">Online service 1997</span>

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -432,8 +432,13 @@
       setActive(id);
       // Lock spy across the smooth-scroll so the click-chosen item
       // doesn't get overridden by the scroll events the animation
-      // generates.
+      // generates. Primary unlock signal is the scrollend event
+      // (Chrome/Firefox/Edge); the 800ms timeout is a fallback for
+      // older browsers and a ceiling if the animation stalls.
       spyLockedUntil = Date.now() + 800;
+      scrollTarget.addEventListener('scrollend', function () {
+        spyLockedUntil = 0;
+      }, { once: true });
 
       var top = sectionTopRelative(target);
       if (scroller) {


### PR DESCRIPTION
## What

Closes #214. Ports the #218 intercom redesign to the dialup theme. Every new CSS class (`.rooms`, `.today-list`, `.connected-row`, `.neighborhood`, `.postcard`, `.settings-layout`, `.theme-card`, `.confirm-dialog`) gets a fully-committed dial-up-client-era treatment. The Families hub is re-authored as a pixel-art neighborhood of homes (Option D: houses throughout, each with roof-mounted antenna + signal arcs; center house has warm-lit gold windows). The confirm dialog becomes a proper Win98 modal with titlebar and warning glyph.

## Why

#218 shipped placeholder dialup CSS so nothing broke during rollout, but the placeholders read as intercom HTML wearing thin bevels. The existing dialup chrome is heavily committed (CRT bezel, Keyword bar, CHANNELS sidebar, AOL-1997 client vocabulary); the content area now matches that bar.

## Screenshots

### Dashboard
![Dashboard](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-01-dashboard.png)

### Families — hub as neighborhood
![Families hub](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-02-families.png)

### Families — invite postcard with neighborhood postmark
![Postcard](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-03-postcard.png)

### Settings — sticky side-nav
![Settings](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-04-settings.png)

### Settings — theme cards (dialup swatches now match the theme tokens)
![Theme cards](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-05-theme-cards.png)

### Confirm dialog — Win98 modal chrome
![Confirm dialog](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-06-confirm-dialog.png)

### Intercom regression — unchanged
![Intercom](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-224-07-intercom-regression.png)

## Highlights

- **Hub as houses, not PCs.** Each family is a chunky Win98 pixel-art house with a roof antenna and gold signal arcs. Center house has warm-lit gold windows ("lights are on"); spokes have dark-blue windows (phone-line color). Product-true metaphor over literal Network-Neighborhood-icon purity.
- **ON LINE badge.** Active-call chip in the rooms grid uses period-native dial-up status vocabulary ("ON LINE" / "READY" / "ASLEEP") on a 2s blink cycle. Chip restyle is scoped to `.rooms__card` so other chip contexts keep their existing look.
- **Neighborhood as address-book.** Replaced the grid-of-tiny-cells placeholder with a single-column list per family, dotted-leader separators.
- **Postcard with postmark.** Dialup theme swaps the soft house-icon stamp for a gold-dashed pixel-art "DIGITS · NEIGHBORHOOD" postmark.
- **Sticky settings side-nav with scrollspy.** Pure-JS spy uses a focus line that slides 10% → 90% with scroll progress so every section gets an active window without special-casing the edges. Click-locks during smooth-scroll so the clicked item stays highlighted. Works in CRT-all, non-CRT dialup, and intercom (different scroll containers in each).
- **Win98 confirm-dialog.** Gradient titlebar, warning glyph, chunky bevels, hard shadow. Reuses existing `.btn--quiet` / `.btn--danger` so focus / hover already work.
- **Connected-row chips now link.** Each chip on the Dashboard anchors to `/links#family-<id>`; the matching neighborhood row picks up the id. Intercom + dialup both get hover states on the anchor.

## Adjacent fixes landed alongside

- **CRT scroll.** In CRT-all mode, `.dialup-window` sits inside `.crt__screen` which clips with `overflow: hidden`; the window's `min-height` exceeded the bezel, clipping anything below the fold. Made the window a flex child of the screen and let `.dialup-main` scroll inside it; scanline + vignette overlays stay fixed to the bezel frame.
- **Non-CRT dialup "browser window" scaling.** Symmetric fix: `body.dialup:not(.crt-all)` now locks to 100vh with `overflow: hidden` and `.dialup-window` takes `max-height: calc(100vh - 16px)`, so title/menu/toolbar/Keyword bar stay fixed and `.dialup-main` is the scroll container.
- **devseed full scenario.** `make dev-seed` now populates the primary dialup user with three lines, two linked families (Grandma Lindh, The Coopers) with their own lines, and one outstanding pending invite, so every redesigned surface renders with real data. Idempotent; `-minimal` flag restores the old one-user-no-lines behavior for onboarding-flow tests.
- **DEV_MODE disk-serve.** `/static/*` now serves from disk instead of the embedded FS when DEV_MODE=true, so CSS/JS edits are visible on browser reload without rebuilding signald. Production remains self-contained via `//go:embed`.
- **Cross-test pollution guard.** `TestSpecDialupHubGlyph` now resets the shared test-user theme on exit so it doesn't poison `TestSpecFamilies`.

## Scope

Dialup CSS + three new SVG / markup partials + theme-conditional swaps in `links.html` and `dashboard.html` + confirm-dialog markup extension + CLAUDE.md docs. No handler logic / business-logic changes. Intercom theme is visually unchanged (regression walk confirmed, see screenshot above).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (unit)
- [x] `go test -tags=integration ./internal/web/...` passes (integration, including new `TestSpecDialupHubGlyph` and updated swatch assertions)
- [x] Manual smoke in dialup theme: every redesigned surface reviewed iteratively, both CRT-on and CRT-off
- [x] Intercom regression walk: no visual changes on Dashboard, Families, Settings, etc.