### PR TITLE
feat(server): 3-way link-health persistence (phase 2 of 4)

### DIFF
--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -179,9 +179,21 @@ func TestConferenceLifecycleHooks(t *testing.T) {
 		t.Fatal("CallIDForPair returned 0 for originating pair")
 	}
 
+	// Seed fired 2-party Init twice; confirm before creating the conference
+	// so a regression that swapped InitConference with Init is catchable.
+	if len(h.inits) != 2 {
+		t.Fatalf("expected 2 Init calls from seeding; got %d", len(h.inits))
+	}
+
 	conf, err := tr.CreateConferencePersistent(ctx, hostNum, originatingCallID, []string{m2, m3})
 	if err != nil {
 		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	// CreateConferencePersistent must NOT have incremented Init (2-party
+	// hooks stay separate from conference hooks).
+	if len(h.inits) != 2 {
+		t.Fatalf("CreateConferencePersistent should not fire Init; got %d total Init calls", len(h.inits))
 	}
 
 	if len(h.confInits) != 1 || h.confInits[0] != conf.ID {

--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -6,8 +6,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/calls"
 )
+
+type fakeHealthLifecycle struct {
+	inits      []int64
+	evicts     []int64
+	confInits  []uuid.UUID
+	confEvicts []uuid.UUID
+}
+
+func (f *fakeHealthLifecycle) Init(id int64)                { f.inits = append(f.inits, id) }
+func (f *fakeHealthLifecycle) Evict(id int64)               { f.evicts = append(f.evicts, id) }
+func (f *fakeHealthLifecycle) InitConference(id uuid.UUID)  { f.confInits = append(f.confInits, id) }
+func (f *fakeHealthLifecycle) EvictConference(id uuid.UUID) { f.confEvicts = append(f.confEvicts, id) }
 
 func TestTrackerBusyWithConference_Integration(t *testing.T) {
 	d := openTestDB(t)
@@ -137,6 +150,88 @@ func TestDropMemberCreatesContinuationCall_Integration(t *testing.T) {
 	// The dropped member is not busy.
 	if tr.Busy(context.Background(), "5550101") {
 		t.Fatalf("dropped member should not be busy")
+	}
+}
+
+func TestConferenceLifecycleHooks(t *testing.T) {
+	d := openTestDB(t)
+	tr := calls.New(d)
+	h := &fakeHealthLifecycle{}
+	tr.SetHealthStore(h)
+
+	ctx := context.Background()
+	hostNum := "+15555550001"
+	m2 := "+15555550002"
+	m3 := "+15555550003"
+
+	// Seed two 2-party calls between the host and the two added members.
+	for _, callee := range []string{m2, m3} {
+		if _, err := tr.OnCallInitiated(ctx, hostNum, callee); err != nil {
+			t.Fatalf("OnCallInitiated %s->%s: %v", hostNum, callee, err)
+		}
+		if err := tr.OnCallAnswered(ctx, hostNum, callee); err != nil {
+			t.Fatalf("OnCallAnswered %s->%s: %v", hostNum, callee, err)
+		}
+	}
+
+	originatingCallID := tr.CallIDForPair(ctx, hostNum, m2)
+	if originatingCallID == 0 {
+		t.Fatal("CallIDForPair returned 0 for originating pair")
+	}
+
+	conf, err := tr.CreateConferencePersistent(ctx, hostNum, originatingCallID, []string{m2, m3})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	if len(h.confInits) != 1 || h.confInits[0] != conf.ID {
+		t.Fatalf("InitConference calls: got %v want [%s]", h.confInits, conf.ID)
+	}
+
+	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+		t.Fatalf("EndConferencePersistent: %v", err)
+	}
+
+	if len(h.confEvicts) != 1 || h.confEvicts[0] != conf.ID {
+		t.Fatalf("EvictConference calls: got %v want [%s]", h.confEvicts, conf.ID)
+	}
+}
+
+func TestDropMemberFiresEvictConference(t *testing.T) {
+	d := openTestDB(t)
+	tr := calls.New(d)
+	h := &fakeHealthLifecycle{}
+	tr.SetHealthStore(h)
+
+	ctx := context.Background()
+	hostNum := "+15555550001"
+	m2 := "+15555550002"
+	m3 := "+15555550003"
+
+	for _, callee := range []string{m2, m3} {
+		if _, err := tr.OnCallInitiated(ctx, hostNum, callee); err != nil {
+			t.Fatalf("OnCallInitiated: %v", err)
+		}
+		if err := tr.OnCallAnswered(ctx, hostNum, callee); err != nil {
+			t.Fatalf("OnCallAnswered: %v", err)
+		}
+	}
+	originatingCallID := tr.CallIDForPair(ctx, hostNum, m2)
+	conf, err := tr.CreateConferencePersistent(ctx, hostNum, originatingCallID, []string{m2, m3})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	_, ended, err := tr.DropMemberPersistent(ctx, conf.ID, m3, "kick")
+	if err != nil {
+		t.Fatalf("DropMemberPersistent: %v", err)
+	}
+	if !ended {
+		t.Fatal("v1 DropMember should end the conference (3 -> 2 terminates)")
+	}
+
+	if len(h.confEvicts) != 1 || h.confEvicts[0] != conf.ID {
+		t.Fatalf("EvictConference from DropMember: got %v want [%s]", h.confEvicts, conf.ID)
 	}
 }
 

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -66,7 +66,7 @@ func (k SessionKey) IsConf() bool { return k.ConfID != uuid.Nil }
 
 // endpointKey is the composite map key for per-endpoint sample rings.
 // Peer is zero for 2-party samples; set to the remote endpoint phone
-// for 3-way per-edge samples (populated in a later phase).
+// for 3-way per-edge samples.
 type endpointKey struct {
 	From string // phone that emitted the sample
 	Peer string // remote endpoint the sample describes; "" for 2-party

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -539,6 +539,9 @@ func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sess
 // (no conflict target) handles either of the two partial unique indexes
 // introduced by the v20 migration, so idempotency works for both kinds.
 func (s *HealthStore) writeSample(ctx context.Context, key SessionKey, ep endpointKey, sample Sample) error {
+	if key.IsConf() && ep.Peer == "" {
+		return fmt.Errorf("writeSample: conference session requires non-empty peer (from=%q)", ep.From)
+	}
 	var (
 		callID sql.NullInt64
 		confID sql.NullString
@@ -546,7 +549,7 @@ func (s *HealthStore) writeSample(ctx context.Context, key SessionKey, ep endpoi
 	)
 	if key.IsConf() {
 		confID = sql.NullString{String: key.ConfID.String(), Valid: true}
-		peer = sql.NullString{String: ep.Peer, Valid: ep.Peer != ""}
+		peer = sql.NullString{String: ep.Peer, Valid: true}
 	} else {
 		callID = sql.NullInt64{Int64: key.CallID, Valid: key.CallID != 0}
 	}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -484,12 +484,6 @@ func (s *HealthStore) FlushOnce(ctx context.Context) error {
 }
 
 func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sessionRings) error {
-	if key.IsConf() {
-		// Conference flush lands in a later phase with schema support for
-		// conference_id + peer columns. Until then, conference-keyed sessions
-		// live in memory only; the ticker loop must not try to persist them.
-		return nil
-	}
 	sr.mu.Lock()
 	// Collect work under lock, then release before DB I/O.
 	type pending struct {

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -609,20 +610,42 @@ func (s *HealthStore) Run(ctx context.Context) {
 	}
 }
 
-// Readback returns the last `limit` samples for a call+endpoint from the DB,
-// oldest first. Used when in-memory state is empty (ended call, post-restart).
+// Readback returns the last `limit` samples for a 2-party call+endpoint from
+// the DB, oldest first. Used when in-memory state is empty (ended call,
+// post-restart).
 func (s *HealthStore) Readback(ctx context.Context, callID int64, endpoint string, limit int) ([]Sample, error) {
 	if s.db == nil {
 		return nil, nil
 	}
-	rows, err := s.db.DB.QueryContext(ctx,
-		`SELECT ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out
-		 FROM call_link_health
-		 WHERE call_id = $1 AND endpoint = $2
-		 ORDER BY ts DESC
-		 LIMIT $3`,
-		callID, endpoint, limit,
+	return s.readbackSession(ctx,
+		`WHERE call_id = $1 AND endpoint = $2`,
+		[]any{callID, endpoint},
+		limit,
 	)
+}
+
+// ReadbackEdge returns the last `limit` samples for a conference edge
+// (from -> peer) from the DB, oldest first. Mirrors Readback for the
+// conference path.
+func (s *HealthStore) ReadbackEdge(ctx context.Context, confID uuid.UUID, from, peer string, limit int) ([]Sample, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	return s.readbackSession(ctx,
+		`WHERE conference_id = $1 AND endpoint = $2 AND peer = $3`,
+		[]any{confID, from, peer},
+		limit,
+	)
+}
+
+func (s *HealthStore) readbackSession(ctx context.Context, where string, args []any, limit int) ([]Sample, error) {
+	sqlStr := `SELECT ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out
+		 FROM call_link_health ` + where + `
+		 ORDER BY ts DESC
+		 LIMIT $` + strconv.Itoa(len(args)+1)
+	args = append(args, limit)
+
+	rows, err := s.db.DB.QueryContext(ctx, sqlStr, args...)
 	if err != nil {
 		return nil, fmt.Errorf("readback query: %w", err)
 	}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -638,12 +638,19 @@ func (s *HealthStore) ReadbackEdge(ctx context.Context, confID uuid.UUID, from, 
 	)
 }
 
+// readbackSession runs a parameterized readback query against call_link_health
+// with a caller-supplied WHERE fragment. `where` must begin with "WHERE " and
+// its placeholders must be numbered $1..$N in order of `args`. Returns samples
+// oldest-first.
 func (s *HealthStore) readbackSession(ctx context.Context, where string, args []any, limit int) ([]Sample, error) {
+	// Compute $N before appending limit so the index is correct; swapping
+	// these two lines would misalign the placeholder.
+	limitPlaceholder := "$" + strconv.Itoa(len(args)+1)
+	args = append(args, limit)
 	sqlStr := `SELECT ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out
 		 FROM call_link_health ` + where + `
 		 ORDER BY ts DESC
-		 LIMIT $` + strconv.Itoa(len(args)+1)
-	args = append(args, limit)
+		 LIMIT ` + limitPlaceholder
 
 	rows, err := s.db.DB.QueryContext(ctx, sqlStr, args...)
 	if err != nil {

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -519,8 +519,8 @@ func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sess
 		return nil
 	}
 	for _, p := range todo {
-		if err := s.writeSample(ctx, key.CallID, p.epKey.From, p.sample); err != nil {
-			return fmt.Errorf("write sample (%v,%s): %w", key, p.epKey.From, err)
+		if err := s.writeSample(ctx, key, p.epKey, p.sample); err != nil {
+			return fmt.Errorf("write sample (%v,%v): %w", key, p.epKey, err)
 		}
 	}
 	// On success, advance lastFlushed.
@@ -534,13 +534,29 @@ func (s *HealthStore) flushSession(ctx context.Context, key SessionKey, sr *sess
 	return nil
 }
 
-func (s *HealthStore) writeSample(ctx context.Context, callID int64, endpoint string, sample Sample) error {
+// writeSample inserts a single link-health sample for either a 2-party call
+// or a 3-way conference, depending on key.IsConf(). ON CONFLICT DO NOTHING
+// (no conflict target) handles either of the two partial unique indexes
+// introduced by the v20 migration, so idempotency works for both kinds.
+func (s *HealthStore) writeSample(ctx context.Context, key SessionKey, ep endpointKey, sample Sample) error {
+	var (
+		callID sql.NullInt64
+		confID sql.NullString
+		peer   sql.NullString
+	)
+	if key.IsConf() {
+		confID = sql.NullString{String: key.ConfID.String(), Valid: true}
+		peer = sql.NullString{String: ep.Peer, Valid: ep.Peer != ""}
+	} else {
+		callID = sql.NullInt64{Int64: key.CallID, Valid: key.CallID != 0}
+	}
 	_, err := s.db.DB.ExecContext(ctx,
 		`INSERT INTO call_link_health
-		   (call_id, endpoint, ts, loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		 ON CONFLICT (call_id, endpoint, ts) DO NOTHING`,
-		callID, endpoint, sample.TS,
+		   (call_id, conference_id, endpoint, peer, ts,
+		    loss_pct, jitter_ms, rtt_ms, conn_type, bytes_in, bytes_out)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		 ON CONFLICT DO NOTHING`,
+		callID, confID, ep.From, peer, sample.TS,
 		nullableFloat(sample.LossPct),
 		nullableFloat(sample.JitterMs),
 		nullableFloat(sample.RttMs),

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -4,9 +4,11 @@ package calls
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/db"
 )
 
@@ -134,5 +136,143 @@ func TestCallLinkHealthSchemaV20(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected CHECK violation inserting with neither call_id nor conference_id set")
+	}
+}
+
+func TestWriteSample2PartyPostV20(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Seed a call row so the FK is satisfied.
+	var callID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&callID); err != nil {
+		t.Fatalf("seed call: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	loss := float32(1.5)
+	sample := Sample{TS: time.Unix(0, 1), LossPct: &loss, ConnType: "host"}
+
+	if err := s.writeSample(context.Background(),
+		SessionKey{CallID: callID},
+		endpointKey{From: "+15555550001"},
+		sample,
+	); err != nil {
+		t.Fatalf("writeSample: %v", err)
+	}
+
+	var (
+		dbCallID sql.NullInt64
+		dbConfID sql.NullString
+		dbEp     string
+		dbPeer   sql.NullString
+	)
+	if err := d.DB.QueryRow(
+		`SELECT call_id, conference_id, endpoint, peer FROM call_link_health
+		 WHERE call_id = $1`, callID,
+	).Scan(&dbCallID, &dbConfID, &dbEp, &dbPeer); err != nil {
+		t.Fatalf("readback row: %v", err)
+	}
+	if !dbCallID.Valid || dbCallID.Int64 != callID {
+		t.Fatalf("call_id not persisted correctly: %v", dbCallID)
+	}
+	if dbConfID.Valid {
+		t.Fatalf("conference_id should be NULL for 2-party rows; got %v", dbConfID)
+	}
+	if dbPeer.Valid {
+		t.Fatalf("peer should be NULL for 2-party rows; got %v", dbPeer)
+	}
+	if dbEp != "+15555550001" {
+		t.Fatalf("endpoint: got %q want +15555550001", dbEp)
+	}
+
+	// Idempotent: second write of the same (call, endpoint, ts) is silently skipped.
+	if err := s.writeSample(context.Background(),
+		SessionKey{CallID: callID},
+		endpointKey{From: "+15555550001"},
+		sample,
+	); err != nil {
+		t.Fatalf("second writeSample: %v", err)
+	}
+	var rowCount int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM call_link_health WHERE call_id = $1`, callID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("ON CONFLICT DO NOTHING broken; got %d rows want 1", rowCount)
+	}
+}
+
+func TestWriteSampleConferencePostV20(t *testing.T) {
+	d := setupTestDB(t)
+
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed originating call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	jitter := float32(4.2)
+	sample := Sample{TS: time.Unix(0, 1), JitterMs: &jitter}
+
+	if err := s.writeSample(context.Background(),
+		SessionKey{ConfID: confID},
+		endpointKey{From: "+15555550001", Peer: "+15555550002"},
+		sample,
+	); err != nil {
+		t.Fatalf("writeSample conference: %v", err)
+	}
+
+	var (
+		dbCallID sql.NullInt64
+		dbConfID sql.NullString
+		dbEp     string
+		dbPeer   sql.NullString
+	)
+	if err := d.DB.QueryRow(
+		`SELECT call_id, conference_id, endpoint, peer FROM call_link_health
+		 WHERE conference_id = $1`, confID,
+	).Scan(&dbCallID, &dbConfID, &dbEp, &dbPeer); err != nil {
+		t.Fatalf("readback row: %v", err)
+	}
+	if dbCallID.Valid {
+		t.Fatalf("call_id should be NULL for conference rows; got %v", dbCallID)
+	}
+	if !dbConfID.Valid || dbConfID.String != confID.String() {
+		t.Fatalf("conference_id: got %v want %s", dbConfID, confID)
+	}
+	if !dbPeer.Valid || dbPeer.String != "+15555550002" {
+		t.Fatalf("peer: got %v want +15555550002", dbPeer)
+	}
+	if dbEp != "+15555550001" {
+		t.Fatalf("endpoint: got %q want +15555550001", dbEp)
+	}
+
+	// Cascade delete: dropping the conference wipes the sample row.
+	if _, err := d.DB.Exec(`DELETE FROM conferences WHERE id = $1`, confID); err != nil {
+		t.Fatalf("delete conference: %v", err)
+	}
+	var rowCount int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM call_link_health WHERE conference_id = $1`, confID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows after cascade: %v", err)
+	}
+	if rowCount != 0 {
+		t.Fatalf("cascade delete broken; got %d rows want 0", rowCount)
 	}
 }

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -87,3 +87,52 @@ func TestReadbackFromDB(t *testing.T) {
 		t.Fatalf("readback value mismatch: %+v", got[0])
 	}
 }
+
+func TestCallLinkHealthSchemaV20(t *testing.T) {
+	d := setupTestDB(t)
+
+	// conference_id and peer columns exist.
+	var colCount int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM information_schema.columns
+         WHERE table_name = 'call_link_health'
+           AND column_name IN ('conference_id', 'peer')`,
+	).Scan(&colCount); err != nil {
+		t.Fatalf("query columns: %v", err)
+	}
+	if colCount != 2 {
+		t.Fatalf("expected 2 new columns (conference_id, peer); got %d", colCount)
+	}
+
+	// call_id is now nullable.
+	var isNullable string
+	if err := d.DB.QueryRow(
+		`SELECT is_nullable FROM information_schema.columns
+         WHERE table_name = 'call_link_health' AND column_name = 'call_id'`,
+	).Scan(&isNullable); err != nil {
+		t.Fatalf("query call_id nullability: %v", err)
+	}
+	if isNullable != "YES" {
+		t.Fatalf("call_id should be nullable after v20; got %q", isNullable)
+	}
+
+	// XOR CHECK: both set should fail.
+	_, err := d.DB.Exec(
+		`INSERT INTO call_link_health (call_id, conference_id, endpoint, ts)
+         VALUES ($1, $2, $3, NOW())`,
+		1, "00000000-0000-0000-0000-000000000000", "+15555550001",
+	)
+	if err == nil {
+		t.Fatal("expected CHECK violation inserting with both call_id and conference_id set")
+	}
+
+	// XOR CHECK: neither set should fail.
+	_, err = d.DB.Exec(
+		`INSERT INTO call_link_health (call_id, conference_id, endpoint, ts)
+         VALUES (NULL, NULL, $1, NOW())`,
+		"+15555550001",
+	)
+	if err == nil {
+		t.Fatal("expected CHECK violation inserting with neither call_id nor conference_id set")
+	}
+}

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -418,6 +418,51 @@ func TestReadbackEdgeFromDB(t *testing.T) {
 	}
 }
 
+func TestCallLinkHealthSchemaV21ConfRequiresPeer(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Seed a conference and its originating call so the FK is satisfied.
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	// Conference row with NULL peer must be rejected.
+	_, err := d.DB.Exec(
+		`INSERT INTO call_link_health (conference_id, endpoint, ts) VALUES ($1, $2, NOW())`,
+		confID, "+15555550001",
+	)
+	if err == nil {
+		t.Fatal("expected CHECK violation inserting conference row with NULL peer")
+	}
+
+	// Conference row with peer set succeeds.
+	if _, err := d.DB.Exec(
+		`INSERT INTO call_link_health (conference_id, endpoint, peer, ts) VALUES ($1, $2, $3, NOW())`,
+		confID, "+15555550001", "+15555550002",
+	); err != nil {
+		t.Fatalf("conference row with peer should succeed: %v", err)
+	}
+
+	// 2-party row (conference_id NULL, peer NULL) still succeeds.
+	if _, err := d.DB.Exec(
+		`INSERT INTO call_link_health (call_id, endpoint, ts) VALUES ($1, $2, NOW())`,
+		originatingCallID, "+15555550001",
+	); err != nil {
+		t.Fatalf("2-party row should succeed: %v", err)
+	}
+}
+
 func TestFlushOnceWritesConferenceRows(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -276,3 +276,86 @@ func TestWriteSampleConferencePostV20(t *testing.T) {
 		t.Fatalf("cascade delete broken; got %d rows want 0", rowCount)
 	}
 }
+
+func TestWriteSampleConferenceIdempotent(t *testing.T) {
+	d := setupTestDB(t)
+
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed originating call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	loss := float32(2.0)
+	sample := Sample{TS: time.Unix(0, 1), LossPct: &loss}
+
+	for i := 0; i < 2; i++ {
+		if err := s.writeSample(context.Background(),
+			SessionKey{ConfID: confID},
+			endpointKey{From: "+15555550001", Peer: "+15555550002"},
+			sample,
+		); err != nil {
+			t.Fatalf("writeSample iteration %d: %v", i, err)
+		}
+	}
+
+	var rowCount int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM call_link_health WHERE conference_id = $1`, confID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("conference ON CONFLICT DO NOTHING broken; got %d rows want 1", rowCount)
+	}
+}
+
+func TestWriteSampleConferenceRejectsEmptyPeer(t *testing.T) {
+	d := setupTestDB(t)
+
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed originating call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	err := s.writeSample(context.Background(),
+		SessionKey{ConfID: confID},
+		endpointKey{From: "+15555550001", Peer: ""},
+		Sample{TS: time.Unix(0, 1)},
+	)
+	if err == nil {
+		t.Fatal("writeSample with empty Peer on conference key must return an error")
+	}
+
+	// No row should have been inserted.
+	var rowCount int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM call_link_health WHERE conference_id = $1`, confID,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 0 {
+		t.Fatalf("no row should be inserted when empty-peer rejected; got %d", rowCount)
+	}
+}

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -361,6 +361,63 @@ func TestWriteSampleConferenceRejectsEmptyPeer(t *testing.T) {
 	}
 }
 
+func TestReadbackEdgeFromDB(t *testing.T) {
+	d := setupTestDB(t)
+
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	s.InitConference(confID)
+
+	base := time.Unix(0, 0)
+	for i := 0; i < 3; i++ {
+		loss := float32(i)
+		s.RecordEdge(confID, "+15555550001", "+15555550002",
+			Sample{TS: base.Add(time.Duration(i+1) * time.Second), LossPct: &loss})
+		if err := s.FlushOnce(context.Background()); err != nil {
+			t.Fatalf("FlushOnce iter %d: %v", i, err)
+		}
+	}
+	// Unrelated edge at a later timestamp; must not leak into the single-edge readback.
+	s.RecordEdge(confID, "+15555550002", "+15555550001",
+		Sample{TS: base.Add(10 * time.Second)})
+	if err := s.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOnce unrelated: %v", err)
+	}
+
+	got, err := s.ReadbackEdge(context.Background(), confID,
+		"+15555550001", "+15555550002", 10)
+	if err != nil {
+		t.Fatalf("ReadbackEdge: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 rows for edge A->B; got %d", len(got))
+	}
+
+	// Oldest first, matching Window ordering.
+	for i, s := range got {
+		if s.LossPct == nil {
+			t.Fatalf("row %d missing LossPct", i)
+		}
+		if *s.LossPct != float32(i) {
+			t.Fatalf("row %d LossPct: got %v want %d", i, *s.LossPct, i)
+		}
+	}
+}
+
 func TestFlushOnceWritesConferenceRows(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -411,7 +411,7 @@ func TestFlushOnceWritesConferenceRows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select conference rows: %v", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var got []string
 	for rows.Next() {
@@ -420,6 +420,9 @@ func TestFlushOnceWritesConferenceRows(t *testing.T) {
 			t.Fatalf("scan: %v", err)
 		}
 		got = append(got, ep+"|"+peer)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows iteration: %v", err)
 	}
 	want := []string{"+15555550001|+15555550002", "+15555550002|+15555550001"}
 	if !reflect.DeepEqual(got, want) {

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -5,6 +5,7 @@ package calls
 import (
 	"context"
 	"database/sql"
+	"reflect"
 	"testing"
 	"time"
 
@@ -357,5 +358,71 @@ func TestWriteSampleConferenceRejectsEmptyPeer(t *testing.T) {
 	}
 	if rowCount != 0 {
 		t.Fatalf("no row should be inserted when empty-peer rejected; got %d", rowCount)
+	}
+}
+
+func TestFlushOnceWritesConferenceRows(t *testing.T) {
+	d := setupTestDB(t)
+
+	confID := uuid.New()
+	var originatingCallID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		"+15555550001", "+15555550002",
+	).Scan(&originatingCallID); err != nil {
+		t.Fatalf("seed call: %v", err)
+	}
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, "+15555550001", originatingCallID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	s := NewHealthStore(d)
+	s.InitConference(confID)
+
+	loss := float32(1.1)
+	s.RecordEdge(confID, "+15555550001", "+15555550002",
+		Sample{TS: time.Unix(0, 1000), LossPct: &loss, ConnType: "host"})
+	jitter := float32(2.2)
+	s.RecordEdge(confID, "+15555550002", "+15555550001",
+		Sample{TS: time.Unix(0, 2000), JitterMs: &jitter, ConnType: "srflx"})
+
+	if err := s.FlushOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOnce: %v", err)
+	}
+
+	var count int
+	if err := d.DB.QueryRow(
+		`SELECT COUNT(*) FROM call_link_health WHERE conference_id = $1`, confID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count conference rows: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 conference rows after flush; got %d", count)
+	}
+
+	// Sanity: both edges land with correct (endpoint, peer) pairs.
+	rows, err := d.DB.Query(
+		`SELECT endpoint, peer FROM call_link_health
+		 WHERE conference_id = $1 ORDER BY ts`, confID,
+	)
+	if err != nil {
+		t.Fatalf("select conference rows: %v", err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var ep, peer string
+		if err := rows.Scan(&ep, &peer); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, ep+"|"+peer)
+	}
+	want := []string{"+15555550001|+15555550002", "+15555550002|+15555550001"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("edges: got %v want %v", got, want)
 	}
 }

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -67,10 +67,13 @@ type activeCall struct {
 }
 
 // healthLifecycle is the subset of *HealthStore that Tracker drives for
-// per-call lifecycle. Init is called at call start; Evict at call end.
+// per-session lifecycle. Init/Evict handle 2-party calls; InitConference/
+// EvictConference handle 3-way conferences.
 type healthLifecycle interface {
 	Init(callID int64)
 	Evict(callID int64)
+	InitConference(confID uuid.UUID)
+	EvictConference(confID uuid.UUID)
 }
 
 type Tracker struct {
@@ -448,8 +451,12 @@ func (t *Tracker) CreateConferencePersistent(ctx context.Context, host string, o
 			delete(t.active, k)
 		}
 	}
+	h := t.health
 	t.mu.Unlock()
 
+	if h != nil {
+		h.InitConference(conf.ID)
+	}
 	return conf, nil
 }
 
@@ -459,7 +466,11 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 	if _, err := t.conferences.EndConference(confID, reason); err != nil {
 		return err
 	}
-	return withTx(ctx, t.db.DB, func(tx *sql.Tx) error {
+	t.mu.Lock()
+	h := t.health
+	t.mu.Unlock()
+
+	if err := withTx(ctx, t.db.DB, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE conferences SET state = 'ended', ended_at = NOW(), end_reason = $1 WHERE id = $2`,
 			reason, confID,
@@ -474,7 +485,14 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 			return fmt.Errorf("update members: %w", err)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	if h != nil {
+		h.EvictConference(confID)
+	}
+	return nil
 }
 
 // DropMemberPersistent drops a single member from an active conference, ends the
@@ -540,16 +558,20 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 	// Register the surviving pair in the 2-party active map so Busy() and
 	// InCall() continue to work after the conference ends. The conference
 	// tracker already removed them from its own memberIndex in DropMember.
+	t.mu.Lock()
 	if len(remaining) == 2 {
 		a, b := remaining[0], remaining[1]
 		if b < a {
 			a, b = b, a
 		}
-		t.mu.Lock()
 		t.active[callKey(a, b)] = &activeCall{ID: continuationCallID, Caller: a, Callee: b, StartedAt: time.Now()}
-		t.mu.Unlock()
 	}
+	h := t.health
+	t.mu.Unlock()
 
+	if h != nil && ended {
+		h.EvictConference(confID)
+	}
 	return remaining, ended, nil
 }
 

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -321,6 +321,22 @@ BEGIN
         INSERT INTO schema_version (version) VALUES (20);
     END IF;
 END $$;`,
+		// v21: enforce that conference-scoped link-health rows always have a
+		// non-NULL peer. The partial unique index on (conference_id, endpoint,
+		// peer, ts) cannot dedupe NULL peer rows because NULLs are distinct in
+		// unique indexes; Go-side writeSample rejects this case but any non-Go
+		// write path would bypass that guard. Belt-and-suspenders at the DB
+		// layer.
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 21) THEN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'call_link_health_conf_requires_peer') THEN
+            ALTER TABLE call_link_health ADD CONSTRAINT call_link_health_conf_requires_peer
+                CHECK (conference_id IS NULL OR peer IS NOT NULL);
+        END IF;
+        INSERT INTO schema_version (version) VALUES (21);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -288,6 +288,37 @@ END $$;`,
 		// v19: capture which user initiated a force-disconnect on a call.
 		// NULL for peer-initiated hangups.
 		`ALTER TABLE calls ADD COLUMN IF NOT EXISTS force_ended_by UUID REFERENCES users(id)`,
+		// v20: conference-scoped link-health samples.
+		// Relaxes call_id to nullable and adds conference_id + peer with an
+		// XOR CHECK so exactly one session type is attributed per row. The
+		// old PRIMARY KEY (call_id, endpoint, ts) is replaced by two partial
+		// unique indexes (one per session kind) and a conference-scoped ts
+		// index used by the Phase 3 readback path. Gated on schema_version
+		// so re-running on a v20-applied DB is a no-op.
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 20) THEN
+
+        ALTER TABLE call_link_health DROP CONSTRAINT IF EXISTS call_link_health_pkey;
+        ALTER TABLE call_link_health ALTER COLUMN call_id DROP NOT NULL;
+        ALTER TABLE call_link_health ADD COLUMN IF NOT EXISTS conference_id UUID NULL REFERENCES conferences(id) ON DELETE CASCADE;
+        ALTER TABLE call_link_health ADD COLUMN IF NOT EXISTS peer TEXT NULL;
+        ALTER TABLE call_link_health ADD CONSTRAINT call_link_health_exactly_one_session
+            CHECK ((call_id IS NOT NULL) != (conference_id IS NOT NULL));
+
+        CREATE UNIQUE INDEX IF NOT EXISTS call_link_health_call_ep_ts
+            ON call_link_health (call_id, endpoint, ts)
+            WHERE call_id IS NOT NULL;
+        CREATE UNIQUE INDEX IF NOT EXISTS call_link_health_conf_ep_peer_ts
+            ON call_link_health (conference_id, endpoint, peer, ts)
+            WHERE conference_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_call_link_health_conf_ts
+            ON call_link_health (conference_id, ts DESC)
+            WHERE conference_id IS NOT NULL;
+
+        INSERT INTO schema_version (version) VALUES (20);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -303,8 +303,10 @@ BEGIN
         ALTER TABLE call_link_health ALTER COLUMN call_id DROP NOT NULL;
         ALTER TABLE call_link_health ADD COLUMN IF NOT EXISTS conference_id UUID NULL REFERENCES conferences(id) ON DELETE CASCADE;
         ALTER TABLE call_link_health ADD COLUMN IF NOT EXISTS peer TEXT NULL;
-        ALTER TABLE call_link_health ADD CONSTRAINT call_link_health_exactly_one_session
-            CHECK ((call_id IS NOT NULL) != (conference_id IS NOT NULL));
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'call_link_health_exactly_one_session') THEN
+            ALTER TABLE call_link_health ADD CONSTRAINT call_link_health_exactly_one_session
+                CHECK ((call_id IS NOT NULL) != (conference_id IS NOT NULL));
+        END IF;
 
         CREATE UNIQUE INDEX IF NOT EXISTS call_link_health_call_ep_ts
             ON call_link_health (call_id, endpoint, ts)


