### PR TITLE
refactor(server): drop vacuous requireNumberOwnership wrapper

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -986,7 +986,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !h.requireNumberOwnership(w, r, number) {
+	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
 	online := h.hub.Get(number) != nil
@@ -1128,7 +1128,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings) error 
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !h.requireNumberOwnership(w, r, number) {
+	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -1174,7 +1174,7 @@ func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !h.requireNumberOwnership(w, r, number) {
+	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
 	status := h.hub.GetUpdateStatus(number)
@@ -1192,7 +1192,7 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !h.requireNumberOwnership(w, r, number) {
+	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
 
@@ -1225,7 +1225,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !h.requireNumberOwnership(w, r, number) {
+	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -2082,13 +2082,6 @@ func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, n
 	}
 	http.NotFound(w, r)
 	return nil
-}
-
-// requireNumberOwnership verifies the authenticated user's household owns the
-// given phone number without needing the full line record. Returns true if
-// ownership is confirmed, or false after writing an HTTP 404 response.
-func (h *Handler) requireNumberOwnership(w http.ResponseWriter, r *http.Request, number string) bool {
-	return h.requireLineOwnership(w, r, number) != nil
 }
 
 // ownedLinesForUser returns the lines owned by any household the user belongs


### PR DESCRIPTION
## Summary

- `requireNumberOwnership` in `internal/web/handler.go` was documented as checking ownership "without needing the full line record," but the body was literally `return h.requireLineOwnership(w, r, number) != nil`: the same DB lookup, with the line thrown away.
- Delete the wrapper and inline `== nil` at the five call sites (`handlePhoneOnline`, `handlePhoneUpdate`, `handlePhoneUpdateStatus`, `handlePhoneFactoryReset`, `handlePhoneRestart`). If a cheaper path ever matters, the right move is a real `OwnsNumber` on the store, not a wrapper that lies in its doc comment.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhNj1Zr7j51oxWaxdeguvU)_