### PR TITLE
fix(server): autodeploy waits for GHCR manifest before deploying

### DIFF
--- a/server/internal/autodeploy/deploy.go
+++ b/server/internal/autodeploy/deploy.go
@@ -15,12 +15,13 @@ import (
 type Action string
 
 const (
-	ActionNoop       Action = "noop"
-	ActionSkipFailed Action = "skip_failed_tag"
-	ActionDeployed   Action = "deployed"
-	ActionReverted   Action = "reverted"
-	ActionFailed     Action = "failed"
-	ActionCritical   Action = "critical"
+	ActionNoop           Action = "noop"
+	ActionSkipFailed     Action = "skip_failed_tag"
+	ActionImagesNotReady Action = "images_not_ready"
+	ActionDeployed       Action = "deployed"
+	ActionReverted       Action = "reverted"
+	ActionFailed         Action = "failed"
+	ActionCritical       Action = "critical"
 )
 
 // Step identifies which phase of a deploy attempt produced an error.
@@ -140,6 +141,23 @@ func (d *Deployer) Run(ctx context.Context) (Result, error) {
 
 	version := strings.TrimPrefix(rel.TagName, d.Cfg.TagPrefix)
 	prevVersion := strings.TrimPrefix(state.LastDeployedTag, d.Cfg.TagPrefix)
+
+	// Pre-flight: verify all images exist in GHCR before committing to a
+	// deploy. CI publishes the GitHub Release before publish-images finishes
+	// pushing, leaving a window where the release is visible but `docker pull`
+	// returns "manifest unknown". Proceeding would trip spin-protection and
+	// require a manual --retry. Instead, exit cleanly and retry next tick.
+	for _, svc := range d.Cfg.Services {
+		img := fmt.Sprintf("ghcr.io/%s/%s:v%s", d.Cfg.Repo, svc, version)
+		if _, err := d.Runner.Run(ctx, RunSpec{
+			Name: "docker", Args: []string{"manifest", "inspect", img},
+		}); err != nil {
+			d.log().Info("images not yet pushed for tag, will retry",
+				"tag", rel.TagName, "service", svc, "image", img, "err", err)
+			return Result{Action: ActionImagesNotReady, Tag: rel.TagName}, nil
+		}
+	}
+
 	d.log().Info("new release, deploying", "tag", rel.TagName, "commit", rel.CommitSHA, "version", version)
 
 	state.LastAttemptTag = rel.TagName

--- a/server/internal/autodeploy/deploy_test.go
+++ b/server/internal/autodeploy/deploy_test.go
@@ -143,8 +143,11 @@ func TestDeployHappyPath_NoGHCRToken_SkipsLogin(t *testing.T) {
 	if len(runner.calls) == 0 {
 		t.Fatal("no runner calls")
 	}
-	if !strings.Contains(strings.Join(runner.calls[0].Args, " "), "pull") {
-		t.Errorf("first call should be pull when login is skipped, got: %v", runner.calls[0].Args)
+	// Strip the manifest-inspect pre-flight calls (one per service) before
+	// asserting on the post-preflight sequence.
+	post := runner.calls[len(baseCfg().Services):]
+	if len(post) == 0 || !strings.Contains(strings.Join(post[0].Args, " "), "pull") {
+		t.Errorf("first post-preflight call should be pull when login is skipped, got: %v", post)
 	}
 }
 
@@ -179,20 +182,71 @@ func TestDeployHappyPath(t *testing.T) {
 	for _, c := range runner.calls {
 		names = append(names, c.Name+" "+strings.Join(c.Args, " "))
 	}
-	if len(names) < 3 {
-		t.Fatalf("not enough runner calls: %v", names)
+	// First N calls are manifest-inspect pre-flight (one per service); the
+	// deploy sequence (login/pull/up) follows.
+	post := names[len(baseCfg().Services):]
+	if len(post) < 3 {
+		t.Fatalf("not enough post-preflight runner calls: %v", names)
 	}
-	if !strings.Contains(names[0], "login") {
-		t.Errorf("first call not login: %s", names[0])
+	if !strings.Contains(post[0], "login") {
+		t.Errorf("first post-preflight call not login: %s", post[0])
 	}
-	if !strings.Contains(names[1], "pull") {
-		t.Errorf("second call not pull: %s", names[1])
+	if !strings.Contains(post[1], "pull") {
+		t.Errorf("second post-preflight call not pull: %s", post[1])
 	}
-	if !strings.Contains(names[2], "up") || !strings.Contains(names[2], "--wait") {
-		t.Errorf("third call not up --wait: %s", names[2])
+	if !strings.Contains(post[2], "up") || !strings.Contains(post[2], "--wait") {
+		t.Errorf("third post-preflight call not up --wait: %s", post[2])
 	}
 	if len(mailer.sent) != 0 {
 		t.Errorf("email sent on success: %+v", mailer.sent)
+	}
+}
+
+func TestDeploy_ImagesNotReady_SkipsAndExitsClean(t *testing.T) {
+	// CI race: semantic-release publishes the GitHub Release before
+	// publish-images finishes pushing to GHCR. Autodeploy must wait quietly:
+	// no in-progress state write (would trip spin-protection), no email, no
+	// pull/up. Next tick retries once the manifests land.
+	runner := &mockRunner{errs: map[string]error{
+		"docker manifest": errors.New("manifest unknown"),
+	}}
+	mailer := &mockMailer{}
+	store := &memStore{s: State{LastDeployedTag: "server/v1.9.0"}}
+	d := &Deployer{
+		Cfg:    baseCfg(),
+		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
+		Runner: runner, Health: &mockHealth{}, Mailer: mailer, Store: store,
+		Now: func() time.Time { return time.Unix(1000, 0).UTC() },
+	}
+	res, err := d.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Action != ActionImagesNotReady {
+		t.Errorf("action=%q, want %q", res.Action, ActionImagesNotReady)
+	}
+	if res.Tag != "server/v1.9.1" {
+		t.Errorf("tag=%q", res.Tag)
+	}
+	if store.s.LastAttemptTag != "" {
+		t.Errorf("LastAttemptTag=%q, want empty (must not activate spin-protection)", store.s.LastAttemptTag)
+	}
+	if store.s.LastAttemptStatus != "" {
+		t.Errorf("LastAttemptStatus=%q, want empty", store.s.LastAttemptStatus)
+	}
+	if store.s.LastDeployedTag != "server/v1.9.0" {
+		t.Errorf("LastDeployedTag changed to %q", store.s.LastDeployedTag)
+	}
+	if len(mailer.sent) != 0 {
+		t.Errorf("email sent on images-not-ready: %+v", mailer.sent)
+	}
+	if len(runner.calls) == 0 {
+		t.Fatal("no manifest inspect call was made")
+	}
+	for _, c := range runner.calls {
+		if len(c.Args) < 1 || c.Args[0] != "manifest" {
+			t.Errorf("unexpected runner call (should only be manifest inspect): %v", c.Args)
+		}
 	}
 }
 
@@ -220,9 +274,10 @@ func TestDeploy_LoginFails(t *testing.T) {
 		t.Errorf("LastAttemptStatus=%q", store.s.LastAttemptStatus)
 	}
 	// Login failure must NOT trigger a revert: nothing was pulled or restarted,
-	// so the only docker call should be the failed login itself.
-	if len(runner.calls) != 1 {
-		t.Errorf("expected exactly 1 runner call (the failed login), got %d", len(runner.calls))
+	// so the only non-preflight docker call should be the failed login itself.
+	want := len(baseCfg().Services) + 1 // N manifest-inspect + 1 login
+	if len(runner.calls) != want {
+		t.Errorf("expected %d runner calls (preflight + failed login), got %d", want, len(runner.calls))
 	}
 	if len(mailer.sent) != 1 {
 		t.Fatalf("expected 1 email, got %d", len(mailer.sent))


### PR DESCRIPTION
## Summary

- Add a `docker manifest inspect` pre-flight per service before committing to a deploy. If any manifest is missing, log INFO and exit cleanly with the new `ActionImagesNotReady` — no state write, no spin-protection, no email.
- Fixes a CI race where semantic-release publishes the GitHub Release before `publish-images` finishes pushing. Autodeploy sees the tag, pull fails with "manifest unknown", state goes to failed, spin-protection kicks in, and a false-positive email ships.

## Background

Reproduced in prod with v1.27.0: the images landed a couple of minutes after the release, by which point autodeploy had already tripped. Recovery required SSH + `sudo /usr/local/bin/autodeploy --retry`.

The pre-flight runs before the in-progress state write, so a miss doesn't activate spin-protection — the next tick retries once publish-images catches up.

The check reuses the existing `Runner` interface (docker shell-out), so no new abstraction and the existing mocks cover it.

## Test plan

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] New `TestDeploy_ImagesNotReady_SkipsAndExitsClean` asserts no state write, no email, no pull/up
- [x] Existing happy-path + login-fail tests updated for the preflight calls preceding login
- [ ] After merge, re-run `scripts/install-autodeploy.sh` so the systemd timer picks up the new binary