### PR TITLE
fix(server): stop leaking raw errors from handlePhoneEditPost

### DIFF
--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -17,9 +17,6 @@ import (
 // ErrNotFound is returned when a line cannot be found.
 var ErrNotFound = errors.New("line not found")
 
-// ErrNumberTaken is returned when a line number is already in use.
-var ErrNumberTaken = errors.New("line number is already in use")
-
 var numberRegex = regexp.MustCompile(`^\d{3}-?\d{4}$`)
 
 // scanSettings parses the settings JSONB value returned by Postgres into a

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1024,7 +1024,8 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.lineStore.Update(ln.ID, number, name); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		slog.Error("line update failed", "err", err, "line_id", ln.ID)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- `handlePhoneEditPost` at `internal/web/handler.go:1027` returned `err.Error()` verbatim as a `400`. `lineStore.Update` can only fail with a wrapped `"update line: ..."` error (e.g. a Postgres error) or a `"line N not found"` message. Neither is a user-facing validation error, so a 500 is the right status and the raw text should not reach the browser. Log with `slog` and return `"internal server error"`, matching the rest of the file.
- Drop `line.ErrNumberTaken`. It was declared exported but never returned by anything in the `line` package (grep shows only the declaration itself and the identically-named `pairing.ErrNumberTaken`, which is the one actually in use).

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhNj1Zr7j51oxWaxdeguvU)_