### PR TITLE
fix(ci): fire release-groom on automated fw/pi releases

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -74,4 +74,8 @@ jobs:
             npx semantic-release --extends "$RELEASERC"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Publish the release with ADMIN_PAT so that `release: published`
+          # fires downstream workflows (release-groom.yml). Releases created
+          # via the default GITHUB_TOKEN are suppressed by GitHub's recursive
+          # workflow prevention rule.
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -82,4 +82,8 @@ jobs:
             npx semantic-release --extends ./pi/.releaserc.cjs
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Publish the release with ADMIN_PAT so that `release: published`
+          # fires downstream workflows (release-groom.yml). Releases created
+          # via the default GITHUB_TOKEN are suppressed by GitHub's recursive
+          # workflow prevention rule.
+          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}


### PR DESCRIPTION
## What

Pass `secrets.ADMIN_PAT` as `GITHUB_TOKEN` to semantic-release in `fw-release.yml` and `pi-release.yml` so the `release: published` event actually fires downstream workflows (specifically `release-groom.yml`).

## Why

GitHub's [recursive-workflow-prevention rule](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) says events triggered by the default `GITHUB_TOKEN` do not create new workflow runs. Both release workflows were publishing releases with `GITHUB_TOKEN`, so every downstream grooming attempt was silent: the release went out with the raw semantic-release body and nothing re-groomed it.

Confirmation from run history of `release-groom.yml`: **every invocation on record is `workflow_dispatch`**. Zero `release` events despite `fw/v1.4.1`, `pi/v1.11.4`, and today's earlier tags shipping through the auto-release pipeline.

## Fix

One-line swap in each release workflow:

```diff
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
```

Both workflows already use `ADMIN_PAT` for `actions/checkout` so semantic-release can push commit and tag back to `main`. Reusing it for release publication means the resulting release event propagates normally.

## Scope

- `fw-release.yml` and `pi-release.yml` only.
- `server-release.yml` has the same pattern but `release-groom.yml` does not watch `server/v*` tags; out of scope here. If grooming ever expands to server releases, that workflow needs the same swap.

## Test plan

- [x] YAML parses for both files.
- [ ] Merge, then on the next real firmware or Pi commit to main, confirm a new `release-groom.yml` run appears with `event=release` (not `workflow_dispatch`) in the run history.