### PR TITLE
fix(server): exempt /healthz from root-domain redirect

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -491,8 +491,11 @@ func rootDomainRedirect(appURL string, next http.Handler) http.Handler {
 			return
 		}
 
-		// Don't redirect WebSocket or API paths
-		if strings.HasPrefix(r.URL.Path, "/ws") || strings.HasPrefix(r.URL.Path, "/api/") {
+		// Don't redirect WebSocket, API, or healthcheck paths. /healthz in
+		// particular is hit over plain HTTP against localhost by the
+		// autodeploy binary, which expects 200 + JSON and would mis-fire
+		// on every tick if redirected to the canonical HTTPS origin.
+		if strings.HasPrefix(r.URL.Path, "/ws") || strings.HasPrefix(r.URL.Path, "/api/") || r.URL.Path == "/healthz" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/server/internal/web/redirect_test.go
+++ b/server/internal/web/redirect_test.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Upstream handler that rootDomainRedirect should pass through.
+func testOKHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("pass"))
+	})
+}
+
+func TestRootDomainRedirect(t *testing.T) {
+	const appURL = "https://app.digits.family"
+
+	cases := map[string]struct {
+		host     string
+		path     string
+		wantCode int
+		wantLoc  string // expected Location header when a redirect is expected
+	}{
+		"canonical host passes through": {
+			host:     "app.digits.family",
+			path:     "/",
+			wantCode: http.StatusOK,
+		},
+		"empty host passes through": {
+			host:     "",
+			path:     "/",
+			wantCode: http.StatusOK,
+		},
+		"non-canonical host redirects root": {
+			host:     "digits.family",
+			path:     "/",
+			wantCode: http.StatusMovedPermanently,
+			wantLoc:  "https://app.digits.family/",
+		},
+		"non-canonical host redirects arbitrary page": {
+			host:     "digits.family",
+			path:     "/phones",
+			wantCode: http.StatusMovedPermanently,
+			wantLoc:  "https://app.digits.family/phones",
+		},
+		"/ws is exempt": {
+			host:     "localhost:8090",
+			path:     "/ws",
+			wantCode: http.StatusOK,
+		},
+		"/api/* is exempt": {
+			host:     "localhost:8090",
+			path:     "/api/version",
+			wantCode: http.StatusOK,
+		},
+		"/healthz is exempt": {
+			host:     "localhost:8090",
+			path:     "/healthz",
+			wantCode: http.StatusOK,
+		},
+		"canonical host with port is treated as canonical": {
+			host:     "app.digits.family:443",
+			path:     "/",
+			wantCode: http.StatusOK,
+		},
+	}
+
+	h := rootDomainRedirect(appURL, testOKHandler())
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Host = tc.host
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("code=%d, want %d", rec.Code, tc.wantCode)
+			}
+			if tc.wantLoc != "" {
+				if got := rec.Header().Get("Location"); got != tc.wantLoc {
+					t.Errorf("Location=%q, want %q", got, tc.wantLoc)
+				}
+			}
+		})
+	}
+}
+
+func TestRootDomainRedirectEmptyAppURLDisables(t *testing.T) {
+	// If appURL is unset, the middleware should be a no-op on every request.
+	h := rootDomainRedirect("", testOKHandler())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "anywhere.example"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("code=%d, want 200 (middleware disabled)", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

`rootDomainRedirect` middleware 301s any request whose `Host` header is not the canonical app origin. It already exempts `/ws` and `/api/*`; `/healthz` was not, so a plain-HTTP request to `http://localhost:8090/healthz` gets redirected to `https://app.digits.family/healthz` — the full public-origin round-trip.

Noticed during the live rollout of the autodeploy pipeline (#249). Autodeploy polls `/healthz` over plain HTTP against localhost and expects `200` + JSON (to version-match the just-pulled container). With the redirect, every 60s tick would mis-fire as "healthcheck timeout" and trigger a revert.

Docker's internal container healthcheck uses `curl -f`, which accepts 3xx, so it happily interpreted the 301 as "alive." Only the stricter 200+JSON contract notices.

## Changes

- `handler.go:495` — add `/healthz` to the exemption list alongside `/ws` and `/api/*`
- `redirect_test.go` (new) — table-driven test locking in the exemption contract. The middleware had no test coverage before; this covers the canonical-host pass-through, non-canonical redirects, each exempt path, and the empty-appURL disabled-middleware case

## Test plan

- [x] New test fails without the handler change and passes with it (verified by running before/after)
- [x] Full `go test -race -count=1 ./...` green
- [x] `go vet` and `golangci-lint run` clean
- [ ] After merge + publish-images: `curl -fsS http://localhost:8090/healthz` on the prod box returns `{"status":"ok","version":"<new>"}` instead of a 301