### PR TITLE
feat(server): link-health telemetry plumbing

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -573,7 +573,7 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 				}
 				return sig.Send(&sigclient.Message{Type: sigclient.TypeLinkHealth, LinkHealth: payload})
 			}
-			reporter := owebrtc.NewReporter(pm.PeerConnection(), send, interval)
+			reporter := owebrtc.NewReporter(pm, send, interval)
 			go reporter.Run(rctx)
 		} else {
 			d.mu.Unlock()

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -88,6 +89,12 @@ type daemonCallbacks struct {
 	isCaller         bool     // true if we initiated the current call
 	isRestartingICE  bool     // true while an ICE restart is in progress
 	restartTimer     *time.Timer // timeout for ICE restart attempt
+
+	// Link-health reporter: spawned when a call reaches Connected, canceled on teardown.
+	// Protected by mu.
+	reporterCancel      context.CancelFunc
+	linkHealthDisabled  bool
+	linkHealthInterval  time.Duration
 }
 
 // sendSignal sends a signaling message and logs failures.
@@ -446,6 +453,13 @@ func (d *daemonCallbacks) HangupCall() {
 		d.pipeline.Stop()
 		d.pipeline = nil
 	}
+	// Cancel link-health reporter before closing the PeerConnection so
+	// GetStats() is never called on a closed peer.
+	if d.reporterCancel != nil {
+		d.reporterCancel()
+		d.reporterCancel = nil
+	}
+
 	if d.peerMgr != nil {
 		if err := d.peerMgr.Close(); err != nil {
 			slog.Warn("peerMgr close failed", "error", err)
@@ -539,7 +553,31 @@ func (d *daemonCallbacks) handleConnectionStateChange(state webrtc.PeerConnectio
 			d.restartTimer.Stop()
 			d.restartTimer = nil
 		}
-		d.mu.Unlock()
+		// Spawn the link-health reporter once per call (not on ICE restart recovery).
+		if !d.linkHealthDisabled && d.reporterCancel == nil && d.peerMgr != nil {
+			rctx, cancel := context.WithCancel(context.Background())
+			d.reporterCancel = cancel
+			pm := d.peerMgr
+			sig := d.sig
+			interval := d.linkHealthInterval
+			d.mu.Unlock()
+			send := func(s owebrtc.Sample) error {
+				payload := &sigclient.LinkHealthPayload{
+					TS:       s.TS.UnixMilli(),
+					LossPct:  s.LossPct,
+					JitterMs: s.JitterMs,
+					RttMs:    s.RttMs,
+					ConnType: s.ConnType,
+					BytesIn:  s.BytesIn,
+					BytesOut: s.BytesOut,
+				}
+				return sig.Send(&sigclient.Message{Type: sigclient.TypeLinkHealth, LinkHealth: payload})
+			}
+			reporter := owebrtc.NewReporter(pm.PeerConnection(), send, interval)
+			go reporter.Run(rctx)
+		} else {
+			d.mu.Unlock()
+		}
 		if wasRestarting {
 			slog.Info("webrtc: ICE restart succeeded -- connection recovered")
 		}
@@ -1235,16 +1273,31 @@ func main() {
 	})
 
 	// 7. Create callbacks
+
+	// Link-health env vars: kill switch and cadence.
+	linkHealthDisabled := os.Getenv("DIGITSD_LINK_HEALTH_DISABLED") == "1"
+	linkHealthIntervalMs := 2000
+	if v := os.Getenv("DIGITSD_LINK_HEALTH_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			linkHealthIntervalMs = n
+		} else {
+			slog.Warn("invalid DIGITSD_LINK_HEALTH_INTERVAL_MS; using default", "raw", v)
+		}
+	}
+	linkHealthInterval := time.Duration(linkHealthIntervalMs) * time.Millisecond
+
 	cb := &daemonCallbacks{
-		serial:       sp,
-		sig:          sig,
-		mixer:        mixer,
-		serviceCodes: svcCodes,
-		encoder:      enc,
-		decoder:      dec,
-		number:       effectiveNumber,
-		cfg:          cfg,
-		debugMode:    os.Getenv("DIGITS_DEBUG") == "1",
+		serial:             sp,
+		sig:                sig,
+		mixer:              mixer,
+		serviceCodes:       svcCodes,
+		encoder:            enc,
+		decoder:            dec,
+		number:             effectiveNumber,
+		cfg:                cfg,
+		debugMode:          os.Getenv("DIGITS_DEBUG") == "1",
+		linkHealthDisabled: linkHealthDisabled,
+		linkHealthInterval: linkHealthInterval,
 	}
 	if cfg.DeviceToken != "" {
 		cb.paired.Store(true)

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -51,7 +51,25 @@ const (
 	// TypeLineSettings is sent by the server to push an updated Settings blob
 	// for the line this device is registered as. Applied live.
 	TypeLineSettings = "line_settings"
+
+	// TypeLinkHealth is sent by the phone to the server with a per-call
+	// quality telemetry snapshot. Phone → Server only.
+	TypeLinkHealth = "link_health"
 )
+
+// LinkHealthPayload carries per-sample call-quality telemetry from phone to
+// signald. Mirrors server/internal/signaling.LinkHealthPayload; the two must
+// stay in sync. All numeric fields are pointers so "not available" is omitted
+// from JSON.
+type LinkHealthPayload struct {
+	TS       int64    `json:"ts"`
+	LossPct  *float32 `json:"loss_pct,omitempty"`
+	JitterMs *float32 `json:"jitter_ms,omitempty"`
+	RttMs    *float32 `json:"rtt_ms,omitempty"`
+	ConnType string   `json:"conn_type,omitempty"`
+	BytesIn  *int64   `json:"bytes_in,omitempty"`
+	BytesOut *int64   `json:"bytes_out,omitempty"`
+}
 
 // ContactEntry represents a single contact in a sync payload.
 type ContactEntry struct {
@@ -116,6 +134,9 @@ type Message struct {
 
 	// Per-line settings updates (line_settings messages)
 	LineSettings *LineSettings `json:"line_settings,omitempty"`
+
+	// Link-health telemetry (link_health messages)
+	LinkHealth *LinkHealthPayload `json:"link_health,omitempty"`
 }
 
 // ParseMessage deserializes a JSON-encoded signaling message.

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -1,6 +1,8 @@
 package signal
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -168,5 +170,80 @@ func TestParseSyncRequest(t *testing.T) {
 	}
 	if parsed.Type != TypeSync {
 		t.Errorf("expected type %q, got %q", TypeSync, parsed.Type)
+	}
+}
+
+func TestLinkHealthRoundTrip(t *testing.T) {
+	loss := float32(1.2)
+	jitter := float32(15.4)
+	rtt := float32(72.0)
+	in := int64(1000)
+	out := int64(950)
+	m := &Message{
+		Type: TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{
+			TS:       1714000000000,
+			LossPct:  &loss,
+			JitterMs: &jitter,
+			RttMs:    &rtt,
+			ConnType: "srflx",
+			BytesIn:  &in,
+			BytesOut: &out,
+		},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Message
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Type != TypeLinkHealth {
+		t.Fatalf("type: got %q want %q", got.Type, TypeLinkHealth)
+	}
+	if got.LinkHealth == nil {
+		t.Fatal("LinkHealth nil")
+	}
+	if got.LinkHealth.ConnType != "srflx" {
+		t.Fatalf("ConnType: got %q", got.LinkHealth.ConnType)
+	}
+	if got.LinkHealth.LossPct == nil || *got.LinkHealth.LossPct != 1.2 {
+		t.Fatalf("LossPct mismatch")
+	}
+}
+
+func TestLinkHealthOmitEmpty(t *testing.T) {
+	m := &Message{Type: TypeLinkHealth, LinkHealth: &LinkHealthPayload{TS: 1, ConnType: "host"}}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte(`"loss_pct"`)) {
+		t.Fatalf("expected loss_pct to be omitted, got %s", data)
+	}
+}
+
+func TestLinkHealthParseOmittedFieldsAreNil(t *testing.T) {
+	data := []byte(`{"type":"link_health","link_health":{"ts":1714000000000,"conn_type":"host"}}`)
+	var m Message
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.LinkHealth == nil {
+		t.Fatal("LinkHealth nil")
+	}
+	if m.LinkHealth.LossPct != nil {
+		t.Fatal("LossPct should be nil when omitted")
+	}
+	if m.LinkHealth.JitterMs != nil || m.LinkHealth.RttMs != nil ||
+		m.LinkHealth.BytesIn != nil || m.LinkHealth.BytesOut != nil {
+		t.Fatal("all optional pointer fields should be nil when omitted")
+	}
+	if m.LinkHealth.TS != 1714000000000 {
+		t.Fatalf("TS: got %v", m.LinkHealth.TS)
+	}
+	if m.LinkHealth.ConnType != "host" {
+		t.Fatalf("ConnType: got %q", m.LinkHealth.ConnType)
 	}
 }

--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -3,6 +3,7 @@ package owebrtc
 import (
 	"context"
 	"log/slog"
+	"runtime/debug"
 	"time"
 
 	pionwebrtc "github.com/pion/webrtc/v4"
@@ -12,6 +13,10 @@ import (
 // server-side calls.Sample mirrors these fields; conversion to the
 // signaling wire format happens in the send callback provided by the
 // caller.
+//
+// ConnType reflects the ICE candidate type of the local end of the
+// nominated pair: one of "host", "srflx", "prflx", "relay", or empty if
+// no pair is nominated.
 type Sample struct {
 	TS       time.Time
 	LossPct  *float32
@@ -54,7 +59,7 @@ func NewReporter(getter StatsGetter, send func(Sample) error, interval time.Dura
 func (r *Reporter) Run(ctx context.Context) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			slog.Warn("link-health reporter panic; exiting", "panic", rec)
+			slog.Warn("link-health reporter panic; exiting", "panic", rec, "stack", string(debug.Stack()))
 		}
 	}()
 	t := time.NewTicker(r.interval)

--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -119,7 +119,6 @@ func (r *Reporter) sample() (Sample, bool) {
 		bout := int64(nominated.BytesSent)
 		out.BytesIn = &bin
 		out.BytesOut = &bout
-		// Look up the local candidate to get the connection type.
 		if local, ok := report[nominated.LocalCandidateID]; ok {
 			if lc, ok := local.(pionwebrtc.ICECandidateStats); ok {
 				out.ConnType = lc.CandidateType.String()

--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -1,0 +1,131 @@
+package owebrtc
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	pionwebrtc "github.com/pion/webrtc/v4"
+)
+
+// Sample is the phone-local representation of one telemetry point. The
+// server-side calls.Sample mirrors these fields; conversion to the
+// signaling wire format happens in the send callback provided by the
+// caller.
+type Sample struct {
+	TS       time.Time
+	LossPct  *float32
+	JitterMs *float32
+	RttMs    *float32
+	ConnType string
+	BytesIn  *int64
+	BytesOut *int64
+}
+
+// StatsGetter is the minimal Pion surface the Reporter depends on.
+// *pionwebrtc.PeerConnection satisfies this.
+type StatsGetter interface {
+	GetStats() pionwebrtc.StatsReport
+}
+
+// Reporter samples WebRTC stats on a ticker and invokes send on each
+// non-empty sample. Zero-valued samples (no RR received yet AND no ICE
+// pair) are skipped entirely to avoid wire noise.
+type Reporter struct {
+	getter   StatsGetter
+	send     func(Sample) error
+	interval time.Duration
+}
+
+const defaultInterval = 2 * time.Second
+
+// NewReporter constructs a Reporter. interval <= 0 selects defaultInterval.
+func NewReporter(getter StatsGetter, send func(Sample) error, interval time.Duration) *Reporter {
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	return &Reporter{getter: getter, send: send, interval: interval}
+}
+
+// Run blocks until ctx is canceled. Each tick samples the peer connection
+// and invokes the send callback. A top-level panic recovery ensures a
+// misbehaving send callback or unexpected Pion state cannot take down the
+// call -- we log and exit the goroutine instead.
+func (r *Reporter) Run(ctx context.Context) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Warn("link-health reporter panic; exiting", "panic", rec)
+		}
+	}()
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			sample, ok := r.sample()
+			if !ok {
+				continue
+			}
+			if r.send != nil {
+				if err := r.send(sample); err != nil {
+					slog.Debug("link-health send failed; will retry next tick", "err", err)
+				}
+			}
+		}
+	}
+}
+
+// sample walks a GetStats() report and extracts a Sample. Returns ok=false
+// if the report has no useful data to report (no RR yet AND no nominated
+// ICE pair).
+func (r *Reporter) sample() (Sample, bool) {
+	report := r.getter.GetStats()
+	out := Sample{TS: time.Now()}
+
+	// RemoteInboundRTP: the remote's latest Receiver Report ABOUT our
+	// outbound stream. Gives loss and jitter as reported by the peer.
+	for _, st := range report {
+		if rr, ok := st.(pionwebrtc.RemoteInboundRTPStreamStats); ok {
+			loss := float32(rr.FractionLost * 100.0)
+			out.LossPct = &loss
+			jitter := float32(rr.Jitter * 1000.0)
+			out.JitterMs = &jitter
+			break // typical voice call: one audio track
+		}
+	}
+
+	// Nominated ICE candidate pair: the pair carrying media right now.
+	var nominated *pionwebrtc.ICECandidatePairStats
+	for _, st := range report {
+		if p, ok := st.(pionwebrtc.ICECandidatePairStats); ok {
+			if p.Nominated && p.State == pionwebrtc.StatsICECandidatePairStateSucceeded {
+				cp := p
+				nominated = &cp
+				break
+			}
+		}
+	}
+	if nominated != nil {
+		rtt := float32(nominated.CurrentRoundTripTime * 1000.0)
+		out.RttMs = &rtt
+		bin := int64(nominated.BytesReceived)
+		bout := int64(nominated.BytesSent)
+		out.BytesIn = &bin
+		out.BytesOut = &bout
+		// Look up the local candidate to get the connection type.
+		if local, ok := report[nominated.LocalCandidateID]; ok {
+			if lc, ok := local.(pionwebrtc.ICECandidateStats); ok {
+				out.ConnType = lc.CandidateType.String()
+			}
+		}
+	}
+
+	// Drop if neither RR nor ICE pair produced anything useful.
+	if out.LossPct == nil && out.JitterMs == nil && out.RttMs == nil &&
+		out.BytesIn == nil && out.BytesOut == nil && out.ConnType == "" {
+		return Sample{}, false
+	}
+	return out, true
+}

--- a/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BenchmarkReporterSample(b *testing.B) {
-	report := buildFakeReport(&testing.T{}, fakeInput{
+	report := buildFakeReport(b, fakeInput{
 		FractionLost:  0.012,
 		JitterSec:     0.0154,
 		RttSec:        0.072,

--- a/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
@@ -1,0 +1,40 @@
+package owebrtc
+
+import (
+	"testing"
+
+	pionwebrtc "github.com/pion/webrtc/v4"
+)
+
+func BenchmarkReporterSample(b *testing.B) {
+	report := buildFakeReport(&testing.T{}, fakeInput{
+		FractionLost:  0.012,
+		JitterSec:     0.0154,
+		RttSec:        0.072,
+		LocalCandType: pionwebrtc.ICECandidateTypeSrflx,
+		BytesSent:     5000,
+		BytesReceived: 4800,
+	})
+	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = r.sample()
+	}
+}
+
+// TestReporterSampleCostBound fails when sample() takes longer than a
+// budget that is already far larger than the expected ARM cost. This guards
+// against regressions that would silently inflate per-call CPU on Pi Zero
+// 2 W hardware (where telemetry claims "invisible" overhead -- see the spec
+// §7 measurement plan).
+func TestReporterSampleCostBound(t *testing.T) {
+	// Budget: 500 μs per sample. At the default 2s cadence this is
+	// 0.025% of a core -- well above the expected cost of reading a
+	// handful of Pion counters. A regression above this bound means
+	// something changed structurally; this test flags it early.
+	const budgetNs = 500_000
+	res := testing.Benchmark(BenchmarkReporterSample)
+	if res.NsPerOp() > budgetNs {
+		t.Fatalf("Reporter.sample() too slow: %d ns/op > %d ns/op budget", res.NsPerOp(), budgetNs)
+	}
+}

--- a/pi/digitsd/internal/webrtc/linkhealth_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_test.go
@@ -136,8 +136,8 @@ type fakeInput struct {
 	BytesReceived uint64
 }
 
-func buildFakeReport(t *testing.T, in fakeInput) pionwebrtc.StatsReport {
-	t.Helper()
+func buildFakeReport(tb testing.TB, in fakeInput) pionwebrtc.StatsReport {
+	tb.Helper()
 	report := pionwebrtc.StatsReport{}
 	report["remote-inbound-0"] = pionwebrtc.RemoteInboundRTPStreamStats{
 		FractionLost: in.FractionLost,

--- a/pi/digitsd/internal/webrtc/linkhealth_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_test.go
@@ -1,0 +1,159 @@
+package owebrtc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pionwebrtc "github.com/pion/webrtc/v4"
+)
+
+// fakeStatsGetter satisfies the StatsGetter interface for tests.
+type fakeStatsGetter struct {
+	report pionwebrtc.StatsReport
+}
+
+func (f *fakeStatsGetter) GetStats() pionwebrtc.StatsReport { return f.report }
+
+func TestReporterSampleNominalPath(t *testing.T) {
+	report := buildFakeReport(t, fakeInput{
+		FractionLost:  0.012, // 1.2%
+		JitterSec:     0.0154,
+		RttSec:        0.072,
+		LocalCandType: pionwebrtc.ICECandidateTypeSrflx,
+		BytesSent:     5000,
+		BytesReceived: 4800,
+	})
+	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
+
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("expected sample, got drop")
+	}
+	if s.LossPct == nil || *s.LossPct < 1.15 || *s.LossPct > 1.25 {
+		t.Fatalf("loss_pct: got %v want ≈1.2", s.LossPct)
+	}
+	if s.JitterMs == nil || *s.JitterMs < 15.0 || *s.JitterMs > 16.0 {
+		t.Fatalf("jitter_ms: got %v want ≈15.4", s.JitterMs)
+	}
+	if s.RttMs == nil || *s.RttMs < 71.0 || *s.RttMs > 73.0 {
+		t.Fatalf("rtt_ms: got %v want ≈72", s.RttMs)
+	}
+	if s.ConnType != "srflx" {
+		t.Fatalf("conn_type: got %q", s.ConnType)
+	}
+	if s.BytesIn == nil || *s.BytesIn != 4800 {
+		t.Fatalf("bytes_in: got %v", s.BytesIn)
+	}
+	if s.BytesOut == nil || *s.BytesOut != 5000 {
+		t.Fatalf("bytes_out: got %v", s.BytesOut)
+	}
+}
+
+func TestReporterSampleSkipsEmptyReport(t *testing.T) {
+	r := NewReporter(&fakeStatsGetter{report: pionwebrtc.StatsReport{}}, nil, 0)
+	if _, ok := r.sample(); ok {
+		t.Fatal("expected drop on empty report")
+	}
+}
+
+func TestReporterSampleOnlyRemoteInbound(t *testing.T) {
+	// Only RR data (loss + jitter), no ICE pair. Should still emit a sample.
+	report := pionwebrtc.StatsReport{
+		"remote-inbound-0": pionwebrtc.RemoteInboundRTPStreamStats{
+			FractionLost: 0.05,
+			Jitter:       0.010,
+		},
+	}
+	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("expected sample from RR-only report")
+	}
+	if s.LossPct == nil {
+		t.Fatalf("LossPct nil")
+	}
+	if s.RttMs != nil {
+		t.Fatalf("RttMs should be nil without ICE pair")
+	}
+	if s.ConnType != "" {
+		t.Fatalf("ConnType should be empty without ICE pair")
+	}
+}
+
+func TestReporterSampleOnlyICEPair(t *testing.T) {
+	// Only ICE pair (rtt + bytes + conn_type), no RR. Should still emit.
+	report := pionwebrtc.StatsReport{
+		"candidate-local-0": pionwebrtc.ICECandidateStats{
+			ID:            "candidate-local-0",
+			CandidateType: pionwebrtc.ICECandidateTypeHost,
+		},
+		"pair-0": pionwebrtc.ICECandidatePairStats{
+			Nominated:            true,
+			State:                pionwebrtc.StatsICECandidatePairStateSucceeded,
+			CurrentRoundTripTime: 0.050,
+			BytesSent:            100,
+			BytesReceived:        90,
+			LocalCandidateID:     "candidate-local-0",
+		},
+	}
+	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("expected sample from ICE-only report")
+	}
+	if s.LossPct != nil {
+		t.Fatal("LossPct should be nil without RR")
+	}
+	if s.RttMs == nil {
+		t.Fatal("RttMs nil despite ICE pair")
+	}
+	if s.ConnType != "host" {
+		t.Fatalf("ConnType: got %q", s.ConnType)
+	}
+}
+
+func TestReporterRunCancelsCleanly(t *testing.T) {
+	calls := 0
+	r := NewReporter(
+		&fakeStatsGetter{report: pionwebrtc.StatsReport{}},
+		func(Sample) error { calls++; return nil },
+		10*time.Millisecond,
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Millisecond)
+	defer cancel()
+	r.Run(ctx) // must return within the context deadline
+}
+
+// --- Test helpers ---
+
+type fakeInput struct {
+	FractionLost  float64
+	JitterSec     float64
+	RttSec        float64
+	LocalCandType pionwebrtc.ICECandidateType
+	BytesSent     uint64
+	BytesReceived uint64
+}
+
+func buildFakeReport(t *testing.T, in fakeInput) pionwebrtc.StatsReport {
+	t.Helper()
+	report := pionwebrtc.StatsReport{}
+	report["remote-inbound-0"] = pionwebrtc.RemoteInboundRTPStreamStats{
+		FractionLost: in.FractionLost,
+		Jitter:       in.JitterSec,
+	}
+	report["candidate-local-0"] = pionwebrtc.ICECandidateStats{
+		ID:            "candidate-local-0",
+		CandidateType: in.LocalCandType,
+	}
+	report["pair-0"] = pionwebrtc.ICECandidatePairStats{
+		Nominated:            true,
+		State:                pionwebrtc.StatsICECandidatePairStateSucceeded,
+		CurrentRoundTripTime: in.RttSec,
+		BytesSent:            in.BytesSent,
+		BytesReceived:        in.BytesReceived,
+		LocalCandidateID:     "candidate-local-0",
+	}
+	return report
+}

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -167,6 +167,12 @@ func (m *PeerManager) LocalTrack() *webrtc.TrackLocalStaticSample {
 	return m.track
 }
 
+// PeerConnection returns the underlying Pion PeerConnection. Intended for
+// read-only use such as polling GetStats(). Do not mutate.
+func (m *PeerManager) PeerConnection() *webrtc.PeerConnection {
+	return m.pc
+}
+
 // Close closes the underlying PeerConnection.
 func (m *PeerManager) Close() error {
 	return m.pc.Close()

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -167,10 +167,10 @@ func (m *PeerManager) LocalTrack() *webrtc.TrackLocalStaticSample {
 	return m.track
 }
 
-// PeerConnection returns the underlying Pion PeerConnection. Intended for
-// read-only use such as polling GetStats(). Do not mutate.
-func (m *PeerManager) PeerConnection() *webrtc.PeerConnection {
-	return m.pc
+// GetStats returns a snapshot of WebRTC statistics for this peer. Safe to
+// call concurrently with audio; Pion's stats collector is thread-safe.
+func (m *PeerManager) GetStats() webrtc.StatsReport {
+	return m.pc.GetStats()
 }
 
 // Close closes the underlying PeerConnection.

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -60,8 +60,15 @@ func main() {
 	tracker.SetHealthStore(healthStore)
 
 	healthCtx, cancelHealth := context.WithCancel(context.Background())
-	go healthStore.Run(healthCtx)
-	defer cancelHealth()
+	healthDone := make(chan struct{})
+	go func() {
+		defer close(healthDone)
+		healthStore.Run(healthCtx)
+	}()
+	defer func() {
+		cancelHealth()
+		<-healthDone // wait for final flush before DB close unwinds
+	}()
 
 	relay := signaling.NewRelay(hub, tracker, line.NewAuthorizer(database), signaling.NewLineStoreAdapter(lineStore))
 	relay.HealthStore = healthStore

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -130,7 +130,7 @@ func main() {
 	// Create web handler
 	handler, err := web.NewHandler(lineStore, deviceStore, hub, tracker, relay, web.HandlerConfig{
 		Addr: cfg.Addr,
-	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, cfg.BaseURL, cfg.AdminSecret)
+	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, cfg.BaseURL, cfg.AdminSecret, healthStore)
 	if err != nil {
 		log.Fatalf("create handler: %v", err)
 	}

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -56,7 +56,11 @@ func main() {
 	// Link store
 	linkStore := household.NewLinkStore(database.DB)
 
-	healthStore := calls.NewHealthStore(database)
+	flushDisabled := os.Getenv("SIGNALD_LINK_HEALTH_FLUSH_DISABLED") == "1"
+	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled(flushDisabled))
+	if flushDisabled {
+		slog.Warn("link-health flusher disabled via SIGNALD_LINK_HEALTH_FLUSH_DISABLED")
+	}
 	tracker.SetHealthStore(healthStore)
 
 	healthCtx, cancelHealth := context.WithCancel(context.Background())

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"html/template"
 	"log"
 	"log/slog"
@@ -55,7 +56,15 @@ func main() {
 	// Link store
 	linkStore := household.NewLinkStore(database.DB)
 
+	healthStore := calls.NewHealthStore(database)
+	tracker.SetHealthStore(healthStore)
+
+	healthCtx, cancelHealth := context.WithCancel(context.Background())
+	go healthStore.Run(healthCtx)
+	defer cancelHealth()
+
 	relay := signaling.NewRelay(hub, tracker, line.NewAuthorizer(database), signaling.NewLineStoreAdapter(lineStore))
+	relay.HealthStore = healthStore
 
 	// Configure TURN credential generation if enabled
 	if cfg.TURNEnabled {

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -68,16 +68,32 @@ func (r *ring) latest() *Sample {
 // nil the store operates in memory-only mode. Zero-value is NOT valid; use
 // NewHealthStore.
 type HealthStore struct {
-	db    *db.Database
-	mu    sync.Mutex
-	calls map[int64]*callRings
+	db            *db.Database
+	mu            sync.Mutex
+	calls         map[int64]*callRings
+	flushDisabled bool
 }
 
-func NewHealthStore(d *db.Database) *HealthStore {
-	return &HealthStore{
+// HealthStoreOption configures a HealthStore at construction time.
+type HealthStoreOption func(*HealthStore)
+
+// WithFlushDisabled causes HealthStore.Run to skip periodic DB flushes
+// and final shutdown flush. Ingest (Record/Init/Evict) and in-memory
+// reads (Latest/Window) remain fully operational. Intended for DB
+// maintenance windows; the in-memory rings still bound memory usage.
+func WithFlushDisabled(disabled bool) HealthStoreOption {
+	return func(s *HealthStore) { s.flushDisabled = disabled }
+}
+
+func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
+	s := &HealthStore{
 		db:    d,
 		calls: make(map[int64]*callRings),
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 // Init creates an empty rings entry for a call. Called by Tracker on
@@ -285,9 +301,10 @@ func nullableString(s string) any {
 
 // Run blocks until ctx is canceled, flushing every flushInterval. On ctx
 // cancellation it runs one final flush before returning (bounded at 2s so
-// a graceful shutdown doesn't hang).
+// a graceful shutdown doesn't hang). If flushDisabled is true, Run still
+// blocks until ctx is canceled but skips all DB writes (periodic and final).
 func (s *HealthStore) Run(ctx context.Context) {
-	if s.db == nil {
+	if s.db == nil || s.flushDisabled {
 		<-ctx.Done()
 		return
 	}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -80,16 +80,30 @@ func NewHealthStore(d *db.Database) *HealthStore {
 	}
 }
 
+// Init creates an empty rings entry for a call. Called by Tracker on
+// OnCallInitiated so that subsequent Record calls have a place to land
+// without needing auto-creation (which would resurrect evicted calls).
+// Safe to call multiple times; idempotent.
+func (s *HealthStore) Init(callID int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.calls[callID]; ok {
+		return
+	}
+	s.calls[callID] = &callRings{byEndpoint: make(map[string]*ring)}
+}
+
 // Record appends a sample for the given call and endpoint. Safe for
-// concurrent use.
+// concurrent use. No-op if Init was not called for this callID first
+// or if the call has been Evicted — this matches the tracker-authoritative
+// lifecycle and prevents post-Evict resurrection of map entries.
 func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 	s.mu.Lock()
 	cr, ok := s.calls[callID]
-	if !ok {
-		cr = &callRings{byEndpoint: make(map[string]*ring)}
-		s.calls[callID] = cr
-	}
 	s.mu.Unlock()
+	if !ok {
+		return // not initialized or already evicted
+	}
 
 	cr.mu.Lock()
 	defer cr.mu.Unlock()

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -1,0 +1,142 @@
+package calls
+
+import (
+	"sync"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/db"
+)
+
+// Sample is one point of per-endpoint call telemetry. Pointer fields are
+// nullable: nil means "not available this sample."
+type Sample struct {
+	TS       time.Time
+	LossPct  *float32
+	JitterMs *float32
+	RttMs    *float32
+	ConnType string
+	BytesIn  *int64
+	BytesOut *int64
+}
+
+// ringCapacity is the per-endpoint in-memory sample retention.
+// At the default 2s reporting cadence this holds 2 minutes of history.
+const ringCapacity = 60
+
+// callRings holds two bounded rings, one per endpoint, plus last-flushed
+// timestamps used by the DB flusher (added in Task 5). All state is guarded
+// by mu.
+type callRings struct {
+	mu         sync.Mutex
+	byEndpoint map[string]*ring
+}
+
+type ring struct {
+	samples []Sample // length up to ringCapacity
+	// lastFlushed is set by the flusher (Task 5). Unused in this task.
+	lastFlushed time.Time
+}
+
+func (r *ring) append(s Sample) {
+	if len(r.samples) < ringCapacity {
+		r.samples = append(r.samples, s)
+		return
+	}
+	copy(r.samples, r.samples[1:])
+	r.samples[ringCapacity-1] = s
+}
+
+func (r *ring) latest() *Sample {
+	if len(r.samples) == 0 {
+		return nil
+	}
+	s := r.samples[len(r.samples)-1]
+	return &s
+}
+
+// HealthStore holds per-call in-memory telemetry. The database handle is
+// accepted by the constructor for use by the flusher added in Task 5; when
+// nil the store operates in memory-only mode. Zero-value is NOT valid; use
+// NewHealthStore.
+type HealthStore struct {
+	db    *db.Database
+	mu    sync.Mutex
+	calls map[int64]*callRings
+}
+
+func NewHealthStore(d *db.Database) *HealthStore {
+	return &HealthStore{
+		db:    d,
+		calls: make(map[int64]*callRings),
+	}
+}
+
+// Record appends a sample for the given call and endpoint. Safe for
+// concurrent use.
+func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
+	s.mu.Lock()
+	cr, ok := s.calls[callID]
+	if !ok {
+		cr = &callRings{byEndpoint: make(map[string]*ring)}
+		s.calls[callID] = cr
+	}
+	s.mu.Unlock()
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	r, ok := cr.byEndpoint[endpoint]
+	if !ok {
+		r = &ring{}
+		cr.byEndpoint[endpoint] = r
+	}
+	r.append(sample)
+}
+
+// Latest returns the most recent sample for the caller and callee endpoints
+// of the given call. Either may be nil if no samples have been recorded yet.
+func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
+	s.mu.Lock()
+	cr, ok := s.calls[callID]
+	s.mu.Unlock()
+	if !ok {
+		return nil, nil
+	}
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	var a, b *Sample
+	if r := cr.byEndpoint[caller]; r != nil {
+		a = r.latest()
+	}
+	if r := cr.byEndpoint[callee]; r != nil {
+		b = r.latest()
+	}
+	return a, b
+}
+
+// Window returns a copy of the retained sample ring for an endpoint, oldest
+// first. Returns an empty slice if the call or endpoint is unknown.
+func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
+	s.mu.Lock()
+	cr, ok := s.calls[callID]
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	r, ok := cr.byEndpoint[endpoint]
+	if !ok {
+		return nil
+	}
+	out := make([]Sample, len(r.samples))
+	copy(out, r.samples)
+	return out
+}
+
+// Evict drops all in-memory state for a call. Called by Tracker on call end.
+// A final flush to DB is added in Task 5.
+func (s *HealthStore) Evict(callID int64) {
+	s.mu.Lock()
+	delete(s.calls, callID)
+	s.mu.Unlock()
+}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -64,7 +64,7 @@ func (r *ring) latest() *Sample {
 }
 
 // HealthStore holds per-call in-memory telemetry. The database handle is
-// accepted by the constructor for use by the flusher added in Task 5; when
+// accepted by the constructor for use by the periodic DB flusher; when
 // nil the store operates in memory-only mode. Zero-value is NOT valid; use
 // NewHealthStore.
 type HealthStore struct {
@@ -221,11 +221,12 @@ func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings
 		endpoint string
 		sample   Sample
 	}
-	var todo []pending
-	var advance []struct {
+	type flushAdvance struct {
 		endpoint string
 		ts       time.Time
 	}
+	var todo []pending
+	var advance []flushAdvance
 	for ep, r := range cr.byEndpoint {
 		latest := r.latest()
 		if latest == nil {
@@ -235,10 +236,7 @@ func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings
 			continue // nothing new since last flush
 		}
 		todo = append(todo, pending{endpoint: ep, sample: *latest})
-		advance = append(advance, struct {
-			endpoint string
-			ts       time.Time
-		}{ep, latest.TS})
+		advance = append(advance, flushAdvance{ep, latest.TS})
 	}
 	cr.mu.Unlock()
 

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -111,8 +111,17 @@ func (s *HealthStore) Init(callID int64) {
 
 // Record appends a sample for the given call and endpoint. Safe for
 // concurrent use. No-op if Init was not called for this callID first
-// or if the call has been Evicted — this matches the tracker-authoritative
+// or if the call has been Evicted -- this matches the tracker-authoritative
 // lifecycle and prevents post-Evict resurrection of map entries.
+//
+// Race note: between releasing the top-level map lock and acquiring the
+// per-call lock, a concurrent Evict can remove the callRings entry from
+// the map. The captured *callRings reference remains valid (the struct is
+// not freed) but is no longer reachable from the map; the sample appended
+// to it will be silently dropped -- never flushed, eventually GC'd. This
+// is intentional telemetry loss on a racing call-end. The alternative --
+// auto-recreating the map entry -- would resurrect evicted calls, which
+// was the exact bug fixed during the T6 review cycle.
 func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 	s.mu.Lock()
 	cr, ok := s.calls[callID]

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -9,6 +9,12 @@ import (
 
 // Sample is one point of per-endpoint call telemetry. Pointer fields are
 // nullable: nil means "not available this sample."
+//
+// Ownership: once a Sample is passed to HealthStore.Record, its pointer
+// fields must not be mutated by the caller. The store retains the pointers
+// as-is (no deep copy on the hot path); concurrent readers will see
+// whatever the pointers point to. Callers should construct fresh
+// *float32 / *int64 values per sample and not reuse backing storage.
 type Sample struct {
 	TS       time.Time
 	LossPct  *float32

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -1,6 +1,10 @@
 package calls
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -29,17 +33,15 @@ type Sample struct {
 // At the default 2s reporting cadence this holds 2 minutes of history.
 const ringCapacity = 60
 
-// callRings holds two bounded rings, one per endpoint, plus last-flushed
-// timestamps used by the DB flusher (added in Task 5). All state is guarded
-// by mu.
+// callRings holds per-endpoint bounded sample rings and last-flushed
+// timestamps used by the DB flusher. All state is guarded by mu.
 type callRings struct {
 	mu         sync.Mutex
 	byEndpoint map[string]*ring
 }
 
 type ring struct {
-	samples []Sample // length up to ringCapacity
-	// lastFlushed is set by the flusher (Task 5). Unused in this task.
+	samples     []Sample // length up to ringCapacity
 	lastFlushed time.Time
 }
 
@@ -140,9 +142,214 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 }
 
 // Evict drops all in-memory state for a call. Called by Tracker on call end.
-// A final flush to DB is added in Task 5.
 func (s *HealthStore) Evict(callID int64) {
 	s.mu.Lock()
 	delete(s.calls, callID)
 	s.mu.Unlock()
+}
+
+// flushInterval is how often the background flusher runs. See spec §2.
+const flushInterval = 10 * time.Second
+
+// FlushOnce walks every tracked call and writes one row per (endpoint) for
+// any endpoint with samples newer than its lastFlushed timestamp. Exported
+// for tests; production use goes through Run.
+func (s *HealthStore) FlushOnce(ctx context.Context) error {
+	if s.db == nil {
+		return nil
+	}
+	// Snapshot call ids under the top-level lock to avoid holding it while
+	// doing DB I/O.
+	s.mu.Lock()
+	ids := make([]int64, 0, len(s.calls))
+	for id := range s.calls {
+		ids = append(ids, id)
+	}
+	s.mu.Unlock()
+
+	for _, id := range ids {
+		s.mu.Lock()
+		cr := s.calls[id]
+		s.mu.Unlock()
+		if cr == nil {
+			continue
+		}
+		if err := s.flushCall(ctx, id, cr); err != nil {
+			slog.Error("link-health flush failed", "call_id", id, "err", err)
+			// Do NOT advance lastFlushed on error; next cycle retries.
+			// Continue to next call; one call's DB error shouldn't stop others.
+			continue
+		}
+	}
+	return nil
+}
+
+func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings) error {
+	cr.mu.Lock()
+	// Collect work under lock, then release before DB I/O.
+	type pending struct {
+		endpoint string
+		sample   Sample
+	}
+	var todo []pending
+	var advance []struct {
+		endpoint string
+		ts       time.Time
+	}
+	for ep, r := range cr.byEndpoint {
+		latest := r.latest()
+		if latest == nil {
+			continue
+		}
+		if !latest.TS.After(r.lastFlushed) {
+			continue // nothing new since last flush
+		}
+		todo = append(todo, pending{endpoint: ep, sample: *latest})
+		advance = append(advance, struct {
+			endpoint string
+			ts       time.Time
+		}{ep, latest.TS})
+	}
+	cr.mu.Unlock()
+
+	if len(todo) == 0 {
+		return nil
+	}
+	for _, p := range todo {
+		if err := s.writeSample(ctx, callID, p.endpoint, p.sample); err != nil {
+			return fmt.Errorf("write sample (%d,%s): %w", callID, p.endpoint, err)
+		}
+	}
+	// On success, advance lastFlushed.
+	cr.mu.Lock()
+	for _, a := range advance {
+		if r := cr.byEndpoint[a.endpoint]; r != nil {
+			r.lastFlushed = a.ts
+		}
+	}
+	cr.mu.Unlock()
+	return nil
+}
+
+func (s *HealthStore) writeSample(ctx context.Context, callID int64, endpoint string, sample Sample) error {
+	_, err := s.db.DB.ExecContext(ctx,
+		`INSERT INTO call_link_health
+		   (call_id, endpoint, ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 ON CONFLICT (call_id, endpoint, ts) DO NOTHING`,
+		callID, endpoint, sample.TS,
+		nullableFloat(sample.LossPct),
+		nullableFloat(sample.JitterMs),
+		nullableFloat(sample.RttMs),
+		nullableString(sample.ConnType),
+		nullableInt(sample.BytesIn),
+		nullableInt(sample.BytesOut),
+	)
+	return err
+}
+
+func nullableFloat(p *float32) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableInt(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// Run blocks until ctx is canceled, flushing every flushInterval. On ctx
+// cancellation it runs one final flush before returning (bounded at 2s so
+// a graceful shutdown doesn't hang).
+func (s *HealthStore) Run(ctx context.Context) {
+	if s.db == nil {
+		<-ctx.Done()
+		return
+	}
+	t := time.NewTicker(flushInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			_ = s.FlushOnce(shutdownCtx)
+			cancel()
+			return
+		case <-t.C:
+			_ = s.FlushOnce(ctx)
+		}
+	}
+}
+
+// Readback returns the last `limit` samples for a call+endpoint from the DB,
+// oldest first. Used when in-memory state is empty (ended call, post-restart).
+func (s *HealthStore) Readback(ctx context.Context, callID int64, endpoint string, limit int) ([]Sample, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	rows, err := s.db.DB.QueryContext(ctx,
+		`SELECT ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out
+		 FROM call_link_health
+		 WHERE call_id = $1 AND endpoint = $2
+		 ORDER BY ts DESC
+		 LIMIT $3`,
+		callID, endpoint, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("readback query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Sample
+	for rows.Next() {
+		var ts time.Time
+		var loss, jitter, rtt sql.NullFloat64
+		var conn sql.NullString
+		var bin, bout sql.NullInt64
+		if err := rows.Scan(&ts, &loss, &jitter, &rtt, &conn, &bin, &bout); err != nil {
+			return nil, fmt.Errorf("readback scan: %w", err)
+		}
+		sample := Sample{TS: ts}
+		if loss.Valid {
+			v := float32(loss.Float64)
+			sample.LossPct = &v
+		}
+		if jitter.Valid {
+			v := float32(jitter.Float64)
+			sample.JitterMs = &v
+		}
+		if rtt.Valid {
+			v := float32(rtt.Float64)
+			sample.RttMs = &v
+		}
+		if conn.Valid {
+			sample.ConnType = conn.String
+		}
+		if bin.Valid {
+			sample.BytesIn = &bin.Int64
+		}
+		if bout.Valid {
+			sample.BytesOut = &bout.Int64
+		}
+		out = append(out, sample)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("readback rows: %w", err)
+	}
+	// Reverse to oldest-first to match in-memory Window ordering.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
 }

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -3,6 +3,7 @@ package calls
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -167,6 +168,7 @@ func (s *HealthStore) FlushOnce(ctx context.Context) error {
 	}
 	s.mu.Unlock()
 
+	var errs []error
 	for _, id := range ids {
 		s.mu.Lock()
 		cr := s.calls[id]
@@ -176,12 +178,10 @@ func (s *HealthStore) FlushOnce(ctx context.Context) error {
 		}
 		if err := s.flushCall(ctx, id, cr); err != nil {
 			slog.Error("link-health flush failed", "call_id", id, "err", err)
-			// Do NOT advance lastFlushed on error; next cycle retries.
-			// Continue to next call; one call's DB error shouldn't stop others.
-			continue
+			errs = append(errs, fmt.Errorf("call %d: %w", id, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings) error {
@@ -309,7 +309,7 @@ func (s *HealthStore) Readback(ctx context.Context, callID int64, endpoint strin
 	if err != nil {
 		return nil, fmt.Errorf("readback query: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []Sample
 	for rows.Next() {

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package calls
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/db"
+)
+
+func openTestDB(t *testing.T) *db.Database {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	d, err := db.Open(dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { d.DB.Close() })
+	return d
+}
+
+func insertCall(t *testing.T, d *db.Database, caller, callee string) int64 {
+	var id int64
+	err := d.DB.QueryRow(
+		"INSERT INTO calls (caller, callee, status) VALUES ($1,$2,'connected') RETURNING id",
+		caller, callee,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert call: %v", err)
+	}
+	return id
+}
+
+func TestFlusherWritesLatestPerEndpoint(t *testing.T) {
+	d := openTestDB(t)
+	s := NewHealthStore(d)
+	callID := insertCall(t, d, "555-1111", "555-2222")
+	loss1 := float32(0.1)
+	loss2 := float32(0.2)
+	loss3 := float32(0.3)
+	s.Record(callID, "555-1111", Sample{TS: time.Now().Add(-2 * time.Second), LossPct: &loss1})
+	s.Record(callID, "555-1111", Sample{TS: time.Now().Add(-1 * time.Second), LossPct: &loss2})
+	s.Record(callID, "555-2222", Sample{TS: time.Now(), LossPct: &loss3})
+
+	if err := s.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOnce: %v", err)
+	}
+
+	var n int
+	if err := d.DB.QueryRow(
+		"SELECT COUNT(*) FROM call_link_health WHERE call_id = $1", callID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("row count: got %d want 2", n)
+	}
+
+	// Second flush with no new samples must write 0 rows.
+	if err := s.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if err := d.DB.QueryRow(
+		"SELECT COUNT(*) FROM call_link_health WHERE call_id = $1", callID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("no-new-sample flush wrote rows: got %d want 2", n)
+	}
+}
+
+func TestReadbackFromDB(t *testing.T) {
+	d := openTestDB(t)
+	s := NewHealthStore(d)
+	callID := insertCall(t, d, "555-3333", "555-4444")
+	loss := float32(0.5)
+	s.Record(callID, "555-3333", Sample{TS: time.Now(), LossPct: &loss})
+	if err := s.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOnce: %v", err)
+	}
+
+	// Simulate post-restart: drop in-memory state.
+	s.Evict(callID)
+
+	got, err := s.Readback(context.Background(), callID, "555-3333", ringCapacity)
+	if err != nil {
+		t.Fatalf("Readback: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("readback len: got %d want 1", len(got))
+	}
+	if got[0].LossPct == nil || *got[0].LossPct != 0.5 {
+		t.Fatalf("readback value mismatch: %+v", got[0])
+	}
+}

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -26,6 +26,7 @@ func TestFlusherWritesLatestPerEndpoint(t *testing.T) {
 	d := setupTestDB(t)
 	s := NewHealthStore(d)
 	callID := insertCall(t, d, "555-1111", "555-2222")
+	s.Init(callID)
 	loss1 := float32(0.1)
 	loss2 := float32(0.2)
 	loss3 := float32(0.3)
@@ -65,6 +66,7 @@ func TestReadbackFromDB(t *testing.T) {
 	d := setupTestDB(t)
 	s := NewHealthStore(d)
 	callID := insertCall(t, d, "555-3333", "555-4444")
+	s.Init(callID)
 	loss := float32(0.5)
 	s.Record(callID, "555-3333", Sample{TS: time.Now(), LossPct: &loss})
 	if err := s.FlushOnce(context.Background()); err != nil {

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -4,25 +4,11 @@ package calls
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/db"
 )
-
-func openTestDB(t *testing.T) *db.Database {
-	dsn := os.Getenv("TEST_DATABASE_URL")
-	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set")
-	}
-	d, err := db.Open(dsn)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	t.Cleanup(func() { d.DB.Close() })
-	return d
-}
 
 func insertCall(t *testing.T, d *db.Database, caller, callee string) int64 {
 	var id int64
@@ -37,7 +23,7 @@ func insertCall(t *testing.T, d *db.Database, caller, callee string) int64 {
 }
 
 func TestFlusherWritesLatestPerEndpoint(t *testing.T) {
-	d := openTestDB(t)
+	d := setupTestDB(t)
 	s := NewHealthStore(d)
 	callID := insertCall(t, d, "555-1111", "555-2222")
 	loss1 := float32(0.1)
@@ -76,7 +62,7 @@ func TestFlusherWritesLatestPerEndpoint(t *testing.T) {
 }
 
 func TestReadbackFromDB(t *testing.T) {
-	d := openTestDB(t)
+	d := setupTestDB(t)
 	s := NewHealthStore(d)
 	callID := insertCall(t, d, "555-3333", "555-4444")
 	loss := float32(0.5)

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -1,6 +1,7 @@
 package calls
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -134,5 +135,36 @@ func TestHealthStoreRecordIsNoOpAfterEvict(t *testing.T) {
 	a, b := s.Latest(1, "A", "B")
 	if a != nil || b != nil {
 		t.Fatalf("post-evict Record must not resurrect rings; got (%v,%v)", a, b)
+	}
+}
+
+func TestHealthStoreFlushDisabledOption(t *testing.T) {
+	// With FlushDisabled, Run returns when ctx is canceled without
+	// attempting any DB writes. Since NewHealthStore(nil, ...) is also
+	// a valid construction (nil DB), use that to avoid needing a DB
+	// in this unit test.
+	s := NewHealthStore(nil, WithFlushDisabled(true))
+	if !s.flushDisabled {
+		t.Fatal("expected flushDisabled == true")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Run(ctx)
+	}()
+	cancel()
+	select {
+	case <-done:
+		// good
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestHealthStoreFlushDisabledDefaultsFalse(t *testing.T) {
+	s := NewHealthStore(nil)
+	if s.flushDisabled {
+		t.Fatal("expected flushDisabled default false")
 	}
 }

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -13,6 +13,7 @@ func sample(ts int64, loss float32) Sample {
 
 func TestHealthStoreRecordAndLatest(t *testing.T) {
 	s := NewHealthStore(nil) // nil DB => flusher disabled (flusher not implemented in T3 but constructor must accept nil cleanly)
+	s.Init(1)
 	s.Record(1, "A", sample(100, 0.5))
 	s.Record(1, "A", sample(200, 0.7))
 	s.Record(1, "B", sample(150, 0.2))
@@ -28,6 +29,7 @@ func TestHealthStoreRecordAndLatest(t *testing.T) {
 
 func TestHealthStoreRingWraparound(t *testing.T) {
 	s := NewHealthStore(nil)
+	s.Init(1)
 	for i := 0; i < 80; i++ {
 		s.Record(1, "A", sample(int64(i), float32(i)))
 	}
@@ -46,6 +48,7 @@ func TestHealthStoreRingWraparound(t *testing.T) {
 
 func TestHealthStoreEvict(t *testing.T) {
 	s := NewHealthStore(nil)
+	s.Init(1)
 	s.Record(1, "A", sample(100, 0.5))
 	s.Evict(1)
 	if win := s.Window(1, "A"); len(win) != 0 {
@@ -62,6 +65,7 @@ func TestHealthStoreConcurrentWritersSameRing(t *testing.T) {
 	// exercise in-ring contention under the per-call mutex. This is the
 	// contract Record documents: safe for concurrent use.
 	s := NewHealthStore(nil)
+	s.Init(1)
 	var wg sync.WaitGroup
 	const writers = 4
 	const samplesPerWriter = 500
@@ -92,6 +96,9 @@ func TestHealthStoreConcurrentCallsAndEndpoints(t *testing.T) {
 	// [1,4] ends up with samples on BOTH "A" and "B". Exercises top-level
 	// map races + per-call-map-creation races.
 	s := NewHealthStore(nil)
+	for id := int64(1); id <= 4; id++ {
+		s.Init(id)
+	}
 	var wg sync.WaitGroup
 	for w := 0; w < 8; w++ {
 		wg.Add(1)
@@ -112,5 +119,20 @@ func TestHealthStoreConcurrentCallsAndEndpoints(t *testing.T) {
 		if a, b := s.Latest(id, "A", "B"); a == nil || b == nil {
 			t.Fatalf("call %d missing samples: %v %v", id, a, b)
 		}
+	}
+}
+
+func TestHealthStoreRecordIsNoOpAfterEvict(t *testing.T) {
+	s := NewHealthStore(nil)
+	s.Init(1)
+	s.Record(1, "A", sample(100, 0.5))
+	s.Evict(1)
+	s.Record(1, "A", sample(200, 0.9)) // should NOT resurrect map entry
+	if win := s.Window(1, "A"); len(win) != 0 {
+		t.Fatalf("post-evict Record must not create entry; got window len %d", len(win))
+	}
+	a, b := s.Latest(1, "A", "B")
+	if a != nil || b != nil {
+		t.Fatalf("post-evict Record must not resurrect rings; got (%v,%v)", a, b)
 	}
 }

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -1,0 +1,83 @@
+package calls
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func sample(ts int64, loss float32) Sample {
+	l := loss
+	return Sample{TS: time.Unix(0, ts*int64(time.Millisecond)), LossPct: &l}
+}
+
+func TestHealthStoreRecordAndLatest(t *testing.T) {
+	s := NewHealthStore(nil) // nil DB => flusher disabled (flusher not implemented in T3 but constructor must accept nil cleanly)
+	s.Record(1, "A", sample(100, 0.5))
+	s.Record(1, "A", sample(200, 0.7))
+	s.Record(1, "B", sample(150, 0.2))
+
+	callerLatest, calleeLatest := s.Latest(1, "A", "B")
+	if callerLatest == nil || *callerLatest.LossPct != 0.7 {
+		t.Fatalf("Latest A: got %+v want 0.7", callerLatest)
+	}
+	if calleeLatest == nil || *calleeLatest.LossPct != 0.2 {
+		t.Fatalf("Latest B: got %+v want 0.2", calleeLatest)
+	}
+}
+
+func TestHealthStoreRingWraparound(t *testing.T) {
+	s := NewHealthStore(nil)
+	for i := 0; i < 80; i++ {
+		s.Record(1, "A", sample(int64(i), float32(i)))
+	}
+	win := s.Window(1, "A")
+	if len(win) != 60 {
+		t.Fatalf("window size: got %d want 60", len(win))
+	}
+	// Oldest retained should be sample 20 (80 - 60).
+	if *win[0].LossPct != 20.0 {
+		t.Fatalf("oldest retained: got %v want 20", *win[0].LossPct)
+	}
+	if *win[59].LossPct != 79.0 {
+		t.Fatalf("newest retained: got %v want 79", *win[59].LossPct)
+	}
+}
+
+func TestHealthStoreEvict(t *testing.T) {
+	s := NewHealthStore(nil)
+	s.Record(1, "A", sample(100, 0.5))
+	s.Evict(1)
+	if win := s.Window(1, "A"); len(win) != 0 {
+		t.Fatalf("post-evict window: got %d want 0", len(win))
+	}
+	a, b := s.Latest(1, "A", "B")
+	if a != nil || b != nil {
+		t.Fatalf("post-evict latest: got (%v,%v)", a, b)
+	}
+}
+
+func TestHealthStoreConcurrentWriters(t *testing.T) {
+	s := NewHealthStore(nil)
+	var wg sync.WaitGroup
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			callID := int64(w/2 + 1) // calls 1-4, two goroutines each
+			endpoint := "A"
+			if w%2 == 1 {
+				endpoint = "B"
+			}
+			for i := 0; i < 500; i++ {
+				s.Record(callID, endpoint, sample(int64(i), float32(i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+	for id := int64(1); id <= 4; id++ {
+		if a, b := s.Latest(id, "A", "B"); a == nil || b == nil {
+			t.Fatalf("call %d missing samples: %v %v", id, a, b)
+		}
+	}
+}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -57,14 +57,47 @@ func TestHealthStoreEvict(t *testing.T) {
 	}
 }
 
-func TestHealthStoreConcurrentWriters(t *testing.T) {
+func TestHealthStoreConcurrentWritersSameRing(t *testing.T) {
+	// Multiple goroutines hammer the SAME (callID, endpoint) ring to
+	// exercise in-ring contention under the per-call mutex. This is the
+	// contract Record documents: safe for concurrent use.
+	s := NewHealthStore(nil)
+	var wg sync.WaitGroup
+	const writers = 4
+	const samplesPerWriter = 500
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < samplesPerWriter; i++ {
+				s.Record(1, "A", sample(int64(w)*100000+int64(i), float32(i)))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Sanity: ring holds ringCapacity samples and latest() returns one.
+	win := s.Window(1, "A")
+	if len(win) != ringCapacity {
+		t.Fatalf("window size: got %d want %d", len(win), ringCapacity)
+	}
+	a, _ := s.Latest(1, "A", "B")
+	if a == nil {
+		t.Fatalf("Latest returned nil after %d concurrent samples", writers*samplesPerWriter)
+	}
+}
+
+func TestHealthStoreConcurrentCallsAndEndpoints(t *testing.T) {
+	// Spread goroutines across calls and endpoints so every callID in
+	// [1,4] ends up with samples on BOTH "A" and "B". Exercises top-level
+	// map races + per-call-map-creation races.
 	s := NewHealthStore(nil)
 	var wg sync.WaitGroup
 	for w := 0; w < 8; w++ {
 		wg.Add(1)
 		go func(w int) {
 			defer wg.Done()
-			callID := int64(w/2 + 1) // calls 1-4, two goroutines each
+			callID := int64(w/2 + 1) // w=0,1->1 ; 2,3->2 ; 4,5->3 ; 6,7->4
 			endpoint := "A"
 			if w%2 == 1 {
 				endpoint = "B"

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -1,6 +1,8 @@
 package calls
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -251,6 +253,30 @@ func (t *Tracker) Recent(limit int) ([]Call, error) {
 		calls = append(calls, c)
 	}
 	return calls, rows.Err()
+}
+
+// GetCall returns the call row by id. Returns zero-value Call and nil error
+// if not found (callers should test Call.ID == 0).
+func (t *Tracker) GetCall(id int64) (Call, error) {
+	var c Call
+	var answered, ended sql.NullTime
+	err := t.db.DB.QueryRow(
+		`SELECT id, caller, callee, status, started_at, answered_at, ended_at, duration_s
+		 FROM calls WHERE id = $1`, id,
+	).Scan(&c.ID, &c.Caller, &c.Callee, &c.Status, &c.StartedAt, &answered, &ended, &c.DurationS)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Call{}, nil
+	}
+	if err != nil {
+		return Call{}, fmt.Errorf("get call: %w", err)
+	}
+	if answered.Valid {
+		c.AnsweredAt = &answered.Time
+	}
+	if ended.Valid {
+		c.EndedAt = &ended.Time
+	}
+	return c, nil
 }
 
 // RecentForPhones returns the most recent calls where either caller or callee

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -28,10 +28,10 @@ type activeCall struct {
 	StartedAt time.Time
 }
 
-// healthEvictor is the subset of *HealthStore needed by Tracker to drop
-// per-call in-memory state on call end. Declared as an interface so Tracker
-// and HealthStore can live in the same package without a circular init.
-type healthEvictor interface {
+// healthLifecycle is the subset of *HealthStore that Tracker drives for
+// per-call lifecycle. Init is called at call start; Evict at call end.
+type healthLifecycle interface {
+	Init(callID int64)
 	Evict(callID int64)
 }
 
@@ -39,7 +39,7 @@ type Tracker struct {
 	db     *db.Database
 	mu     sync.Mutex
 	active map[string]*activeCall // "caller→callee" → call
-	health healthEvictor
+	health healthLifecycle
 }
 
 func New(d *db.Database) *Tracker {
@@ -49,9 +49,9 @@ func New(d *db.Database) *Tracker {
 	}
 }
 
-// SetHealthStore registers an optional health store for per-call eviction
-// on call end. Safe to call once at startup; subsequent calls overwrite.
-func (t *Tracker) SetHealthStore(h healthEvictor) {
+// SetHealthStore registers an optional health store for per-call lifecycle
+// management. Safe to call once at startup; subsequent calls overwrite.
+func (t *Tracker) SetHealthStore(h healthLifecycle) {
 	t.mu.Lock()
 	t.health = h
 	t.mu.Unlock()
@@ -70,6 +70,7 @@ func (t *Tracker) OnCallInitiated(from, to string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("track call: %w", err)
 	}
+
 	t.mu.Lock()
 	t.active[callKey(from, to)] = &activeCall{
 		ID:        id,
@@ -77,7 +78,12 @@ func (t *Tracker) OnCallInitiated(from, to string) (int64, error) {
 		Callee:    to,
 		StartedAt: time.Now(),
 	}
+	h := t.health
 	t.mu.Unlock()
+
+	if h != nil {
+		h.Init(id)
+	}
 	return id, nil
 }
 

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -28,10 +28,18 @@ type activeCall struct {
 	StartedAt time.Time
 }
 
+// healthEvictor is the subset of *HealthStore needed by Tracker to drop
+// per-call in-memory state on call end. Declared as an interface so Tracker
+// and HealthStore can live in the same package without a circular init.
+type healthEvictor interface {
+	Evict(callID int64)
+}
+
 type Tracker struct {
 	db     *db.Database
 	mu     sync.Mutex
 	active map[string]*activeCall // "caller→callee" → call
+	health healthEvictor
 }
 
 func New(d *db.Database) *Tracker {
@@ -39,6 +47,14 @@ func New(d *db.Database) *Tracker {
 		db:     d,
 		active: make(map[string]*activeCall),
 	}
+}
+
+// SetHealthStore registers an optional health store for per-call eviction
+// on call end. Safe to call once at startup; subsequent calls overwrite.
+func (t *Tracker) SetHealthStore(h healthEvictor) {
+	t.mu.Lock()
+	t.health = h
+	t.mu.Unlock()
 }
 
 func callKey(a, b string) string {
@@ -84,9 +100,20 @@ func (t *Tracker) OnCallEnded(caller, callee string) error {
 	key2 := callKey(callee, caller)
 
 	t.mu.Lock()
+	var id int64
+	if c, ok := t.active[key1]; ok {
+		id = c.ID
+	} else if c, ok := t.active[key2]; ok {
+		id = c.ID
+	}
 	delete(t.active, key1)
 	delete(t.active, key2)
+	h := t.health
 	t.mu.Unlock()
+
+	if h != nil && id != 0 {
+		h.Evict(id)
+	}
 
 	_, err := t.db.DB.Exec(
 		`UPDATE calls SET status = 'ended', ended_at = CURRENT_TIMESTAMP,
@@ -107,15 +134,26 @@ func (t *Tracker) OnCallEnded(caller, callee string) error {
 func (t *Tracker) ClearByNumber(number string) {
 	t.mu.Lock()
 	var toDelete []string
+	var evictIDs []int64
 	for key, c := range t.active {
 		if c.Caller == number || c.Callee == number {
 			toDelete = append(toDelete, key)
+			evictIDs = append(evictIDs, c.ID)
 		}
 	}
 	for _, key := range toDelete {
 		delete(t.active, key)
 	}
+	h := t.health
 	t.mu.Unlock()
+
+	if h != nil {
+		for _, id := range evictIDs {
+			if id != 0 {
+				h.Evict(id)
+			}
+		}
+	}
 
 	// End any open calls in the database
 	if _, err := t.db.DB.Exec(

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -22,6 +22,7 @@ type Call struct {
 }
 
 type activeCall struct {
+	ID        int64
 	Caller    string
 	Callee    string
 	StartedAt time.Time
@@ -44,18 +45,24 @@ func callKey(a, b string) string {
 	return a + "→" + b
 }
 
-func (t *Tracker) OnCallInitiated(from, to string) error {
-	_, err := t.db.DB.Exec(
-		"INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated')",
+func (t *Tracker) OnCallInitiated(from, to string) (int64, error) {
+	var id int64
+	err := t.db.DB.QueryRow(
+		"INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id",
 		from, to,
-	)
+	).Scan(&id)
 	if err != nil {
-		return fmt.Errorf("track call: %w", err)
+		return 0, fmt.Errorf("track call: %w", err)
 	}
 	t.mu.Lock()
-	t.active[callKey(from, to)] = &activeCall{Caller: from, Callee: to, StartedAt: time.Now()}
+	t.active[callKey(from, to)] = &activeCall{
+		ID:        id,
+		Caller:    from,
+		Callee:    to,
+		StartedAt: time.Now(),
+	}
 	t.mu.Unlock()
-	return nil
+	return id, nil
 }
 
 func (t *Tracker) OnCallAnswered(caller, callee string) error {
@@ -147,6 +154,19 @@ func (t *Tracker) PeerOf(number string) string {
 		}
 	}
 	return ""
+}
+
+// CallIDFor returns the active call id for an endpoint phone number.
+// Returns (0, false) if the number is not currently in a call.
+func (t *Tracker) CallIDFor(number string) (int64, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, c := range t.active {
+		if c.Caller == number || c.Callee == number {
+			return c.ID, true
+		}
+	}
+	return 0, false
 }
 
 func (t *Tracker) InCall(a, b string) bool {

--- a/server/internal/calls/tracker_test.go
+++ b/server/internal/calls/tracker_test.go
@@ -33,7 +33,7 @@ func TestCallLifecycle(t *testing.T) {
 	tr := New(d)
 
 	// Initiate
-	err := tr.OnCallInitiated("3140001", "3140002")
+	_, err := tr.OnCallInitiated("3140001", "3140002")
 	if err != nil {
 		t.Fatalf("OnCallInitiated: %v", err)
 	}
@@ -63,11 +63,29 @@ func TestCallLifecycle(t *testing.T) {
 	}
 }
 
+func TestOnCallInitiatedReturnsCallID(t *testing.T) {
+	d := setupTestDB(t)
+	tr := New(d)
+	id, err := tr.OnCallInitiated("555-1111", "555-2222")
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("want positive id, got %d", id)
+	}
+	if got, ok := tr.CallIDFor("555-1111"); !ok || got != id {
+		t.Fatalf("CallIDFor caller: got (%d,%v), want (%d,true)", got, ok, id)
+	}
+	if got, ok := tr.CallIDFor("555-2222"); !ok || got != id {
+		t.Fatalf("CallIDFor callee: got (%d,%v), want (%d,true)", got, ok, id)
+	}
+}
+
 func TestActiveCalls(t *testing.T) {
 	d := setupTestDB(t)
 	tr := New(d)
 
-	_ = tr.OnCallInitiated("3140001", "3140002")
+	_, _ = tr.OnCallInitiated("3140001", "3140002")
 	_ = tr.OnCallAnswered("3140001", "3140002")
 
 	active := tr.Active()

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -229,6 +229,21 @@ END $$;`,
 		// v15: per-user CRT bezel preference for the dialup theme.
 		// 'off' / 'connecting' (default) / 'all'.
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS crt_mode TEXT NOT NULL DEFAULT 'connecting'`,
+		// v16: per-call link-health telemetry samples
+		`CREATE TABLE IF NOT EXISTS call_link_health (
+			call_id     INTEGER     NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+			endpoint    TEXT        NOT NULL,
+			ts          TIMESTAMPTZ NOT NULL,
+			loss_pct    REAL,
+			jitter_ms   REAL,
+			rtt_ms      REAL,
+			conn_type   TEXT,
+			bytes_in    BIGINT,
+			bytes_out   BIGINT,
+			PRIMARY KEY (call_id, endpoint, ts)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_call_link_health_call_ts
+			ON call_link_health (call_id, ts DESC)`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -41,6 +41,10 @@ type LineSettings struct {
 	SilentMode bool   `json:"silent_mode,omitempty"`
 }
 
+// NOTE: this struct is mirrored in pi/digitsd/internal/signal/protocol.go.
+// Any field change must be applied in both places; drift-detection tests
+// on each side assert the round-trip shape.
+//
 // LinkHealthPayload carries per-sample call-quality telemetry from phone to
 // signald. All numeric fields are pointers so "not available this sample" is
 // expressed as nil (omitted from JSON). Units:

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -25,7 +25,7 @@ const (
 	TypeFactoryReset    = "factory_reset"    // Server → Phone: trigger factory reset
 	TypeRestart         = "restart"            // Server → Phone: restart service or reboot
 	TypeLineSettings    = "line_settings"      // Server → Phone: per-line config update
-	TypeLinkHealth      = "link_health"        // Phone -> Server: per-call stats snapshot
+	TypeLinkHealth      = "link_health"        // Phone → Server: per-call stats snapshot
 )
 
 // LineSettings is the wire-format copy of server/internal/line.Settings used

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -25,6 +25,7 @@ const (
 	TypeFactoryReset    = "factory_reset"    // Server → Phone: trigger factory reset
 	TypeRestart         = "restart"            // Server → Phone: restart service or reboot
 	TypeLineSettings    = "line_settings"      // Server → Phone: per-line config update
+	TypeLinkHealth      = "link_health"        // Phone -> Server: per-call stats snapshot
 )
 
 // LineSettings is the wire-format copy of server/internal/line.Settings used
@@ -38,6 +39,28 @@ const (
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 	SilentMode bool   `json:"silent_mode,omitempty"`
+}
+
+// LinkHealthPayload carries per-sample call-quality telemetry from phone to
+// signald. All numeric fields are pointers so "not available this sample" is
+// expressed as nil (omitted from JSON). Units:
+//
+//	LossPct:  packet loss as percent (0-100)
+//	JitterMs: RTCP jitter, milliseconds
+//	RttMs:    ICE nominated-pair round-trip time, milliseconds
+//	BytesIn:  bytes received on the nominated pair since call start
+//	BytesOut: bytes sent on the nominated pair since call start
+//
+// ConnType is "host", "srflx", or "relay" (empty if nominated pair unknown).
+// TS is phone-local unix milliseconds at the moment of sampling.
+type LinkHealthPayload struct {
+	TS       int64    `json:"ts"`
+	LossPct  *float32 `json:"loss_pct,omitempty"`
+	JitterMs *float32 `json:"jitter_ms,omitempty"`
+	RttMs    *float32 `json:"rtt_ms,omitempty"`
+	ConnType string   `json:"conn_type,omitempty"`
+	BytesIn  *int64   `json:"bytes_in,omitempty"`
+	BytesOut *int64   `json:"bytes_out,omitempty"`
 }
 
 // ICEServer represents a STUN or TURN server configuration.
@@ -83,6 +106,9 @@ type Message struct {
 
 	// Per-line settings updates (line_settings messages)
 	LineSettings *LineSettings `json:"line_settings,omitempty"`
+
+	// Link-health telemetry (link_health messages)
+	LinkHealth *LinkHealthPayload `json:"link_health,omitempty"`
 }
 
 func ParseMessage(data []byte) (*Message, error) {

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -51,7 +51,11 @@ type LineSettings struct {
 //	BytesIn:  bytes received on the nominated pair since call start
 //	BytesOut: bytes sent on the nominated pair since call start
 //
-// ConnType is "host", "srflx", or "relay" (empty if nominated pair unknown).
+// ConnType is one of "host", "srflx", "prflx", "relay" (ICE candidate type
+// of the local end of the nominated pair per RFC 8445). Empty if no pair
+// is nominated. "prflx" (peer-reflexive) is less common than srflx but
+// legitimate when the remote observes an address the local side didn't
+// anticipate; downstream consumers should treat it as a valid state.
 // TS is phone-local unix milliseconds at the moment of sampling.
 type LinkHealthPayload struct {
 	TS       int64    `json:"ts"`

--- a/server/internal/signaling/protocol_test.go
+++ b/server/internal/signaling/protocol_test.go
@@ -1,0 +1,58 @@
+package signaling
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestLinkHealthRoundTrip(t *testing.T) {
+	loss := float32(1.2)
+	jitter := float32(15.4)
+	rtt := float32(72.0)
+	in := int64(1000)
+	out := int64(950)
+	m := &Message{
+		Type: TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{
+			TS:       1714000000000,
+			LossPct:  &loss,
+			JitterMs: &jitter,
+			RttMs:    &rtt,
+			ConnType: "srflx",
+			BytesIn:  &in,
+			BytesOut: &out,
+		},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Type != TypeLinkHealth {
+		t.Fatalf("type: got %q want %q", got.Type, TypeLinkHealth)
+	}
+	if got.LinkHealth == nil {
+		t.Fatal("LinkHealth nil")
+	}
+	if got.LinkHealth.ConnType != "srflx" {
+		t.Fatalf("ConnType: got %q", got.LinkHealth.ConnType)
+	}
+	if got.LinkHealth.LossPct == nil || *got.LinkHealth.LossPct != 1.2 {
+		t.Fatalf("LossPct mismatch")
+	}
+}
+
+func TestLinkHealthOmitEmpty(t *testing.T) {
+	m := &Message{Type: TypeLinkHealth, LinkHealth: &LinkHealthPayload{TS: 1, ConnType: "host"}}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte(`"loss_pct"`)) {
+		t.Fatalf("expected loss_pct to be omitted, got %s", data)
+	}
+}

--- a/server/internal/signaling/protocol_test.go
+++ b/server/internal/signaling/protocol_test.go
@@ -56,3 +56,36 @@ func TestLinkHealthOmitEmpty(t *testing.T) {
 		t.Fatalf("expected loss_pct to be omitted, got %s", data)
 	}
 }
+
+func TestLinkHealthParseOmittedFieldsAreNil(t *testing.T) {
+	// Wire representation when phone has TS and ConnType but no RTCP stats yet.
+	data := []byte(`{"type":"link_health","link_health":{"ts":1714000000000,"conn_type":"host"}}`)
+	m, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.LinkHealth == nil {
+		t.Fatal("LinkHealth nil")
+	}
+	if m.LinkHealth.LossPct != nil {
+		t.Fatalf("LossPct: got %v, want nil", *m.LinkHealth.LossPct)
+	}
+	if m.LinkHealth.JitterMs != nil {
+		t.Fatalf("JitterMs: got %v, want nil", *m.LinkHealth.JitterMs)
+	}
+	if m.LinkHealth.RttMs != nil {
+		t.Fatalf("RttMs: got %v, want nil", *m.LinkHealth.RttMs)
+	}
+	if m.LinkHealth.BytesIn != nil {
+		t.Fatalf("BytesIn: got %v, want nil", *m.LinkHealth.BytesIn)
+	}
+	if m.LinkHealth.BytesOut != nil {
+		t.Fatalf("BytesOut: got %v, want nil", *m.LinkHealth.BytesOut)
+	}
+	if m.LinkHealth.TS != 1714000000000 {
+		t.Fatalf("TS: got %v, want 1714000000000", m.LinkHealth.TS)
+	}
+	if m.LinkHealth.ConnType != "host" {
+		t.Fatalf("ConnType: got %q", m.LinkHealth.ConnType)
+	}
+}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CallTracker interface {
-	OnCallInitiated(from, to string) error
+	OnCallInitiated(from, to string) (int64, error)
 	OnCallAnswered(caller, callee string) error
 	OnCallEnded(caller, callee string) error
 	ClearByNumber(number string)
@@ -110,7 +110,7 @@ func (r *Relay) handleCall(from string, msg *Message) {
 			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}
-		if err := r.Tracker.OnCallInitiated(from, msg.To); err != nil {
+		if _, err := r.Tracker.OnCallInitiated(from, msg.To); err != nil {
 			slog.Error("failed to track call initiation", "err", err)
 		}
 	}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -3,7 +3,9 @@ package signaling
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
+	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/turn"
 )
 
@@ -15,11 +17,17 @@ type CallTracker interface {
 	InCall(a, b string) bool
 	Busy(number string) bool
 	PeerOf(number string) string
+	CallIDFor(number string) (int64, bool)
 }
 
 // CallAuthorizer determines whether a call from one number to another is permitted.
 type CallAuthorizer interface {
 	CanCall(fromNumber, toNumber string) (bool, error)
+}
+
+// HealthRecorder is the subset of *calls.HealthStore used by Relay.
+type HealthRecorder interface {
+	Record(callID int64, endpoint string, sample calls.Sample)
 }
 
 type Relay struct {
@@ -29,6 +37,7 @@ type Relay struct {
 	TURNDomain     string
 	CallAuthorizer CallAuthorizer
 	LineStore      LineStore
+	HealthStore    HealthRecorder
 }
 
 func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer, lineStore LineStore) *Relay {
@@ -81,6 +90,9 @@ func (r *Relay) HandleMessage(from string, msg *Message) {
 		return // No relay — server consumes this
 	case TypeRestart:
 		return // Server → device only; ignore if echoed back
+	case TypeLinkHealth:
+		r.handleLinkHealth(from, msg)
+		return
 	default:
 		slog.Warn("unknown message type", "type", msg.Type, "from", from)
 	}
@@ -223,4 +235,29 @@ func (r *Relay) forward(msg *Message) {
 	if err := r.Hub.SendTo(msg.To, msg); err != nil {
 		slog.Error("forward failed", "to", msg.To, "err", err)
 	}
+}
+
+// handleLinkHealth records a telemetry sample for the active call the
+// session endpoint (from, derived from the authenticated websocket) is
+// currently on. msg.From is ignored by design (forgery defense). Unknown
+// calls and missing payloads are dropped silently.
+func (r *Relay) handleLinkHealth(from string, msg *Message) {
+	if r.HealthStore == nil || r.Tracker == nil || msg.LinkHealth == nil {
+		return
+	}
+	callID, ok := r.Tracker.CallIDFor(from)
+	if !ok {
+		slog.Debug("link_health for endpoint not in active call", "endpoint", from)
+		return
+	}
+	p := msg.LinkHealth
+	r.HealthStore.Record(callID, from, calls.Sample{
+		TS:       time.UnixMilli(p.TS),
+		LossPct:  p.LossPct,
+		JitterMs: p.JitterMs,
+		RttMs:    p.RttMs,
+		ConnType: p.ConnType,
+		BytesIn:  p.BytesIn,
+		BytesOut: p.BytesOut,
+	})
 }

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -4,22 +4,29 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/justinlindh/digits/server/internal/calls"
 )
 
 type mockTracker struct {
 	initiated []string
 	answered  []string
 	ended     []string
-	calls     map[string]bool // "a→b" keys for active calls
+	calls     map[string]bool  // "a→b" keys for active calls
+	callIDs   map[string]int64 // "a→b" keys for active call IDs
 }
 
 func newMockTracker() *mockTracker {
-	return &mockTracker{calls: make(map[string]bool)}
+	return &mockTracker{
+		calls:   make(map[string]bool),
+		callIDs: make(map[string]int64),
+	}
 }
 
 func (m *mockTracker) OnCallInitiated(from, to string) (int64, error) {
 	m.initiated = append(m.initiated, from+"→"+to)
 	m.calls[from+"→"+to] = true
+	m.callIDs[from+"→"+to] = 1
 	return 1, nil
 }
 func (m *mockTracker) OnCallAnswered(caller, callee string) error {
@@ -30,6 +37,8 @@ func (m *mockTracker) OnCallEnded(caller, callee string) error {
 	m.ended = append(m.ended, caller+"→"+callee)
 	delete(m.calls, caller+"→"+callee)
 	delete(m.calls, callee+"→"+caller)
+	delete(m.callIDs, caller+"→"+callee)
+	delete(m.callIDs, callee+"→"+caller)
 	return nil
 }
 func (m *mockTracker) ClearByNumber(number string) {
@@ -37,6 +46,7 @@ func (m *mockTracker) ClearByNumber(number string) {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number || b == number {
 			delete(m.calls, k)
+			delete(m.callIDs, k)
 		}
 	}
 }
@@ -65,6 +75,33 @@ func (m *mockTracker) PeerOf(number string) string {
 		}
 	}
 	return ""
+}
+
+func (m *mockTracker) CallIDFor(number string) (int64, bool) {
+	for k, id := range m.callIDs {
+		a, b, _ := strings.Cut(k, "→")
+		if a == number || b == number {
+			return id, true
+		}
+	}
+	return 0, false
+}
+
+// fakeHealthRecorder records calls for assertion in tests.
+type fakeHealthRecorder struct {
+	records []struct {
+		callID   int64
+		endpoint string
+		sample   calls.Sample
+	}
+}
+
+func (f *fakeHealthRecorder) Record(id int64, ep string, s calls.Sample) {
+	f.records = append(f.records, struct {
+		callID   int64
+		endpoint string
+		sample   calls.Sample
+	}{id, ep, s})
 }
 
 type mockCallAuthorizer struct {
@@ -520,4 +557,69 @@ func TestRelayRestartMessageNotPanics(t *testing.T) {
 	// Restart messages are server->device, not relayed through HandleMessage.
 	// But verify it doesn't crash if one passes through.
 	relay.HandleMessage("3140001", &Message{Type: TypeRestart, RestartMode: "service"})
+}
+
+func TestLinkHealthDispatchRecordsSample(t *testing.T) {
+	tr := newMockTracker()
+	// Seed an active call so CallIDFor("555-1111") returns (42, true).
+	tr.calls["555-1111→555-2222"] = true
+	tr.callIDs["555-1111→555-2222"] = 42
+
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tr, HealthStore: store}
+
+	loss := float32(0.5)
+	msg := &Message{
+		Type: TypeLinkHealth,
+		From: "555-OTHER", // forged -- MUST be ignored
+		LinkHealth: &LinkHealthPayload{
+			TS:      1714000000000,
+			LossPct: &loss,
+		},
+	}
+	r.handleLinkHealth("555-1111", msg)
+
+	if len(store.records) != 1 {
+		t.Fatalf("record count: got %d want 1", len(store.records))
+	}
+	got := store.records[0]
+	if got.callID != 42 {
+		t.Fatalf("callID: got %d want 42", got.callID)
+	}
+	if got.endpoint != "555-1111" {
+		t.Fatalf("endpoint: got %q want %q (forged From must be ignored)", got.endpoint, "555-1111")
+	}
+	if got.sample.LossPct == nil || *got.sample.LossPct != 0.5 {
+		t.Fatalf("loss: %+v", got.sample)
+	}
+}
+
+func TestLinkHealthDispatchDropsForUnknownCall(t *testing.T) {
+	tr := newMockTracker()
+	// No active calls -- CallIDFor returns (0, false).
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tr, HealthStore: store}
+
+	loss := float32(0.5)
+	r.handleLinkHealth("555-1111", &Message{
+		Type:       TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{TS: 1, LossPct: &loss},
+	})
+	if len(store.records) != 0 {
+		t.Fatalf("expected drop; got %d records", len(store.records))
+	}
+}
+
+func TestLinkHealthDispatchIgnoresNilPayload(t *testing.T) {
+	tr := newMockTracker()
+	tr.calls["555-1111→555-2222"] = true
+	tr.callIDs["555-1111→555-2222"] = 42
+
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tr, HealthStore: store}
+
+	r.handleLinkHealth("555-1111", &Message{Type: TypeLinkHealth, LinkHealth: nil})
+	if len(store.records) != 0 {
+		t.Fatalf("expected drop on nil LinkHealth; got %d", len(store.records))
+	}
 }

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -17,10 +17,10 @@ func newMockTracker() *mockTracker {
 	return &mockTracker{calls: make(map[string]bool)}
 }
 
-func (m *mockTracker) OnCallInitiated(from, to string) error {
+func (m *mockTracker) OnCallInitiated(from, to string) (int64, error) {
 	m.initiated = append(m.initiated, from+"→"+to)
 	m.calls[from+"→"+to] = true
-	return nil
+	return 1, nil
 }
 func (m *mockTracker) OnCallAnswered(caller, callee string) error {
 	m.answered = append(m.answered, caller+"→"+callee)

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -54,8 +54,8 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	h, err := NewHandler(nil, nil, hub, tracker, relay, HandlerConfig{
-		Addr:        ":0",
-	}, authStore, authHandlers, googleAuth, nil, nil, nil, nil, "", "")
+		Addr: ":0",
+	}, authStore, authHandlers, googleAuth, nil, nil, nil, nil, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -138,7 +138,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 
 	// === Step 4: Insert call records via tracker ===
 	// Call A: household-A phone calls an external number
-	if err := tracker.OnCallInitiated(phoneNumA, "5559999"); err != nil {
+	if _, err := tracker.OnCallInitiated(phoneNumA, "5559999"); err != nil {
 		t.Fatalf("initiate call A: %v", err)
 	}
 	if err := tracker.OnCallEnded(phoneNumA, "5559999"); err != nil {
@@ -146,7 +146,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 	}
 
 	// Call B: household-B phone calls a different external number
-	if err := tracker.OnCallInitiated(phoneNumB, "5558888"); err != nil {
+	if _, err := tracker.OnCallInitiated(phoneNumB, "5558888"); err != nil {
 		t.Fatalf("initiate call B: %v", err)
 	}
 	if err := tracker.OnCallEnded(phoneNumB, "5558888"); err != nil {

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -22,9 +22,23 @@ import (
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
-// setupCallsTestServer creates a full server with householdStore wired in,
-// which is required by handleCalls.
-func setupCallsTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store, *calls.Tracker, *auth.Store, *household.Store) {
+// callsTestEnv bundles the pieces that integration tests for the calls-related
+// endpoints need. Callers that only need a subset can ignore fields.
+type callsTestEnv struct {
+	srv            *httptest.Server
+	database       *db.Database
+	lineStore      *line.Store
+	tracker        *calls.Tracker
+	authStore      *auth.Store
+	householdStore *household.Store
+	linkStore      *household.LinkStore
+	pairingStore   *pairing.Store
+	healthStore    *calls.HealthStore
+}
+
+// setupCallsTestServer creates a full server with householdStore, linkStore,
+// and healthStore wired in. Returns the bundled callsTestEnv.
+func setupCallsTestServer(t *testing.T) callsTestEnv {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
@@ -44,7 +58,10 @@ func setupCallsTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.S
 
 	authStore := auth.NewStoreFromDB(database.DB)
 	householdStore := household.NewStore(database.DB)
+	linkStore := household.NewLinkStore(database.DB)
 	pairingStore := pairing.NewStore(database.DB)
+	healthStore := calls.NewHealthStore(database)
+	tracker.SetHealthStore(healthStore)
 
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)
 	emailSender := email.NewNoopSender()
@@ -56,21 +73,36 @@ func setupCallsTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.S
 
 	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
 		Addr:        ":0",
-	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, nil, emailSender, "", "")
+	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, "", "", healthStore)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
 
 	srv := httptest.NewServer(h.Router())
 	t.Cleanup(srv.Close)
-	return srv, database, lineStore, tracker, authStore, householdStore
+	return callsTestEnv{
+		srv:            srv,
+		database:       database,
+		lineStore:      lineStore,
+		tracker:        tracker,
+		authStore:      authStore,
+		householdStore: householdStore,
+		linkStore:      linkStore,
+		pairingStore:   pairingStore,
+		healthStore:    healthStore,
+	}
 }
 
 // TestCallsPageScopedToHousehold verifies that the /calls page only shows
 // calls involving phones belonging to the authenticated user's household.
 func TestCallsPageScopedToHousehold(t *testing.T) {
 	// === Step 1: Set up test server with householdStore wired in ===
-	srv, database, _, tracker, authStore, householdStore := setupCallsTestServer(t)
+	env := setupCallsTestServer(t)
+	srv := env.srv
+	database := env.database
+	tracker := env.tracker
+	authStore := env.authStore
+	householdStore := env.householdStore
 
 	// === Step 2: Create two users in two separate households ===
 	userA, err := authStore.CreateUser("e2e-calls-a@example.com", "Calls User A", nil)
@@ -103,7 +135,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 	}
 
 	// === Step 3: Pair phones into each household ===
-	pairingStore := pairing.NewStore(database.DB)
+	pairingStore := env.pairingStore
 	hwA := "e2e-calls-hw-a"
 	hwB := "e2e-calls-hw-b"
 	phoneNumA := "5550001"

--- a/server/internal/web/e2e_test.go
+++ b/server/internal/web/e2e_test.go
@@ -56,7 +56,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store,
 
 	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
 		Addr:        ":0",
-	}, authStore, authHandlers, googleAuth, householdStore, nil, nil, nil, "", "")
+	}, authStore, authHandlers, googleAuth, householdStore, nil, nil, nil, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -2010,38 +2010,37 @@ func (h *Handler) requireNumberOwnership(w http.ResponseWriter, r *http.Request,
 	return h.requireLineOwnership(w, r, number) != nil
 }
 
-// ownedNumbersForUser returns the set of phone numbers owned by any household
-// the user belongs to, plus the list of household IDs. Returns (nil, nil, false)
+// ownedLinesForUser returns the lines owned by any household the user belongs
+// to, keyed by number, plus the primary household ID. Returns (nil, "", false)
 // if the user has no households or any lookup fails — caller writes 404, same
 // response shape as nonexistent.
-func (h *Handler) ownedNumbersForUser(user *auth.User) (map[string]struct{}, []string, bool) {
+func (h *Handler) ownedLinesForUser(user *auth.User) (map[string]*line.Line, string, bool) {
 	households, err := h.householdStore.GetForUser(user.ID)
 	if err != nil {
 		slog.Error("link_health: list households failed", "user_id", user.ID, "err", err)
-		return nil, nil, false
+		return nil, "", false
 	}
 	if len(households) == 0 {
-		return nil, nil, false
+		return nil, "", false
 	}
-	householdIDs := make([]string, 0, len(households))
-	numbers := make(map[string]struct{})
+	lines := make(map[string]*line.Line)
 	for _, hh := range households {
-		householdIDs = append(householdIDs, hh.ID)
-		lines, err := h.lineStore.ListByHousehold(hh.ID)
+		hhLines, err := h.lineStore.ListByHousehold(hh.ID)
 		if err != nil {
 			slog.Error("link_health: list lines failed", "household_id", hh.ID, "err", err)
-			return nil, nil, false
+			return nil, "", false
 		}
-		for _, ln := range lines {
-			numbers[ln.Number] = struct{}{}
+		for i := range hhLines {
+			ln := hhLines[i]
+			lines[ln.Number] = &ln
 		}
 	}
-	return numbers, householdIDs, true
+	return lines, households[0].ID, true
 }
 
 // requireCallEndpointOwnership verifies the authenticated user owns either
 // endpoint of the call (across ANY household the user belongs to). Returns
-// the call, the user's household IDs (for later display-name resolution),
+// the call, the owned-lines map (keyed by number), the primary household ID,
 // and true on success. On any failure, writes 404 (unauthorized and
 // nonexistent are indistinguishable).
 //
@@ -2049,34 +2048,34 @@ func (h *Handler) ownedNumbersForUser(user *auth.User) (map[string]struct{}, []s
 // regardless of auth outcome, to avoid a timing side channel on call-id
 // enumeration. Linked households do NOT grant access to telemetry; only
 // direct household ownership of a call endpoint does.
-func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, []string, bool) {
+func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, map[string]*line.Line, string, bool) {
 	user := auth.UserFromContext(r.Context())
-	if user == nil || h.lineStore == nil || h.householdStore == nil || h.tracker == nil || h.healthStore == nil {
+	if user == nil {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, false
+		return calls.Call{}, nil, "", false
 	}
 
 	// Always do both queries in the same order, regardless of miss reason.
-	numbers, householdIDs, ok := h.ownedNumbersForUser(user)
+	ownedLines, primaryHH, ok := h.ownedLinesForUser(user)
 	call, callErr := h.tracker.GetCall(callID)
 
 	if callErr != nil {
 		slog.Error("link_health: get call failed", "call_id", callID, "err", callErr)
 		http.NotFound(w, r)
-		return calls.Call{}, nil, false
+		return calls.Call{}, nil, "", false
 	}
 	if !ok || call.ID == 0 {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, false
+		return calls.Call{}, nil, "", false
 	}
 
-	_, ownsCaller := numbers[call.Caller]
-	_, ownsCallee := numbers[call.Callee]
+	_, ownsCaller := ownedLines[call.Caller]
+	_, ownsCallee := ownedLines[call.Callee]
 	if !ownsCaller && !ownsCallee {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, false
+		return calls.Call{}, nil, "", false
 	}
-	return call, householdIDs, true
+	return call, ownedLines, primaryHH, true
 }
 
 // ---- Link Health API ----
@@ -2128,7 +2127,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	call, householdIDs, ok := h.requireCallEndpointOwnership(w, r, callID)
+	call, ownedLines, primaryHH, ok := h.requireCallEndpointOwnership(w, r, callID)
 	if !ok {
 		return
 	}
@@ -2138,19 +2137,19 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	// their call log; the underlying auth check does not grant read access to
 	// calls the user was not part of.
 	var linkedIndex map[string]string
-	if len(householdIDs) > 0 {
-		linkedFamilies := h.buildLinkedFamilies(householdIDs[0])
+	if primaryHH != "" {
+		linkedFamilies := h.buildLinkedFamilies(primaryHH)
 		linkedIndex = buildLinkedLineIndex(linkedFamilies)
 	}
 
 	resp := LinkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
-	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex)
+	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex, ownedLines)
 	if err != nil {
 		slog.Error("link_health: build caller endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
-	calleeEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex)
+	calleeEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex, ownedLines)
 	if err != nil {
 		slog.Error("link_health: build callee endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -2165,12 +2164,12 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) (LinkHealthEndpointResp, error) {
+func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string, ownedLines map[string]*line.Line) (LinkHealthEndpointResp, error) {
 	out := LinkHealthEndpointResp{Number: number, Window: []LinkHealthSample{}}
 
-	// Display name resolution — silent fallback on error is appropriate here;
-	// GetByNumber failure is non-security-critical for display purposes.
-	if ln, err := h.lineStore.GetByNumber(number); err == nil && ln != nil {
+	// Display name resolution: owned line first (no extra DB query), then
+	// linked-index for peer names, then bare number as fallback.
+	if ln, ok := ownedLines[number]; ok && ln != nil {
 		out.DisplayName = ln.Name
 	} else {
 		out.DisplayName = resolvePeerName(number, linkedIndex)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,9 +45,10 @@ type Handler struct {
 	upgrader websocket.Upgrader
 	lineStore   *line.Store
 	deviceStore *device.Store
-	hub      *signaling.Hub
-	tracker  *calls.Tracker
-	relay    *signaling.Relay
+	hub         *signaling.Hub
+	tracker     *calls.Tracker
+	relay       *signaling.Relay
+	healthStore *calls.HealthStore
 	// Per-page template sets to avoid {{define}} name conflicts
 	tmplDashboard   *template.Template
 	tmplPhones      *template.Template
@@ -82,7 +85,7 @@ type HandlerConfig struct {
 	Addr string
 }
 
-func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling.Hub, tracker *calls.Tracker, relay *signaling.Relay, cfg HandlerConfig, authStore *auth.Store, authHandlers *auth.Handlers, googleAuth *auth.GoogleAuth, householdStore *household.Store, pairingStore *pairing.Store, linkStore *household.LinkStore, emailSender email.Sender, baseURL string, adminSecret string) (*Handler, error) {
+func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling.Hub, tracker *calls.Tracker, relay *signaling.Relay, cfg HandlerConfig, authStore *auth.Store, authHandlers *auth.Handlers, googleAuth *auth.GoogleAuth, householdStore *household.Store, pairingStore *pairing.Store, linkStore *household.LinkStore, emailSender email.Sender, baseURL string, adminSecret string, healthStore *calls.HealthStore) (*Handler, error) {
 	funcMap := template.FuncMap{
 		"fmtPhone": line.FormatNumber,
 		"fmtDuration": func(seconds int) string {
@@ -154,6 +157,7 @@ func NewHandler(lineStore *line.Store, deviceStore *device.Store, hub *signaling
 		hub:             hub,
 		tracker:         tracker,
 		relay:           relay,
+		healthStore:     healthStore,
 		tmplDashboard:   tmplDashboard,
 		tmplPhones:      tmplPhones,
 		tmplCalls:       tmplCalls,
@@ -245,6 +249,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /links/{id}/revoke", h.handleLinksRevokePost)
 	protected.HandleFunc("GET /api/status", h.handleAPIStatus)
 	protected.HandleFunc("GET /api/active-calls", h.handleAPIActiveCalls)
+	protected.HandleFunc("GET /api/call/{id}/link-health", h.handleCallLinkHealth)
 	protected.HandleFunc("GET /api/lines/number-available", h.handleAPINumberAvailable)
 
 	// Onboarding gate: redirect users without a household to /onboard
@@ -2003,6 +2008,153 @@ func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, n
 // ownership is confirmed, or false after writing an HTTP 404 response.
 func (h *Handler) requireNumberOwnership(w http.ResponseWriter, r *http.Request, number string) bool {
 	return h.requireLineOwnership(w, r, number) != nil
+}
+
+// requireCallEndpointOwnership verifies the authenticated user's household
+// owns at least one endpoint of the given call. Returns the call row and
+// true on success. On any failure (unauthenticated, call not found, not
+// owned) it writes 404 and returns false — unauthorized and nonexistent
+// are indistinguishable to the client.
+//
+// Linked-household status does NOT grant access to telemetry; the user's
+// household must own caller OR callee directly.
+func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, bool) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil || h.lineStore == nil || h.householdStore == nil || h.tracker == nil {
+		http.NotFound(w, r)
+		return calls.Call{}, false
+	}
+	households, err := h.householdStore.GetForUser(user.ID)
+	if err != nil || len(households) == 0 {
+		http.NotFound(w, r)
+		return calls.Call{}, false
+	}
+	householdID := households[0].ID
+
+	call, err := h.tracker.GetCall(callID)
+	if err != nil || call.ID == 0 {
+		http.NotFound(w, r)
+		return calls.Call{}, false
+	}
+
+	callerLine, _ := h.lineStore.GetByNumber(call.Caller)
+	calleeLine, _ := h.lineStore.GetByNumber(call.Callee)
+	if (callerLine != nil && callerLine.HouseholdID == householdID) ||
+		(calleeLine != nil && calleeLine.HouseholdID == householdID) {
+		return call, true
+	}
+	http.NotFound(w, r)
+	return calls.Call{}, false
+}
+
+// ---- Link Health API ----
+
+type linkHealthSample struct {
+	TS       int64    `json:"ts"`
+	LossPct  *float32 `json:"loss_pct,omitempty"`
+	JitterMs *float32 `json:"jitter_ms,omitempty"`
+	RttMs    *float32 `json:"rtt_ms,omitempty"`
+	ConnType string   `json:"conn_type,omitempty"`
+	BytesIn  *int64   `json:"bytes_in,omitempty"`
+	BytesOut *int64   `json:"bytes_out,omitempty"`
+}
+
+type linkHealthEndpointResp struct {
+	Number      string             `json:"number"`
+	DisplayName string             `json:"display_name"`
+	Latest      *linkHealthSample  `json:"latest,omitempty"`
+	Window      []linkHealthSample `json:"window"`
+}
+
+type linkHealthResp struct {
+	CallID    int64                  `json:"call_id"`
+	StartedAt time.Time              `json:"started_at"`
+	Caller    linkHealthEndpointResp `json:"caller"`
+	Callee    linkHealthEndpointResp `json:"callee"`
+}
+
+func toAPISample(s calls.Sample) linkHealthSample {
+	return linkHealthSample{
+		TS:       s.TS.UnixMilli(),
+		LossPct:  s.LossPct,
+		JitterMs: s.JitterMs,
+		RttMs:    s.RttMs,
+		ConnType: s.ConnType,
+		BytesIn:  s.BytesIn,
+		BytesOut: s.BytesOut,
+	}
+}
+
+func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
+	idStr := r.PathValue("id")
+	callID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || callID <= 0 {
+		http.NotFound(w, r)
+		return
+	}
+	call, ok := h.requireCallEndpointOwnership(w, r, callID)
+	if !ok {
+		return
+	}
+
+	user := auth.UserFromContext(r.Context())
+	var linkedIndex map[string]string
+	if user != nil && h.householdStore != nil {
+		households, _ := h.householdStore.GetForUser(user.ID)
+		if len(households) > 0 {
+			linkedFamilies := h.buildLinkedFamilies(households[0].ID)
+			linkedIndex = buildLinkedLineIndex(linkedFamilies)
+		}
+	}
+
+	resp := linkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
+	resp.Caller = h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex)
+	resp.Callee = h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("link_health encode failed", "call_id", callID, "err", err)
+	}
+}
+
+func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) linkHealthEndpointResp {
+	out := linkHealthEndpointResp{Number: number, Window: []linkHealthSample{}}
+	if line, _ := h.lineStore.GetByNumber(number); line != nil {
+		out.DisplayName = line.Name
+	} else {
+		out.DisplayName = resolvePeerName(number, linkedIndex)
+	}
+	if out.DisplayName == "" {
+		out.DisplayName = number
+	}
+
+	// Try memory first.
+	windowMem := h.healthStore.Window(callID, number)
+	if len(windowMem) > 0 {
+		out.Window = make([]linkHealthSample, len(windowMem))
+		for i, s := range windowMem {
+			out.Window[i] = toAPISample(s)
+		}
+		last := windowMem[len(windowMem)-1]
+		la := toAPISample(last)
+		out.Latest = &la
+		return out
+	}
+	// Fallback to DB.
+	db, err := h.healthStore.Readback(ctx, callID, number, 60)
+	if err != nil {
+		slog.Error("link_health readback failed", "call_id", callID, "err", err)
+		return out
+	}
+	out.Window = make([]linkHealthSample, len(db))
+	for i, s := range db {
+		out.Window[i] = toAPISample(s)
+	}
+	if len(db) > 0 {
+		la := toAPISample(db[len(db)-1])
+		out.Latest = &la
+	}
+	return out
 }
 
 // householdNumbers returns the set of phone numbers belonging to the

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -2081,7 +2081,9 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 
 // ---- Link Health API ----
 
-type linkHealthSample struct {
+// LinkHealthSample is the JSON representation of a single link-health
+// measurement returned by GET /api/call/{id}/link-health.
+type LinkHealthSample struct {
 	TS       int64    `json:"ts"`
 	LossPct  *float32 `json:"loss_pct,omitempty"`
 	JitterMs *float32 `json:"jitter_ms,omitempty"`
@@ -2091,22 +2093,24 @@ type linkHealthSample struct {
 	BytesOut *int64   `json:"bytes_out,omitempty"`
 }
 
-type linkHealthEndpointResp struct {
-	Number      string             `json:"number"`
-	DisplayName string             `json:"display_name"`
-	Latest      *linkHealthSample  `json:"latest,omitempty"`
-	Window      []linkHealthSample `json:"window"`
+// LinkHealthEndpointResp is the per-endpoint section of a LinkHealthResp.
+type LinkHealthEndpointResp struct {
+	Number      string            `json:"number"`
+	DisplayName string            `json:"display_name"`
+	Latest      *LinkHealthSample `json:"latest,omitempty"`
+	Window      []LinkHealthSample `json:"window"`
 }
 
-type linkHealthResp struct {
+// LinkHealthResp is the top-level response body for GET /api/call/{id}/link-health.
+type LinkHealthResp struct {
 	CallID    int64                  `json:"call_id"`
 	StartedAt time.Time              `json:"started_at"`
-	Caller    linkHealthEndpointResp `json:"caller"`
-	Callee    linkHealthEndpointResp `json:"callee"`
+	Caller    LinkHealthEndpointResp `json:"caller"`
+	Callee    LinkHealthEndpointResp `json:"callee"`
 }
 
-func toAPISample(s calls.Sample) linkHealthSample {
-	return linkHealthSample{
+func toAPISample(s calls.Sample) LinkHealthSample {
+	return LinkHealthSample{
 		TS:       s.TS.UnixMilli(),
 		LossPct:  s.LossPct,
 		JitterMs: s.JitterMs,
@@ -2139,7 +2143,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 		linkedIndex = buildLinkedLineIndex(linkedFamilies)
 	}
 
-	resp := linkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
+	resp := LinkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
 	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex)
 	if err != nil {
 		slog.Error("link_health: build caller endpoint failed", "call_id", callID, "err", err)
@@ -2161,8 +2165,8 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) (linkHealthEndpointResp, error) {
-	out := linkHealthEndpointResp{Number: number, Window: []linkHealthSample{}}
+func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) (LinkHealthEndpointResp, error) {
+	out := LinkHealthEndpointResp{Number: number, Window: []LinkHealthSample{}}
 
 	// Display name resolution — silent fallback on error is appropriate here;
 	// GetByNumber failure is non-security-critical for display purposes.
@@ -2178,7 +2182,7 @@ func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, num
 	// Memory first.
 	windowMem := h.healthStore.Window(callID, number)
 	if len(windowMem) > 0 {
-		out.Window = make([]linkHealthSample, len(windowMem))
+		out.Window = make([]LinkHealthSample, len(windowMem))
 		for i, s := range windowMem {
 			out.Window[i] = toAPISample(s)
 		}
@@ -2192,7 +2196,7 @@ func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, num
 	if err != nil {
 		return out, fmt.Errorf("readback %d/%s: %w", callID, number, err)
 	}
-	out.Window = make([]linkHealthSample, len(dbSamples))
+	out.Window = make([]LinkHealthSample, len(dbSamples))
 	for i, s := range dbSamples {
 		out.Window[i] = toAPISample(s)
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -2010,41 +2010,73 @@ func (h *Handler) requireNumberOwnership(w http.ResponseWriter, r *http.Request,
 	return h.requireLineOwnership(w, r, number) != nil
 }
 
-// requireCallEndpointOwnership verifies the authenticated user's household
-// owns at least one endpoint of the given call. Returns the call row and
-// true on success. On any failure (unauthenticated, call not found, not
-// owned) it writes 404 and returns false — unauthorized and nonexistent
-// are indistinguishable to the client.
-//
-// Linked-household status does NOT grant access to telemetry; the user's
-// household must own caller OR callee directly.
-func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, bool) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil || h.lineStore == nil || h.householdStore == nil || h.tracker == nil {
-		http.NotFound(w, r)
-		return calls.Call{}, false
-	}
+// ownedNumbersForUser returns the set of phone numbers owned by any household
+// the user belongs to, plus the list of household IDs. Returns (nil, nil, false)
+// if the user has no households or any lookup fails — caller writes 404, same
+// response shape as nonexistent.
+func (h *Handler) ownedNumbersForUser(user *auth.User) (map[string]struct{}, []string, bool) {
 	households, err := h.householdStore.GetForUser(user.ID)
-	if err != nil || len(households) == 0 {
-		http.NotFound(w, r)
-		return calls.Call{}, false
+	if err != nil {
+		slog.Error("link_health: list households failed", "user_id", user.ID, "err", err)
+		return nil, nil, false
 	}
-	householdID := households[0].ID
+	if len(households) == 0 {
+		return nil, nil, false
+	}
+	householdIDs := make([]string, 0, len(households))
+	numbers := make(map[string]struct{})
+	for _, hh := range households {
+		householdIDs = append(householdIDs, hh.ID)
+		lines, err := h.lineStore.ListByHousehold(hh.ID)
+		if err != nil {
+			slog.Error("link_health: list lines failed", "household_id", hh.ID, "err", err)
+			return nil, nil, false
+		}
+		for _, ln := range lines {
+			numbers[ln.Number] = struct{}{}
+		}
+	}
+	return numbers, householdIDs, true
+}
 
-	call, err := h.tracker.GetCall(callID)
-	if err != nil || call.ID == 0 {
+// requireCallEndpointOwnership verifies the authenticated user owns either
+// endpoint of the call (across ANY household the user belongs to). Returns
+// the call, the user's household IDs (for later display-name resolution),
+// and true on success. On any failure, writes 404 (unauthorized and
+// nonexistent are indistinguishable).
+//
+// Implementation detail: always performs the same sequence of DB queries
+// regardless of auth outcome, to avoid a timing side channel on call-id
+// enumeration. Linked households do NOT grant access to telemetry; only
+// direct household ownership of a call endpoint does.
+func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, []string, bool) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil || h.lineStore == nil || h.householdStore == nil || h.tracker == nil || h.healthStore == nil {
 		http.NotFound(w, r)
-		return calls.Call{}, false
+		return calls.Call{}, nil, false
 	}
 
-	callerLine, _ := h.lineStore.GetByNumber(call.Caller)
-	calleeLine, _ := h.lineStore.GetByNumber(call.Callee)
-	if (callerLine != nil && callerLine.HouseholdID == householdID) ||
-		(calleeLine != nil && calleeLine.HouseholdID == householdID) {
-		return call, true
+	// Always do both queries in the same order, regardless of miss reason.
+	numbers, householdIDs, ok := h.ownedNumbersForUser(user)
+	call, callErr := h.tracker.GetCall(callID)
+
+	if callErr != nil {
+		slog.Error("link_health: get call failed", "call_id", callID, "err", callErr)
+		http.NotFound(w, r)
+		return calls.Call{}, nil, false
 	}
-	http.NotFound(w, r)
-	return calls.Call{}, false
+	if !ok || call.ID == 0 {
+		http.NotFound(w, r)
+		return calls.Call{}, nil, false
+	}
+
+	_, ownsCaller := numbers[call.Caller]
+	_, ownsCallee := numbers[call.Callee]
+	if !ownsCaller && !ownsCallee {
+		http.NotFound(w, r)
+		return calls.Call{}, nil, false
+	}
+	return call, householdIDs, true
 }
 
 // ---- Link Health API ----
@@ -2092,24 +2124,36 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	call, ok := h.requireCallEndpointOwnership(w, r, callID)
+	call, householdIDs, ok := h.requireCallEndpointOwnership(w, r, callID)
 	if !ok {
 		return
 	}
 
-	user := auth.UserFromContext(r.Context())
+	// Display-name resolution — same helpers as /calls page. No new data exposure.
+	// Linked-household names are shown for peers that the user already sees in
+	// their call log; the underlying auth check does not grant read access to
+	// calls the user was not part of.
 	var linkedIndex map[string]string
-	if user != nil && h.householdStore != nil {
-		households, _ := h.householdStore.GetForUser(user.ID)
-		if len(households) > 0 {
-			linkedFamilies := h.buildLinkedFamilies(households[0].ID)
-			linkedIndex = buildLinkedLineIndex(linkedFamilies)
-		}
+	if len(householdIDs) > 0 {
+		linkedFamilies := h.buildLinkedFamilies(householdIDs[0])
+		linkedIndex = buildLinkedLineIndex(linkedFamilies)
 	}
 
 	resp := linkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
-	resp.Caller = h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex)
-	resp.Callee = h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex)
+	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex)
+	if err != nil {
+		slog.Error("link_health: build caller endpoint failed", "call_id", callID, "err", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	calleeEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex)
+	if err != nil {
+		slog.Error("link_health: build callee endpoint failed", "call_id", callID, "err", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	resp.Caller = callerEndpoint
+	resp.Callee = calleeEndpoint
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
@@ -2117,10 +2161,13 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) linkHealthEndpointResp {
+func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string) (linkHealthEndpointResp, error) {
 	out := linkHealthEndpointResp{Number: number, Window: []linkHealthSample{}}
-	if line, _ := h.lineStore.GetByNumber(number); line != nil {
-		out.DisplayName = line.Name
+
+	// Display name resolution — silent fallback on error is appropriate here;
+	// GetByNumber failure is non-security-critical for display purposes.
+	if ln, err := h.lineStore.GetByNumber(number); err == nil && ln != nil {
+		out.DisplayName = ln.Name
 	} else {
 		out.DisplayName = resolvePeerName(number, linkedIndex)
 	}
@@ -2128,33 +2175,32 @@ func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, num
 		out.DisplayName = number
 	}
 
-	// Try memory first.
+	// Memory first.
 	windowMem := h.healthStore.Window(callID, number)
 	if len(windowMem) > 0 {
 		out.Window = make([]linkHealthSample, len(windowMem))
 		for i, s := range windowMem {
 			out.Window[i] = toAPISample(s)
 		}
-		last := windowMem[len(windowMem)-1]
-		la := toAPISample(last)
+		la := toAPISample(windowMem[len(windowMem)-1])
 		out.Latest = &la
-		return out
+		return out, nil
 	}
-	// Fallback to DB.
-	db, err := h.healthStore.Readback(ctx, callID, number, 60)
+
+	// DB fallback.
+	dbSamples, err := h.healthStore.Readback(ctx, callID, number, 60)
 	if err != nil {
-		slog.Error("link_health readback failed", "call_id", callID, "err", err)
-		return out
+		return out, fmt.Errorf("readback %d/%s: %w", callID, number, err)
 	}
-	out.Window = make([]linkHealthSample, len(db))
-	for i, s := range db {
+	out.Window = make([]linkHealthSample, len(dbSamples))
+	for i, s := range dbSamples {
 		out.Window[i] = toAPISample(s)
 	}
-	if len(db) > 0 {
-		la := toAPISample(db[len(db)-1])
+	if len(dbSamples) > 0 {
+		la := toAPISample(dbSamples[len(dbSamples)-1])
 		out.Latest = &la
 	}
-	return out
+	return out, nil
 }
 
 // householdNumbers returns the set of phone numbers belonging to the

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -56,7 +56,7 @@ func setupHandler(t *testing.T) (*Handler, *db.Database, *auth.Store) {
 
 	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
 		Addr:        ":8443",
-	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, "", "")
+	}, authStore, authHandlers, googleAuth, householdStore, pairingStore, linkStore, emailSender, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -62,21 +62,46 @@ type lhSetup struct {
 
 // newLHEnv creates three users in three independent households, each with one
 // line, and registers cleanup. Users A/B/C own lines numA/numB/numC.
+//
+// Cleanup is registered BEFORE any setup DB work so that partial-setup
+// failures do not leak rows into the shared test database.
 func newLHEnv(t *testing.T) lhSetup {
 	t.Helper()
-	env := setupCallsTestServer(t)
 
-	numA := nextPhone()
-	numB := nextPhone()
-	numC := nextPhone()
+	// Derive all unique identifiers up front, before touching the DB, so that
+	// cleanup can reference them whether or not setup completed.
+	seq := phoneCounter.Add(3) // reserve three numbers atomically
+	numA := fmt.Sprintf("%07d", seq-2)
+	numB := fmt.Sprintf("%07d", seq-1)
+	numC := fmt.Sprintf("%07d", seq)
 	hwA := "lh-hw-" + numA
 	hwB := "lh-hw-" + numB
 	hwC := "lh-hw-" + numC
-
 	emailA := "lh-a-" + numA + "@example.com"
 	emailB := "lh-b-" + numB + "@example.com"
 	emailC := "lh-c-" + numC + "@example.com"
+	hhNameA := "LH Family A " + numA
+	hhNameB := "LH Family B " + numB
+	hhNameC := "LH Family C " + numC
 
+	env := setupCallsTestServer(t)
+	db := env.database.DB
+
+	// Register cleanup IMMEDIATELY — before any partial setup can fail.
+	// All DELETEs are idempotent against missing rows.
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM call_link_health WHERE call_id IN (SELECT id FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3))", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3)", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id IN ($1,$2,$3)", hwA, hwB, hwC)
+		_, _ = db.Exec("DELETE FROM lines WHERE number IN ($1,$2,$3)", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM household_links WHERE household_a_id IN (SELECT id FROM households WHERE name IN ($1,$2,$3)) OR household_b_id IN (SELECT id FROM households WHERE name IN ($1,$2,$3))", hhNameA, hhNameB, hhNameC)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name IN ($1,$2,$3))", hhNameA, hhNameB, hhNameC)
+		_, _ = db.Exec("DELETE FROM households WHERE name IN ($1,$2,$3)", hhNameA, hhNameB, hhNameC)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email IN ($1,$2,$3))", emailA, emailB, emailC)
+		_, _ = db.Exec("DELETE FROM users WHERE email IN ($1,$2,$3)", emailA, emailB, emailC)
+	})
+
+	// Create users.
 	userA, err := env.authStore.CreateUser(emailA, "LH User A", nil)
 	if err != nil {
 		t.Fatalf("create user A: %v", err)
@@ -90,15 +115,16 @@ func newLHEnv(t *testing.T) lhSetup {
 		t.Fatalf("create user C: %v", err)
 	}
 
-	hhA, err := env.householdStore.Create("LH Family A "+numA, userA.ID)
+	// Create households.
+	hhA, err := env.householdStore.Create(hhNameA, userA.ID)
 	if err != nil {
 		t.Fatalf("create household A: %v", err)
 	}
-	hhB, err := env.householdStore.Create("LH Family B "+numB, userB.ID)
+	hhB, err := env.householdStore.Create(hhNameB, userB.ID)
 	if err != nil {
 		t.Fatalf("create household B: %v", err)
 	}
-	hhC, err := env.householdStore.Create("LH Family C "+numC, userC.ID)
+	hhC, err := env.householdStore.Create(hhNameC, userC.ID)
 	if err != nil {
 		t.Fatalf("create household C: %v", err)
 	}
@@ -127,19 +153,6 @@ func newLHEnv(t *testing.T) lhSetup {
 	if _, _, err := env.pairingStore.ClaimDevice(codeC, numC, "Phone C", hhC.ID); err != nil {
 		t.Fatalf("claim phone C: %v", err)
 	}
-
-	db := env.database.DB
-	t.Cleanup(func() {
-		_, _ = db.Exec("DELETE FROM call_link_health WHERE call_id IN (SELECT id FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3))", numA, numB, numC)
-		_, _ = db.Exec("DELETE FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3)", numA, numB, numC)
-		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id IN ($1,$2,$3)", hwA, hwB, hwC)
-		_, _ = db.Exec("DELETE FROM lines WHERE number IN ($1,$2,$3)", numA, numB, numC)
-		_, _ = db.Exec("DELETE FROM household_links WHERE household_a_id IN ($1,$2,$3) OR household_b_id IN ($1,$2,$3)", hhA.ID, hhB.ID, hhC.ID)
-		_, _ = db.Exec("DELETE FROM household_members WHERE user_id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
-		_, _ = db.Exec("DELETE FROM households WHERE id IN ($1,$2,$3)", hhA.ID, hhB.ID, hhC.ID)
-		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
-		_, _ = db.Exec("DELETE FROM users WHERE id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
-	})
 
 	return lhSetup{
 		env:   env,
@@ -207,23 +220,15 @@ func TestLinkHealth_OwnerReadsOwnCall(t *testing.T) {
 		t.Fatalf("caller owner: got %d want 200", resp.StatusCode)
 	}
 
-	var body map[string]any
+	var body LinkHealthResp
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if int64(body["call_id"].(float64)) != callID {
-		t.Fatalf("call_id mismatch: got %v want %d", body["call_id"], callID)
+	if body.CallID != callID {
+		t.Fatalf("call_id mismatch: got %d want %d", body.CallID, callID)
 	}
-	callerObj, ok := body["caller"].(map[string]any)
-	if !ok {
-		t.Fatalf("caller field missing or wrong type")
-	}
-	window, ok := callerObj["window"].([]any)
-	if !ok {
-		t.Fatalf("caller.window missing or wrong type")
-	}
-	if len(window) != 1 {
-		t.Fatalf("caller.window: got %d samples want 1", len(window))
+	if len(body.Caller.Window) != 1 {
+		t.Fatalf("caller.window: got %d samples want 1", len(body.Caller.Window))
 	}
 }
 
@@ -310,9 +315,15 @@ func TestLinkHealth_LinkedHouseholdStillGets404(t *testing.T) {
 func TestLinkHealth_NonexistentCallIs404(t *testing.T) {
 	s := newLHEnv(t)
 
+	// Compute an ID that is guaranteed unused: MAX(id)+10000. This stays within
+	// INT range (< 2^31) and exercises the sql.ErrNoRows -> zero-Call -> 404
+	// branch, not the int32-overflow driver error path.
+	var maxID int64
+	_ = s.env.database.DB.QueryRow("SELECT COALESCE(MAX(id), 0) FROM calls").Scan(&maxID)
+	unknownID := maxID + 10000
+
 	client := authedClient(t, s, s.userA)
-	// Use a very large ID that cannot exist in the test DB.
-	resp, err := client.Get(fmt.Sprintf("%s/api/call/999999999999/link-health", s.env.srv.URL))
+	resp, err := client.Get(fmt.Sprintf("%s/api/call/%d/link-health", s.env.srv.URL, unknownID))
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -380,19 +391,11 @@ func TestLinkHealth_DBFallbackAfterEvict(t *testing.T) {
 		t.Fatalf("post-evict read: got %d want 200", resp.StatusCode)
 	}
 
-	var body map[string]any
+	var body LinkHealthResp
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	callerObj, ok := body["caller"].(map[string]any)
-	if !ok {
-		t.Fatalf("caller field missing or wrong type")
-	}
-	window, ok := callerObj["window"].([]any)
-	if !ok {
-		t.Fatalf("caller.window missing or wrong type")
-	}
-	if len(window) != 1 {
-		t.Fatalf("post-evict window: got %d samples want 1 (DB fallback must serve the flushed sample)", len(window))
+	if len(body.Caller.Window) != 1 {
+		t.Fatalf("post-evict window: got %d samples want 1 (DB fallback must serve the flushed sample)", len(body.Caller.Window))
 	}
 }

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -1,0 +1,398 @@
+//go:build integration
+
+package web
+
+// Integration tests for GET /api/call/{id}/link-health.
+//
+// Security boundary assertions:
+//   - The owner of either call endpoint (caller OR callee) can read.
+//   - A user in a linked household but NOT an endpoint-owning household is denied.
+//   - Nonexistent call IDs return 404.
+//   - Unauthenticated requests are redirected (not 200).
+//   - After a call ends and in-memory state is evicted, the DB-fallback read
+//     path returns the samples that were flushed before eviction.
+//
+// All tests require TEST_DATABASE_URL (skipped otherwise via setupCallsTestServer).
+// Each test uses distinct phone numbers and cleans up on exit so runs are
+// idempotent and -count=2 safe.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/calls"
+)
+
+// phoneCounter gives each test its own non-overlapping number range so
+// concurrent or repeated runs don't collide.
+var phoneCounter atomic.Int64
+
+func init() {
+	// Start well above numbers used in TestCallsPageScopedToHousehold (55500xx).
+	phoneCounter.Store(5551000)
+}
+
+func nextPhone() string {
+	n := phoneCounter.Add(1)
+	return fmt.Sprintf("%07d", n)
+}
+
+// lhSetup holds the per-test state created by newLHEnv.
+type lhSetup struct {
+	env    callsTestEnv
+	userA  *auth.User
+	userB  *auth.User
+	userC  *auth.User
+	hhAID  string
+	hhBID  string
+	hhCID  string
+	numA   string // phone number owned by household A
+	numB   string // phone number owned by household B
+	numC   string // phone number owned by household C
+	hwA    string
+	hwB    string
+	hwC    string
+}
+
+// newLHEnv creates three users in three independent households, each with one
+// line, and registers cleanup. Users A/B/C own lines numA/numB/numC.
+func newLHEnv(t *testing.T) lhSetup {
+	t.Helper()
+	env := setupCallsTestServer(t)
+
+	numA := nextPhone()
+	numB := nextPhone()
+	numC := nextPhone()
+	hwA := "lh-hw-" + numA
+	hwB := "lh-hw-" + numB
+	hwC := "lh-hw-" + numC
+
+	emailA := "lh-a-" + numA + "@example.com"
+	emailB := "lh-b-" + numB + "@example.com"
+	emailC := "lh-c-" + numC + "@example.com"
+
+	userA, err := env.authStore.CreateUser(emailA, "LH User A", nil)
+	if err != nil {
+		t.Fatalf("create user A: %v", err)
+	}
+	userB, err := env.authStore.CreateUser(emailB, "LH User B", nil)
+	if err != nil {
+		t.Fatalf("create user B: %v", err)
+	}
+	userC, err := env.authStore.CreateUser(emailC, "LH User C", nil)
+	if err != nil {
+		t.Fatalf("create user C: %v", err)
+	}
+
+	hhA, err := env.householdStore.Create("LH Family A "+numA, userA.ID)
+	if err != nil {
+		t.Fatalf("create household A: %v", err)
+	}
+	hhB, err := env.householdStore.Create("LH Family B "+numB, userB.ID)
+	if err != nil {
+		t.Fatalf("create household B: %v", err)
+	}
+	hhC, err := env.householdStore.Create("LH Family C "+numC, userC.ID)
+	if err != nil {
+		t.Fatalf("create household C: %v", err)
+	}
+
+	// Pair phones so each household owns its line.
+	codeA, err := env.pairingStore.GenerateCode(hwA)
+	if err != nil {
+		t.Fatalf("generate code A: %v", err)
+	}
+	if _, _, err := env.pairingStore.ClaimDevice(codeA, numA, "Phone A", hhA.ID); err != nil {
+		t.Fatalf("claim phone A: %v", err)
+	}
+
+	codeB, err := env.pairingStore.GenerateCode(hwB)
+	if err != nil {
+		t.Fatalf("generate code B: %v", err)
+	}
+	if _, _, err := env.pairingStore.ClaimDevice(codeB, numB, "Phone B", hhB.ID); err != nil {
+		t.Fatalf("claim phone B: %v", err)
+	}
+
+	codeC, err := env.pairingStore.GenerateCode(hwC)
+	if err != nil {
+		t.Fatalf("generate code C: %v", err)
+	}
+	if _, _, err := env.pairingStore.ClaimDevice(codeC, numC, "Phone C", hhC.ID); err != nil {
+		t.Fatalf("claim phone C: %v", err)
+	}
+
+	db := env.database.DB
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM call_link_health WHERE call_id IN (SELECT id FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3))", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3)", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id IN ($1,$2,$3)", hwA, hwB, hwC)
+		_, _ = db.Exec("DELETE FROM lines WHERE number IN ($1,$2,$3)", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM household_links WHERE household_a_id IN ($1,$2,$3) OR household_b_id IN ($1,$2,$3)", hhA.ID, hhB.ID, hhC.ID)
+		_, _ = db.Exec("DELETE FROM household_members WHERE user_id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
+		_, _ = db.Exec("DELETE FROM households WHERE id IN ($1,$2,$3)", hhA.ID, hhB.ID, hhC.ID)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
+		_, _ = db.Exec("DELETE FROM users WHERE id IN ($1,$2,$3)", userA.ID, userB.ID, userC.ID)
+	})
+
+	return lhSetup{
+		env:   env,
+		userA: userA, userB: userB, userC: userC,
+		hhAID: hhA.ID, hhBID: hhB.ID, hhCID: hhC.ID,
+		numA: numA, numB: numB, numC: numC,
+		hwA: hwA, hwB: hwB, hwC: hwC,
+	}
+}
+
+// authedClient returns an http.Client with a valid session cookie for user.
+// The client does NOT follow redirects so auth-failure 303s are distinguishable
+// from 200 successes.
+func authedClient(t *testing.T, s lhSetup, user *auth.User) *http.Client {
+	t.Helper()
+	token, _, err := s.env.authStore.CreateSession(user.ID, auth.SessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	cookie := &http.Cookie{Name: auth.CookieName, Value: token}
+	jar := &testCookieJar{cookie: cookie, url: s.env.srv.URL}
+	return &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse // don't follow redirects
+		},
+	}
+}
+
+// linkHealthURL builds the endpoint URL for a call ID.
+func linkHealthURL(s lhSetup, callID int64) string {
+	return fmt.Sprintf("%s/api/call/%d/link-health", s.env.srv.URL, callID)
+}
+
+// recordSample inserts one link-health sample for the given call+endpoint.
+func recordSample(s lhSetup, callID int64, endpoint string, lossPct float32) {
+	loss := lossPct
+	s.env.healthStore.Record(callID, endpoint, calls.Sample{
+		TS:      time.Now(),
+		LossPct: &loss,
+	})
+}
+
+// --- Tests ---
+
+// TestLinkHealth_OwnerReadsOwnCall: caller endpoint owner (user A) can read
+// the call A->B and sees the caller's telemetry window.
+func TestLinkHealth_OwnerReadsOwnCall(t *testing.T) {
+	s := newLHEnv(t)
+
+	callID, err := s.env.tracker.OnCallInitiated(s.numA, s.numB)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	recordSample(s, callID, s.numA, 0.5)
+
+	client := authedClient(t, s, s.userA)
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("caller owner: got %d want 200", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if int64(body["call_id"].(float64)) != callID {
+		t.Fatalf("call_id mismatch: got %v want %d", body["call_id"], callID)
+	}
+	callerObj, ok := body["caller"].(map[string]any)
+	if !ok {
+		t.Fatalf("caller field missing or wrong type")
+	}
+	window, ok := callerObj["window"].([]any)
+	if !ok {
+		t.Fatalf("caller.window missing or wrong type")
+	}
+	if len(window) != 1 {
+		t.Fatalf("caller.window: got %d samples want 1", len(window))
+	}
+}
+
+// TestLinkHealth_CalleeOwnerReadsOwnCall: callee endpoint owner (user B) can
+// read call A->B.
+func TestLinkHealth_CalleeOwnerReadsOwnCall(t *testing.T) {
+	s := newLHEnv(t)
+
+	callID, err := s.env.tracker.OnCallInitiated(s.numA, s.numB)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	recordSample(s, callID, s.numB, 0.2)
+
+	client := authedClient(t, s, s.userB)
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("callee owner: got %d want 200", resp.StatusCode)
+	}
+}
+
+// TestLinkHealth_UnrelatedHouseholdGets404: user C (unrelated to A and B)
+// cannot read call A->B.
+func TestLinkHealth_UnrelatedHouseholdGets404(t *testing.T) {
+	s := newLHEnv(t)
+
+	callID, err := s.env.tracker.OnCallInitiated(s.numA, s.numB)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+
+	client := authedClient(t, s, s.userC)
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unrelated household: got %d want 404", resp.StatusCode)
+	}
+}
+
+// TestLinkHealth_LinkedHouseholdStillGets404: user A's household is linked to
+// household B, but call B->C does NOT involve A's household. Linked access
+// must not grant read permission.
+func TestLinkHealth_LinkedHouseholdStillGets404(t *testing.T) {
+	s := newLHEnv(t)
+
+	// Link household A to household B.
+	invite, err := s.env.linkStore.CreateInvite(s.hhAID, s.userA.ID)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if _, err := s.env.linkStore.AcceptInvite(invite.InviteCode, s.userB.ID, s.hhBID); err != nil {
+		t.Fatalf("AcceptInvite: %v", err)
+	}
+
+	// Call is between B and C — A is NOT an endpoint owner.
+	callID, err := s.env.tracker.OnCallInitiated(s.numB, s.numC)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+
+	client := authedClient(t, s, s.userA)
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("linked household access: got %d want 404", resp.StatusCode)
+	}
+}
+
+// TestLinkHealth_NonexistentCallIs404: a call ID that was never created returns
+// 404 and is indistinguishable from an unauthorized access.
+func TestLinkHealth_NonexistentCallIs404(t *testing.T) {
+	s := newLHEnv(t)
+
+	client := authedClient(t, s, s.userA)
+	// Use a very large ID that cannot exist in the test DB.
+	resp, err := client.Get(fmt.Sprintf("%s/api/call/999999999999/link-health", s.env.srv.URL))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("nonexistent call: got %d want 404", resp.StatusCode)
+	}
+}
+
+// TestLinkHealth_UnauthenticatedRedirectsOr401: no session cookie must not
+// return 200. The auth middleware redirects (303) to /auth/login.
+func TestLinkHealth_UnauthenticatedRedirectsOr401(t *testing.T) {
+	s := newLHEnv(t)
+
+	callID, err := s.env.tracker.OnCallInitiated(s.numA, s.numB)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+
+	// Unauthenticated client — no jar, no redirect-following.
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("unauthenticated request: got 200, must not expose telemetry")
+	}
+}
+
+// TestLinkHealth_DBFallbackAfterEvict: samples flushed to DB before eviction
+// are returned via the Readback path even after in-memory state is cleared.
+func TestLinkHealth_DBFallbackAfterEvict(t *testing.T) {
+	s := newLHEnv(t)
+
+	callID, err := s.env.tracker.OnCallInitiated(s.numA, s.numB)
+	if err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	recordSample(s, callID, s.numA, 0.9)
+
+	// Flush to DB so the sample is persisted.
+	if err := s.env.healthStore.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOnce: %v", err)
+	}
+
+	// Evict simulates a server restart or post-call-end state.
+	s.env.healthStore.Evict(callID)
+
+	client := authedClient(t, s, s.userA)
+	resp, err := client.Get(linkHealthURL(s, callID))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("post-evict read: got %d want 200", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	callerObj, ok := body["caller"].(map[string]any)
+	if !ok {
+		t.Fatalf("caller field missing or wrong type")
+	}
+	window, ok := callerObj["window"].([]any)
+	if !ok {
+		t.Fatalf("caller.window missing or wrong type")
+	}
+	if len(window) != 1 {
+		t.Fatalf("post-evict window: got %d samples want 1 (DB fallback must serve the flushed sample)", len(window))
+	}
+}

--- a/server/internal/web/ratelimit_test.go
+++ b/server/internal/web/ratelimit_test.go
@@ -48,7 +48,7 @@ func setupRateLimitTestServer(t *testing.T) *httptest.Server {
 
 	h, err := NewHandler(lineStore, deviceStore, hub, tracker, relay, HandlerConfig{
 		Addr:        ":0",
-	}, authStore, authHandlers, googleAuth, nil, nil, nil, nil, "", "")
+	}, authStore, authHandlers, googleAuth, nil, nil, nil, nil, "", "", nil)
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}


### PR DESCRIPTION
## What

Plumbing for per-call link-health telemetry. Phones sample WebRTC stats on a 2s ticker and send `link_health` signaling messages carrying loss / jitter / RTT / connection type / byte counts. Signald holds per-call per-endpoint bounded ring buffers (60 samples = 2 min at default cadence) and flushes the latest sample per endpoint to a new `call_link_health` Postgres table every 10s. A new `GET /api/call/{id}/link-health` endpoint serves the merged memory + DB view under strict per-call endpoint-ownership auth.

## Why

First slice of #213. The `/call/live` observation-deck page cannot be built until the data plumbing exists; this PR lands that plumbing. The page, signaling-layer force-disconnect, and dialup-theme variant are follow-up issues that consume this API.

Design emphasizes prod-quality from day one:
- Strict auth: user's household must own the caller OR callee line directly. Linked-household status does NOT grant telemetry access (see spec §4; reviewers caught one direct multi-household-auth bug during implementation).
- 404 for unauthorized and nonexistent are indistinguishable (spec §4 — prevents call-id enumeration; also eliminates a 2-query vs 4-query timing side-channel).
- Signald graceful-shutdown synchronizes the final DB flush with DB close so samples aren't lost on SIGTERM (caught in review; would have been silent data loss otherwise).
- Phone-side `Reporter` has panic recovery with stack traces; cannot take down the call.
- Pi Zero 2 W cost: `BenchmarkReporterSample` measures 173 ns/op on amd64, `TestReporterSampleCostBound` guards at 500 μs (~3000× headroom for ARM).

## Test plan

- [x] `go test -race ./...` in `server/` — unit tests pass
- [x] `go test -tags=integration -race -p 1 ./...` in `server/` — integration tests pass (needs Postgres; 7 new link-health integration tests cover owner reads, callee-owner reads, unrelated household 404, linked-household 404 tightening, nonexistent 404, unauthenticated redirect, DB fallback post-evict)
- [x] `go test -race ./...` in `pi/digitsd/` — unit tests + microbench pass
- [x] `golangci-lint run ./...` in both modules — 0 issues
- [x] Playwright e2e: `make e2e` from `server/` — 55 pass / 9 pre-existing skip / 0 fail
- [ ] On-device: `pprof` diff on Pi Zero 2 W mid-call, link-health enabled vs `DIGITSD_LINK_HEALTH_DISABLED=1`; attach summary before merge
- [ ] On-device: call between two phones, confirm `GET /api/call/{id}/link-health` returns non-zero RTT and bytes

## Knobs

- `DIGITSD_LINK_HEALTH_DISABLED=1` — phone-side kill switch
- `DIGITSD_LINK_HEALTH_INTERVAL_MS=<n>` — cadence override (default 2000)
- `SIGNALD_LINK_HEALTH_FLUSH_DISABLED=1` — server-side, stops DB flusher (keeps ingest alive); useful during DB maintenance