### PR TITLE
Potential fix for code scanning alert no. 4: Email content injection

### DIFF
--- a/server/internal/email/email.go
+++ b/server/internal/email/email.go
@@ -1,6 +1,8 @@
 package email
 
 import (
+	"errors"
+	"net/mail"
 	"net/smtp"
 	"strings"
 )
@@ -24,12 +26,26 @@ func NewSMTPSender(host, port, user, pass, from string) *SMTPSender {
 }
 
 func (s *SMTPSender) Send(to, subject, htmlBody string) error {
+	// Prevent header injection via CRLF in header values.
+	if strings.ContainsAny(to, "\r\n") || strings.ContainsAny(subject, "\r\n") || strings.ContainsAny(s.from, "\r\n") {
+		return errors.New("invalid email header value")
+	}
+
+	toAddr, err := mail.ParseAddress(to)
+	if err != nil {
+		return err
+	}
+	fromAddr, err := mail.ParseAddress(s.from)
+	if err != nil {
+		return err
+	}
+
 	// Disable SendGrid click tracking and open tracking via SMTPAPI header.
 	// Without this, SendGrid rewrites URLs in emails through its tracking
 	// servers, which can cause TLS certificate errors on custom subdomains.
 	headers := []string{
-		"From: " + s.from,
-		"To: " + to,
+		"From: " + fromAddr.String(),
+		"To: " + toAddr.String(),
 		"Subject: " + subject,
 		"MIME-Version: 1.0",
 		"Content-Type: text/html; charset=UTF-8",
@@ -40,7 +56,7 @@ func (s *SMTPSender) Send(to, subject, htmlBody string) error {
 	if s.user != "" {
 		auth = smtp.PlainAuth("", s.user, s.pass, s.host)
 	}
-	return smtp.SendMail(s.host+":"+s.port, auth, s.from, []string{to}, []byte(msg))
+	return smtp.SendMail(s.host+":"+s.port, auth, fromAddr.Address, []string{toAddr.Address}, []byte(msg))
 }
 
 // NoopSender captures emails for testing.

--- a/server/internal/email/email.go
+++ b/server/internal/email/email.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"errors"
+	"mime"
 	"net/mail"
 	"net/smtp"
 	"strings"
@@ -46,7 +47,7 @@ func (s *SMTPSender) Send(to, subject, htmlBody string) error {
 	headers := []string{
 		"From: " + fromAddr.String(),
 		"To: " + toAddr.String(),
-		"Subject: " + subject,
+		"Subject: " + mime.QEncoding.Encode("utf-8", subject),
 		"MIME-Version: 1.0",
 		"Content-Type: text/html; charset=UTF-8",
 		`X-SMTPAPI: {"filters":{"clicktrack":{"settings":{"enable":0}},"opentrack":{"settings":{"enable":0}}}}`,


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/4](https://github.com/justinlindh/digits/security/code-scanning/4)

General fix: never place untrusted data directly into raw email headers. Validate recipient address format and reject any header value containing CR (`\r`) or LF (`\n`) before building the SMTP message. Keep body handling separate from headers.

Best targeted fix here (without changing intended behavior): in `server/internal/email/email.go`, add strict validation in `SMTPSender.Send`:
1. Reject `to`, `subject`, and `s.from` if they contain CR/LF (prevents header injection).
2. Parse/validate `to` and `s.from` as email addresses using `net/mail`.
3. Use parsed canonical addresses in headers and SMTP envelope recipient list.
4. Return an error on invalid input rather than sending malformed/injectable mail.

This requires adding imports: `errors` and `net/mail`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