### PR DESCRIPTION
## What

Phase 2 of 4 for 3-way conference link-health. Durable per-edge storage wired end to end: schema migration, dual-session flush path, conference readback, and Tracker lifecycle hooks so conference creation initializes a HealthStore session and conference end evicts it.

Changes:

- **Schema v20:** drops the old composite PK on `call_link_health (call_id, endpoint, ts)`, relaxes `call_id` to nullable, adds `conference_id UUID NULL REFERENCES conferences(id) ON DELETE CASCADE` and `peer TEXT NULL`, enforces exactly-one-of via XOR CHECK, replaces the PK with two partial unique indexes plus a conference-scoped `(conference_id, ts DESC)` readback index. Gated on `schema_version = 20`; the `ADD CONSTRAINT` is additionally guarded by a `pg_constraint` existence check for safe re-runs.
- **`writeSample` reshape:** new signature `(ctx, SessionKey, endpointKey, Sample)`. Conditional NULLs via `sql.NullInt64` / `sql.NullString` for `call_id` / `conference_id` / `peer` based on `key.IsConf()`. `ON CONFLICT DO NOTHING` (no target) handles idempotency for both partial indexes. Explicit error on `IsConf() && ep.Peer == ""` because NULLs are distinct in unique indexes; silent empty-peer writes would bypass dedupe.
- **Flush unblocked:** `flushSession` drops its Phase-1 `IsConf()` early-return now that the write path is dual-session. Conference rings flush on the same ticker cadence as calls.
- **`ReadbackEdge(confID, from, peer, limit)`:** new public method mirroring `Readback`. Both dispatch through a private `readbackSession(where, args, limit)` helper with a documented WHERE contract and an explicit comment on the LIMIT placeholder ordering invariant.
- **`healthLifecycle` extension + Tracker wiring:** interface grows `InitConference(uuid.UUID)` / `EvictConference(uuid.UUID)`. `*HealthStore` already satisfies it from Phase 1. `CreateConferencePersistent` fires `InitConference` after commit; `EndConferencePersistent` and `DropMemberPersistent` fire `EvictConference` after commit (and, in DropMember, only when `ended == true`). All three use the mutex-snapshot-release-call pattern from `OnCallInitiated` / `OnCallEnded`.

