### PR TITLE
fix(digitsd): play DTMF beep on first keypress

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1794,15 +1794,12 @@ func main() {
 				continue // skip normal controller handling
 			}
 
-			// Handle DTMF tone playback for key presses
+			// The controller's FSM stops the dial tone loop on the first key
+			// via SendTone(ToneStop); we only queue the DTMF beep here.
 			if strings.HasPrefix(event, "KEY:") && len(event) > 4 {
 				key := string(event[4])
 				dtmfName := dtmfToneName(key)
 				if dtmfName != "" {
-					// Stop dial tone on first key
-					if mixer.Active() == "tone_dial" {
-						mixer.StopTone()
-					}
 					mixer.PlayOnce(dtmfName)
 				}
 				// Forward DTMF to the remote peer if a call is connected.

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -257,21 +257,16 @@ func (m *Mixer) PlayLoop(name string) {
 	m.loopPos = 0
 }
 
-// StopTone silences any looping tone AND any in-flight one-shot announcement
-// (intercept, disconnected, etc). WebRTC sources are untouched.
-//
-// PlayOnce callers that follow StopTone in the same sequence are safe: the
-// queue clear and the append both acquire m.mu, so PlayOnce only sees the
-// queue after StopTone has finished clearing it. Takes effect within one
-// period (~20ms).
+// StopTone silences the currently looping tone within one period (~20ms).
+// Queued one-shots and WebRTC sources are untouched so the FSM can kill the
+// dial tone without racing a DTMF beep the daemon just queued. Use StopAll
+// to wipe everything.
 func (m *Mixer) StopTone() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.loopSamples = nil
 	m.loopName = ""
 	m.loopPos = 0
-	m.onceQueue = nil
-	m.oncePos = 0
 }
 
 // StopAll stops all audio: loops, one-shots, and clears all WebRTC sources.

--- a/pi/digitsd/internal/audio/mixer_test.go
+++ b/pi/digitsd/internal/audio/mixer_test.go
@@ -212,6 +212,54 @@ func TestMixerPlayOnce(t *testing.T) {
 	}
 }
 
+// TestMixerStopTonePreservesOnceQueue locks in the fix for the first-keypress
+// bug: the daemon layer queues a DTMF beep just before the FSM calls StopTone
+// to kill the dial tone loop. StopTone must stop only the loop, never wipe
+// the one-shot queue, or the beep is silently dropped before the render tick.
+func TestMixerStopTonePreservesOnceQueue(t *testing.T) {
+	w := &mockWriter{}
+	mx := NewMixer(w)
+
+	loop := make([]int16, 960)
+	for i := range loop {
+		loop[i] = 100
+	}
+	beep := make([]int16, 480)
+	for i := range beep {
+		beep[i] = 500
+	}
+	mx.LoadTone("loop", loop)
+	mx.LoadTone("beep", beep)
+
+	// Replay the real sequence that hits on a first keypress in StateDIALTONE:
+	// dial tone is looping, daemon queues a DTMF one-shot, then the FSM fires
+	// StopTone. Do all three before Start so the first rendered period is
+	// deterministic.
+	mx.PlayLoop("loop")
+	mx.PlayOnce("beep")
+	mx.StopTone()
+
+	mx.Start()
+	time.Sleep(50 * time.Millisecond)
+	mx.Stop()
+
+	if len(w.periods) < 1 {
+		t.Fatal("no periods written")
+	}
+	p := w.periods[0]
+	// First 480 samples should be the beep (500), not silence or the loop.
+	if p[0] != 500 {
+		t.Errorf("sample 0: expected 500 (DTMF beep survived StopTone), got %d", p[0])
+	}
+	if p[479] != 500 {
+		t.Errorf("sample 479: expected 500, got %d", p[479])
+	}
+	// After the beep ends, we should be silent — the loop must have stopped.
+	if p[480] != 0 {
+		t.Errorf("sample 480: expected 0 (loop stopped, beep done), got %d", p[480])
+	}
+}
+
 func TestMixerPlayOnceOverLoop(t *testing.T) {
 	w := &mockWriter{}
 	mx := NewMixer(w)


### PR DESCRIPTION
## Summary

- `Mixer.StopTone` was clearing both the looping tone and the one-shot queue. On the first key after hook-off, main.go queued the DTMF beep and the controller's FSM then fired `SendTone(ToneStop)` to kill the dial tone, which also wiped the queued beep before the render goroutine's next 20 ms tick. Net effect: silent first press, subsequent presses fine.
- `StopTone` now stops only the loop. `StopAll` remains the full-reset path. Audited all 23 callers, none relied on queue-clear semantics.
- Removed the redundant `mixer.StopTone()` in main.go's KEY handler since the FSM already does it.
- Added `TestMixerStopTonePreservesOnceQueue` to pin the invariant (verified it fails against the old behavior).

Nothing cold-starts on first press: ALSA handles open at boot, render goroutine runs continuously writing silence as DAC keepalive, WAVs preload into memory. The bug was purely the `StopTone` semantics racing the render tick.

## Test plan

- [x] `go test ./...` passes (unit suite)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] New regression test fails without the fix, passes with it
- [ ] Deploy to a phone and confirm first keypress plays DTMF
- [ ] Verify dial tone still stops on first key (controller path)
- [ ] Verify hang-up still silences everything (`StopAll` path)