### PR TITLE
feat(server,digitsd): 3-way link-health plumbing (phase 1 of 4)

### DIFF
--- a/pi/digitsd/cmd/digitsd/linkhealth.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth.go
@@ -1,14 +1,41 @@
 package main
 
 import (
+	"context"
+
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
+	"github.com/pion/webrtc/v4"
 )
 
 // sigSender is the minimal send surface buildMeshLinkHealthSend needs.
 // *sigclient.Client satisfies it.
 type sigSender interface {
 	Send(*sigclient.Message) error
+}
+
+// meshReporterOnConnected returns a PeerConnectionStateChange callback that
+// spawns a link-health reporter for peerPhone on Connected and stores its
+// cancel in d.meshReporterCancels. Idempotent on ICE restart (cancels any
+// prior reporter for this peer before spawning a fresh one).
+func (d *daemonCallbacks) meshReporterOnConnected(pm *owebrtc.PeerManager, peerPhone string) func(webrtc.PeerConnectionState) {
+	return func(state webrtc.PeerConnectionState) {
+		if state != webrtc.PeerConnectionStateConnected {
+			return
+		}
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if d.linkHealthDisabled {
+			return
+		}
+		if cancel, ok := d.meshReporterCancels[peerPhone]; ok {
+			cancel()
+		}
+		rctx, cancel := context.WithCancel(context.Background())
+		d.meshReporterCancels[peerPhone] = cancel
+		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, peerPhone), d.linkHealthInterval)
+		go reporter.Run(rctx)
+	}
 }
 
 // buildMeshLinkHealthSend returns an owebrtc.Reporter send callback that

--- a/pi/digitsd/cmd/digitsd/linkhealth.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
+	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
+)
+
+// sigSender is the minimal send surface buildMeshLinkHealthSend needs.
+// *sigclient.Client satisfies it.
+type sigSender interface {
+	Send(*sigclient.Message) error
+}
+
+// buildMeshLinkHealthSend returns an owebrtc.Reporter send callback that
+// emits a link_health signaling message stamped with the given remote
+// peer phone. Every other field is copied through from the sample.
+func buildMeshLinkHealthSend(sig sigSender, peer string) func(owebrtc.Sample) error {
+	return func(s owebrtc.Sample) error {
+		payload := &sigclient.LinkHealthPayload{
+			TS:       s.TS.UnixMilli(),
+			LossPct:  s.LossPct,
+			JitterMs: s.JitterMs,
+			RttMs:    s.RttMs,
+			ConnType: s.ConnType,
+			BytesIn:  s.BytesIn,
+			BytesOut: s.BytesOut,
+			Peer:     peer,
+		}
+		return sig.Send(&sigclient.Message{Type: sigclient.TypeLinkHealth, LinkHealth: payload})
+	}
+}

--- a/pi/digitsd/cmd/digitsd/linkhealth_test.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
+	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
+)
+
+type recordingSig struct{ last *sigclient.Message }
+
+func (r *recordingSig) Send(m *sigclient.Message) error {
+	r.last = m
+	return nil
+}
+
+func TestBuildMeshLinkHealthSend_StampsPeer(t *testing.T) {
+	rs := &recordingSig{}
+	send := buildMeshLinkHealthSend(rs, "+15555550123")
+
+	loss := float32(1.25)
+	s := owebrtc.Sample{
+		TS:       time.UnixMilli(1714000000000),
+		LossPct:  &loss,
+		ConnType: "srflx",
+	}
+	if err := send(s); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if rs.last == nil {
+		t.Fatal("no message sent")
+	}
+	if rs.last.Type != sigclient.TypeLinkHealth {
+		t.Fatalf("Type: got %q", rs.last.Type)
+	}
+	if rs.last.LinkHealth == nil {
+		t.Fatal("LinkHealth nil")
+	}
+	if rs.last.LinkHealth.Peer != "+15555550123" {
+		t.Fatalf("Peer: got %q want %q", rs.last.LinkHealth.Peer, "+15555550123")
+	}
+	if rs.last.LinkHealth.ConnType != "srflx" {
+		t.Fatalf("ConnType not preserved: got %q", rs.last.LinkHealth.ConnType)
+	}
+	if rs.last.LinkHealth.LossPct == nil || *rs.last.LinkHealth.LossPct != 1.25 {
+		t.Fatalf("LossPct not preserved")
+	}
+}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -666,25 +666,7 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 		})
 	}
 
-	// Spawn a link-health reporter once the mesh peer reaches Connected.
-	// Idempotent: cancels any prior reporter for this peer (ICE restart).
-	pm.OnConnectionState = func(state webrtc.PeerConnectionState) {
-		if state != webrtc.PeerConnectionStateConnected {
-			return
-		}
-		d.mu.Lock()
-		defer d.mu.Unlock()
-		if d.linkHealthDisabled {
-			return
-		}
-		if cancel, ok := d.meshReporterCancels[phone]; ok {
-			cancel()
-		}
-		rctx, cancel := context.WithCancel(context.Background())
-		d.meshReporterCancels[phone] = cancel
-		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, phone), d.linkHealthInterval)
-		go reporter.Run(rctx)
-	}
+	pm.OnConnectionState = d.meshReporterOnConnected(pm, phone)
 
 	if initiator {
 		// Initiator creates and sends the SDP offer to the peer.
@@ -802,25 +784,7 @@ func (d *daemonCallbacks) setupMeshResponder(peer, offerSDP, confID string) (str
 		})
 	}
 
-	// Spawn a link-health reporter once the mesh peer reaches Connected.
-	// Idempotent: cancels any prior reporter for this peer (ICE restart).
-	pm.OnConnectionState = func(state webrtc.PeerConnectionState) {
-		if state != webrtc.PeerConnectionStateConnected {
-			return
-		}
-		d.mu.Lock()
-		defer d.mu.Unlock()
-		if d.linkHealthDisabled {
-			return
-		}
-		if cancel, ok := d.meshReporterCancels[peer]; ok {
-			cancel()
-		}
-		rctx, cancel := context.WithCancel(context.Background())
-		d.meshReporterCancels[peer] = cancel
-		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, peer), d.linkHealthInterval)
-		go reporter.Run(rctx)
-	}
+	pm.OnConnectionState = d.meshReporterOnConnected(pm, peer)
 
 	// Use confID from the offer rather than ctrl.ConferenceID() so the answer
 	// is correctly routed even if ConferenceMember has not yet arrived.

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -872,6 +872,12 @@ func (d *daemonCallbacks) HangupCall() {
 		}
 		d.peerMgr = nil
 	}
+	// Drain any active mesh reporter goroutines before closing their
+	// PeerConnections so GetStats() is never called on a closed peer.
+	for phone, cancel := range d.meshReporterCancels {
+		cancel()
+		delete(d.meshReporterCancels, phone)
+	}
 	// Tear down any mesh peers as well. The mesh may still hold a peer adopted
 	// from an earlier flash (ADD_DIALTONE MigrateToMesh) that was aborted
 	// before a conference merge; leaving it behind causes the next Adopt to

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -558,6 +558,10 @@ func (d *daemonCallbacks) currentPeer() string {
 func (d *daemonCallbacks) TearDownPeer(phone string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if cancel, ok := d.meshReporterCancels[phone]; ok {
+		cancel()
+		delete(d.meshReporterCancels, phone)
+	}
 	if d.mesh != nil {
 		d.mesh.RemovePeer(phone)
 	}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -92,6 +92,10 @@ type daemonCallbacks struct {
 	reporterCancel      context.CancelFunc
 	linkHealthDisabled  bool
 	linkHealthInterval  time.Duration
+
+	// meshReporterCancels holds one CancelFunc per mesh peer's link-health
+	// reporter. Keyed by peer phone. Protected by mu, same as mesh.
+	meshReporterCancels map[string]context.CancelFunc
 }
 
 // sendSignal sends a signaling message and logs failures.
@@ -658,6 +662,26 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 		})
 	}
 
