### PR TITLE
fix(ci): make release-groom.yml actually groom the release body

### DIFF
--- a/.github/workflows/release-groom.yml
+++ b/.github/workflows/release-groom.yml
@@ -44,6 +44,11 @@ jobs:
           else
             echo "already_groomed=false" >> "$GITHUB_OUTPUT"
           fi
+          {
+            echo 'RAW_BODY<<GROOM_EOF_RAW'
+            cat /tmp/raw.md
+            echo 'GROOM_EOF_RAW'
+          } >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -63,6 +68,11 @@ jobs:
             git log --format='%s' "${TAG}" -n 50 > /tmp/commits.txt
           fi
           wc -l /tmp/commits.txt
+          {
+            echo 'COMMITS<<GROOM_EOF_COMMITS'
+            cat /tmp/commits.txt
+            echo 'GROOM_EOF_COMMITS'
+          } >> "$GITHUB_ENV"
 
       - name: Groom notes with Claude
         if: steps.body.outputs.already_groomed != 'true'
@@ -74,16 +84,19 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --append-system-prompt-file .github/release-voice.md
+            --allowedTools Write Bash
           prompt: |
-            Groom the following release notes for the Digits release ${{ env.TAG }}.
-            Output only the groomed markdown body per the system prompt's
-            output-format section. Write the output to /tmp/groomed.md.
+            Groom these release notes for the Digits release ${{ env.TAG }}.
+            Use the Write tool (or a Bash heredoc) to save your output to
+            exactly /tmp/groomed.md. The first line of the file must be the
+            sentinel `<!-- groomed:v1 -->`. Nothing else. No preamble in chat,
+            no explanation, just write the file.
 
             Raw release body:
-            $(cat /tmp/raw.md)
+            ${{ env.RAW_BODY }}
 
             Commits in this release:
-            $(cat /tmp/commits.txt)
+            ${{ env.COMMITS }}
 
       - name: Update release body
         if: steps.body.outputs.already_groomed != 'true' && steps.claude.outcome == 'success'


### PR DESCRIPTION
## What

Two bugs kept the grooming workflow from ever editing a release body, even though runs exited green:

1. **Prompt expansion**: the `prompt:` input used `\$(cat /tmp/raw.md)` / `\$(cat /tmp/commits.txt)` expecting shell substitution, but the action receives the prompt verbatim. Claude got literal dollar-paren strings and had no actual content to groom, so it output nothing.
2. **No tool access**: the Claude step had no `--allowedTools`, so even with a working prompt Claude couldn't write `/tmp/groomed.md`.

## Why

First real run (manual backfill of `fw/v1.4.1`) exited green but the release body was unchanged. The shell guard `[ ! -s /tmp/groomed.md ]` caught the empty output and printed "Groomed output is empty; leaving raw body in place." instead of editing.

## Fix

- Lift raw body + commit list into multiline `GITHUB_ENV` vars (`RAW_BODY`, `COMMITS`) in the existing Fetch/Collect steps.
- Interpolate via `\${{ env.RAW_BODY }}` / `\${{ env.COMMITS }}` in the prompt.
- Add `--allowedTools Write Bash` so Claude can write the output file.
- Tighten prompt wording so the Write instruction is explicit.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Re-trigger backfill for `fw/v1.4.1` and `pi/v1.11.4` after merge; release body updates with `<!-- groomed:v1 -->` sentinel + groomed prose