### PR TITLE
Potential fix for code scanning alert no. 6: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -171,8 +171,8 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Secure=false: this endpoint only exists in dev mode and CI runs over
-	// plain HTTP. Chromium won't send Secure cookies over http://localhost.
+	// Set Secure when request is HTTPS (directly or via common proxy header),
+	// while keeping local HTTP dev/CI behavior working.
 	http.SetCookie(w, &http.Cookie{
 		Name:     CookieName,
 		Value:    sessionToken,
@@ -180,7 +180,7 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   int(SessionTTL.Seconds()),
 		HttpOnly: true,
-		Secure:   false,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -171,8 +171,7 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set Secure when request is HTTPS (directly or via common proxy header),
-	// while keeping local HTTP dev/CI behavior working.
+	// Dev-only: derive Secure from request scheme so plain HTTP localhost still works.
 	http.SetCookie(w, &http.Cookie{
 		Name:     CookieName,
 		Value:    sessionToken,


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/6](https://github.com/justinlindh/digits/security/code-scanning/6)

General fix: ensure session cookies are set with `Secure: true` whenever the request is over HTTPS, instead of hardcoding `false`.

Best fix for this snippet without changing core functionality: in `server/internal/auth/handlers.go`, inside `HandleDevSession`, replace `Secure: false` with a computed value that is true for HTTPS requests (including reverse-proxy TLS via `X-Forwarded-Proto`) and false for local plain HTTP dev/CI. This keeps localhost HTTP behavior working while making secure deployments compliant.

Needed changes:
- No new imports required (already has `net/http`).
- Update only the cookie literal in `HandleDevSession` to set:
  - `Secure: r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
