### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   integration:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
Potential fix for [https://github.com/justinlindh/digits/security/code-scanning/3](https://github.com/justinlindh/digits/security/code-scanning/3)

Add an explicit `permissions` block with least privilege.  
Best single fix here: add `permissions: contents: read` at the **job level** for `jobs.integration`, so only this job is scoped and behavior elsewhere is unaffected.

In `.github/workflows/server-integration.yml`, insert under `integration:` (before `runs-on`) the following:

- `permissions:`
- `contents: read`

No imports, methods, or external definitions are needed (YAML workflow change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
