### PR TITLE
Potential fix for code scanning alert no. 8: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -63,12 +63,14 @@ func clearSessionCookie(w http.ResponseWriter, domain string) {
 		Domain: domain,
 		MaxAge: -1,
 		Path:   "/",
+		Secure: true,
 	})
 	if domain != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:   CookieName,
 			MaxAge: -1,
 			Path:   "/",
+			Secure: true,
 		})
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/8](https://github.com/justinlindh/digits/security/code-scanning/8)

Set `Secure: true` explicitly on every `http.Cookie` in `clearSessionCookie` so cookie-clearing headers are only sent as secure cookies.

Best minimal fix in `server/internal/auth/middleware.go`:
- In `clearSessionCookie`, update both `http.Cookie` literals (the domain-scoped one and the host-scoped one) to include `Secure: true`.
- Keep all existing behavior unchanged (`Name`, `Domain`, `MaxAge`, `Path`), only add the missing secure attribute.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
