### PR TITLE
feat(server): refine /connecting hierarchy and gold accent

### DIFF
--- a/server/internal/web/static/connecting.css
+++ b/server/internal/web/static/connecting.css
@@ -149,7 +149,7 @@ body.dialup:not(.crt-page) {
   color: var(--dialup-ink);
 }
 .dialer__status-line b {
-  color: var(--dialup-blue-dark);
+  color: #8a6800;
   letter-spacing: 0.02em;
 }
 .dialer__spinner {
@@ -185,7 +185,7 @@ body.dialup:not(.crt-page) {
   transition: background 0.1s;
 }
 .dialer__progress-cell.is-filled {
-  background: linear-gradient(180deg, var(--dialup-blue), var(--dialup-blue-dark));
+  background: linear-gradient(180deg, var(--dialup-gold), var(--dialup-gold-dark));
 }
 
 .dialer__log-wrap {
@@ -203,6 +203,11 @@ body.dialup:not(.crt-page) {
   line-height: 1.5;
   color: #7ad77a;
   text-shadow: 0 0 4px rgba(122, 215, 122, 0.5);
+  transition: height 0.4s cubic-bezier(0.2, 0, 0.2, 1);
+}
+.dialer__log-placeholder {
+  color: #4a8a4a;
+  text-shadow: 0 0 3px rgba(74, 138, 74, 0.4);
 }
 .dialer__log {
   margin: 0;
@@ -255,30 +260,38 @@ body.dialup:not(.crt-page) {
   font-size: 14px;
   font-weight: bold;
   color: var(--dialup-ink);
-  background: linear-gradient(180deg, var(--dialup-gold), var(--dialup-gold-dark));
-  border-top: 2px solid #fff6c0;
-  border-left: 2px solid #fff6c0;
-  border-right: 2px solid #8a6800;
-  border-bottom: 2px solid #8a6800;
+  background: linear-gradient(180deg, #efd989 0%, #c9a44a 100%);
+  border-top: 2px solid #fae6a0;
+  border-left: 2px solid #fae6a0;
+  border-right: 2px solid #7a5a18;
+  border-bottom: 2px solid #7a5a18;
   cursor: pointer;
   letter-spacing: 0.05em;
-  text-shadow: 1px 1px 0 rgba(255,255,255,0.4);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
+  text-shadow: 1px 1px 0 rgba(255, 240, 200, 0.45);
+  box-shadow: inset 0 1px 0 rgba(255, 240, 200, 0.45);
 }
-.dialer__connect:hover { background: linear-gradient(180deg, #ffe54a, var(--dialup-gold-dark)); }
+.dialer__connect:hover { background: linear-gradient(180deg, #f4e29a 0%, #d4ae54 100%); }
 .dialer__connect:active {
-  border-top: 2px solid #8a6800;
-  border-left: 2px solid #8a6800;
-  border-right: 2px solid #fff6c0;
-  border-bottom: 2px solid #fff6c0;
+  border-top: 2px solid #7a5a18;
+  border-left: 2px solid #7a5a18;
+  border-right: 2px solid #fae6a0;
+  border-bottom: 2px solid #fae6a0;
+}
+.dialer__connect-icon {
+  color: #5a3f00;
+  margin-right: 4px;
+  font-size: 12px;
+  vertical-align: 1px;
 }
 .dialer__connect[disabled] { opacity: 0.6; cursor: not-allowed; }
 
-.dialer[data-state="idle"] .dialer__progress,
-.dialer[data-state="idle"] .dialer__log-wrap {
+.dialer[data-state="idle"] .dialer__progress {
   opacity: 0.5;
   filter: saturate(0.6);
   pointer-events: none;
+}
+.dialer[data-state="idle"] .dialer__log-wrap {
+  height: 26px;
 }
 
 .dialer__hint {

--- a/server/internal/web/static/connecting.js
+++ b/server/internal/web/static/connecting.js
@@ -69,7 +69,15 @@
   }
 
   let logLines = [];
+  let placeholderCleared = false;
+  function clearPlaceholder() {
+    if (placeholderCleared) return;
+    placeholderCleared = true;
+    const ph = document.getElementById('log-placeholder');
+    if (ph) ph.remove();
+  }
   function appendLog(html) {
+    clearPlaceholder();
     const li = document.createElement('li');
     li.innerHTML = html + ' <span class="caret"></span>';
     const prev = logEl.querySelector('li .caret');

--- a/server/internal/web/templates/connecting.html
+++ b/server/internal/web/templates/connecting.html
@@ -19,7 +19,7 @@
 
       <header class="dialer__title">
         <span class="dialer__title-icon" aria-hidden="true"></span>
-        <span class="dialer__title-app">Dial-Up Connection {{if .HouseholdName}}{{.HouseholdName}}{{else}}Digits Online{{end}}</span>
+        <span class="dialer__title-app">Dial-Up Connection</span>
         <span class="dialer__title-btns" aria-hidden="true">
           <span class="dialer__title-btn">_</span>
           <span class="dialer__title-btn">&#9634;</span>
@@ -42,7 +42,7 @@
           </div>
           <div class="dialer__hero-copy">
             <p class="dialer__network-label">CONNECTING TO</p>
-            <h1 class="dialer__network">Digits Online {{if .HouseholdName}}{{.HouseholdName}}{{end}}</h1>
+            <h1 class="dialer__network">{{if .HouseholdName}}{{.HouseholdName}}{{else}}Digits Online{{end}}</h1>
             <p class="dialer__phone"><b>555-6390</b> &middot; v.90 &middot; 56 000 bps</p>
           </div>
         </div>
@@ -55,7 +55,9 @@
         <div class="dialer__progress" id="progress" aria-hidden="true"></div>
 
         <div class="dialer__log-wrap" role="log" aria-label="Connection log">
-          <ol class="dialer__log" id="log"></ol>
+          <ol class="dialer__log" id="log">
+            <li class="dialer__log-placeholder is-shown" id="log-placeholder">&gt; waiting for dial tone<span class="caret"></span></li>
+          </ol>
         </div>
 
         <div class="dialer__foot">
@@ -63,7 +65,7 @@
             Number: <b>555-6390</b> &middot; Protocol: <b>PPP</b> &middot; Tone dialing
           </span>
           <button type="button" class="dialer__connect" id="connect-btn">
-            &#9654; Connect
+            <span class="dialer__connect-icon" aria-hidden="true">&#9654;</span>Connect
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

Three style tweaks to the dial-up `/connecting` intro page based on designer feedback.

- **Header hierarchy.** Title bar reads "Dial-Up Connection" only; H1 is the household name. Drops the run-on where service and account collided. The "D I G I T S · O N L I N E" CRT brand bar already carries the service name once.
- **Idle log panel.** Collapsed from 128px to 26px in idle state with a single `> waiting for dial tone` placeholder line, then transitions to the full terminal on Connect. The empty grey void no longer dominates the idle state.
- **Gold accent moved.** Connect button toned from saturated yellow to soft brass. The bright gold now lives where it earns its weight: the status word ("Ready to dial.", "Ringing...") and the filled progress cells. Clicking Connect makes color bloom across the bar instead of demanding attention from idle.

## Screenshots

**Idle.** Clean three-line hierarchy, log collapsed to one ready-state line, brass button.

![idle state](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-256-idle.png)

**Mid-connect.** Log expanded, gold blooming across the progress bar, status word in brass.

![mid connect](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-256-connecting.png)

**Late connect.** Handshake phase, progress nearly full, "Carrier locked" arriving.

![late connect](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-256-late.png)

## Test plan

- [x] Idle state: title, H1, phone line read as a clean three-line hierarchy
- [x] Idle state: log panel is one line tall with placeholder visible
- [x] Click Connect: log expands smoothly, placeholder is replaced by real log lines
- [x] Click Connect: progress cells fill with bright gold gradient
- [x] Connect button no longer fights the chrome for attention from idle
- [x] Sequence still completes and redirects to dashboard