+	// Spawn a link-health reporter once the mesh peer reaches Connected.
+	// Idempotent: cancels any prior reporter for this peer (ICE restart).
+	pm.OnConnectionState = func(state webrtc.PeerConnectionState) {
+		if state != webrtc.PeerConnectionStateConnected {
+			return
+		}
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if d.linkHealthDisabled {
+			return
+		}
+		if cancel, ok := d.meshReporterCancels[phone]; ok {
+			cancel()
+		}
+		rctx, cancel := context.WithCancel(context.Background())
+		d.meshReporterCancels[phone] = cancel
+		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, phone), d.linkHealthInterval)
+		go reporter.Run(rctx)
+	}
+
 	if initiator {
 		// Initiator creates and sends the SDP offer to the peer.
 		offer, err := pm.CreateOffer()
@@ -684,6 +708,10 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 func (d *daemonCallbacks) RemoveMeshPeer(phone string) {
 	d.mu.Lock()
 	mesh := d.mesh
+	if cancel, ok := d.meshReporterCancels[phone]; ok {
+		cancel()
+		delete(d.meshReporterCancels, phone)
+	}
 	d.mu.Unlock()
 	if mesh != nil {
 		mesh.RemovePeer(phone)
@@ -694,6 +722,10 @@ func (d *daemonCallbacks) RemoveMeshPeer(phone string) {
 func (d *daemonCallbacks) TearDownAllMeshPeers() {
 	d.mu.Lock()
 	mesh := d.mesh
+	for phone, cancel := range d.meshReporterCancels {
+		cancel()
+		delete(d.meshReporterCancels, phone)
+	}
 	d.mu.Unlock()
 	if mesh == nil {
 		return
@@ -764,6 +796,26 @@ func (d *daemonCallbacks) setupMeshResponder(peer, offerSDP, confID string) (str
 			ConfID:    confID,
 			Candidate: candidate,
 		})
+	}
+
+	// Spawn a link-health reporter once the mesh peer reaches Connected.
+	// Idempotent: cancels any prior reporter for this peer (ICE restart).
+	pm.OnConnectionState = func(state webrtc.PeerConnectionState) {
+		if state != webrtc.PeerConnectionStateConnected {
+			return
+		}
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if d.linkHealthDisabled {
+			return
+		}
+		if cancel, ok := d.meshReporterCancels[peer]; ok {
+			cancel()
+		}
+		rctx, cancel := context.WithCancel(context.Background())
+		d.meshReporterCancels[peer] = cancel
+		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, peer), d.linkHealthInterval)
+		go reporter.Run(rctx)
 	}
 
 	// Use confID from the offer rather than ctrl.ConferenceID() so the answer
@@ -1644,15 +1696,16 @@ func main() {
 	linkHealthInterval := time.Duration(linkHealthIntervalMs) * time.Millisecond
 
 	cb := &daemonCallbacks{
-		serial:             sp,
-		sig:                sig,
-		mixer:              mixer,
-		serviceCodes:       svcCodes,
-		number:             effectiveNumber,
-		cfg:                cfg,
-		debugMode:          os.Getenv("DIGITS_DEBUG") == "1",
-		linkHealthDisabled: linkHealthDisabled,
-		linkHealthInterval: linkHealthInterval,
+		serial:              sp,
+		sig:                 sig,
+		mixer:               mixer,
+		serviceCodes:        svcCodes,
+		number:              effectiveNumber,
+		cfg:                 cfg,
+		debugMode:           os.Getenv("DIGITS_DEBUG") == "1",
+		linkHealthDisabled:  linkHealthDisabled,
+		linkHealthInterval:  linkHealthInterval,
+		meshReporterCancels: make(map[string]context.CancelFunc),
 	}
 	if cfg.DeviceToken != "" {
 		cb.paired.Store(true)

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -87,7 +87,9 @@ type LinkHealthPayload struct {
 	BytesIn  *int64   `json:"bytes_in,omitempty"`
 	BytesOut *int64   `json:"bytes_out,omitempty"`
 	// Peer identifies the remote endpoint this sample is about. Empty for
-	// 2-party samples; set to the peer's phone number for 3-way mesh samples.
+	// 2-party samples (backward compatible). Set to the peer's phone
+	// number for 3-way mesh samples; each participant emits one sample
+	// per remote peer per tick.
 	Peer string `json:"peer,omitempty"`
 }
 

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -86,6 +86,9 @@ type LinkHealthPayload struct {
 	ConnType string   `json:"conn_type,omitempty"`
 	BytesIn  *int64   `json:"bytes_in,omitempty"`
 	BytesOut *int64   `json:"bytes_out,omitempty"`
+	// Peer identifies the remote endpoint this sample is about. Empty for
+	// 2-party samples; set to the peer's phone number for 3-way mesh samples.
+	Peer string `json:"peer,omitempty"`
 }
 
 // ContactEntry represents a single contact in a sync payload.

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -3,6 +3,7 @@ package signal
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -270,5 +271,46 @@ func TestLinkHealthParseOmittedFieldsAreNil(t *testing.T) {
 	}
 	if m.LinkHealth.ConnType != "host" {
 		t.Fatalf("ConnType: got %q", m.LinkHealth.ConnType)
+	}
+}
+
+func TestLinkHealthPeerRoundTrip(t *testing.T) {
+	loss := float32(1.5)
+	m := &Message{
+		Type: TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{
+			TS:       1714000000000,
+			LossPct:  &loss,
+			ConnType: "relay",
+			Peer:     "+15555550123",
+		},
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"peer":"+15555550123"`) {
+		t.Fatalf("expected peer field in JSON: %s", b)
+	}
+	var got Message
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.LinkHealth == nil {
+		t.Fatal("LinkHealth nil after round trip")
+	}
+	if got.LinkHealth.Peer != "+15555550123" {
+		t.Fatalf("Peer: got %q want %q", got.LinkHealth.Peer, "+15555550123")
+	}
+}
+
+func TestLinkHealthPeerOmitEmpty(t *testing.T) {
+	m := &Message{Type: TypeLinkHealth, LinkHealth: &LinkHealthPayload{TS: 1, ConnType: "host"}}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"peer"`) {
+		t.Fatalf("empty Peer should be omitted from JSON: %s", b)
 	}
 }

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -310,7 +310,13 @@ func TestLinkHealthPeerOmitEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if strings.Contains(string(b), `"peer"`) {
-		t.Fatalf("empty Peer should be omitted from JSON: %s", b)
+	var env struct {
+		LinkHealth map[string]json.RawMessage `json:"link_health"`
+	}
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if _, ok := env.LinkHealth["peer"]; ok {
+		t.Fatalf("empty Peer should be omitted from link_health object: %s", b)
 	}
 }

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -63,12 +63,12 @@ type SessionKey struct {
 // IsConf reports whether this key identifies a conference.
 func (k SessionKey) IsConf() bool { return k.ConfID != uuid.Nil }
 
-// endpointKey is the composite map key for a per-session sample ring.
-// From is the phone that emitted the sample. Peer is the remote endpoint
-// the sample describes; it is empty for 2-party calls.
+// endpointKey is the composite map key for per-endpoint sample rings.
+// Peer is zero for 2-party samples; set to the remote endpoint phone
+// for 3-way per-edge samples (populated in a later phase).
 type endpointKey struct {
-	From string
-	Peer string
+	From string // phone that emitted the sample
+	Peer string // remote endpoint the sample describes; "" for 2-party
 }
 
 // ringCapacity is the per-endpoint in-memory sample retention.
@@ -404,6 +404,12 @@ func (s *HealthStore) FlushOnce(ctx context.Context) error {
 }
 
 func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sessionRings) error {
+	if key.IsConf() {
+		// Conference flush lands in a later phase with schema support for
+		// conference_id + peer columns. Until then, conference-keyed sessions
+		// live in memory only; the ticker loop must not try to persist them.
+		return nil
+	}
 	sr.mu.Lock()
 	// Collect work under lock, then release before DB I/O.
 	type pending struct {

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -30,7 +30,8 @@ const (
 // Event is one delivery to a HealthStore subscriber.
 type Event struct {
 	Kind     EventKind
-	Endpoint string // SampleKind only
+	Endpoint string // phone that emitted the sample (SampleKind only)
+	Peer     string // remote endpoint the sample describes; "" for 2-party (SampleKind only)
 	Sample   Sample // SampleKind only
 	EndedBy  string // DisconnectKind only (user display label)
 }
@@ -143,12 +144,9 @@ func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 	return s
 }
 
-// Init creates an empty rings entry for a call. Called by Tracker on
-// OnCallInitiated so that subsequent Record calls have a place to land
-// without needing auto-creation (which would resurrect evicted calls).
-// Safe to call multiple times; idempotent.
-func (s *HealthStore) Init(callID int64) {
-	key := SessionKey{CallID: callID}
+// initSession creates an empty rings entry for the given session key.
+// Idempotent: no-op if the key already exists.
+func (s *HealthStore) initSession(key SessionKey) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.sessions[key]; ok {
@@ -157,29 +155,24 @@ func (s *HealthStore) Init(callID int64) {
 	s.sessions[key] = &sessionRings{byEndpoint: make(map[endpointKey]*ring)}
 }
 
-// Record appends a sample for the given call and endpoint. Safe for
-// concurrent use. No-op if Init was not called for this callID first
-// or if the call has been Evicted -- this matches the tracker-authoritative
-// lifecycle and prevents post-Evict resurrection of map entries.
+// recordSession appends a sample for the given session key and endpoint pair.
+// No-op if the session was not initialized or has been evicted.
 //
 // Race note: between releasing the top-level map lock and acquiring the
-// per-call lock, a concurrent Evict can remove the sessionRings entry from
-// the map. The captured *sessionRings reference remains valid (the struct is
-// not freed) but is no longer reachable from the map; the sample appended
-// to it will be silently dropped -- never flushed, eventually GC'd. This
-// is intentional telemetry loss on a racing call-end. The alternative --
-// auto-recreating the map entry -- would resurrect evicted calls, which
-// was the exact bug fixed during the T6 review cycle.
-func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
-	key := SessionKey{CallID: callID}
+// per-session lock, a concurrent evictSession can remove the sessionRings
+// entry from the map. The captured *sessionRings reference remains valid
+// (the struct is not freed) but is no longer reachable from the map; the
+// sample appended to it will be silently dropped -- never flushed, eventually
+// GC'd. This is intentional telemetry loss on a racing session-end.
+func (s *HealthStore) recordSession(key SessionKey, from, peer string, sample Sample) {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
-		return // not initialized or already evicted
+		return
 	}
 
-	epKey := endpointKey{From: endpoint}
+	epKey := endpointKey{From: from, Peer: peer}
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	r, ok := sr.byEndpoint[epKey]
@@ -188,35 +181,12 @@ func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 		sr.byEndpoint[epKey] = r
 	}
 	r.append(sample)
-	sr.broadcastLocked(Event{Kind: SampleKind, Endpoint: endpoint, Sample: sample})
+	sr.broadcastLocked(Event{Kind: SampleKind, Endpoint: from, Peer: peer, Sample: sample})
 }
 
-// Latest returns the most recent sample for the caller and callee endpoints
-// of the given call. Either may be nil if no samples have been recorded yet.
-func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
-	key := SessionKey{CallID: callID}
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		return nil, nil
-	}
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	var a, b *Sample
-	if r := sr.byEndpoint[endpointKey{From: caller}]; r != nil {
-		a = r.latest()
-	}
-	if r := sr.byEndpoint[endpointKey{From: callee}]; r != nil {
-		b = r.latest()
-	}
-	return a, b
-}
-
-// Window returns a copy of the retained sample ring for an endpoint, oldest
-// first. Returns an empty slice if the call or endpoint is unknown.
-func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
-	key := SessionKey{CallID: callID}
+// windowSession returns a copy of the retained sample ring for the given
+// session key and endpoint pair, oldest first. Empty if unknown.
+func (s *HealthStore) windowSession(key SessionKey, from, peer string) []Sample {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	s.mu.Unlock()
@@ -225,7 +195,7 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 	}
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
-	r, ok := sr.byEndpoint[endpointKey{From: endpoint}]
+	r, ok := sr.byEndpoint[endpointKey{From: from, Peer: peer}]
 	if !ok {
 		return nil
 	}
@@ -234,13 +204,25 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 	return out
 }
 
-// Evict drops all in-memory state for a call. Broadcasts an EndedKind event
-// to every live subscriber and closes their channels, then clears the ring
-// map entry. Safe to call multiple times; subsequent calls are no-ops.
-//
-// Called by Tracker on call end via the SetHealthStore-registered interface.
-func (s *HealthStore) Evict(callID int64) {
-	key := SessionKey{CallID: callID}
+// latestSession returns the most recent sample for a single session edge or nil.
+func (s *HealthStore) latestSession(key SessionKey, from, peer string) *Sample {
+	s.mu.Lock()
+	sr, ok := s.sessions[key]
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	if r := sr.byEndpoint[endpointKey{From: from, Peer: peer}]; r != nil {
+		return r.latest()
+	}
+	return nil
+}
+
+// evictSession drops all in-memory state for a session. Broadcasts EndedKind
+// to every live subscriber and closes their channels. Idempotent.
+func (s *HealthStore) evictSession(key SessionKey) {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	delete(s.sessions, key)
@@ -252,7 +234,7 @@ func (s *HealthStore) Evict(callID int64) {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	// Every channel op under sr.mu must be non-blocking (select/default or
-	// close) -- we hold the lock that Record also takes on the hot path.
+	// close) -- we hold the lock that recordSession also takes on the hot path.
 	for sub := range sr.subscribers {
 		select {
 		case sub.ch <- Event{Kind: EndedKind}:
@@ -265,6 +247,119 @@ func (s *HealthStore) Evict(callID int64) {
 		close(sub.ch)
 	}
 	sr.subscribers = nil
+}
+
+// subscribeSession opens an event stream for a session. If the session is not
+// currently initialized (or has been evicted), returns a Subscription whose
+// channel is already closed.
+func (s *HealthStore) subscribeSession(key SessionKey) *Subscription {
+	s.mu.Lock()
+	sr, ok := s.sessions[key]
+	s.mu.Unlock()
+	if !ok {
+		ch := make(chan Event)
+		close(ch)
+		return &Subscription{C: ch, close: func() {}}
+	}
+
+	sub := &subscriber{ch: make(chan Event, subscriberBufferSize)}
+
+	sr.mu.Lock()
+	if sr.subscribers == nil {
+		sr.subscribers = make(map[*subscriber]struct{})
+	}
+	sr.subscribers[sub] = struct{}{}
+	sr.mu.Unlock()
+
+	return &Subscription{
+		C: sub.ch,
+		close: func() {
+			sr.mu.Lock()
+			_, stillRegistered := sr.subscribers[sub]
+			delete(sr.subscribers, sub)
+			sr.mu.Unlock()
+			if stillRegistered {
+				close(sub.ch)
+			}
+		},
+	}
+}
+
+// Init creates an empty rings entry for a call. Called by Tracker on
+// OnCallInitiated so that subsequent Record calls have a place to land
+// without needing auto-creation (which would resurrect evicted calls).
+// Safe to call multiple times; idempotent.
+func (s *HealthStore) Init(callID int64) {
+	s.initSession(SessionKey{CallID: callID})
+}
+
+// Record appends a sample for the given call and endpoint. Safe for
+// concurrent use. No-op if Init was not called for this callID first
+// or if the call has been Evicted -- this matches the tracker-authoritative
+// lifecycle and prevents post-Evict resurrection of map entries.
+func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
+	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample)
+}
+
+// Latest returns the most recent sample for the caller and callee endpoints
+// of the given call. Either may be nil if no samples have been recorded yet.
+func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
+	key := SessionKey{CallID: callID}
+	a := s.latestSession(key, caller, "")
+	b := s.latestSession(key, callee, "")
+	return a, b
+}
+
+// Window returns a copy of the retained sample ring for an endpoint, oldest
+// first. Returns an empty slice if the call or endpoint is unknown.
+func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
+	return s.windowSession(SessionKey{CallID: callID}, endpoint, "")
+}
+
+// Evict drops all in-memory state for a call. Broadcasts an EndedKind event
+// to every live subscriber and closes their channels, then clears the ring
+// map entry. Safe to call multiple times; subsequent calls are no-ops.
+//
+// Called by Tracker on call end via the SetHealthStore-registered interface.
+func (s *HealthStore) Evict(callID int64) {
+	s.evictSession(SessionKey{CallID: callID})
+}
+
+// InitConference registers a conference for in-memory sample retention.
+// Mirrors Init for 2-party calls. Safe to call multiple times.
+func (s *HealthStore) InitConference(confID uuid.UUID) {
+	s.initSession(SessionKey{ConfID: confID})
+}
+
+// RecordEdge appends a per-edge sample for a conference. from is the
+// phone that emitted the sample; peer is the remote endpoint the
+// sample describes. No-op if InitConference was not called for this
+// conference (mirrors Record's behavior for unknown callID).
+func (s *HealthStore) RecordEdge(confID uuid.UUID, from, peer string, sample Sample) {
+	s.recordSession(SessionKey{ConfID: confID}, from, peer, sample)
+}
+
+// WindowEdge returns a copy of the retained sample ring for a conference
+// edge, oldest first. Empty if unknown.
+func (s *HealthStore) WindowEdge(confID uuid.UUID, from, peer string) []Sample {
+	return s.windowSession(SessionKey{ConfID: confID}, from, peer)
+}
+
+// LatestEdge returns the most recent sample for a conference edge or nil.
+func (s *HealthStore) LatestEdge(confID uuid.UUID, from, peer string) *Sample {
+	return s.latestSession(SessionKey{ConfID: confID}, from, peer)
+}
+
+// EvictConference drops in-memory state for a conference and broadcasts
+// EndedKind to subscribers.
+func (s *HealthStore) EvictConference(confID uuid.UUID) {
+	s.evictSession(SessionKey{ConfID: confID})
+}
+
+// SubscribeConference returns an event stream for a conference's samples,
+// disconnect broadcasts, and ended events. Mirrors Subscribe for 2-party.
+func (s *HealthStore) SubscribeConference(confID uuid.UUID) *Subscription {
+	return s.subscribeSession(SessionKey{ConfID: confID})
 }
 
 // Subscription delivers per-call telemetry events to one consumer.
@@ -299,37 +394,7 @@ const subscriberBufferSize = 16
 // whose channel is already closed -- callers see this the same way as a
 // mid-stream Evict and can treat it uniformly.
 func (s *HealthStore) Subscribe(callID int64) *Subscription {
-	key := SessionKey{CallID: callID}
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		ch := make(chan Event)
-		close(ch)
-		return &Subscription{C: ch, close: func() {}}
-	}
-
-	sub := &subscriber{ch: make(chan Event, subscriberBufferSize)}
-
-	sr.mu.Lock()
-	if sr.subscribers == nil {
-		sr.subscribers = make(map[*subscriber]struct{})
-	}
-	sr.subscribers[sub] = struct{}{}
-	sr.mu.Unlock()
-
-	return &Subscription{
-		C: sub.ch,
-		close: func() {
-			sr.mu.Lock()
-			_, stillRegistered := sr.subscribers[sub]
-			delete(sr.subscribers, sub)
-			sr.mu.Unlock()
-			if stillRegistered {
-				close(sub.ch)
-			}
-		},
-	}
+	return s.subscribeSession(SessionKey{CallID: callID})
 }
 
 // NotifyDisconnected broadcasts a DisconnectKind event naming the user who

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/db"
 )
 
