### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 'feature/**']
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/1](https://github.com/justinlindh/digits/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level permissions to `contents: read`, since the only action requiring token access is `actions/checkout`, and build/test/vet steps do not need write scopes.

Edit **`.github/workflows/server-ci.yml`** near the top-level keys (after `on:` block is a clear location) and add:

- `permissions:`
  - `contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
