### PR TITLE
test(server): replace sleep-based waits in e2e WS tests with polling

### DIFF
--- a/server/internal/web/e2e_test.go
+++ b/server/internal/web/e2e_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
-func setupTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store, *calls.Tracker, *auth.Store) {
+func setupTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store, *calls.Tracker, *auth.Store, *signaling.Hub) {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
@@ -63,7 +63,23 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store,
 
 	srv := httptest.NewServer(h.Router())
 	t.Cleanup(srv.Close)
-	return srv, database, lineStore, tracker, authStore
+	return srv, database, lineStore, tracker, authStore, hub
+}
+
+// waitForRegister polls hub.Get until the given number is registered or the
+// deadline expires. Needed between two test phones on different WebSockets:
+// each ws read goroutine handles its own register independently, so ws1 may
+// start sending Call before ws2's register has run.
+func waitForRegister(t *testing.T, hub *signaling.Hub, number string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if hub.Get(number) != nil {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to register", number)
 }
 
 // seedE2EHousehold creates a household owned by the test user (test@example.com,
@@ -128,7 +144,7 @@ func recvMsg(t *testing.T, conn *websocket.Conn) *signaling.Message {
 }
 
 func TestE2EFullCallFlow(t *testing.T) {
-	srv, database, lineStore, tracker, authStore := setupTestServer(t)
+	srv, database, lineStore, tracker, authStore, hub := setupTestServer(t)
 	// Create authenticated client for protected route checks
 	cookie := addSessionCookie(t, authStore)
 	jar := &testCookieJar{cookie: cookie, url: srv.URL}
@@ -158,8 +174,10 @@ func TestE2EFullCallFlow(t *testing.T) {
 	sendMsg(t, ws1, signaling.Message{Type: signaling.TypeRegister, Number: "3140001", HardwareID: "e2e-hw-a"})
 	sendMsg(t, ws2, signaling.Message{Type: signaling.TypeRegister, Number: "3140002", HardwareID: "e2e-hw-b"})
 
-	// Give server time to register
-	time.Sleep(50 * time.Millisecond)
+	// Both ws goroutines handle their own register; the call below needs ws2's
+	// entry to be present in the hub, which the two sendMsg calls don't order.
+	waitForRegister(t, hub, "3140001")
+	waitForRegister(t, hub, "3140002")
 
 	// Phone 1 calls Phone 2
 	sendMsg(t, ws1, signaling.Message{Type: signaling.TypeCall, To: "3140002"})
@@ -202,9 +220,9 @@ func TestE2EFullCallFlow(t *testing.T) {
 	if hangup.Type != signaling.TypeHangup {
 		t.Fatalf("expected hangup, got %s", hangup.Type)
 	}
-
-	// Give tracker time to update DB
-	time.Sleep(50 * time.Millisecond)
+	// The relay calls Tracker.OnCallEnded synchronously before forwarding
+	// Hangup to the peer, so by the time ws2 has read it the DB UPDATE is
+	// already done.
 
 	// Verify call appears in history via HTTP (authenticated)
 	resp, err := authedClient.Get(srv.URL + "/api/status")
@@ -237,11 +255,11 @@ func TestE2EFullCallFlow(t *testing.T) {
 }
 
 func TestE2ECallToOfflinePhone(t *testing.T) {
-	srv, _, _, _, _ := setupTestServer(t)
+	srv, _, _, _, _, hub := setupTestServer(t)
 
 	ws1 := dialWS(t, srv)
 	sendMsg(t, ws1, signaling.Message{Type: signaling.TypeRegister, Number: "3140001", HardwareID: "e2e-offline-a"})
-	time.Sleep(30 * time.Millisecond)
+	waitForRegister(t, hub, "3140001")
 
 	// Call a phone that's not connected
 	sendMsg(t, ws1, signaling.Message{Type: signaling.TypeCall, To: "3140099"})
@@ -253,7 +271,7 @@ func TestE2ECallToOfflinePhone(t *testing.T) {
 }
 
 func TestE2ENoRegisterRejected(t *testing.T) {
-	srv, _, _, _, _ := setupTestServer(t)
+	srv, _, _, _, _, _ := setupTestServer(t)
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
@@ -279,7 +297,7 @@ func TestE2ENoRegisterRejected(t *testing.T) {
 }
 
 func TestE2EWebUIWithData(t *testing.T) {
-	srv, database, lineStore, _, authStore := setupTestServer(t)
+	srv, database, lineStore, _, authStore, _ := setupTestServer(t)
 
 	hhID := seedE2EHousehold(t, database, authStore)
 	if _, err := lineStore.Add("3140001", "Kitchen", hhID); err != nil {


### PR DESCRIPTION
## Summary

`internal/web/e2e_test.go` had three `time.Sleep` calls used as ad-hoc synchronization. Two are real races; one was never needed.

- `TestE2EFullCallFlow` line 162 (`time.Sleep(50 * time.Millisecond)`): covers the real race that the two test WebSockets run on separate server read goroutines, so ws1's Call can be processed before ws2's Register lands in the hub. Replace with `waitForRegister`, a 2ms-poll on `Hub.Get`.
- `TestE2EFullCallFlow` line 207 (`// Give tracker time to update DB`): not actually needed. `Relay.OnCallEnded` runs `Tracker.OnCallEnded` synchronously before forwarding the Hangup to the peer, so by the time `ws2`'s `recvMsg` returns, the `UPDATE calls SET status='ended'` has already committed. Drop the sleep and note the invariant in a comment.
- `TestE2ECallToOfflinePhone` line 244: same register-race shape as the first one (single WS here, so in practice redundant on current code, but `waitForRegister` keeps the test deterministic against any future change to how the server dispatches reads).

`setupTestServer` now also returns the `*signaling.Hub` so tests can poll it directly. The two integration tests in `internal/calls/history_integration_test.go` that sleep 10ms "so timestamps are distinguishable" are intentionally left alone — those are about wall-clock separation, not async-wait synchronization, and fixing them properly means injecting a clock.

## Test plan

- [x] `go vet ./...` / `go vet -tags=integration ./...`
- [x] `go test ./...`
- [ ] `make test-integration` (requires a Postgres test-db, not available in this sandbox; CI will cover)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JhNj1Zr7j51oxWaxdeguvU)_