### PR TITLE
feat(server): link call log entries to observation deck

### DIFF
--- a/server/internal/web/templates/calls.html
+++ b/server/internal/web/templates/calls.html
@@ -31,6 +31,7 @@
             <th>Status</th>
             <th>Started</th>
             <th>Duration</th>
+            <th class="r"></th>
           </tr>
         </thead>
         <tbody>
@@ -45,6 +46,7 @@
             </td>
             <td class="num">{{.Conference.CreatedAt.Format "Jan 2 15:04:05"}}</td>
             <td class="num">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&mdash;{{end}}</td>
+            <td></td>
           </tr>
           {{else}}
           <tr>
@@ -70,6 +72,7 @@
             </td>
             <td class="num">{{.Call.StartedAt.Format "Jan 2 15:04:05"}}</td>
             <td class="num">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&mdash;{{end}}</td>
+            <td class="r"><a href="/call/live/{{.Call.ID}}" aria-label="View call details">Details &rarr;</a></td>
           </tr>
           {{end}}
           {{end}}
@@ -107,6 +110,7 @@
           {{else}}<span class="chip"><span class="chip__dot"></span>{{.Call.Status}}</span>{{end}}
           <span class="num muted">{{.Call.StartedAt.Format "Jan 2 15:04:05"}}</span>
           {{if gt .Call.DurationS 0}}<span class="num muted">· {{.Call.DurationS}}s</span>{{end}}
+          <a href="/call/live/{{.Call.ID}}" style="margin-left: auto;" aria-label="View call details">Details &rarr;</a>
         </div>
         {{end}}
       </li>


### PR DESCRIPTION
## What

Adds a `Details →` link to each non-conference row on `/calls`, pointing at `/call/live/{id}`. Covers both the desktop table (new trailing column) and the mobile card list. Conference rows stay unlinked since the deck is strictly two-party.

## Why

The observation deck already supports ended calls via DB readback (`handleCallLiveDetail` explicitly does not 404 on `status='ended'`), but there was no UI entry point — users had to hand-type the URL. This surfaces postmortem jitter/loss/bytes data for any ended call from the normal call log view.

Note: this only adds the link for 2-party calls. Live metrics for 3-way conferences are not implemented; the relay's `handleLinkHealth` drops samples for conference members because `CallIDFor` only scans the 2-party active map, and `call_link_health` has no conference_id key. Conference rows remain unlinked until that plumbing lands.

## Test plan

- [x] `go test ./...` (unit) green in worktree
- [x] `make test-integration` green (all integration tests including `TestCallsPageScopedToHousehold`, `TestCallsPageRenders3WayConference`, `TestCallsPageReturns200` — all exercise the real template render)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Browser visual check in both intercom and dialup themes — not performed; port 8080 was occupied and the change is a single-column table addition + one mobile anchor. Happy to screenshot if you want.