### PR TITLE
fix(server): autodeploy treats GHCR token as truly optional

### DIFF
--- a/server/internal/autodeploy/config.go
+++ b/server/internal/autodeploy/config.go
@@ -2,6 +2,7 @@ package autodeploy
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -75,6 +76,9 @@ func LoadConfig(path string) (Config, error) {
 		AlertTo:        raw["ALERT_TO"],
 	}
 
+	// Optional secret files. A missing file is treated as "no value" so a
+	// box with public GHCR images (no token needed) doesn't have to invent
+	// an empty placeholder file just to satisfy config loading.
 	for _, r := range []struct {
 		name, pathKey string
 		dst           *string
@@ -83,13 +87,18 @@ func LoadConfig(path string) (Config, error) {
 		{"SMTP_PASS", "SMTP_PASS_FILE", &c.SMTPPass},
 		{"GITHUB_TOKEN", "GITHUB_TOKEN_FILE", &c.GitHubToken},
 	} {
-		if p := raw[r.pathKey]; p != "" {
-			b, err := os.ReadFile(p)
-			if err != nil {
-				return Config{}, fmt.Errorf("read %s=%s: %w", r.pathKey, p, err)
-			}
-			*r.dst = strings.TrimRight(string(b), "\r\n")
+		p := raw[r.pathKey]
+		if p == "" {
+			continue
 		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return Config{}, fmt.Errorf("read %s=%s: %w", r.pathKey, p, err)
+		}
+		*r.dst = strings.TrimRight(string(b), "\r\n")
 	}
 
 	durations := []struct {

--- a/server/internal/autodeploy/config_test.go
+++ b/server/internal/autodeploy/config_test.go
@@ -77,6 +77,70 @@ func TestLoadConfigMissingRequired(t *testing.T) {
 	}
 }
 
+func TestLoadConfigOptionalTokenFileMissing(t *testing.T) {
+	// GHCR_TOKEN_FILE points at a non-existent path. For public images the
+	// token is optional, so a missing file should leave GHCRToken empty
+	// rather than aborting config load.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.env")
+	body := `
+REPO=justinlindh/digits
+TAG_PREFIX=server/v
+COMPOSE_DIR=/srv
+COMPOSE_FILE=docker-compose.prod.yml
+COMPOSE_PROJECT=digits-prod
+COMPOSE_ENV_FILE=/srv/.env.prod
+SERVICES=signald
+HEALTH_URLS=http://localhost:8090/healthz
+GHCR_USERNAME=justinlindh
+GHCR_TOKEN_FILE=` + filepath.Join(dir, "does-not-exist") + `
+STATE_FILE=/tmp/state.json
+ALERT_TO=alert@example
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v (missing optional token file should not abort)", err)
+	}
+	if got.GHCRToken != "" {
+		t.Errorf("GHCRToken=%q, want empty", got.GHCRToken)
+	}
+}
+
+func TestLoadConfigOptionalTokenFileUnreadable(t *testing.T) {
+	// A file that exists but cannot be read (permission denied, etc) is a
+	// real config problem, not an "optional unset" — must still error.
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "tok")
+	if err := os.WriteFile(tokenPath, []byte("ghp_x"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(dir, "config.env")
+	body := `
+REPO=justinlindh/digits
+TAG_PREFIX=server/v
+COMPOSE_DIR=/srv
+COMPOSE_FILE=docker-compose.prod.yml
+COMPOSE_PROJECT=digits-prod
+COMPOSE_ENV_FILE=/srv/.env.prod
+SERVICES=signald
+HEALTH_URLS=http://localhost:8090/healthz
+GHCR_USERNAME=justinlindh
+GHCR_TOKEN_FILE=` + tokenPath + `
+STATE_FILE=/tmp/state.json
+ALERT_TO=alert@example
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadConfig(cfgPath)
+	if err == nil {
+		t.Fatal("expected error for unreadable token file")
+	}
+}
+
 func TestLoadConfigIgnoresCommentsAndBlankLines(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.env")

--- a/server/internal/autodeploy/deploy.go
+++ b/server/internal/autodeploy/deploy.go
@@ -200,12 +200,16 @@ func (d *Deployer) Run(ctx context.Context) (Result, error) {
 func (d *Deployer) deployVersion(ctx context.Context, version string, healthTimeout time.Duration) error {
 	env := []string{"BUILD_VERSION=" + version}
 
-	if _, err := d.Runner.Run(ctx, RunSpec{
-		Name:  "docker",
-		Args:  []string{"login", "ghcr.io", "-u", d.Cfg.GHCRUsername, "--password-stdin"},
-		Stdin: []byte(d.Cfg.GHCRToken),
-	}); err != nil {
-		return &stepError{Step: StepLogin, Err: err}
+	// Skip docker login for public images: docker pull works unauthenticated
+	// and `login --password-stdin` with an empty token errors anyway.
+	if d.Cfg.GHCRToken != "" {
+		if _, err := d.Runner.Run(ctx, RunSpec{
+			Name:  "docker",
+			Args:  []string{"login", "ghcr.io", "-u", d.Cfg.GHCRUsername, "--password-stdin"},
+			Stdin: []byte(d.Cfg.GHCRToken),
+		}); err != nil {
+			return &stepError{Step: StepLogin, Err: err}
+		}
 	}
 
 	composeArgs := []string{

--- a/server/internal/autodeploy/deploy_test.go
+++ b/server/internal/autodeploy/deploy_test.go
@@ -114,6 +114,40 @@ func TestDeployNoop_NotModified(t *testing.T) {
 	}
 }
 
+func TestDeployHappyPath_NoGHCRToken_SkipsLogin(t *testing.T) {
+	// With an empty GHCRToken (public images), docker login is unnecessary
+	// and would fail with empty stdin. autodeploy must skip it and proceed
+	// straight to pull + up.
+	runner := &mockRunner{}
+	cfg := baseCfg()
+	cfg.GHCRToken = ""
+	d := &Deployer{
+		Cfg:    cfg,
+		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
+		Runner: runner, Health: &mockHealth{}, Mailer: &mockMailer{},
+		Store: &memStore{s: State{LastDeployedTag: "server/v1.9.0"}},
+		Now:   func() time.Time { return time.Unix(1000, 0).UTC() },
+	}
+	res, err := d.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Action != ActionDeployed {
+		t.Errorf("action=%q", res.Action)
+	}
+	for _, c := range runner.calls {
+		if c.Name == "docker" && len(c.Args) > 0 && c.Args[0] == "login" {
+			t.Errorf("docker login was invoked despite empty GHCRToken: %v", c.Args)
+		}
+	}
+	if len(runner.calls) == 0 {
+		t.Fatal("no runner calls")
+	}
+	if !strings.Contains(strings.Join(runner.calls[0].Args, " "), "pull") {
+		t.Errorf("first call should be pull when login is skipped, got: %v", runner.calls[0].Args)
+	}
+}
+
 func TestDeployHappyPath(t *testing.T) {
 	runner := &mockRunner{}
 	mailer := &mockMailer{}

--- a/server/scripts/install-autodeploy.sh
+++ b/server/scripts/install-autodeploy.sh
@@ -44,7 +44,10 @@ COMPOSE_ENV_FILE=$SERVER_DIR/.env.prod
 SERVICES=signald admind
 HEALTH_URLS=http://localhost:8090/healthz http://localhost:9094/healthz
 GHCR_USERNAME=justinlindh
-GHCR_TOKEN_FILE=/etc/digits-autodeploy/ghcr_token
+# Optional: path to a read-only GHCR PAT. Only needed if the images are
+# private; for public packages docker pull works unauthenticated and
+# autodeploy skips the docker login step entirely.
+# GHCR_TOKEN_FILE=/etc/digits-autodeploy/ghcr_token
 # Optional: path to a read-only GitHub PAT for the releases API. With this set,
 # the rate limit goes from 60/hr (unauthenticated) to 5000/hr. Not required.
 # GITHUB_TOKEN_FILE=/etc/digits-autodeploy/github_token


### PR DESCRIPTION
## Summary

Hit two related bugs when running the autodeploy installer on the prod box (which pulls public GHCR images, no token needed).

1. **`LoadConfig` aborted on missing optional token file.** The default config template set `GHCR_TOKEN_FILE=/etc/digits-autodeploy/ghcr_token` even when no token was provided. Config loading then errored with `read GHCR_TOKEN_FILE=/etc/digits-autodeploy/ghcr_token: no such file or directory`, the installer's `--dry-run` self-test exited non-zero, and `set -e` aborted the installer before enabling the systemd timer (good defensive behavior — but the cause was a real config bug).

2. **`deployVersion` always ran `docker login --password-stdin`.** With an empty `GHCRToken` that would fail with EOF on stdin. Even if it didn't, login is unnecessary for public images: `docker pull ghcr.io/justinlindh/digits/signald:vX.Y.Z` works unauthenticated (verified end-to-end on this box).

## Changes

- `config.go` — for all three `*_FILE` optional secrets, treat `ENOENT` as "no value" and continue. Other read errors (permission denied, etc.) still abort because they indicate a real misconfiguration.
- `deploy.go` — wrap the `docker login` call in `if d.Cfg.GHCRToken != ""`. Pull and up are unaffected.
- `install-autodeploy.sh` — comment out `GHCR_TOKEN_FILE` in the default template (matches the existing pattern for `GITHUB_TOKEN_FILE`), with a comment explaining when to uncomment.

## Tests

- `TestLoadConfigOptionalTokenFileMissing` — `GHCR_TOKEN_FILE` points at a non-existent path → load succeeds, `GHCRToken` is empty
- `TestLoadConfigOptionalTokenFileUnreadable` — `GHCR_TOKEN_FILE` exists but is `chmod 000` → load errors (real misconfig)
- `TestDeployHappyPath_NoGHCRToken_SkipsLogin` — empty `GHCRToken` → orchestrator skips login, first runner call is `pull`, deploy succeeds

## Test plan

- [x] New tests pass; existing autodeploy tests still pass
- [x] `golangci-lint run` clean
- [ ] After merge + publish-images: re-run installer on prod box; `--dry-run` self-test passes; timer enables; first tick is a no-op (state already at v1.26.x).

## Followup

Once this is in, the rest of the rollout from PR #249's plan resumes (acceptance tests against the live timer).