### PR TITLE
Potential fix for code scanning alert no. 5: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/server/internal/admin/server.go
+++ b/server/internal/admin/server.go
@@ -178,6 +178,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		Value:    "",
 		Path:     "/admin",
 		HttpOnly: true,
+		Secure:   true,
 		MaxAge:   -1,
 	})
 	http.Redirect(w, r, "/admin/login", http.StatusSeeOther)


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/5](https://github.com/justinlindh/digits/security/code-scanning/5)

Set `Secure: true` on the logout `admin_session` cookie in `server/internal/admin/server.go` (inside `handleLogout`), matching the login cookie settings.

Best single fix without changing functionality:
- In the `http.Cookie` literal passed to `http.SetCookie` in `handleLogout`, add:
  - `Secure:   true,`
- Keep existing fields unchanged (`Name`, `Value`, `Path`, `HttpOnly`, `MaxAge`).
- No new imports, methods, or dependencies are required.

This ensures all writes to `admin_session` enforce HTTPS-only transmission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
