### PR TITLE
Potential fix for code scanning alert no. 10: Cookie 'HttpOnly' attribute is not set to true

### DIFF
--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -59,16 +59,18 @@ func UserFromContext(ctx context.Context) *User {
 // Writing both variants mops up either form.
 func clearSessionCookie(w http.ResponseWriter, domain string) {
 	http.SetCookie(w, &http.Cookie{
-		Name:   CookieName,
-		Domain: domain,
-		MaxAge: -1,
-		Path:   "/",
+		Name:     CookieName,
+		Domain:   domain,
+		MaxAge:   -1,
+		Path:     "/",
+		HttpOnly: true,
 	})
 	if domain != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:   CookieName,
-			MaxAge: -1,
-			Path:   "/",
+			Name:     CookieName,
+			MaxAge:   -1,
+			Path:     "/",
+			HttpOnly: true,
 		})
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/10](https://github.com/justinlindh/digits/security/code-scanning/10)

Set `HttpOnly: true` on both cookie literals inside `clearSessionCookie` in `server/internal/auth/middleware.go`.

Best minimal fix without changing behavior:
- In the first `http.Cookie{...}` (domain-scoped delete cookie), add `HttpOnly: true`.
- In the second `http.Cookie{...}` inside `if domain != ""` (host-scoped delete cookie), add `HttpOnly: true`.

This preserves existing logic (same name/domain/path/max-age deletion behavior) while ensuring all emitted `digits_session` cookies are marked HttpOnly, addressing both alert variants at once.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