@@ -52,15 +53,33 @@ type Sample struct {
 	BytesOut *int64
 }
 
+// SessionKey identifies either a 2-party call or a 3-way conference. Exactly
+// one of CallID / ConfID is non-zero.
+type SessionKey struct {
+	CallID int64     // non-zero for 2-party calls
+	ConfID uuid.UUID // non-zero for 3-way conferences
+}
+
+// IsConf reports whether this key identifies a conference.
+func (k SessionKey) IsConf() bool { return k.ConfID != uuid.Nil }
+
+// endpointKey is the composite map key for a per-session sample ring.
+// From is the phone that emitted the sample. Peer is the remote endpoint
+// the sample describes; it is empty for 2-party calls.
+type endpointKey struct {
+	From string
+	Peer string
+}
+
 // ringCapacity is the per-endpoint in-memory sample retention.
 // At the default 2s reporting cadence this holds 2 minutes of history.
 const ringCapacity = 60
 
-// callRings holds per-endpoint bounded sample rings and last-flushed
+// sessionRings holds per-endpoint bounded sample rings and last-flushed
 // timestamps used by the DB flusher. All state is guarded by mu.
-type callRings struct {
+type sessionRings struct {
 	mu          sync.Mutex
-	byEndpoint  map[string]*ring
+	byEndpoint  map[endpointKey]*ring
 	subscribers map[*subscriber]struct{} // nil until first Subscribe
 }
 
@@ -98,7 +117,7 @@ func (r *ring) latest() *Sample {
 type HealthStore struct {
 	db            *db.Database
 	mu            sync.Mutex
-	calls         map[int64]*callRings
+	sessions      map[SessionKey]*sessionRings
 	flushDisabled bool
 }
 
@@ -115,8 +134,8 @@ func WithFlushDisabled(disabled bool) HealthStoreOption {
 
 func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 	s := &HealthStore{
-		db:    d,
-		calls: make(map[int64]*callRings),
+		db:       d,
+		sessions: make(map[SessionKey]*sessionRings),
 	}
 	for _, o := range opts {
 		o(s)
@@ -129,12 +148,13 @@ func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 // without needing auto-creation (which would resurrect evicted calls).
 // Safe to call multiple times; idempotent.
 func (s *HealthStore) Init(callID int64) {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.calls[callID]; ok {
+	if _, ok := s.sessions[key]; ok {
 		return
 	}
-	s.calls[callID] = &callRings{byEndpoint: make(map[string]*ring)}
+	s.sessions[key] = &sessionRings{byEndpoint: make(map[endpointKey]*ring)}
 }
 
 // Record appends a sample for the given call and endpoint. Safe for
@@ -143,48 +163,51 @@ func (s *HealthStore) Init(callID int64) {
 // lifecycle and prevents post-Evict resurrection of map entries.
 //
 // Race note: between releasing the top-level map lock and acquiring the
-// per-call lock, a concurrent Evict can remove the callRings entry from
-// the map. The captured *callRings reference remains valid (the struct is
+// per-call lock, a concurrent Evict can remove the sessionRings entry from
+// the map. The captured *sessionRings reference remains valid (the struct is
 // not freed) but is no longer reachable from the map; the sample appended
 // to it will be silently dropped -- never flushed, eventually GC'd. This
 // is intentional telemetry loss on a racing call-end. The alternative --
 // auto-recreating the map entry -- would resurrect evicted calls, which
 // was the exact bug fixed during the T6 review cycle.
 func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
+	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
 		return // not initialized or already evicted
 	}
 
-	cr.mu.Lock()
-	defer cr.mu.Unlock()
-	r, ok := cr.byEndpoint[endpoint]
+	epKey := endpointKey{From: endpoint}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	r, ok := sr.byEndpoint[epKey]
 	if !ok {
 		r = &ring{}
-		cr.byEndpoint[endpoint] = r
+		sr.byEndpoint[epKey] = r
 	}
 	r.append(sample)
-	cr.broadcastLocked(Event{Kind: SampleKind, Endpoint: endpoint, Sample: sample})
+	sr.broadcastLocked(Event{Kind: SampleKind, Endpoint: endpoint, Sample: sample})
 }
 
 // Latest returns the most recent sample for the caller and callee endpoints
 // of the given call. Either may be nil if no samples have been recorded yet.
 func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
+	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
 		return nil, nil
 	}
-	cr.mu.Lock()
-	defer cr.mu.Unlock()
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
 	var a, b *Sample
-	if r := cr.byEndpoint[caller]; r != nil {
+	if r := sr.byEndpoint[endpointKey{From: caller}]; r != nil {
 		a = r.latest()
 	}
-	if r := cr.byEndpoint[callee]; r != nil {
+	if r := sr.byEndpoint[endpointKey{From: callee}]; r != nil {
 		b = r.latest()
 	}
 	return a, b
@@ -193,15 +216,16 @@ func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sam
 // Window returns a copy of the retained sample ring for an endpoint, oldest
 // first. Returns an empty slice if the call or endpoint is unknown.
 func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
+	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
 		return nil
 	}
-	cr.mu.Lock()
-	defer cr.mu.Unlock()
-	r, ok := cr.byEndpoint[endpoint]
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	r, ok := sr.byEndpoint[endpointKey{From: endpoint}]
 	if !ok {
 		return nil
 	}
@@ -216,19 +240,20 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 //
 // Called by Tracker on call end via the SetHealthStore-registered interface.
 func (s *HealthStore) Evict(callID int64) {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
-	delete(s.calls, callID)
+	sr, ok := s.sessions[key]
+	delete(s.sessions, key)
 	s.mu.Unlock()
 	if !ok {
 		return
 	}
 
-	cr.mu.Lock()
-	defer cr.mu.Unlock()
-	// Every channel op under cr.mu must be non-blocking (select/default or
-	// close) — we hold the lock that Record also takes on the hot path.
-	for sub := range cr.subscribers {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	// Every channel op under sr.mu must be non-blocking (select/default or
+	// close) -- we hold the lock that Record also takes on the hot path.
+	for sub := range sr.subscribers {
 		select {
 		case sub.ch <- Event{Kind: EndedKind}:
 		default:
@@ -239,7 +264,7 @@ func (s *HealthStore) Evict(callID int64) {
 		}
 		close(sub.ch)
 	}
-	cr.subscribers = nil
+	sr.subscribers = nil
 }
 
 // Subscription delivers per-call telemetry events to one consumer.
@@ -265,7 +290,7 @@ func (s *Subscription) Close() {
 
 // subscriberBufferSize is the per-subscription channel depth. At the 2s
 // sample cadence with two endpoints per call, 16 slots tolerates ~16s of
-// consumer stall before events drop — generous for a well-behaved SSE
+// consumer stall before events drop -- generous for a well-behaved SSE
 // consumer on a LAN.
 const subscriberBufferSize = 16
 
@@ -274,8 +299,9 @@ const subscriberBufferSize = 16
 // whose channel is already closed -- callers see this the same way as a
 // mid-stream Evict and can treat it uniformly.
 func (s *HealthStore) Subscribe(callID int64) *Subscription {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
+	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
 		ch := make(chan Event)
@@ -285,20 +311,20 @@ func (s *HealthStore) Subscribe(callID int64) *Subscription {
 
 	sub := &subscriber{ch: make(chan Event, subscriberBufferSize)}
 
-	cr.mu.Lock()
-	if cr.subscribers == nil {
-		cr.subscribers = make(map[*subscriber]struct{})
+	sr.mu.Lock()
+	if sr.subscribers == nil {
+		sr.subscribers = make(map[*subscriber]struct{})
 	}
-	cr.subscribers[sub] = struct{}{}
-	cr.mu.Unlock()
+	sr.subscribers[sub] = struct{}{}
+	sr.mu.Unlock()
 
 	return &Subscription{
 		C: sub.ch,
 		close: func() {
-			cr.mu.Lock()
-			_, stillRegistered := cr.subscribers[sub]
-			delete(cr.subscribers, sub)
-			cr.mu.Unlock()
+			sr.mu.Lock()
+			_, stillRegistered := sr.subscribers[sub]
+			delete(sr.subscribers, sub)
+			sr.mu.Unlock()
 			if stillRegistered {
 				close(sub.ch)
 			}
@@ -313,23 +339,24 @@ func (s *HealthStore) Subscribe(callID int64) *Subscription {
 //
 // No-op for unknown callIDs.
 func (s *HealthStore) NotifyDisconnected(callID int64, endedBy string) {
+	key := SessionKey{CallID: callID}
 	s.mu.Lock()
-	cr, ok := s.calls[callID]
+	sr, ok := s.sessions[key]
 	s.mu.Unlock()
 	if !ok {
 		return
 	}
-	cr.mu.Lock()
-	defer cr.mu.Unlock()
-	cr.broadcastLocked(Event{Kind: DisconnectKind, EndedBy: endedBy})
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	sr.broadcastLocked(Event{Kind: DisconnectKind, EndedBy: endedBy})
 }
 
-// broadcastLocked sends an event to every subscriber under cr.mu. Non-blocking
+// broadcastLocked sends an event to every subscriber under sr.mu. Non-blocking
 // per subscriber: if a channel is full, the event drops and a debug log fires
 // once per 32 drops to avoid log spam under sustained slow-client pressure.
-// Caller MUST hold cr.mu.
-func (cr *callRings) broadcastLocked(ev Event) {
-	for sub := range cr.subscribers {
+// Caller MUST hold sr.mu.
+func (sr *sessionRings) broadcastLocked(ev Event) {
+	for sub := range sr.subscribers {
 		select {
 		case sub.ch <- ev:
 		default:
@@ -351,45 +378,45 @@ func (s *HealthStore) FlushOnce(ctx context.Context) error {
 	if s.db == nil {
 		return nil
 	}
-	// Snapshot call ids under the top-level lock to avoid holding it while
+	// Snapshot session keys under the top-level lock to avoid holding it while
 	// doing DB I/O.
 	s.mu.Lock()
-	ids := make([]int64, 0, len(s.calls))
-	for id := range s.calls {
-		ids = append(ids, id)
+	keys := make([]SessionKey, 0, len(s.sessions))
+	for k := range s.sessions {
+		keys = append(keys, k)
 	}
 	s.mu.Unlock()
 
 	var errs []error
-	for _, id := range ids {
+	for _, k := range keys {
 		s.mu.Lock()
-		cr := s.calls[id]
+		sr := s.sessions[k]
 		s.mu.Unlock()
-		if cr == nil {
+		if sr == nil {
 			continue
 		}
-		if err := s.flushCall(ctx, id, cr); err != nil {
-			slog.Error("link-health flush failed", "call_id", id, "err", err)
-			errs = append(errs, fmt.Errorf("call %d: %w", id, err))
+		if err := s.flushSession(ctx, k, sr); err != nil {
+			slog.Error("link-health flush failed", "session_key", k, "err", err)
+			errs = append(errs, fmt.Errorf("session %v: %w", k, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings) error {
-	cr.mu.Lock()
+func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sessionRings) error {
+	sr.mu.Lock()
 	// Collect work under lock, then release before DB I/O.
 	type pending struct {
-		endpoint string
-		sample   Sample
+		epKey  endpointKey
+		sample Sample
 	}
 	type flushAdvance struct {
-		endpoint string
-		ts       time.Time
+		epKey endpointKey
+		ts    time.Time
 	}
 	var todo []pending
 	var advance []flushAdvance
-	for ep, r := range cr.byEndpoint {
+	for epKey, r := range sr.byEndpoint {
 		latest := r.latest()
 		if latest == nil {
 			continue
@@ -397,27 +424,27 @@ func (s *HealthStore) flushCall(ctx context.Context, callID int64, cr *callRings
 		if !latest.TS.After(r.lastFlushed) {
 			continue // nothing new since last flush
 		}
-		todo = append(todo, pending{endpoint: ep, sample: *latest})
-		advance = append(advance, flushAdvance{ep, latest.TS})
+		todo = append(todo, pending{epKey: epKey, sample: *latest})
+		advance = append(advance, flushAdvance{epKey, latest.TS})
 	}
-	cr.mu.Unlock()
+	sr.mu.Unlock()
 
 	if len(todo) == 0 {
 		return nil
 	}
 	for _, p := range todo {
-		if err := s.writeSample(ctx, callID, p.endpoint, p.sample); err != nil {
-			return fmt.Errorf("write sample (%d,%s): %w", callID, p.endpoint, err)
+		if err := s.writeSample(ctx, key.CallID, p.epKey.From, p.sample); err != nil {
+			return fmt.Errorf("write sample (%v,%s): %w", key, p.epKey.From, err)
 		}
 	}
 	// On success, advance lastFlushed.
-	cr.mu.Lock()
+	sr.mu.Lock()
 	for _, a := range advance {
-		if r := cr.byEndpoint[a.endpoint]; r != nil {
+		if r := sr.byEndpoint[a.epKey]; r != nil {
 			r.lastFlushed = a.ts
 		}
 	}
-	cr.mu.Unlock()
+	sr.mu.Unlock()
 	return nil
 }
 

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -301,12 +301,27 @@ func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample)
 }
 
-// Latest returns the most recent sample for the caller and callee endpoints
-// of the given call. Either may be nil if no samples have been recorded yet.
+// Latest returns the most recent samples for caller and callee on a 2-party
+// call, captured under a single lock so the two values are consistent. nil
+// pointers if no sample has been recorded for that endpoint yet. nil/nil if
+// the call is unknown.
 func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
 	key := SessionKey{CallID: callID}
-	a := s.latestSession(key, caller, "")
-	b := s.latestSession(key, callee, "")
+	s.mu.Lock()
+	sr, ok := s.sessions[key]
+	s.mu.Unlock()
+	if !ok {
+		return nil, nil
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	var a, b *Sample
+	if r := sr.byEndpoint[endpointKey{From: caller}]; r != nil {
+		a = r.latest()
+	}
+	if r := sr.byEndpoint[endpointKey{From: callee}]; r != nil {
+		b = r.latest()
+	}
 	return a, b
 }
 

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -376,3 +376,70 @@ func TestSessionKeyIsConfConfIDWins(t *testing.T) {
 		t.Fatal("double-populated SessionKey should report IsConf() == true (ConfID wins)")
 	}
 }
+
+func TestHealthStoreConferenceRoundTrip(t *testing.T) {
+	s := NewHealthStore(nil)
+	confID := uuid.New()
+	s.InitConference(confID)
+
+	loss := float32(2.5)
+	sample := Sample{TS: time.Unix(0, 1), LossPct: &loss, ConnType: "host"}
+	s.RecordEdge(confID, "A", "B", sample)
+
+	w := s.WindowEdge(confID, "A", "B")
+	if len(w) != 1 {
+		t.Fatalf("WindowEdge len: got %d want 1", len(w))
+	}
+	if w[0].LossPct == nil || *w[0].LossPct != 2.5 {
+		t.Fatalf("sample LossPct not preserved")
+	}
+
+	latest := s.LatestEdge(confID, "A", "B")
+	if latest == nil {
+		t.Fatal("LatestEdge nil")
+	}
+	if latest.LossPct == nil || *latest.LossPct != 2.5 {
+		t.Fatalf("LatestEdge LossPct not preserved")
+	}
+
+	s.EvictConference(confID)
+	if w2 := s.WindowEdge(confID, "A", "B"); len(w2) != 0 {
+		t.Fatalf("after EvictConference WindowEdge should be empty, got %d", len(w2))
+	}
+}
+
+func TestHealthStoreConferenceSubscribeReceivesPeer(t *testing.T) {
+	s := NewHealthStore(nil)
+	confID := uuid.New()
+	s.InitConference(confID)
+
+	sub := s.SubscribeConference(confID)
+	defer sub.Close()
+
+	loss := float32(3.0)
+	s.RecordEdge(confID, "A", "B", Sample{TS: time.Unix(0, 1), LossPct: &loss})
+
+	select {
+	case ev := <-sub.C:
+		if ev.Kind != SampleKind {
+			t.Fatalf("event kind: got %v", ev.Kind)
+		}
+		if ev.Endpoint != "A" {
+			t.Fatalf("event Endpoint: got %q want A", ev.Endpoint)
+		}
+		if ev.Peer != "B" {
+			t.Fatalf("event Peer: got %q want B", ev.Peer)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected SampleKind event within 500ms")
+	}
+}
+
+func TestHealthStoreRecordEdgeDropsIfNotInit(t *testing.T) {
+	s := NewHealthStore(nil)
+	confID := uuid.New() // never InitConference'd
+	s.RecordEdge(confID, "A", "B", Sample{TS: time.Unix(0, 1)})
+	if w := s.WindowEdge(confID, "A", "B"); len(w) != 0 {
+		t.Fatalf("RecordEdge without InitConference should be a no-op: got %d", len(w))
+	}
+}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -365,3 +365,14 @@ func TestSessionKeyIsConf(t *testing.T) {
 		t.Fatal("conference SessionKey should be conf")
 	}
 }
+
+func TestSessionKeyIsConfConfIDWins(t *testing.T) {
+	// Guard against malformed double-populated keys. ConfID != uuid.Nil
+	// is the authoritative signal, even if CallID is also set. No code
+	// path produces such a key today; this test documents the tiebreak
+	// semantics so a future change to IsConf doesn't silently drift.
+	k := SessionKey{CallID: 1, ConfID: uuid.New()}
+	if !k.IsConf() {
+		t.Fatal("double-populated SessionKey should report IsConf() == true (ConfID wins)")
+	}
+}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -430,8 +430,8 @@ func TestHealthStoreConferenceSubscribeReceivesPeer(t *testing.T) {
 		if ev.Peer != "B" {
 			t.Fatalf("event Peer: got %q want B", ev.Peer)
 		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("expected SampleKind event within 500ms")
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for SampleKind event")
 	}
 }
 

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func sample(ts int64, loss float32) Sample {
@@ -330,5 +332,36 @@ func TestHealthStoreNotifyDisconnectedDoesNotCrossCalls(t *testing.T) {
 		t.Fatalf("sub2 should not have received an event, got %+v", ev)
 	case <-time.After(50 * time.Millisecond):
 		// good
+	}
+}
+
+func TestSessionKeyEquality(t *testing.T) {
+	a := SessionKey{CallID: 42}
+	b := SessionKey{CallID: 42}
+	if a != b {
+		t.Fatal("equal SessionKeys must be ==")
+	}
+	u := uuid.New()
+	c := SessionKey{ConfID: u}
+	d := SessionKey{ConfID: u}
+	if c != d {
+		t.Fatal("equal conference SessionKeys must be ==")
+	}
+	if a == c {
+		t.Fatal("call and conf keys must not be equal")
+	}
+
+	m := map[SessionKey]int{a: 1, c: 2}
+	if m[b] != 1 || m[d] != 2 {
+		t.Fatalf("SessionKey not usable as map key: %v", m)
+	}
+}
+
+func TestSessionKeyIsConf(t *testing.T) {
+	if (SessionKey{CallID: 1}).IsConf() {
+		t.Fatal("2-party SessionKey should not be conf")
+	}
+	if !(SessionKey{ConfID: uuid.New()}).IsConf() {
+		t.Fatal("conference SessionKey should be conf")
 	}
 }

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -92,6 +92,11 @@ type LinkHealthPayload struct {
 	ConnType string   `json:"conn_type,omitempty"`
 	BytesIn  *int64   `json:"bytes_in,omitempty"`
 	BytesOut *int64   `json:"bytes_out,omitempty"`
+	// Peer identifies the remote endpoint this sample is about. Empty for
+	// 2-party samples (backward compatible). Set to the peer's phone
+	// number for 3-way mesh samples; each participant emits one sample
+	// per remote peer per tick.
+	Peer string `json:"peer,omitempty"`
 }
 
 // ICEServer represents a STUN or TURN server configuration.

--- a/server/internal/signaling/protocol_test.go
+++ b/server/internal/signaling/protocol_test.go
@@ -179,7 +179,13 @@ func TestLinkHealthPeerOmitEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if strings.Contains(string(b), `"peer"`) {
-		t.Fatalf("empty Peer should be omitted from JSON: %s", b)
+	var env struct {
+		LinkHealth map[string]json.RawMessage `json:"link_health"`
+	}
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if _, ok := env.LinkHealth["peer"]; ok {
+		t.Fatalf("empty Peer should be omitted from link_health object: %s", b)
 	}
 }

--- a/server/internal/signaling/protocol_test.go
+++ b/server/internal/signaling/protocol_test.go
@@ -3,6 +3,7 @@ package signaling
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -139,5 +140,46 @@ func TestLinkHealthParseOmittedFieldsAreNil(t *testing.T) {
 	}
 	if m.LinkHealth.ConnType != "host" {
 		t.Fatalf("ConnType: got %q", m.LinkHealth.ConnType)
+	}
+}
+
+func TestLinkHealthPeerRoundTrip(t *testing.T) {
+	loss := float32(1.5)
+	m := &Message{
+		Type: TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{
+			TS:       1714000000000,
+			LossPct:  &loss,
+			ConnType: "relay",
+			Peer:     "+15555550123",
+		},
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"peer":"+15555550123"`) {
+		t.Fatalf("expected peer field in JSON: %s", b)
+	}
+	var got Message
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.LinkHealth == nil {
+		t.Fatal("LinkHealth nil after round trip")
+	}
+	if got.LinkHealth.Peer != "+15555550123" {
+		t.Fatalf("Peer: got %q want %q", got.LinkHealth.Peer, "+15555550123")
+	}
+}
+
+func TestLinkHealthPeerOmitEmpty(t *testing.T) {
+	m := &Message{Type: TypeLinkHealth, LinkHealth: &LinkHealthPayload{TS: 1, ConnType: "host"}}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"peer"`) {
+		t.Fatalf("empty Peer should be omitted from JSON: %s", b)
 	}
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -37,6 +37,7 @@ type CallAuthorizer interface {
 // HealthRecorder is the subset of *calls.HealthStore used by Relay.
 type HealthRecorder interface {
 	Record(callID int64, endpoint string, sample calls.Sample)
+	RecordEdge(confID uuid.UUID, from, peer string, sample calls.Sample)
 }
 
 type Relay struct {
@@ -334,21 +335,17 @@ func (r *Relay) ForceHangup(ctx context.Context, caller, callee string) {
 	}
 }
 
-// handleLinkHealth records a telemetry sample for the active call the
-// session endpoint (from, derived from the authenticated websocket) is
-// currently on. msg.From is ignored by design (forgery defense). Unknown
-// calls and missing payloads are dropped silently.
+// handleLinkHealth records a telemetry sample. 2-party calls route through
+// CallIDFor; 3-way conferences route through ConferenceByPhone with a
+// co-membership guard to reject phantom edges from a rogue Pi. msg.From
+// is ignored by design (forgery defense) - the authenticated from wins.
 func (r *Relay) handleLinkHealth(ctx context.Context, from string, msg *Message) {
 	if r.HealthStore == nil || r.Tracker == nil || msg.LinkHealth == nil {
 		return
 	}
-	callID, ok := r.Tracker.CallIDFor(ctx, from)
-	if !ok {
-		slog.Debug("link_health for endpoint not in active call", "endpoint", from)
-		return
-	}
 	p := msg.LinkHealth
-	r.HealthStore.Record(callID, from, calls.Sample{
+
+	sample := calls.Sample{
 		TS:       time.UnixMilli(p.TS),
 		LossPct:  p.LossPct,
 		JitterMs: p.JitterMs,
@@ -356,5 +353,28 @@ func (r *Relay) handleLinkHealth(ctx context.Context, from string, msg *Message)
 		ConnType: p.ConnType,
 		BytesIn:  p.BytesIn,
 		BytesOut: p.BytesOut,
-	})
+	}
+
+	if p.Peer == "" {
+		callID, ok := r.Tracker.CallIDFor(ctx, from)
+		if !ok {
+			slog.Debug("link_health for endpoint not in active call", "endpoint", from)
+			return
+		}
+		r.HealthStore.Record(callID, from, sample)
+		return
+	}
+
+	conf := r.Tracker.Conferences().ConferenceByPhone(from)
+	if conf == nil {
+		slog.Debug("link_health peer set but endpoint not in an active conference",
+			"endpoint", from, "peer", p.Peer)
+		return
+	}
+	if !r.Tracker.Conferences().ConferenceContains(conf.ID, from, p.Peer) {
+		slog.Debug("link_health peer not a co-member - phantom edge, dropping",
+			"endpoint", from, "peer", p.Peer, "conf_id", conf.ID)
+		return
+	}
+	r.HealthStore.RecordEdge(conf.ID, from, p.Peer, sample)
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -365,14 +365,15 @@ func (r *Relay) handleLinkHealth(ctx context.Context, from string, msg *Message)
 		return
 	}
 
-	conf := r.Tracker.Conferences().ConferenceByPhone(from)
+	ct := r.Tracker.Conferences()
+	conf := ct.ConferenceByPhone(from)
 	if conf == nil {
 		slog.Debug("link_health peer set but endpoint not in an active conference",
 			"endpoint", from, "peer", p.Peer)
 		return
 	}
-	if !r.Tracker.Conferences().ConferenceContains(conf.ID, from, p.Peer) {
-		slog.Debug("link_health peer not a co-member - phantom edge, dropping",
+	if !ct.ConferenceContains(conf.ID, from, p.Peer) {
+		slog.Debug("link_health peer not a co-member (phantom edge, dropping)",
 			"endpoint", from, "peer", p.Peer, "conf_id", conf.ID)
 		return
 	}

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -163,6 +163,14 @@ type fakeHealthRecorder struct {
 		endpoint string
 		sample   calls.Sample
 	}
+	edges []recordedEdge
+}
+
+type recordedEdge struct {
+	ConfID uuid.UUID
+	From   string
+	Peer   string
+	Sample calls.Sample
 }
 
 func (f *fakeHealthRecorder) Record(id int64, ep string, s calls.Sample) {
@@ -171,6 +179,10 @@ func (f *fakeHealthRecorder) Record(id int64, ep string, s calls.Sample) {
 		endpoint string
 		sample   calls.Sample
 	}{id, ep, s})
+}
+
+func (f *fakeHealthRecorder) RecordEdge(confID uuid.UUID, from, peer string, s calls.Sample) {
+	f.edges = append(f.edges, recordedEdge{ConfID: confID, From: from, Peer: peer, Sample: s})
 }
 
 type mockCallAuthorizer struct {
@@ -932,5 +944,103 @@ func TestRelayForceHangupTolerantOfOnePeerOffline(t *testing.T) {
 		}
 	default:
 		t.Fatal("555-2222 did not receive hangup despite being online")
+	}
+}
+
+func TestHandleLinkHealth_3WayPath_RecordsEdge(t *testing.T) {
+	tracker := newMockTracker()
+	conf, err := tracker.conferences.CreateConference("A", 1, []string{"B", "C"})
+	if err != nil {
+		t.Fatalf("CreateConference: %v", err)
+	}
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tracker, HealthStore: store}
+
+	loss := float32(4.2)
+	m := &Message{
+		Type: TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{TS: 1, LossPct: &loss, Peer: "B"},
+	}
+	r.handleLinkHealth(context.Background(), "A", m)
+
+	if len(store.edges) != 1 {
+		t.Fatalf("expected 1 RecordEdge; got %d", len(store.edges))
+	}
+	e := store.edges[0]
+	if e.ConfID != conf.ID {
+		t.Fatalf("ConfID: got %s want %s", e.ConfID, conf.ID)
+	}
+	if e.From != "A" || e.Peer != "B" {
+		t.Fatalf("From/Peer: got %s/%s want A/B", e.From, e.Peer)
+	}
+	if e.Sample.LossPct == nil || *e.Sample.LossPct != 4.2 {
+		t.Fatalf("sample LossPct not preserved")
+	}
+}
+
+func TestHandleLinkHealth_3WayPath_BogusPeerDropped(t *testing.T) {
+	tracker := newMockTracker()
+	if _, err := tracker.conferences.CreateConference("A", 1, []string{"B", "C"}); err != nil {
+		t.Fatalf("CreateConference: %v", err)
+	}
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tracker, HealthStore: store}
+
+	m := &Message{
+		Type:       TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{TS: 1, Peer: "Z"}, // Z not in conference
+	}
+	r.handleLinkHealth(context.Background(), "A", m)
+
+	if len(store.edges) != 0 {
+		t.Fatalf("bogus peer must be dropped; got %d edges", len(store.edges))
+	}
+}
+
+func TestHandleLinkHealth_3WayPath_FromNotInConferenceDropped(t *testing.T) {
+	tracker := newMockTracker() // no conference created
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tracker, HealthStore: store}
+
+	m := &Message{
+		Type:       TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{TS: 1, Peer: "B"},
+	}
+	r.handleLinkHealth(context.Background(), "A", m)
+
+	if len(store.edges) != 0 {
+		t.Fatalf("from-not-in-conference must drop; got %d edges", len(store.edges))
+	}
+}
+
+func TestHandleLinkHealth_2WayPath_UnchangedBehavior(t *testing.T) {
+	tracker := newMockTracker()
+	tracker.onCallInitiated("A", "B")
+	tracker.setCallID("A", "B", 42)
+	store := &fakeHealthRecorder{}
+	r := &Relay{Tracker: tracker, HealthStore: store}
+
+	loss := float32(0.5)
+	m := &Message{
+		Type:       TypeLinkHealth,
+		LinkHealth: &LinkHealthPayload{TS: 1, LossPct: &loss},
+	}
+	r.handleLinkHealth(context.Background(), "A", m)
+
+	if len(store.edges) != 0 {
+		t.Fatalf("2-party path must not touch RecordEdge; got %d edges", len(store.edges))
+	}
+	if len(store.records) != 1 {
+		t.Fatalf("expected 1 Record for 2-party path; got %d", len(store.records))
+	}
+	rec := store.records[0]
+	if rec.callID != 42 {
+		t.Fatalf("callID: got %d want 42", rec.callID)
+	}
+	if rec.endpoint != "A" {
+		t.Fatalf("endpoint: got %q want A", rec.endpoint)
+	}
+	if rec.sample.LossPct == nil || *rec.sample.LossPct != 0.5 {
+		t.Fatalf("sample LossPct not preserved: %+v", rec.sample)
 	}
 }


### PR DESCRIPTION
## What

Phase 1 of 4: wire plumbing for 3-way conference link-health observation. Opens a path for per-edge telemetry samples to flow Pi → wire → relay → HealthStore in memory. No persistence, no UI, no kick logic; those land in Phases 2/3/4.

Changes:

- Wire protocol: `LinkHealthPayload.Peer string` (omitempty) added on both Pi and server. Backward compatible; absent for 2-party samples.
- Pi: each mesh peer spawns a dedicated `owebrtc.Reporter` goroutine on `PeerConnectionStateConnected`. All four teardown paths (`RemoveMeshPeer`, `TearDownAllMeshPeers`, `TearDownPeer`, `HangupCall`) drain the matching cancel before releasing the peer.
- Server: `HealthStore` internals re-keyed on `SessionKey{CallID, ConfID}` with composite `endpointKey{From, Peer}`. Every existing 2-party public method stays signature-identical; internals dispatch through shared session-key helpers. Six new conference methods: `InitConference`, `RecordEdge`, `WindowEdge`, `LatestEdge`, `EvictConference`, `SubscribeConference`.
- Server: `Relay.handleLinkHealth` branches on `msg.LinkHealth.Peer`. Non-empty routes through `ConferenceByPhone` plus a `ConferenceContains` co-membership guard before `RecordEdge`. Empty preserves the existing 2-party path.
- Guards: `flushSession` early-returns on `SessionKey.IsConf()` so the periodic flush never tries to write conference rows without the Phase 2 schema. `Latest` reads both endpoints under a single `sr.mu` so the dual-return snapshot is atomic.

## Why

Before this branch, conferences silently dropped every `link_health` frame. `CallIDFor` only scans the 2-party active map, which conference members are removed from at merge time, so the relay would log "not in active call" and throw the sample away. Phase 1 fixes attribution end to end; Phase 2 adds the `conference_id` / `peer` columns and persistence; Phase 3 lands the observation deck UI; Phase 4 adds host-gated kick.

Note: `RecordEdge` is a no-op until Phase 2 adds `InitConference` callers at conference creation. 3-way samples are now received and routed correctly but land in an uninitialized session and drop silently. That is the intended Phase 1 contract.

## Test plan

- [x] `go test ./...` passes on both `server/` and `pi/digitsd/`
- [x] `make test-integration` green (all packages)
- [x] `golangci-lint run ./...` clean on both modules
- [x] New coverage: Peer round-trip + omit-empty on both sides of the wire, `buildMeshLinkHealthSend` Peer stamping, HealthStore conference methods, relay 3-way path (record, bogus peer, from-not-in-conf) and 2-party regression, SessionKey map-key semantics.
- [ ] End-to-end 3-way through real phones: deferred to Phase 2 once persistence lands and the observation deck is reachable.