### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/server-e2e.yml
+++ b/.github/workflows/server-e2e.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+  actions: read
+  artifacts: write
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-e2e.yml
+++ b/.github/workflows/server-e2e.yml
@@ -15,8 +15,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: read
-  artifacts: write
 
 jobs:
   e2e:


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/2](https://github.com/justinlindh/digits/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default.  
Best fix (without changing functionality): define workflow-level permissions right after `concurrency` and before `jobs`, setting only what this workflow needs. A safe minimal baseline is:

- `contents: read` (needed by `actions/checkout`)
- `actions: read` (safe for action metadata access)
- `artifacts: write` (for `actions/upload-artifact`)

In `.github/workflows/server-e2e.yml`, insert this root-level block so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
