### PR TITLE
fix(server): drop CRT bezel on portrait mobile

### DIFF
--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2086,6 +2086,50 @@ body.crt-all .crt__brand::after {
   body.crt-all .crt__brand { bottom: 8px; font-size: 9px; letter-spacing: 0.3em; }
 }
 
+/* Portrait mobile: drop the CRT bezel entirely (closes #225). The bezel
+   is a desktop-era frame; at phone-portrait aspect ratios the filled
+   rectangle leaves dead teal around the dialup window, doesn't track
+   the inner chrome's rounded corners, and pushes the DIGITS ONLINE
+   brand label well below the fold. Fall back to the same viewport
+   lock the non-CRT path uses so the dialup window still scales to
+   100vh with chrome pinned and .dialup-main scrolling inside. */
+@media (max-width: 640px) and (orientation: portrait) {
+  body.crt-all {
+    height: 100vh;
+    overflow: hidden;
+  }
+  body.crt-all .crt {
+    display: contents;
+    background: none;
+    position: static;
+    perspective: none;
+  }
+  body.crt-all .crt__screen {
+    position: static;
+    display: block;
+    width: auto;
+    max-width: none;
+    height: auto;
+    max-height: none;
+    padding: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+    overflow: visible;
+    aspect-ratio: auto;
+  }
+  body.crt-all .crt__screen::before,
+  body.crt-all .crt__screen::after { display: none; }
+  body.crt-all .crt__brand { display: none; }
+  body.crt-all .crt__screen > .dialup-window {
+    flex: initial;
+    overflow-y: visible;
+    min-height: calc(100vh - 16px);
+    max-height: calc(100vh - 16px);
+  }
+}
+
 /* Dialup: the Ringer panel is a Win95 groupbox-style frame. The checkbox
    uses native rendering with the Win95 highlight blue. */
 body.dialup .checkbox-row {


### PR DESCRIPTION
Closes #225.

## What

Drops the CRT bezel on portrait mobile viewports (`max-width: 640px and orientation: portrait`). Landscape mobile and desktop are unchanged.

## Why

The CRT frame is a desktop-era conceit — at a phone's portrait aspect ratio it rendered as a tall flat rectangle that (a) didn't hug its contents, (b) cut the inner chrome's rounded corners with its own flat edges, and (c) pushed the `DIGITS · ONLINE` brand label below the fold. Screenshot in #225 shows the state before the fix.

## How

CSS-only. Added a `@media (max-width: 640px) and (orientation: portrait)` branch that:

- Reverts `.crt` / `.crt__screen` to the same `display: contents` passthrough the non-CRT path uses (transparent, no position, no shadow, no transform).
- Hides the scanline + vignette overlays and the `DIGITS ONLINE` brand label.
- Applies the same `body { height: 100vh; overflow: hidden; }` viewport lock the non-CRT dialup path uses, so `.dialup-window` fills the viewport with `.dialup-main` as the inner scroll container.
- Pins `.dialup-window` back to its natural `min-height: calc(100vh - 16px)` (my earlier CRT-scroll fix had reset it to `0` for the bezel chain, which on this code path would let the window shrink to content and leave dead space).

No template changes, no Go changes.

## Screenshots

### Before — portrait mobile (412×915)
The issue this PR closes: bezel dominates, dead teal around the window, brand label in the lower dead zone.

![Before](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-01-before-portrait.png)

### After — portrait mobile, Dashboard
Bezel dropped. Dialup window fills the viewport cleanly; status bar at bottom.

![After dashboard](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-02-after-portrait-dashboard.png)

### After — portrait mobile, Families
Hub with all three houses + antennas, neighborhood rows below.

![After families](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-03-after-portrait-families.png)

### After — portrait mobile, Settings
Sticky side-nav collapses to the horizontal row layout (existing behavior at <680px), theme cards and all sections render.

![After settings](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-04-after-portrait-settings.png)

### Unchanged — landscape mobile (915×412) keeps the bezel

![Landscape bezel](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-05-after-landscape-mobile.png)

### Unchanged — desktop (1280×820) keeps the bezel

![Desktop bezel](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-226-06-after-desktop-regression.png)

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (unit)
- [x] `go test -tags=integration ./internal/web/...` passes (integration, no changes to asserted markup)
- [x] Manual verification at 412×915 (portrait phone), 915×412 (landscape phone), 1280×820 (desktop) via `agent-browser` — screenshots above confirm only portrait changed.