### PR TITLE
fix(server): move update <details> out of lines__row anchor on mobile

### DIFF
--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2365,3 +2365,8 @@ body.dialup .phone-silent__text {
   padding: 0 4px;
 }
 .pair-banner__close:hover { color: #ffffff; }
+
+/* Mobile variant: full-width details sibling below the .lines__row anchor. */
+.update-details--mobile { display: block; margin: 0 10px 8px; }
+.update-details--mobile > summary { display: inline-flex; align-items: center; gap: 4px; }
+.update-details--mobile .update-notes { max-width: none; margin-top: 6px; }

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1638,3 +1638,8 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   padding: 0 4px;
 }
 .pair-banner__close:hover { color: #2e231b; }
+
+/* Mobile variant: full-width details sibling below the .lines__row anchor. */
+.update-details--mobile { display: block; margin: 0 12px 8px; }
+.update-details--mobile > summary { display: inline-flex; align-items: center; gap: 4px; }
+.update-details--mobile .update-notes { max-width: none; margin-top: 6px; }

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -336,28 +336,27 @@
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
         <span class="lines__name">{{.Line.Name}}{{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}</span>
         <span class="lines__num">{{fmtPhone .Line.Number}}</span>
-        {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
-          <details class="update-details">
-            <summary class="chip chip--warn"><span class="chip__dot"></span>update</summary>
-            <div class="update-notes">
-              {{range .FirmwareUpdateNotes}}
-                <article class="update-note">
-                  <span class="update-note__version">fw {{.Version}}</span>
-                  {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
-                </article>
-              {{end}}
-              {{range .PiUpdateNotes}}
-                <article class="update-note">
-                  <span class="update-note__version">pi {{.Version}}</span>
-                  {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
-                </article>
-              {{end}}
-            </div>
-          </details>
-        {{else}}
-          <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
-        {{end}}
+        <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
       </a>
+      {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
+        <details class="update-details update-details--mobile">
+          <summary class="chip chip--warn"><span class="chip__dot"></span>update available</summary>
+          <div class="update-notes">
+            {{range .FirmwareUpdateNotes}}
+              <article class="update-note">
+                <span class="update-note__version">fw {{.Version}}</span>
+                {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+              </article>
+            {{end}}
+            {{range .PiUpdateNotes}}
+              <article class="update-note">
+                <span class="update-note__version">pi {{.Version}}</span>
+                {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+              </article>
+            {{end}}
+          </div>
+        </details>
+      {{end}}
     </li>
     {{end}}
   </ul>


### PR DESCRIPTION
## What

On the mobile Lines card, the update chip was rendering as a bare "▶ Details" fallback marker below each row instead of an "update" chip with notes inside. Moves the `<details>` element out of the surrounding `<a>` anchor so the HTML parser stops doing error-recovery.

## Why

HTML spec forbids interactive elements (`<details>` is one) inside `<a>`. Browsers recover by aborting and restarting the `<a>` around the invalid child. That breaks rendering in two ways:

- `<summary>` content does not paint; the browser shows the default triangle + "Details" text.
- The original `<a>` tree gets fragmented. DOM inspection showed `.lines__row` inflating from 3 actual elements to 15 matches.

The desktop table is unaffected: it uses `<tr>` / `<td>`, not `<a>`, so the same `<details>` structure was always valid there.

## Reproduction (prod, forced mobile layout)

![Before: ▶ Details fallback text below each row](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-mobile-fix-before.png)

## Fix

Restructure the mobile card so `<details>` is a sibling of the `<a>`:

```html
<li>
  <a class="lines__row" href="/phones/{number}">
    ...online/offline inline...
  </a>
  {{if update notes}}
    <details class="update-details update-details--mobile">
      <summary class="chip chip--warn">update available</summary>
      <div class="update-notes">...</div>
    </details>
  {{end}}
</li>
```

- Online/offline returns to being shown inline inside the row (matches pre-update-chip behavior for devices with no update).
- When an update is available, a full-width chip sits below the row and expands into the stacked per-version groomed notes.
- Added a `.update-details--mobile` modifier in both themes so the sibling block fills the card width with sensible spacing.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration ./internal/web/` green
- [x] DOM inspection confirms `<details>` is now a `<li>` child, not inside `<a>`. Parser will not fragment the anchor.
- [ ] After-merge deploy: take after screenshot from prod at mobile viewport to confirm chip renders correctly.