## Why

Phase 1 routed conference samples correctly but dropped them because `InitConference` had no callers. Phase 2 closes that gap so every conference gets a HealthStore session at creation, samples survive flushes, and ended conferences stay readable from the DB. Unlocks the Phase 3 `/conference/live/{uuid}` observation deck.

## Test plan

- [x] Unit: `go test ./...`
- [x] Integration: `make test-integration`
- [x] Lint: `golangci-lint run ./...` clean (pre-existing unrelated issues in `web/linkhealth_integration_test.go` not introduced by this branch)
- [x] New integration coverage:
  - `TestCallLinkHealthSchemaV20` (column shape + XOR CHECK)
  - `TestWriteSample2PartyPostV20` (2-party write + idempotency)
  - `TestWriteSampleConferencePostV20` (conference write + cascade delete)
  - `TestWriteSampleConferenceIdempotent` (conference ON CONFLICT DO NOTHING)
  - `TestWriteSampleConferenceRejectsEmptyPeer` (empty-peer invariant)
  - `TestFlushOnceWritesConferenceRows` (flush persists conference rows)
  - `TestReadbackEdgeFromDB` (oldest-first + no cross-edge leakage)
  - `TestConferenceLifecycleHooks` (Init/Evict fire at correct times, 2-party Init count unchanged)
  - `TestDropMemberFiresEvictConference` (EvictConference fires on drop)