### PR TITLE
Potential fix for code scanning alert no. 9: Disabled TLS certificate check

### DIFF
--- a/pi/digitsd/cmd/latclient/main.go
+++ b/pi/digitsd/cmd/latclient/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -42,9 +41,7 @@ func main() {
 	q.Set("number", *number)
 	u.RawQuery = q.Encode()
 
-	dialer := websocket.Dialer{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
+	dialer := websocket.Dialer{}
 	ws, _, err := dialer.Dial(u.String(), nil)
 	if err != nil {
 		log.Fatalf("dial signald: %v", err)


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/9](https://github.com/justinlindh/digits/security/code-scanning/9)

To fix this safely without changing intended behavior, remove the explicit insecure TLS override so Go’s default TLS verification is used. In `pi/digitsd/cmd/latclient/main.go`, replace the `websocket.Dialer` initialization that sets `InsecureSkipVerify: true` with a default dialer configuration (`websocket.Dialer{}`), allowing standard certificate and hostname validation.

Concretely:
- Edit the dialer block around lines 45–47.
- Remove dependency on `crypto/tls` in this file since it is no longer used.
- No new methods/definitions are required; no behavior changes besides enforcing proper TLS verification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
