### PR TITLE
feat(server): 3-way link-health observation deck (phase 3 of 4)

### DIFF
--- a/server/e2e/tests/10-call-live.spec.ts
+++ b/server/e2e/tests/10-call-live.spec.ts
@@ -17,29 +17,12 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
-import { isServerUp } from './helpers';
+import { isServerUp, devLogin } from './helpers';
 
 test.beforeEach(async ({}, testInfo) => {
   const up = await isServerUp();
   testInfo.skip(!up, 'Dev server not running');
 });
-
-/**
- * Log in as a seeded user via the dev-session endpoint.
- * Only works when the server runs with DEV_MODE=true.
- * Returns false if the endpoint is unavailable.
- */
-async function devLogin(page: Page, email: string): Promise<boolean> {
-  const resp = await page.goto(`/auth/dev-session?email=${encodeURIComponent(email)}`);
-  const status = resp?.status() ?? 0;
-  if (status === 404) return false;
-  const url = page.url();
-  if (url.includes('/auth/login')) return false;
-  // If we land on /onboard the user exists but has no household yet — treat
-  // as unavailable for this test rather than completing onboarding inline.
-  if (url.includes('/onboard')) return false;
-  return true;
-}
 
 /**
  * Seed an active call via the DEV_MODE harness endpoint.

--- a/server/e2e/tests/11-conference-live.spec.ts
+++ b/server/e2e/tests/11-conference-live.spec.ts
@@ -20,27 +20,12 @@
  */
 
 import { test, expect, Page } from '@playwright/test';
-import { isServerUp } from './helpers';
+import { isServerUp, devLogin } from './helpers';
 
 test.beforeEach(async ({}, testInfo) => {
   const up = await isServerUp();
   testInfo.skip(!up, 'Dev server not running');
 });
-
-/**
- * Log in as a seeded user via the dev-session endpoint.
- * Only works when the server runs with DEV_MODE=true.
- * Returns false if the endpoint is unavailable.
- */
-async function devLogin(page: Page, email: string): Promise<boolean> {
-  const resp = await page.goto(`/auth/dev-session?email=${encodeURIComponent(email)}`);
-  const status = resp?.status() ?? 0;
-  if (status === 404) return false;
-  const url = page.url();
-  if (url.includes('/auth/login')) return false;
-  if (url.includes('/onboard')) return false;
-  return true;
-}
 
 /**
  * Seed an active 3-way conference via the DEV_MODE harness endpoint.

--- a/server/e2e/tests/11-conference-live.spec.ts
+++ b/server/e2e/tests/11-conference-live.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * 11-conference-live.spec.ts -- /conference/live observation deck
+ *
+ * Seeds a 3-way conference via the DEV_MODE test-harness endpoint and
+ * verifies:
+ *   - The deck page renders with three member cards and a 3x3 matrix
+ *     (6 filled cells + 3 blank diagonal cells = 9 total matrix cells).
+ *   - The matrix contains the expected grid markup.
+ *   - /calls links conference rows to /conference/live/{uuid}.
+ *   - Intercom and dialup themes each render their respective chrome.
+ *   - Ended conferences render the terminal state without SSE wiring.
+ *
+ * Requires a server running with DEV_MODE=true and the dev database
+ * seeded by `make dev-seed` (or `make dev-up`). Tests skip gracefully
+ * when the server is unavailable.
+ *
+ * Dev-seed users (server/cmd/devseed/main.go):
+ *   dev@digits.local       theme=dialup   lines: 2480001, 2480002, 2480003
+ *   grandma@digits.local   theme=intercom lines: 5550001
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { isServerUp } from './helpers';
+
+test.beforeEach(async ({}, testInfo) => {
+  const up = await isServerUp();
+  testInfo.skip(!up, 'Dev server not running');
+});
+
+/**
+ * Log in as a seeded user via the dev-session endpoint.
+ * Only works when the server runs with DEV_MODE=true.
+ * Returns false if the endpoint is unavailable.
+ */
+async function devLogin(page: Page, email: string): Promise<boolean> {
+  const resp = await page.goto(`/auth/dev-session?email=${encodeURIComponent(email)}`);
+  const status = resp?.status() ?? 0;
+  if (status === 404) return false;
+  const url = page.url();
+  if (url.includes('/auth/login')) return false;
+  if (url.includes('/onboard')) return false;
+  return true;
+}
+
+/**
+ * Seed an active 3-way conference via the DEV_MODE harness endpoint.
+ * Returns the new conference UUID.
+ */
+async function seedConference(page: Page, host: string, added: [string, string]): Promise<string> {
+  const r = await page.request.post('/test-harness/start-conference', {
+    data: { host, added },
+  });
+  if (!r.ok()) {
+    throw new Error(`seed-conference failed: ${r.status()} ${await r.text()}`);
+  }
+  const body = await r.json();
+  return body.conf_id as string;
+}
+
+// ---------------------------------------------------------------------------
+// Intercom theme (grandma@digits.local: theme=intercom, owns 5550001).
+// Host = 5550001 so grandma's household owns the conference host.
+// ---------------------------------------------------------------------------
+
+test.describe('conference-live: intercom theme', () => {
+  test('renders deck with three member cards and full matrix', async ({ page }) => {
+    const ok = await devLogin(page, 'grandma@digits.local');
+    if (!ok) {
+      test.skip(true, 'dev-session not available or user needs onboarding');
+      return;
+    }
+
+    const confID = await seedConference(page, '5550001', ['2480001', '2480002']);
+    await page.goto(`/conference/live/${confID}`);
+
+    expect(page.url()).not.toContain('/auth/login');
+
+    // Title heading is visible.
+    await expect(page.locator('.deck-title')).toBeVisible();
+
+    // Three member cards (one per conference member).
+    await expect(page.locator('.deck-card')).toHaveCount(3);
+
+    // Exactly one host-marked card.
+    await expect(page.locator('.deck-card--host')).toHaveCount(1);
+
+    // 3x3 matrix: 6 non-blank cells + 3 blank diagonal cells = 9 total.
+    await expect(page.locator('.deck-matrix__cell')).toHaveCount(9);
+    await expect(page.locator('.deck-matrix__cell--blank')).toHaveCount(3);
+
+    // Intercom layout: rail header, not dialup window.
+    await expect(page.locator('header.rail')).toBeVisible();
+
+    // SSE wiring is live for an active conference.
+    await expect(page.locator('#conference-live-panel')).toHaveAttribute('sse-connect', /\/api\/conference\/[^/]+\/link-health\/stream/);
+  });
+
+  test('/calls links conference row to conference-live page', async ({ page }) => {
+    const ok = await devLogin(page, 'grandma@digits.local');
+    if (!ok) {
+      test.skip(true, 'dev-session not available or user needs onboarding');
+      return;
+    }
+
+    const confID = await seedConference(page, '5550001', ['2480001', '2480002']);
+
+    // Verify the live page resolves and the URL shape is correct.
+    // The /calls link is tested in Go integration tests, which are authoritative.
+    // This test confirms the URL shape resolves when navigated to directly.
+    await page.goto(`/conference/live/${confID}`);
+    await expect(page).toHaveURL(new RegExp(`/conference/live/${confID}`));
+    await expect(page.locator('.deck-matrix')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dialup theme (dev@digits.local: theme=dialup, owns 2480001..2480003).
+// All three conference members are dev's own lines.
+// ---------------------------------------------------------------------------
+
+test.describe('conference-live: dialup theme', () => {
+  test('renders dialup chrome with three member cards and full matrix', async ({ page }) => {
+    const ok = await devLogin(page, 'dev@digits.local');
+    if (!ok) {
+      test.skip(true, 'dev-session not available or user needs onboarding');
+      return;
+    }
+
+    const confID = await seedConference(page, '2480001', ['2480002', '2480003']);
+    await page.goto(`/conference/live/${confID}`);
+
+    expect(page.url()).not.toContain('/auth/login');
+
+    // Dialup layout chrome is present.
+    await expect(page.locator('.dialup-window')).toBeVisible();
+
+    // Three member cards.
+    await expect(page.locator('.deck-card')).toHaveCount(3);
+
+    // Full matrix rendered.
+    await expect(page.locator('.deck-matrix__cell')).toHaveCount(9);
+    await expect(page.locator('.deck-matrix__cell--blank')).toHaveCount(3);
+  });
+});

--- a/server/e2e/tests/helpers.ts
+++ b/server/e2e/tests/helpers.ts
@@ -117,3 +117,18 @@ export async function expectNavActive(page: Page, labelPattern: RegExp) {
   const text = await link.textContent();
   expect(text ?? '').toMatch(labelPattern);
 }
+
+/**
+ * Log in as a seeded user via the dev-session endpoint.
+ * Only works when the server runs with DEV_MODE=true.
+ * Returns false if the endpoint is unavailable or the user needs onboarding.
+ */
+export async function devLogin(page: Page, email: string): Promise<boolean> {
+  const resp = await page.goto(`/auth/dev-session?email=${encodeURIComponent(email)}`);
+  const status = resp?.status() ?? 0;
+  if (status === 404) return false;
+  const url = page.url();
+  if (url.includes('/auth/login')) return false;
+  if (url.includes('/onboard')) return false;
+  return true;
+}

--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -297,7 +297,7 @@ func TestCreateConferenceEvictsActiveEntries_Integration(t *testing.T) {
 	}
 }
 
-func TestGetConferenceByID(t *testing.T) {
+func TestGetConferenceByID_Integration(t *testing.T) {
 	d := openTestDB(t)
 	tr := calls.New(d)
 	ctx := context.Background()

--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -296,3 +296,77 @@ func TestCreateConferenceEvictsActiveEntries_Integration(t *testing.T) {
 		}
 	}
 }
+
+func TestGetConferenceByID(t *testing.T) {
+	d := openTestDB(t)
+	tr := calls.New(d)
+	ctx := context.Background()
+
+	// Seed two calls, create a conference.
+	if _, err := tr.OnCallInitiated(ctx, "+15555550001", "+15555550002"); err != nil {
+		t.Fatalf("seed call 1: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, "+15555550001", "+15555550003"); err != nil {
+		t.Fatalf("seed call 2: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, "+15555550001", "+15555550002"); err != nil {
+		t.Fatalf("answer call 1: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, "+15555550001", "+15555550003"); err != nil {
+		t.Fatalf("answer call 2: %v", err)
+	}
+	originatingCallID := tr.CallIDForPair(ctx, "+15555550001", "+15555550002")
+	conf, err := tr.CreateConferencePersistent(ctx, "+15555550001", originatingCallID, []string{"+15555550002", "+15555550003"})
+	if err != nil {
+		t.Fatalf("create conference: %v", err)
+	}
+
+	// Active conference fetch.
+	got, err := tr.GetConferenceByID(ctx, conf.ID)
+	if err != nil {
+		t.Fatalf("GetConferenceByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil conference")
+	}
+	if got.ID != conf.ID {
+		t.Fatalf("ID: got %s want %s", got.ID, conf.ID)
+	}
+	if got.Host != "+15555550001" {
+		t.Fatalf("Host: got %s want +15555550001", got.Host)
+	}
+	if len(got.Members) != 3 {
+		t.Fatalf("Members len: got %d want 3", len(got.Members))
+	}
+	// Host sorts first, added members alphabetically.
+	if got.Members[0] != "+15555550001" {
+		t.Fatalf("Members[0]: got %s want host", got.Members[0])
+	}
+
+	// Unknown ID returns (nil, nil).
+	got, err = tr.GetConferenceByID(ctx, uuid.New())
+	if err != nil {
+		t.Fatalf("GetConferenceByID unknown: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for unknown id; got %v", got)
+	}
+
+	// Ended conference is still retrievable.
+	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+		t.Fatalf("EndConferencePersistent: %v", err)
+	}
+	got, err = tr.GetConferenceByID(ctx, conf.ID)
+	if err != nil {
+		t.Fatalf("GetConferenceByID after end: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ended conference not retrievable")
+	}
+	if got.EndReason != "host_hangup" {
+		t.Fatalf("EndReason: got %q want host_hangup", got.EndReason)
+	}
+	if got.EndedAt == nil {
+		t.Fatal("EndedAt should be populated on an ended conference")
+	}
+}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -73,9 +73,10 @@ type endpointKey struct {
 	Peer string // remote endpoint the sample describes; "" for 2-party
 }
 
-// ringCapacity is the per-endpoint in-memory sample retention.
+// RingCapacity is the per-endpoint in-memory sample retention.
 // At the default 2s reporting cadence this holds 2 minutes of history.
-const ringCapacity = 60
+// Readback and ReadbackEdge callers use this constant for the limit argument.
+const RingCapacity = 60
 
 // sessionRings holds per-endpoint bounded sample rings and last-flushed
 // timestamps used by the DB flusher. All state is guarded by mu.
@@ -91,17 +92,17 @@ type subscriber struct {
 }
 
 type ring struct {
-	samples     []Sample // length up to ringCapacity
+	samples     []Sample // length up to RingCapacity
 	lastFlushed time.Time
 }
 
 func (r *ring) append(s Sample) {
-	if len(r.samples) < ringCapacity {
+	if len(r.samples) < RingCapacity {
 		r.samples = append(r.samples, s)
 		return
 	}
 	copy(r.samples, r.samples[1:])
-	r.samples[ringCapacity-1] = s
+	r.samples[RingCapacity-1] = s
 }
 
 func (r *ring) latest() *Sample {

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -79,7 +79,7 @@ func TestReadbackFromDB(t *testing.T) {
 	// Simulate post-restart: drop in-memory state.
 	s.Evict(callID)
 
-	got, err := s.Readback(context.Background(), callID, "555-3333", ringCapacity)
+	got, err := s.Readback(context.Background(), callID, "555-3333", RingCapacity)
 	if err != nil {
 		t.Fatalf("Readback: %v", err)
 	}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -83,10 +83,10 @@ func TestHealthStoreConcurrentWritersSameRing(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Sanity: ring holds ringCapacity samples and latest() returns one.
+	// Sanity: ring holds RingCapacity samples and latest() returns one.
 	win := s.Window(1, "A")
-	if len(win) != ringCapacity {
-		t.Fatalf("window size: got %d want %d", len(win), ringCapacity)
+	if len(win) != RingCapacity {
+		t.Fatalf("window size: got %d want %d", len(win), RingCapacity)
 	}
 	a, _ := s.Latest(1, "A", "B")
 	if a == nil {

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/dbutil"
 )
@@ -493,6 +494,39 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 		h.EvictConference(confID)
 	}
 	return nil
+}
+
+// GetConferenceByID returns a conference summary from the DB by ID. Returns
+// (nil, nil) if not found. Handles both active and ended conferences.
+func (t *Tracker) GetConferenceByID(ctx context.Context, confID uuid.UUID) (*ConferenceSummary, error) {
+	const query = `
+		SELECT c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at,
+		       c.end_reason,
+		       COALESCE(EXTRACT(EPOCH FROM (c.ended_at - c.created_at))::INT, 0) AS duration_s,
+		       array_agg(m.phone ORDER BY CASE WHEN m.phone = c.host_phone THEN 0 ELSE 1 END, m.phone) AS members
+		FROM conferences c
+		JOIN conference_members m ON m.conference_id = c.id
+		WHERE c.id = $1
+		GROUP BY c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at, c.end_reason`
+
+	var cs ConferenceSummary
+	var endReason *string
+	var members pq.StringArray
+	err := t.db.DB.QueryRowContext(ctx, query, confID).Scan(
+		&cs.ID, &cs.Host, &cs.OriginatingCallID, &cs.CreatedAt, &cs.EndedAt,
+		&endReason, &cs.DurationS, &members,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if endReason != nil {
+		cs.EndReason = *endReason
+	}
+	cs.Members = []string(members)
+	return &cs, nil
 }
 
 // DropMemberPersistent drops a single member from an active conference, ends the

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/dbutil"
 )
@@ -520,7 +521,7 @@ func (t *Tracker) GetConferenceByID(ctx context.Context, confID uuid.UUID) (*Con
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get conference %s: %w", confID, err)
 	}
 	if endReason != nil {
 		cs.EndReason = *endReason

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -330,6 +330,51 @@ func TestCallsPageRenders3WayConference(t *testing.T) {
 	t.Logf("✓ /calls page renders 3-way conference with chip--conf and all participant numbers")
 }
 
+func TestCallsPageConferenceRowLinksToLive(t *testing.T) {
+	s := newLHEnv(t)
+	ctx := context.Background()
+	tr := s.env.tracker
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
+	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+	// End the conference so it shows up in /calls history (active ones
+	// aren't in the historical list).
+	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	// /calls needs CallHistoryEnabled. Enable it for userA's household.
+	if err := s.env.householdStore.SetCallHistoryEnabled(ctx, s.hhAID, true); err != nil {
+		t.Fatalf("enable call history: %v", err)
+	}
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/calls", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", resp.StatusCode, string(body))
+	}
+	wantLink := `href="/conference/live/` + conf.ID.String() + `"`
+	if !strings.Contains(string(body), wantLink) {
+		t.Errorf("expected /calls to link conference row to %s", wantLink)
+	}
+}
+
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -31,6 +31,7 @@ type callsTestEnv struct {
 	linkStore      *household.LinkStore
 	pairingStore   *pairing.Store
 	healthStore    *calls.HealthStore
+	handler        *Handler
 }
 
 // setupCallsTestServer creates a full server with all stores wired via
@@ -65,6 +66,7 @@ func setupCallsTestServer(t *testing.T) callsTestEnv {
 		linkStore:      deps.LinkStore,
 		pairingStore:   deps.PairingStore,
 		healthStore:    deps.HealthStore,
+		handler:        h,
 	}
 }
 

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -333,23 +333,10 @@ func TestCallsPageRenders3WayConference(t *testing.T) {
 func TestCallsPageConferenceRowLinksToLive(t *testing.T) {
 	s := newLHEnv(t)
 	ctx := context.Background()
-	tr := s.env.tracker
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
-	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
+	confID := startConference(t, s)
 	// End the conference so it shows up in /calls history (active ones
 	// aren't in the historical list).
-	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+	if err := s.env.tracker.EndConferencePersistent(ctx, confID, "host_hangup"); err != nil {
 		t.Fatalf("end: %v", err)
 	}
 
@@ -369,7 +356,7 @@ func TestCallsPageConferenceRowLinksToLive(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d want 200; body=%s", resp.StatusCode, string(body))
 	}
-	wantLink := `href="/conference/live/` + conf.ID.String() + `"`
+	wantLink := `href="/conference/live/` + confID.String() + `"`
 	if !strings.Contains(string(body), wantLink) {
 		t.Errorf("expected /calls to link conference row to %s", wantLink)
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -86,9 +86,10 @@ type Handler struct {
 	tmplPhoneDetail    *template.Template
 	tmplLinks          *template.Template
 	tmplConnecting     *template.Template
-	tmplCallLivePanel       *template.Template
-	tmplCallLiveDetail      *template.Template
-	tmplConferenceLivePanel *template.Template
+	tmplCallLivePanel          *template.Template
+	tmplCallLiveDetail         *template.Template
+	tmplConferenceLivePanel    *template.Template
+	tmplConferenceLiveDetail   *template.Template
 	cfg                HandlerConfig
 	// Auth
 	authStore    *auth.Store
@@ -302,6 +303,14 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if _, err := tmplCallLiveDetail.ParseFS(templateFS, "templates/_call-live-panel.html"); err != nil {
 		return nil, fmt.Errorf("parse call-live-panel partial into detail: %w", err)
 	}
+	tmplConferenceLiveDetail, err := parsePage("conference-live-detail.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse conference-live-detail: %w", err)
+	}
+	// Merge the panel partial so {{template "conference-live-panel"}} resolves inside the detail page.
+	if _, err := tmplConferenceLiveDetail.ParseFS(templateFS, "templates/_conference-live-panel.html"); err != nil {
+		return nil, fmt.Errorf("parse conference-live-panel partial into detail: %w", err)
+	}
 
 	u := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
@@ -330,9 +339,10 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplPhoneDetail:    tmplPhoneDetail,
 		tmplLinks:          tmplLinks,
 		tmplConnecting:     tmplConnecting,
-		tmplCallLivePanel:       tmplCallLivePanel,
-		tmplCallLiveDetail:      tmplCallLiveDetail,
-		tmplConferenceLivePanel: tmplConferenceLivePanel,
+		tmplCallLivePanel:          tmplCallLivePanel,
+		tmplCallLiveDetail:         tmplCallLiveDetail,
+		tmplConferenceLivePanel:    tmplConferenceLivePanel,
+		tmplConferenceLiveDetail:   tmplConferenceLiveDetail,
 		cfg:                cfg,
 		authStore:          deps.AuthStore,
 		authHandlers:       deps.AuthHandlers,
@@ -393,6 +403,9 @@ func (h *Handler) Router() http.Handler {
 		// Harness endpoint for /call/live e2e tests to seed an active call
 		// without going through the full signaling dance.
 		mux.HandleFunc("POST /test-harness/start-call", h.handleTestStartCall)
+		// Harness endpoint for /conference/live e2e tests to seed a conference
+		// without going through the full signaling dance.
+		mux.HandleFunc("POST /test-harness/start-conference", h.handleTestStartConference)
 		// Seed a fake hub entry so e2e tests can exercise the firmware update
 		// chip without a real device connection.
 		mux.HandleFunc("POST /dev/seed-firmware", h.handleDevSeedFirmware)
@@ -432,6 +445,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /api/status", h.handleAPIStatus)
 	protected.HandleFunc("GET /api/active-calls", h.handleAPIActiveCalls)
 	protected.HandleFunc("GET /call/live/{id}", h.handleCallLiveDetail)
+	protected.HandleFunc("GET /conference/live/{uuid}", h.handleConferenceLiveDetail)
 	protected.HandleFunc("GET /api/call/{id}/link-health", h.handleCallLinkHealth)
 	protected.HandleFunc("GET /api/call/{id}/link-health/stream", h.handleCallLinkHealthStream)
 	protected.HandleFunc("GET /api/conference/{uuid}/link-health", h.handleConferenceLinkHealth)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -435,6 +435,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /api/call/{id}/link-health", h.handleCallLinkHealth)
 	protected.HandleFunc("GET /api/call/{id}/link-health/stream", h.handleCallLinkHealthStream)
 	protected.HandleFunc("GET /api/conference/{uuid}/link-health", h.handleConferenceLinkHealth)
+	protected.HandleFunc("GET /api/conference/{uuid}/link-health/stream", h.handleConferenceLinkHealthStream)
 	protected.HandleFunc("POST /api/call/{id}/disconnect", h.handleCallDisconnect)
 	protected.HandleFunc("GET /api/lines/number-available", h.handleAPINumberAvailable)
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -86,8 +86,9 @@ type Handler struct {
 	tmplPhoneDetail    *template.Template
 	tmplLinks          *template.Template
 	tmplConnecting     *template.Template
-	tmplCallLivePanel  *template.Template
-	tmplCallLiveDetail *template.Template
+	tmplCallLivePanel       *template.Template
+	tmplCallLiveDetail      *template.Template
+	tmplConferenceLivePanel *template.Template
 	cfg                HandlerConfig
 	// Auth
 	authStore    *auth.Store
@@ -233,6 +234,14 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			return segDesc{Lit: lit, Severity: sev}
 		},
 		"renderNotes": renderNotes,
+		"edgeFor": func(edges []ConferenceLinkHealthEdge, from, peer string) *ConferenceLinkHealthEdge {
+			for i := range edges {
+				if edges[i].From == from && edges[i].Peer == peer {
+					return &edges[i]
+				}
+			}
+			return nil
+		},
 	}
 	// parsePage closes over the layout + shared-partials file list so each
 	// page only names itself. Adding a new layout or partial touches one line.
@@ -281,6 +290,10 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse call-live-panel: %w", err)
 	}
+	tmplConferenceLivePanel, err := template.New("conference-live-panel").Funcs(funcMap).ParseFS(templateFS, "templates/_conference-live-panel.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse conference-live-panel: %w", err)
+	}
 	tmplCallLiveDetail, err := parsePage("call-live-detail.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse call-live-detail: %w", err)
@@ -317,8 +330,9 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplPhoneDetail:    tmplPhoneDetail,
 		tmplLinks:          tmplLinks,
 		tmplConnecting:     tmplConnecting,
-		tmplCallLivePanel:  tmplCallLivePanel,
-		tmplCallLiveDetail: tmplCallLiveDetail,
+		tmplCallLivePanel:       tmplCallLivePanel,
+		tmplCallLiveDetail:      tmplCallLiveDetail,
+		tmplConferenceLivePanel: tmplConferenceLivePanel,
 		cfg:                cfg,
 		authStore:          deps.AuthStore,
 		authHandlers:       deps.AuthHandlers,

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -420,6 +420,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /call/live/{id}", h.handleCallLiveDetail)
 	protected.HandleFunc("GET /api/call/{id}/link-health", h.handleCallLinkHealth)
 	protected.HandleFunc("GET /api/call/{id}/link-health/stream", h.handleCallLinkHealthStream)
+	protected.HandleFunc("GET /api/conference/{uuid}/link-health", h.handleConferenceLinkHealth)
 	protected.HandleFunc("POST /api/call/{id}/disconnect", h.handleCallDisconnect)
 	protected.HandleFunc("GET /api/lines/number-available", h.handleAPINumberAvailable)
 

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -57,7 +57,6 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Display-name resolution via linked-families index (same as 2-party).
 	var linkedIndex map[string]string
 	if primaryHH != "" {
 		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
@@ -79,7 +78,7 @@ func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls
 	for _, m := range conf.Members {
 		members = append(members, ConferenceMemberInfo{
 			Number:      m,
-			DisplayName: h.resolveMemberDisplayName(m, ownedLines, linkedIndex),
+			DisplayName: resolveMemberDisplayName(m, ownedLines, linkedIndex),
 			IsHost:      m == conf.Host,
 		})
 	}
@@ -102,6 +101,16 @@ func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls
 	}
 }
 
+// lastSample returns a pointer to the last element of window, or nil if empty.
+// Copies the value to avoid aliasing the slice backing array.
+func lastSample(window []LinkHealthSample) *LinkHealthSample {
+	if len(window) == 0 {
+		return nil
+	}
+	s := window[len(window)-1]
+	return &s
+}
+
 func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid.UUID, from, peer string) ConferenceLinkHealthEdge {
 	out := ConferenceLinkHealthEdge{From: from, Peer: peer, Window: []LinkHealthSample{}}
 
@@ -112,12 +121,11 @@ func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid
 		for i, s := range windowMem {
 			out.Window[i] = toAPISample(s)
 		}
-		la := toAPISample(windowMem[len(windowMem)-1])
-		out.Latest = &la
+		out.Latest = lastSample(out.Window)
 		return out
 	}
 	// DB fallback.
-	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, 60)
+	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, calls.RingCapacity)
 	if err != nil {
 		slog.Warn("ReadbackEdge failed; serving empty window",
 			"conf_id", confID, "from", from, "peer", peer, "err", err)
@@ -127,26 +135,8 @@ func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid
 	for i, s := range dbSamples {
 		out.Window[i] = toAPISample(s)
 	}
-	if len(dbSamples) > 0 {
-		la := toAPISample(dbSamples[len(dbSamples)-1])
-		out.Latest = &la
-	}
+	out.Latest = lastSample(out.Window)
 	return out
-}
-
-// resolveMemberDisplayName picks the best label for a member phone.
-// Priority: owned-line name (only if non-empty), linked-index peer name,
-// bare number fallback. The non-empty guard on the owned line is an
-// intentional tightening over the 2-party inline behavior: a blank line
-// name should not preempt a useful linked-family name.
-func (h *Handler) resolveMemberDisplayName(number string, ownedLines map[string]*line.Line, linkedIndex map[string]string) string {
-	if ln, ok := ownedLines[number]; ok && ln != nil && ln.Name != "" {
-		return ln.Name
-	}
-	if name := resolvePeerName(number, linkedIndex); name != "" {
-		return name
-	}
-	return number
 }
 
 // handleConferenceLinkHealthStream opens an SSE stream for a conference's
@@ -234,24 +224,17 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
-	switch ev.Kind {
-	case calls.SampleKind:
-		snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
-		fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
-		if err != nil {
-			return err
-		}
-		if err := writeSSE(w, "sample", fragment); err != nil {
-			return err
-		}
-	case calls.EndedKind:
-		if err := writeSSE(w, "ended", renderEndedFragment("")); err != nil {
-			return err
-		}
-	case calls.DisconnectKind:
-		if err := writeSSE(w, "disconnect", renderEndedFragment(ev.EndedBy)); err != nil {
-			return err
-		}
+	if handled, err := writeTerminalEvent(w, flusher, ev); handled {
+		return err
+	}
+	// SampleKind
+	snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
+	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
+	if err != nil {
+		return err
+	}
+	if err := writeSSE(w, "sample", fragment); err != nil {
+		return err
 	}
 	flusher.Flush()
 	return nil
@@ -272,9 +255,7 @@ type conferenceLiveDetailData struct {
 	User               *auth.User
 	HouseholdName      string
 	CallHistoryEnabled bool
-	Conf               *calls.ConferenceSummary
 	Resp               ConferenceLinkHealthResp
-	Ended              bool
 }
 
 // handleConferenceLiveDetail renders the observation deck for a conference.
@@ -303,9 +284,7 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 		User:               user,
 		HouseholdName:      h.householdNameFromContext(r),
 		CallHistoryEnabled: h.callHistoryEnabled(r),
-		Conf:               conf,
 		Resp:               resp,
-		Ended:              conf.EndedAt != nil,
 	}
 	renderWith(w, h.tmplConferenceLiveDetail, layoutFor(r), data)
 }

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/justinlindh/digits/server/internal/calls"
+	"github.com/justinlindh/digits/server/internal/line"
+)
+
+// ConferenceLinkHealthEdge is the per-directed-edge section of
+// ConferenceLinkHealthResp. For a 3-way conference there are always 6 edges
+// (each of 3 members reports 2 remote peers).
+type ConferenceLinkHealthEdge struct {
+	From   string             `json:"from"`
+	Peer   string             `json:"peer"`
+	Latest *LinkHealthSample  `json:"latest,omitempty"`
+	Window []LinkHealthSample `json:"window"`
+}
+
+// ConferenceMemberInfo is the per-member section of ConferenceLinkHealthResp.
+type ConferenceMemberInfo struct {
+	Number      string `json:"number"`
+	DisplayName string `json:"display_name"`
+	IsHost      bool   `json:"is_host"`
+}
+
+// ConferenceLinkHealthResp is the top-level response body for
+// GET /api/conference/{uuid}/link-health.
+type ConferenceLinkHealthResp struct {
+	ConfID    uuid.UUID                  `json:"conf_id"`
+	CreatedAt time.Time                  `json:"created_at"`
+	Ended     bool                       `json:"ended"`
+	Members   []ConferenceMemberInfo     `json:"members"`
+	Edges     []ConferenceLinkHealthEdge `json:"edges"`
+}
+
+func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Request) {
+	confID, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	conf, ownedLines, primaryHH, ok := h.requireConferenceOwnership(w, r, confID)
+	if !ok {
+		return
+	}
+
+	// Display-name resolution via linked-families index (same as 2-party).
+	var linkedIndex map[string]string
+	if primaryHH != "" {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	}
+
+	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("conference_link_health encode failed", "conf_id", confID, "err", err)
+	}
+}
+
+// buildConferenceLinkHealthResp builds the response in-memory (or via DB
+// readback for an ended conference). Always emits all N*(N-1) edges,
+// even if an edge has no samples yet.
+func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string) ConferenceLinkHealthResp {
+	members := make([]ConferenceMemberInfo, 0, len(conf.Members))
+	for _, m := range conf.Members {
+		members = append(members, ConferenceMemberInfo{
+			Number:      m,
+			DisplayName: h.resolveMemberDisplayName(m, ownedLines, linkedIndex),
+			IsHost:      m == conf.Host,
+		})
+	}
+
+	edges := make([]ConferenceLinkHealthEdge, 0, len(conf.Members)*(len(conf.Members)-1))
+	for _, from := range conf.Members {
+		for _, peer := range conf.Members {
+			if from == peer {
+				continue
+			}
+			edges = append(edges, h.buildConferenceLinkHealthEdge(ctx, conf.ID, from, peer))
+		}
+	}
+	return ConferenceLinkHealthResp{
+		ConfID:    conf.ID,
+		CreatedAt: conf.CreatedAt,
+		Ended:     conf.EndedAt != nil,
+		Members:   members,
+		Edges:     edges,
+	}
+}
+
+func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid.UUID, from, peer string) ConferenceLinkHealthEdge {
+	out := ConferenceLinkHealthEdge{From: from, Peer: peer, Window: []LinkHealthSample{}}
+
+	// Memory first.
+	windowMem := h.healthStore.WindowEdge(confID, from, peer)
+	if len(windowMem) > 0 {
+		out.Window = make([]LinkHealthSample, len(windowMem))
+		for i, s := range windowMem {
+			out.Window[i] = toAPISample(s)
+		}
+		la := toAPISample(windowMem[len(windowMem)-1])
+		out.Latest = &la
+		return out
+	}
+	// DB fallback.
+	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, 60)
+	if err != nil {
+		slog.Debug("ReadbackEdge failed; serving empty window",
+			"conf_id", confID, "from", from, "peer", peer, "err", err)
+		return out
+	}
+	out.Window = make([]LinkHealthSample, len(dbSamples))
+	for i, s := range dbSamples {
+		out.Window[i] = toAPISample(s)
+	}
+	if len(dbSamples) > 0 {
+		la := toAPISample(dbSamples[len(dbSamples)-1])
+		out.Latest = &la
+	}
+	return out
+}
+
+// resolveMemberDisplayName picks the best label for a member phone: owned
+// line name first, then linked-index peer name, then bare number fallback.
+func (h *Handler) resolveMemberDisplayName(number string, ownedLines map[string]*line.Line, linkedIndex map[string]string) string {
+	if ln, ok := ownedLines[number]; ok && ln != nil && ln.Name != "" {
+		return ln.Name
+	}
+	if name := resolvePeerName(number, linkedIndex); name != "" {
+		return name
+	}
+	return number
+}

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -113,7 +113,7 @@ func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid
 	// DB fallback.
 	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, 60)
 	if err != nil {
-		slog.Debug("ReadbackEdge failed; serving empty window",
+		slog.Warn("ReadbackEdge failed; serving empty window",
 			"conf_id", confID, "from", from, "peer", peer, "err", err)
 		return out
 	}
@@ -128,8 +128,11 @@ func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid
 	return out
 }
 
-// resolveMemberDisplayName picks the best label for a member phone: owned
-// line name first, then linked-index peer name, then bare number fallback.
+// resolveMemberDisplayName picks the best label for a member phone.
+// Priority: owned-line name (only if non-empty), linked-index peer name,
+// bare number fallback. The non-empty guard on the owned line is an
+// intentional tightening over the 2-party inline behavior: a blank line
+// name should not preempt a useful linked-family name.
 func (h *Handler) resolveMemberDisplayName(number string, ownedLines map[string]*line.Line, linkedIndex map[string]string) string {
 	if ln, ok := ownedLines[number]; ok && ln != nil && ln.Name != "" {
 		return ln.Name

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -182,6 +182,11 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
 	}
 
+	// Subscribe FIRST so samples arriving between the initial snapshot and
+	// the select loop are buffered rather than silently dropped.
+	sub := h.healthStore.SubscribeConference(confID)
+	defer sub.Close()
+
 	// Initial snapshot.
 	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
@@ -194,9 +199,6 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	}
 	flusher.Flush()
 
-	sub := h.healthStore.SubscribeConference(confID)
-	defer sub.Close()
-
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
 
@@ -206,7 +208,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 			return
 		case ev, okEv := <-sub.C:
 			if !okEv {
-				_ = writeSSE(w, "ended", renderEndedFragment(""))
+				_ = writeSSE(w, "ended", renderEndedConferenceFragment(""))
 				flusher.Flush()
 				return
 			}
@@ -224,17 +226,24 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
-	if handled, err := writeTerminalEvent(w, flusher, ev); handled {
-		return err
-	}
-	// SampleKind
-	snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
-	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
-	if err != nil {
-		return err
-	}
-	if err := writeSSE(w, "sample", fragment); err != nil {
-		return err
+	switch ev.Kind {
+	case calls.SampleKind:
+		snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
+		fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
+		if err != nil {
+			return err
+		}
+		if err := writeSSE(w, "sample", fragment); err != nil {
+			return err
+		}
+	case calls.EndedKind:
+		if err := writeSSE(w, "ended", renderEndedConferenceFragment("")); err != nil {
+			return err
+		}
+	case calls.DisconnectKind:
+		if err := writeSSE(w, "disconnect", renderEndedConferenceFragment(ev.EndedBy)); err != nil {
+			return err
+		}
 	}
 	flusher.Flush()
 	return nil

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/line"
+	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // ConferenceLinkHealthEdge is the per-directed-edge section of
@@ -261,4 +263,49 @@ func (h *Handler) renderConferenceLinkHealthPanel(resp ConferenceLinkHealthResp)
 		return "", fmt.Errorf("render conference-live-panel: %w", err)
 	}
 	return strings.TrimRight(buf.String(), "\n"), nil
+}
+
+// conferenceLiveDetailData is the render payload for conference-live-detail.html.
+type conferenceLiveDetailData struct {
+	Page               string
+	Version            string
+	User               *auth.User
+	HouseholdName      string
+	CallHistoryEnabled bool
+	Conf               *calls.ConferenceSummary
+	Resp               ConferenceLinkHealthResp
+	Ended              bool
+}
+
+// handleConferenceLiveDetail renders the observation deck for a conference.
+// Ended conferences render in terminal state (no SSE wiring, no kick button).
+func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Request) {
+	confID, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	conf, ownedLines, primaryHH, ok := h.requireConferenceOwnership(w, r, confID)
+	if !ok {
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+
+	var linkedIndex map[string]string
+	if primaryHH != "" {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	}
+	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+
+	data := conferenceLiveDetailData{
+		Page:               "conference-live",
+		Version:            version.Version,
+		User:               user,
+		HouseholdName:      h.householdNameFromContext(r),
+		CallHistoryEnabled: h.callHistoryEnabled(r),
+		Conf:               conf,
+		Resp:               resp,
+		Ended:              conf.EndedAt != nil,
+	}
+	renderWith(w, h.tmplConferenceLiveDetail, layoutFor(r), data)
 }

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -1,10 +1,14 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -141,4 +145,120 @@ func (h *Handler) resolveMemberDisplayName(number string, ownedLines map[string]
 		return name
 	}
 	return number
+}
+
+// handleConferenceLinkHealthStream opens an SSE stream for a conference's
+// per-edge telemetry. Delivers:
+//   - one initial "sample" event with the full 6-edge matrix snapshot
+//   - one "sample" event per future per-edge Record
+//   - one "ended" event when the conference ends, then closes
+//   - periodic "heartbeat" events for client-side liveness
+//
+// Auth: same as the JSON endpoint (requireConferenceOwnership). Ended
+// conferences return 404 before any stream bytes are written.
+func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *http.Request) {
+	confID, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	conf, ownedLines, primaryHH, ok := h.requireConferenceOwnership(w, r, confID)
+	if !ok {
+		return
+	}
+	if conf.EndedAt != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		slog.Error("SSE conference stream: ResponseWriter does not implement Flusher")
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	var linkedIndex map[string]string
+	if primaryHH != "" {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	}
+
+	// Initial snapshot.
+	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
+	if err != nil {
+		slog.Error("SSE conference stream: initial render failed", "conf_id", confID, "err", err)
+		return
+	}
+	if werr := writeSSE(w, "sample", fragment); werr != nil {
+		return
+	}
+	flusher.Flush()
+
+	sub := h.healthStore.SubscribeConference(confID)
+	defer sub.Close()
+
+	heartbeat := time.NewTicker(sseHeartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, okEv := <-sub.C:
+			if !okEv {
+				_ = writeSSE(w, "ended", renderEndedFragment(""))
+				flusher.Flush()
+				return
+			}
+			if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, ownedLines, linkedIndex, ev); err != nil {
+				slog.Debug("SSE conference stream: write failed", "conf_id", confID, "err", err)
+				return
+			}
+		case <-heartbeat.C:
+			if err := writeSSE(w, "heartbeat", "{}"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
+	switch ev.Kind {
+	case calls.SampleKind:
+		snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
+		fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
+		if err != nil {
+			return err
+		}
+		if err := writeSSE(w, "sample", fragment); err != nil {
+			return err
+		}
+	case calls.EndedKind:
+		if err := writeSSE(w, "ended", renderEndedFragment("")); err != nil {
+			return err
+		}
+	case calls.DisconnectKind:
+		if err := writeSSE(w, "disconnect", renderEndedFragment(ev.EndedBy)); err != nil {
+			return err
+		}
+	}
+	flusher.Flush()
+	return nil
+}
+
+func (h *Handler) renderConferenceLinkHealthPanel(resp ConferenceLinkHealthResp) (string, error) {
+	var buf bytes.Buffer
+	if err := h.tmplConferenceLivePanel.ExecuteTemplate(&buf, "conference-live-panel", resp); err != nil {
+		return "", fmt.Errorf("render conference-live-panel: %w", err)
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
 }

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -114,6 +115,52 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 		return calls.Call{}, nil, "", false
 	}
 	return call, ownedLines, primaryHH, true
+}
+
+// requireConferenceOwnership verifies the authenticated user directly owns
+// at least one conference member line (across any household the user belongs
+// to). Linked households do NOT grant observation; only direct household
+// ownership of a member line does. Returns the conference, the owned-lines
+// map (keyed by number), the primary household ID, and true on success. On
+// any failure, writes 404 (unauthorized and nonexistent are
+// indistinguishable).
+//
+// Mirrors requireCallEndpointOwnership's constant-time query sequence to
+// avoid a timing side channel on conference-id enumeration.
+func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.NotFound(w, r)
+		return nil, nil, "", false
+	}
+
+	// Always do both queries in the same order, regardless of miss reason.
+	ownedLines, primaryHH, ok := h.ownedLinesForUser(r.Context(), user)
+	conf, confErr := h.tracker.GetConferenceByID(r.Context(), confID)
+
+	if confErr != nil {
+		slog.Error("conference_link_health: get conference failed", "conf_id", confID, "err", confErr)
+		http.NotFound(w, r)
+		return nil, nil, "", false
+	}
+	if !ok || conf == nil {
+		http.NotFound(w, r)
+		return nil, nil, "", false
+	}
+
+	// User must directly own at least one member.
+	anyOwned := false
+	for _, member := range conf.Members {
+		if _, has := ownedLines[member]; has {
+			anyOwned = true
+			break
+		}
+	}
+	if !anyOwned {
+		http.NotFound(w, r)
+		return nil, nil, "", false
+	}
+	return conf, ownedLines, primaryHH, true
 }
 
 // userDisplayLabel returns a human-friendly label for a user: Name if set,

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -127,7 +127,6 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 //
 // Mirrors requireCallEndpointOwnership's constant-time query sequence to
 // avoid a timing side channel on conference-id enumeration.
-//nolint:unused // First production caller lands in the next commit.
 func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -163,6 +163,19 @@ func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Requ
 	return conf, ownedLines, primaryHH, true
 }
 
+// resolveMemberDisplayName picks the best label for a member phone.
+// Priority: owned-line name (only if non-empty), linked-index peer name,
+// bare number fallback.
+func resolveMemberDisplayName(number string, ownedLines map[string]*line.Line, linkedIndex map[string]string) string {
+	if ln, ok := ownedLines[number]; ok && ln != nil && ln.Name != "" {
+		return ln.Name
+	}
+	if name := resolvePeerName(number, linkedIndex); name != "" {
+		return name
+	}
+	return number
+}
+
 // userDisplayLabel returns a human-friendly label for a user: Name if set,
 // else the email local-part, else the bare email. Nil user returns "".
 func userDisplayLabel(u *auth.User) string {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -127,6 +127,7 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 //
 // Mirrors requireCallEndpointOwnership's constant-time query sequence to
 // avoid a timing side channel on conference-id enumeration.
+//nolint:unused // First production caller lands in the next commit.
 func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -104,16 +104,9 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string, ownedLines map[string]*line.Line) (LinkHealthEndpointResp, error) {
 	out := LinkHealthEndpointResp{Number: number, Window: []LinkHealthSample{}}
 
-	// Display name resolution: owned line first (no extra DB query), then
+	// Display name resolution: owned line first (non-empty name only), then
 	// linked-index for peer names, then bare number as fallback.
-	if ln, ok := ownedLines[number]; ok && ln != nil {
-		out.DisplayName = ln.Name
-	} else {
-		out.DisplayName = resolvePeerName(number, linkedIndex)
-	}
-	if out.DisplayName == "" {
-		out.DisplayName = number
-	}
+	out.DisplayName = resolveMemberDisplayName(number, ownedLines, linkedIndex)
 
 	// Memory first.
 	windowMem := h.healthStore.Window(callID, number)
@@ -128,7 +121,7 @@ func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, num
 	}
 
 	// DB fallback.
-	dbSamples, err := h.healthStore.Readback(ctx, callID, number, 60)
+	dbSamples, err := h.healthStore.Readback(ctx, callID, number, calls.RingCapacity)
 	if err != nil {
 		return out, fmt.Errorf("readback %d/%s: %w", callID, number, err)
 	}
@@ -265,32 +258,45 @@ func (h *Handler) writeInitialSnapshot(ctx context.Context, w io.Writer, flusher
 	return nil
 }
 
-func (h *Handler) writeEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
+// writeTerminalEvent writes an SSE frame for an EndedKind or DisconnectKind
+// event using renderEndedFragment. Returns true if the event was a terminal
+// kind and was handled, false for SampleKind (which the caller handles).
+func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event) (bool, error) {
 	switch ev.Kind {
-	case calls.SampleKind:
-		callerEp, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Caller, linkedIndex, ownedLines)
-		if err != nil {
-			return err
-		}
-		calleeEp, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Callee, linkedIndex, ownedLines)
-		if err != nil {
-			return err
-		}
-		fragment, err := h.renderLinkHealthPanel(call, callerEp, calleeEp)
-		if err != nil {
-			return err
-		}
-		if err := writeSSE(w, "sample", fragment); err != nil {
-			return err
+	case calls.EndedKind:
+		if err := writeSSE(w, "ended", renderEndedFragment("")); err != nil {
+			return true, err
 		}
 	case calls.DisconnectKind:
 		if err := writeSSE(w, "disconnect", renderEndedFragment(ev.EndedBy)); err != nil {
-			return err
+			return true, err
 		}
-	case calls.EndedKind:
-		if err := writeSSE(w, "ended", renderEndedFragment("")); err != nil {
-			return err
-		}
+	default:
+		return false, nil
+	}
+	flusher.Flush()
+	return true, nil
+}
+
+func (h *Handler) writeEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
+	if handled, err := writeTerminalEvent(w, flusher, ev); handled {
+		return err
+	}
+	// SampleKind
+	callerEp, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Caller, linkedIndex, ownedLines)
+	if err != nil {
+		return err
+	}
+	calleeEp, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Callee, linkedIndex, ownedLines)
+	if err != nil {
+		return err
+	}
+	fragment, err := h.renderLinkHealthPanel(call, callerEp, calleeEp)
+	if err != nil {
+		return err
+	}
+	if err := writeSSE(w, "sample", fragment); err != nil {
+		return err
 	}
 	flusher.Flush()
 	return nil

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -332,6 +332,15 @@ func renderEndedFragment(endedBy string) string {
 	return `<div class="deck-ended">Call ended.</div>`
 }
 
+// renderEndedConferenceFragment is the matrix-deck counterpart of
+// renderEndedFragment. Returns the small HTML shown when a conference ends.
+func renderEndedConferenceFragment(endedBy string) string {
+	if endedBy != "" {
+		return fmt.Sprintf(`<div class="deck-ended">Conference ended by %s.</div>`, html.EscapeString(endedBy))
+	}
+	return `<div class="deck-ended">Conference ended.</div>`
+}
+
 // handleCallDisconnect force-ends an active call. Any user whose household
 // owns either endpoint (direct ownership only; linked households do NOT
 // qualify) can trigger this. The server records the actor in calls.force_ended_by,

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -192,6 +192,49 @@ func (h *Handler) handleTestStartCall(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 }
 
+// handleTestStartConference is a DEV_MODE test-harness endpoint that seeds
+// two 2-party calls and then merges them into a conference. Used by the
+// Playwright suite to drive the observation deck without going through
+// signaling.
+func (h *Handler) handleTestStartConference(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Host  string   `json:"host"`
+		Added []string `json:"added"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if body.Host == "" || len(body.Added) != 2 {
+		http.Error(w, "host and exactly 2 added members required", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	for _, callee := range body.Added {
+		if _, err := h.tracker.OnCallInitiated(ctx, body.Host, callee); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := h.tracker.OnCallAnswered(ctx, body.Host, callee); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	originatingCallID := h.tracker.CallIDForPair(ctx, body.Host, body.Added[0])
+	if originatingCallID == 0 {
+		http.Error(w, "originating call not found", http.StatusInternalServerError)
+		return
+	}
+	conf, err := h.tracker.CreateConferencePersistent(ctx, body.Host, originatingCallID, body.Added)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"conf_id": conf.ID.String()})
+}
+
 // handleDevSeedFirmware registers a fake hub entry for a line number with the
 // given firmware version. It is only reachable when DevMode is true and lets
 // the Playwright e2e suite exercise the firmware update chip without a real

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -684,6 +684,12 @@ func TestRequireConferenceOwnership(t *testing.T) {
 		if !wantOK && rec.Code != wantCode {
 			t.Errorf("%s: code=%d want %d", label, rec.Code, wantCode)
 		}
+		if wantOK && rec.Code != http.StatusOK && rec.Code != 0 {
+			// httptest.NewRecorder starts at 200 implicitly; if nothing was written,
+			// rec.Code is 0, which is also acceptable for a success path that did
+			// not invoke WriteHeader.
+			t.Errorf("%s: success path wrote unexpected code %d", label, rec.Code)
+		}
 	}
 
 	// Household A owns the host line: expect ok.
@@ -695,17 +701,32 @@ func TestRequireConferenceOwnership(t *testing.T) {
 
 	// A user whose household owns no conference member gets 404.
 	numD := nextPhone()
-	userD, err := env.env.authStore.CreateUser(context.Background(), "ownership-d-"+numD+"@example.com", "User D", nil)
+	hwD := "ownership-d-" + numD
+	emailD := "ownership-d-" + numD + "@example.com"
+	hhNameD := "Ownership D " + numD
+
+	// Register cleanup BEFORE any fallible DB work so partial-setup failures
+	// don't leak rows. All DELETEs are idempotent against missing rows.
+	t.Cleanup(func() {
+		db := env.env.database.DB
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
+		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
+		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
+		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
+	})
+
+	userD, err := env.env.authStore.CreateUser(context.Background(), emailD, "User D", nil)
 	if err != nil {
 		t.Fatalf("create user D: %v", err)
 	}
-	hhD, err := env.env.householdStore.Create(context.Background(), "Ownership D "+numD, userD.ID)
+	hhD, err := env.env.householdStore.Create(context.Background(), hhNameD, userD.ID)
 	if err != nil {
 		t.Fatalf("create household D: %v", err)
 	}
 	// Seed a line owned by D so ownedLinesForUser returns non-empty (proving
 	// the 404 is due to lack of conference membership, not lack of any line).
-	hwD := "ownership-d-" + numD
 	codeD, err := env.env.pairingStore.GenerateCode(context.Background(), hwD)
 	if err != nil {
 		t.Fatalf("gen code D: %v", err)
@@ -713,15 +734,6 @@ func TestRequireConferenceOwnership(t *testing.T) {
 	if _, _, err := env.env.pairingStore.ClaimDevice(context.Background(), codeD, numD, "Phone D", hhD.ID); err != nil {
 		t.Fatalf("claim D: %v", err)
 	}
-	t.Cleanup(func() {
-		db := env.env.database.DB
-		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
-		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
-		_, _ = db.Exec("DELETE FROM household_members WHERE household_id = $1", hhD.ID)
-		_, _ = db.Exec("DELETE FROM households WHERE id = $1", hhD.ID)
-		_, _ = db.Exec("DELETE FROM sessions WHERE user_id = $1", userD.ID)
-		_, _ = db.Exec("DELETE FROM users WHERE id = $1", userD.ID)
-	})
 
 	check("userD (unrelated household)", userD.ID, false, http.StatusNotFound)
 

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -889,6 +889,103 @@ func TestRequireConferenceOwnership(t *testing.T) {
 	}
 }
 
+func TestConferenceLiveDetailPage_OwnerRenders(t *testing.T) {
+	s := newLHEnv(t)
+	ctx := context.Background()
+	tr := s.env.tracker
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
+	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+conf.ID.String(), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", resp.StatusCode, string(body))
+	}
+	bodyStr := string(body)
+	for _, want := range []string{
+		"/api/conference/" + conf.ID.String() + "/link-health/stream",
+		s.numA, s.numB, s.numC,
+		"deck-matrix",
+	} {
+		if !strings.Contains(bodyStr, want) {
+			t.Errorf("expected body to contain %q", want)
+		}
+	}
+}
+
+func TestConferenceLiveDetailPage_EndedRendersTerminalNoSSE(t *testing.T) {
+	s := newLHEnv(t)
+	ctx := context.Background()
+	tr := s.env.tracker
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
+	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
+	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+conf.ID.String(), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ended status: got %d want 200 (terminal render); body=%s", resp.StatusCode, string(body))
+	}
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, `sse-connect="/api/conference/`) {
+		t.Error("ended page should NOT wire the SSE stream")
+	}
+	if !strings.Contains(bodyStr, "deck-ended-chip") {
+		t.Error("ended page should show the terminal chip")
+	}
+}
+
+func TestConferenceLiveDetailPage_UnknownUUID_404(t *testing.T) {
+	s := newLHEnv(t)
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+uuid.New().String(), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown uuid: got %d want 404", resp.StatusCode)
+	}
+}
+
 // TestConferenceLinkHealthJSON_DBFallback verifies that after a conference
 // ends and its in-memory rings are evicted, ReadbackEdge restores the edge
 // window from the flushed DB rows so the JSON response still carries

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -644,6 +644,140 @@ func TestDashboardLineCardLinksToCallLive(t *testing.T) {
 	}
 }
 
+func TestConferenceLinkHealthJSON(t *testing.T) {
+	env := newLHEnv(t)
+	ctx := context.Background()
+	tr := env.env.tracker
+
+	// Seed two 2-party calls and merge into a conference. All three phones
+	// are owned by separate households (A, B, C); A is host.
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
+	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	// Record one per-edge sample so the JSON carries a non-empty window.
+	loss := float32(1.5)
+	env.env.healthStore.RecordEdge(conf.ID, env.numA, env.numB,
+		calls.Sample{TS: time.Unix(0, 1), LossPct: &loss})
+
+	// GET as user A.
+	token, _, err := env.env.authStore.CreateSession(ctx, env.userA.ID, auth.SessionTTL)
+	if err != nil {
+		t.Fatalf("create session A: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet,
+		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := env.env.srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", resp.StatusCode, string(body))
+	}
+	var got ConferenceLinkHealthResp
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v; body=%s", err, string(body))
+	}
+	if got.ConfID != conf.ID {
+		t.Fatalf("ConfID: got %s want %s", got.ConfID, conf.ID)
+	}
+	if len(got.Members) != 3 {
+		t.Fatalf("Members len: got %d want 3", len(got.Members))
+	}
+	if len(got.Edges) != 6 {
+		t.Fatalf("Edges len: got %d want 6 (3x2 directed edges)", len(got.Edges))
+	}
+
+	// Host flag.
+	var hostCount int
+	for _, m := range got.Members {
+		if m.IsHost {
+			hostCount++
+			if m.Number != env.numA {
+				t.Errorf("IsHost on wrong member: got %s want %s", m.Number, env.numA)
+			}
+		}
+	}
+	if hostCount != 1 {
+		t.Errorf("exactly one host expected; got %d", hostCount)
+	}
+
+	// Host -> numB edge carries the recorded sample.
+	var foundHostToB bool
+	for _, e := range got.Edges {
+		if e.From == env.numA && e.Peer == env.numB {
+			foundHostToB = true
+			if e.Latest == nil || e.Latest.LossPct == nil || *e.Latest.LossPct != 1.5 {
+				t.Errorf("A->B edge latest lossPct not preserved: %+v", e.Latest)
+			}
+		}
+	}
+	if !foundHostToB {
+		t.Errorf("A->B edge missing from response")
+	}
+
+	// 404 for a user whose household owns no conference member (parallels
+	// TestRequireConferenceOwnership userD case, but via HTTP).
+	numD := nextPhone()
+	hwD := "json-d-" + numD
+	emailD := "json-d-" + numD + "@example.com"
+	hhNameD := "JSON D " + numD
+	t.Cleanup(func() {
+		db := env.env.database.DB
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
+		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
+		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
+		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
+	})
+	userD, err := env.env.authStore.CreateUser(ctx, emailD, "JSON D", nil)
+	if err != nil {
+		t.Fatalf("create user D: %v", err)
+	}
+	hhD, err := env.env.householdStore.Create(ctx, hhNameD, userD.ID)
+	if err != nil {
+		t.Fatalf("create household D: %v", err)
+	}
+	codeD, err := env.env.pairingStore.GenerateCode(ctx, hwD)
+	if err != nil {
+		t.Fatalf("gen code D: %v", err)
+	}
+	if _, _, err := env.env.pairingStore.ClaimDevice(ctx, codeD, numD, "Phone D", hhD.ID); err != nil {
+		t.Fatalf("claim D: %v", err)
+	}
+
+	tokenD, _, err := env.env.authStore.CreateSession(ctx, userD.ID, auth.SessionTTL)
+	if err != nil {
+		t.Fatalf("create session D: %v", err)
+	}
+	reqD, _ := http.NewRequest(http.MethodGet,
+		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+	reqD.AddCookie(&http.Cookie{Name: auth.CookieName, Value: tokenD})
+	respD, err := env.env.srv.Client().Do(reqD)
+	if err != nil {
+		t.Fatalf("do D: %v", err)
+	}
+	_ = respD.Body.Close()
+	if respD.StatusCode != http.StatusNotFound {
+		t.Errorf("unrelated user: got %d want 404", respD.StatusCode)
+	}
+}
+
 // TestRequireConferenceOwnership verifies the conference-scope auth helper.
 // Any household that directly owns at least one member may observe; others
 // get 404; unknown conferences get 404; linked households do NOT grant

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -97,7 +97,15 @@ func newLHEnv(t *testing.T) lhSetup {
 	// All DELETEs are idempotent against missing rows.
 	t.Cleanup(func() {
 		_, _ = db.Exec("DELETE FROM call_link_health WHERE call_id IN (SELECT id FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3))", numA, numB, numC)
+		// Conference-scoped link-health rows. Phase 2 flush writes rows with
+		// conference_id set; the existing call_id-scoped delete above does
+		// not catch them.
+		_, _ = db.Exec("DELETE FROM call_link_health WHERE conference_id IN (SELECT id FROM conferences WHERE host_phone IN ($1,$2,$3))", numA, numB, numC)
 		_, _ = db.Exec("DELETE FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3)", numA, numB, numC)
+		// conference_members before conferences (FK cascade would also work,
+		// but keeping the deletes explicit matches the pattern).
+		_, _ = db.Exec("DELETE FROM conference_members WHERE conference_id IN (SELECT id FROM conferences WHERE host_phone IN ($1,$2,$3))", numA, numB, numC)
+		_, _ = db.Exec("DELETE FROM conferences WHERE host_phone IN ($1,$2,$3)", numA, numB, numC)
 		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id IN ($1,$2,$3)", hwA, hwB, hwC)
 		_, _ = db.Exec("DELETE FROM lines WHERE number IN ($1,$2,$3)", numA, numB, numC)
 		_, _ = db.Exec("DELETE FROM household_links WHERE household_a_id IN (SELECT id FROM households WHERE name IN ($1,$2,$3)) OR household_b_id IN (SELECT id FROM households WHERE name IN ($1,$2,$3))", hhNameA, hhNameB, hhNameC)

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -655,27 +655,11 @@ func TestDashboardLineCardLinksToCallLive(t *testing.T) {
 func TestConferenceLinkHealthJSON(t *testing.T) {
 	env := newLHEnv(t)
 	ctx := context.Background()
-	tr := env.env.tracker
-
-	// Seed two 2-party calls and merge into a conference. All three phones
-	// are owned by separate households (A, B, C); A is host.
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
-	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
+	confID := startConference(t, env)
 
 	// Record one per-edge sample so the JSON carries a non-empty window.
 	loss := float32(1.5)
-	env.env.healthStore.RecordEdge(conf.ID, env.numA, env.numB,
+	env.env.healthStore.RecordEdge(confID, env.numA, env.numB,
 		calls.Sample{TS: time.Unix(0, 1), LossPct: &loss})
 
 	// GET as user A.
@@ -684,7 +668,7 @@ func TestConferenceLinkHealthJSON(t *testing.T) {
 		t.Fatalf("create session A: %v", err)
 	}
 	req, _ := http.NewRequest(http.MethodGet,
-		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+		env.env.srv.URL+"/api/conference/"+confID.String()+"/link-health", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := env.env.srv.Client().Do(req)
 	if err != nil {
@@ -700,8 +684,8 @@ func TestConferenceLinkHealthJSON(t *testing.T) {
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("decode body: %v; body=%s", err, string(body))
 	}
-	if got.ConfID != conf.ID {
-		t.Fatalf("ConfID: got %s want %s", got.ConfID, conf.ID)
+	if got.ConfID != confID {
+		t.Fatalf("ConfID: got %s want %s", got.ConfID, confID)
 	}
 	if got.Ended {
 		t.Errorf("expected Ended=false for a live conference; got true")
@@ -743,41 +727,13 @@ func TestConferenceLinkHealthJSON(t *testing.T) {
 
 	// 404 for a user whose household owns no conference member (parallels
 	// TestRequireConferenceOwnership userD case, but via HTTP).
-	numD := nextPhone()
-	hwD := "json-d-" + numD
-	emailD := "json-d-" + numD + "@example.com"
-	hhNameD := "JSON D " + numD
-	t.Cleanup(func() {
-		db := env.env.database.DB
-		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
-		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
-		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
-		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
-		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
-		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
-	})
-	userD, err := env.env.authStore.CreateUser(ctx, emailD, "JSON D", nil)
-	if err != nil {
-		t.Fatalf("create user D: %v", err)
-	}
-	hhD, err := env.env.householdStore.Create(ctx, hhNameD, userD.ID)
-	if err != nil {
-		t.Fatalf("create household D: %v", err)
-	}
-	codeD, err := env.env.pairingStore.GenerateCode(ctx, hwD)
-	if err != nil {
-		t.Fatalf("gen code D: %v", err)
-	}
-	if _, _, err := env.env.pairingStore.ClaimDevice(ctx, codeD, numD, "Phone D", hhD.ID); err != nil {
-		t.Fatalf("claim D: %v", err)
-	}
-
+	userD := seedUnrelatedUser(t, env.env, "json-d")
 	tokenD, _, err := env.env.authStore.CreateSession(ctx, userD.ID, auth.SessionTTL)
 	if err != nil {
 		t.Fatalf("create session D: %v", err)
 	}
 	reqD, _ := http.NewRequest(http.MethodGet,
-		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+		env.env.srv.URL+"/api/conference/"+confID.String()+"/link-health", nil)
 	reqD.AddCookie(&http.Cookie{Name: auth.CookieName, Value: tokenD})
 	respD, err := env.env.srv.Client().Do(reqD)
 	if err != nil {
@@ -795,34 +751,18 @@ func TestConferenceLinkHealthJSON(t *testing.T) {
 // observation (parity with requireCallEndpointOwnership).
 func TestRequireConferenceOwnership(t *testing.T) {
 	env := newLHEnv(t)
-	ctx := context.Background()
-	tr := env.env.tracker
-
-	// Seed two 2-party calls and merge into a conference.
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
-	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
+	confID := startConference(t, env)
 
 	// Use the Handler that shares state with the tracker used to seed data above.
 	h := env.env.handler
 
 	check := func(label, userID string, wantOK bool, wantCode int) {
 		t.Helper()
-		req := httptest.NewRequest(http.MethodGet, "/conference/live/"+conf.ID.String(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/conference/live/"+confID.String(), nil)
 		ctx2 := context.WithValue(req.Context(), auth.UserContextKey, &auth.User{ID: userID, Email: "x", Name: "x"})
 		req = req.WithContext(ctx2)
 		rec := httptest.NewRecorder()
-		_, _, _, ok := h.requireConferenceOwnership(rec, req, conf.ID)
+		_, _, _, ok := h.requireConferenceOwnership(rec, req, confID)
 		if ok != wantOK {
 			t.Errorf("%s: ok=%v want %v", label, ok, wantOK)
 		}
@@ -845,41 +785,7 @@ func TestRequireConferenceOwnership(t *testing.T) {
 	check("userC (member household)", env.userC.ID, true, 0)
 
 	// A user whose household owns no conference member gets 404.
-	numD := nextPhone()
-	hwD := "ownership-d-" + numD
-	emailD := "ownership-d-" + numD + "@example.com"
-	hhNameD := "Ownership D " + numD
-
-	// Register cleanup BEFORE any fallible DB work so partial-setup failures
-	// don't leak rows. All DELETEs are idempotent against missing rows.
-	t.Cleanup(func() {
-		db := env.env.database.DB
-		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
-		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
-		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
-		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
-		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
-		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
-	})
-
-	userD, err := env.env.authStore.CreateUser(context.Background(), emailD, "User D", nil)
-	if err != nil {
-		t.Fatalf("create user D: %v", err)
-	}
-	hhD, err := env.env.householdStore.Create(context.Background(), hhNameD, userD.ID)
-	if err != nil {
-		t.Fatalf("create household D: %v", err)
-	}
-	// Seed a line owned by D so ownedLinesForUser returns non-empty (proving
-	// the 404 is due to lack of conference membership, not lack of any line).
-	codeD, err := env.env.pairingStore.GenerateCode(context.Background(), hwD)
-	if err != nil {
-		t.Fatalf("gen code D: %v", err)
-	}
-	if _, _, err := env.env.pairingStore.ClaimDevice(context.Background(), codeD, numD, "Phone D", hhD.ID); err != nil {
-		t.Fatalf("claim D: %v", err)
-	}
-
+	userD := seedUnrelatedUser(t, env.env, "ownership-d")
 	check("userD (unrelated household)", userD.ID, false, http.StatusNotFound)
 
 	// Unknown conference ID returns 404.
@@ -899,24 +805,10 @@ func TestRequireConferenceOwnership(t *testing.T) {
 
 func TestConferenceLiveDetailPage_OwnerRenders(t *testing.T) {
 	s := newLHEnv(t)
-	ctx := context.Background()
-	tr := s.env.tracker
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
-	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
+	confID := startConference(t, s)
 
 	client := authedClient(t, s, s.userA)
-	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+conf.ID.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+confID.String(), nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
@@ -929,7 +821,7 @@ func TestConferenceLiveDetailPage_OwnerRenders(t *testing.T) {
 	}
 	bodyStr := string(body)
 	for _, want := range []string{
-		"/api/conference/" + conf.ID.String() + "/link-health/stream",
+		"/api/conference/" + confID.String() + "/link-health/stream",
 		s.numA, s.numB, s.numC,
 		"deck-matrix",
 	} {
@@ -941,27 +833,13 @@ func TestConferenceLiveDetailPage_OwnerRenders(t *testing.T) {
 
 func TestConferenceLiveDetailPage_EndedRendersTerminalNoSSE(t *testing.T) {
 	s := newLHEnv(t)
-	ctx := context.Background()
-	tr := s.env.tracker
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numB)
-	_ = tr.OnCallAnswered(ctx, s.numA, s.numC)
-	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
-	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+	confID := startConference(t, s)
+	if err := s.env.tracker.EndConferencePersistent(context.Background(), confID, "host_hangup"); err != nil {
 		t.Fatalf("end: %v", err)
 	}
 
 	client := authedClient(t, s, s.userA)
-	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+conf.ID.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, s.env.srv.URL+"/conference/live/"+confID.String(), nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
@@ -1001,36 +879,22 @@ func TestConferenceLiveDetailPage_UnknownUUID_404(t *testing.T) {
 func TestConferenceLinkHealthJSON_DBFallback(t *testing.T) {
 	env := newLHEnv(t)
 	ctx := context.Background()
-	tr := env.env.tracker
-
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
-		t.Fatalf("seed call A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
-		t.Fatalf("seed call A->C: %v", err)
-	}
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
-	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
-	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
+	confID := startConference(t, env)
 
 	// Record + flush one per-edge sample, then end the conference so the
 	// in-memory ring is evicted. Subsequent reads must come from the DB.
 	loss := float32(2.5)
-	env.env.healthStore.RecordEdge(conf.ID, env.numA, env.numB,
+	env.env.healthStore.RecordEdge(confID, env.numA, env.numB,
 		calls.Sample{TS: time.Unix(0, 1000), LossPct: &loss})
 	if err := env.env.healthStore.FlushOnce(ctx); err != nil {
 		t.Fatalf("FlushOnce: %v", err)
 	}
-	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+	if err := env.env.tracker.EndConferencePersistent(ctx, confID, "host_hangup"); err != nil {
 		t.Fatalf("EndConferencePersistent: %v", err)
 	}
 
 	// Confirm the in-memory window is now empty.
-	if w := env.env.healthStore.WindowEdge(conf.ID, env.numA, env.numB); len(w) != 0 {
+	if w := env.env.healthStore.WindowEdge(confID, env.numA, env.numB); len(w) != 0 {
 		t.Fatalf("expected in-memory window to be empty post-evict; got %d", len(w))
 	}
 
@@ -1041,7 +905,7 @@ func TestConferenceLinkHealthJSON_DBFallback(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 	req, _ := http.NewRequest(http.MethodGet,
-		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+		env.env.srv.URL+"/api/conference/"+confID.String()+"/link-health", nil)
 	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
 	resp, err := env.env.srv.Client().Do(req)
 	if err != nil {

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -23,12 +23,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 )
@@ -639,5 +641,101 @@ func TestDashboardLineCardLinksToCallLive(t *testing.T) {
 	expected := `href="/call/live/` + strconv.FormatInt(callID, 10) + `"`
 	if !strings.Contains(bodyStr, expected) {
 		t.Fatalf("dashboard missing link %q", expected)
+	}
+}
+
+// TestRequireConferenceOwnership verifies the conference-scope auth helper.
+// Any household that directly owns at least one member may observe; others
+// get 404; unknown conferences get 404; linked households do NOT grant
+// observation (parity with requireCallEndpointOwnership).
+func TestRequireConferenceOwnership(t *testing.T) {
+	env := newLHEnv(t)
+	ctx := context.Background()
+	tr := env.env.tracker
+
+	// Seed two 2-party calls and merge into a conference.
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
+	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	// Use the Handler that shares state with the tracker used to seed data above.
+	h := env.env.handler
+
+	check := func(label, userID string, wantOK bool, wantCode int) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/conference/live/"+conf.ID.String(), nil)
+		ctx2 := context.WithValue(req.Context(), auth.UserContextKey, &auth.User{ID: userID, Email: "x", Name: "x"})
+		req = req.WithContext(ctx2)
+		rec := httptest.NewRecorder()
+		_, _, _, ok := h.requireConferenceOwnership(rec, req, conf.ID)
+		if ok != wantOK {
+			t.Errorf("%s: ok=%v want %v", label, ok, wantOK)
+		}
+		if !wantOK && rec.Code != wantCode {
+			t.Errorf("%s: code=%d want %d", label, rec.Code, wantCode)
+		}
+	}
+
+	// Household A owns the host line: expect ok.
+	check("userA (host household)", env.userA.ID, true, 0)
+	// Household B owns an added-member line: expect ok.
+	check("userB (member household)", env.userB.ID, true, 0)
+	// Household C owns an added-member line: expect ok.
+	check("userC (member household)", env.userC.ID, true, 0)
+
+	// A user whose household owns no conference member gets 404.
+	numD := nextPhone()
+	userD, err := env.env.authStore.CreateUser(context.Background(), "ownership-d-"+numD+"@example.com", "User D", nil)
+	if err != nil {
+		t.Fatalf("create user D: %v", err)
+	}
+	hhD, err := env.env.householdStore.Create(context.Background(), "Ownership D "+numD, userD.ID)
+	if err != nil {
+		t.Fatalf("create household D: %v", err)
+	}
+	// Seed a line owned by D so ownedLinesForUser returns non-empty (proving
+	// the 404 is due to lack of conference membership, not lack of any line).
+	hwD := "ownership-d-" + numD
+	codeD, err := env.env.pairingStore.GenerateCode(context.Background(), hwD)
+	if err != nil {
+		t.Fatalf("gen code D: %v", err)
+	}
+	if _, _, err := env.env.pairingStore.ClaimDevice(context.Background(), codeD, numD, "Phone D", hhD.ID); err != nil {
+		t.Fatalf("claim D: %v", err)
+	}
+	t.Cleanup(func() {
+		db := env.env.database.DB
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
+		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id = $1", hhD.ID)
+		_, _ = db.Exec("DELETE FROM households WHERE id = $1", hhD.ID)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id = $1", userD.ID)
+		_, _ = db.Exec("DELETE FROM users WHERE id = $1", userD.ID)
+	})
+
+	check("userD (unrelated household)", userD.ID, false, http.StatusNotFound)
+
+	// Unknown conference ID returns 404.
+	unknownID := uuid.New()
+	req := httptest.NewRequest(http.MethodGet, "/conference/live/"+unknownID.String(), nil)
+	reqCtx := context.WithValue(req.Context(), auth.UserContextKey, &auth.User{ID: env.userA.ID, Email: "x", Name: "x"})
+	req = req.WithContext(reqCtx)
+	rec := httptest.NewRecorder()
+	_, _, _, ok := h.requireConferenceOwnership(rec, req, unknownID)
+	if ok {
+		t.Error("unknown conference id: should not be ok")
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown conference id: code=%d want 404", rec.Code)
 	}
 }

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -562,7 +562,7 @@ func TestCallLiveDetail_OwnerRenders(t *testing.T) {
 	s.env.healthStore.Record(callID, s.numA, calls.Sample{TS: time.Now(), LossPct: &loss})
 
 	resp := authedGet(t, s, s.userA, "/call/live/"+strconv.FormatInt(callID, 10))
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d want 200", resp.StatusCode)
 	}
@@ -592,7 +592,7 @@ func TestCallLiveDetail_UnrelatedHouseholdGets404(t *testing.T) {
 	callID := startCall(t, s, s.numA, s.numB)
 
 	resp := authedGet(t, s, s.userC, "/call/live/"+strconv.FormatInt(callID, 10))
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("status: got %d want 404", resp.StatusCode)
 	}
@@ -607,7 +607,7 @@ func TestCallLiveDetail_EndedCallStillRenders(t *testing.T) {
 	}
 
 	resp := authedGet(t, s, s.userA, "/call/live/"+strconv.FormatInt(callID, 10))
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d want 200 (postmortem view)", resp.StatusCode)
 	}
@@ -632,7 +632,7 @@ func TestDashboardLineCardLinksToCallLive(t *testing.T) {
 	callID := startCall(t, s, s.numA, s.numB)
 
 	resp := authedGet(t, s, s.userA, "/")
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: got %d want 200", resp.StatusCode)
 	}
@@ -694,6 +694,9 @@ func TestConferenceLinkHealthJSON(t *testing.T) {
 	}
 	if got.ConfID != conf.ID {
 		t.Fatalf("ConfID: got %s want %s", got.ConfID, conf.ID)
+	}
+	if got.Ended {
+		t.Errorf("expected Ended=false for a live conference; got true")
 	}
 	if len(got.Members) != 3 {
 		t.Fatalf("Members len: got %d want 3", len(got.Members))
@@ -883,5 +886,91 @@ func TestRequireConferenceOwnership(t *testing.T) {
 	}
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("unknown conference id: code=%d want 404", rec.Code)
+	}
+}
+
+// TestConferenceLinkHealthJSON_DBFallback verifies that after a conference
+// ends and its in-memory rings are evicted, ReadbackEdge restores the edge
+// window from the flushed DB rows so the JSON response still carries
+// historical samples.
+func TestConferenceLinkHealthJSON_DBFallback(t *testing.T) {
+	env := newLHEnv(t)
+	ctx := context.Background()
+	tr := env.env.tracker
+
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numB); err != nil {
+		t.Fatalf("seed call A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, env.numA, env.numC); err != nil {
+		t.Fatalf("seed call A->C: %v", err)
+	}
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numB)
+	_ = tr.OnCallAnswered(ctx, env.numA, env.numC)
+	originatingCallID := tr.CallIDForPair(ctx, env.numA, env.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, env.numA, originatingCallID, []string{env.numB, env.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+
+	// Record + flush one per-edge sample, then end the conference so the
+	// in-memory ring is evicted. Subsequent reads must come from the DB.
+	loss := float32(2.5)
+	env.env.healthStore.RecordEdge(conf.ID, env.numA, env.numB,
+		calls.Sample{TS: time.Unix(0, 1000), LossPct: &loss})
+	if err := env.env.healthStore.FlushOnce(ctx); err != nil {
+		t.Fatalf("FlushOnce: %v", err)
+	}
+	if err := tr.EndConferencePersistent(ctx, conf.ID, "host_hangup"); err != nil {
+		t.Fatalf("EndConferencePersistent: %v", err)
+	}
+
+	// Confirm the in-memory window is now empty.
+	if w := env.env.healthStore.WindowEdge(conf.ID, env.numA, env.numB); len(w) != 0 {
+		t.Fatalf("expected in-memory window to be empty post-evict; got %d", len(w))
+	}
+
+	// GET the JSON endpoint as user A. The A->B edge should carry the
+	// flushed sample from the DB fallback.
+	token, _, err := env.env.authStore.CreateSession(ctx, env.userA.ID, auth.SessionTTL)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet,
+		env.env.srv.URL+"/api/conference/"+conf.ID.String()+"/link-health", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := env.env.srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", resp.StatusCode, string(body))
+	}
+
+	var got ConferenceLinkHealthResp
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !got.Ended {
+		t.Error("expected Ended=true for an ended conference")
+	}
+
+	var foundHostToB bool
+	for _, e := range got.Edges {
+		if e.From == env.numA && e.Peer == env.numB {
+			foundHostToB = true
+			if e.Latest == nil {
+				t.Errorf("A->B edge Latest should be populated from DB fallback")
+			} else if e.Latest.LossPct == nil || *e.Latest.LossPct != 2.5 {
+				t.Errorf("A->B edge LossPct not preserved: %+v", e.Latest)
+			}
+			if len(e.Window) == 0 {
+				t.Errorf("A->B edge Window should be non-empty from DB fallback")
+			}
+		}
+	}
+	if !foundHostToB {
+		t.Errorf("A->B edge missing from response")
 	}
 }

--- a/server/internal/web/sse_integration_test.go
+++ b/server/internal/web/sse_integration_test.go
@@ -384,6 +384,12 @@ func TestConferenceSSEStream_ReceivesSampleOnRecordEdge(t *testing.T) {
 		t.Fatalf("drain initial: %v", err)
 	}
 
+	// Give the handler goroutine time to reach SubscribeConference after
+	// flushing the initial snapshot. Without this, a RecordEdge that fires
+	// immediately may miss the not-yet-registered subscriber. Matches the
+	// pattern in TestSSEStream_ReceivesSamples.
+	time.Sleep(50 * time.Millisecond)
+
 	// RecordEdge after subscription is live.
 	loss := float32(1.25)
 	s.env.healthStore.RecordEdge(confID, s.numA, s.numB,
@@ -422,6 +428,11 @@ func TestConferenceSSEStream_ReceivesEndedOnEvict(t *testing.T) {
 	if _, _, err := readSSEFrame(t, ctx, sr); err != nil {
 		t.Fatalf("drain initial: %v", err)
 	}
+
+	// Same subscribe-window sleep as the sample-event test; cheap
+	// consistency insurance even though EvictConference closes the
+	// channel rather than broadcasting.
+	time.Sleep(50 * time.Millisecond)
 
 	// EndConferencePersistent fires EvictConference which closes the subscription.
 	if err := s.env.tracker.EndConferencePersistent(context.Background(), confID, "host_hangup"); err != nil {

--- a/server/internal/web/sse_integration_test.go
+++ b/server/internal/web/sse_integration_test.go
@@ -411,12 +411,15 @@ func TestConferenceSSEStream_ReceivesEndedOnEvict(t *testing.T) {
 		t.Fatalf("EndConferencePersistent: %v", err)
 	}
 
-	ev, _, err := readSSEFrame(t, ctx, sr)
+	ev, data, err := readSSEFrame(t, ctx, sr)
 	if err != nil {
 		t.Fatalf("read ended frame: %v", err)
 	}
 	if ev != "ended" {
 		t.Fatalf("event on evict: got %q want ended", ev)
+	}
+	if !strings.Contains(data, "Conference") {
+		t.Fatalf("ended data missing conference copy: %q", data)
 	}
 }
 

--- a/server/internal/web/sse_integration_test.go
+++ b/server/internal/web/sse_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/calls"
 )
 
@@ -286,5 +287,218 @@ func TestSSEStream_EndedCallGets404(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("ended call: got %d want 404", resp.StatusCode)
+	}
+}
+
+// startConference seeds two 2-party calls (host->A, host->B where host is
+// numA, A is numB, B is numC), then merges them into a conference. Returns
+// the conference UUID. Caller owns cleanup via t.Cleanup on any rows
+// created (newLHEnv already cleans up calls table).
+func startConference(t *testing.T, s lhSetup) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	tr := s.env.tracker
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("OnCallInitiated A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("OnCallInitiated A->C: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("OnCallAnswered A->B: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("OnCallAnswered A->C: %v", err)
+	}
+	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+	return conf.ID
+}
+
+// confStreamURL builds the SSE stream endpoint URL for a conference UUID.
+func confStreamURL(s lhSetup, confID uuid.UUID) string {
+	return s.env.srv.URL + "/api/conference/" + confID.String() + "/link-health/stream"
+}
+
+func TestConferenceSSEStream_ReceivesInitialSample(t *testing.T) {
+	s := newLHEnv(t)
+	confID := startConference(t, s)
+
+	client := authedClient(t, s, s.userA)
+	req, err := http.NewRequest("GET", confStreamURL(s, confID), nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type: got %q want text/event-stream", ct)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	event, data, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read initial frame: %v", err)
+	}
+	if event != "sample" {
+		t.Fatalf("initial event: got %q want sample", event)
+	}
+	// The data is the rendered matrix partial -- just verify it contains
+	// the matrix wrapper element so we know it is the conference partial.
+	if !strings.Contains(data, "deck-matrix") {
+		t.Fatalf("initial data missing matrix marker; data=%q", data)
+	}
+}
+
+func TestConferenceSSEStream_ReceivesSampleOnRecordEdge(t *testing.T) {
+	s := newLHEnv(t)
+	confID := startConference(t, s)
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest("GET", confStreamURL(s, confID), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	// Drain the initial sample.
+	if _, _, err := readSSEFrame(t, ctx, sr); err != nil {
+		t.Fatalf("drain initial: %v", err)
+	}
+
+	// RecordEdge after subscription is live.
+	loss := float32(1.25)
+	s.env.healthStore.RecordEdge(confID, s.numA, s.numB,
+		calls.Sample{TS: time.Now(), LossPct: &loss})
+
+	ev, data, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read post-record frame: %v", err)
+	}
+	if ev != "sample" {
+		t.Fatalf("post-record event: got %q want sample", ev)
+	}
+	if !strings.Contains(data, "1.2%") && !strings.Contains(data, "1.3%") {
+		// The matrix renders LossPct with "%.1f%%" so 1.25 displays as "1.2%"
+		// or "1.3%" depending on rounding mode. Accept either.
+		t.Errorf("post-record data missing rendered lossPct; data=%q", data)
+	}
+}
+
+func TestConferenceSSEStream_ReceivesEndedOnEvict(t *testing.T) {
+	s := newLHEnv(t)
+	confID := startConference(t, s)
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest("GET", confStreamURL(s, confID), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	if _, _, err := readSSEFrame(t, ctx, sr); err != nil {
+		t.Fatalf("drain initial: %v", err)
+	}
+
+	// EndConferencePersistent fires EvictConference which closes the subscription.
+	if err := s.env.tracker.EndConferencePersistent(context.Background(), confID, "host_hangup"); err != nil {
+		t.Fatalf("EndConferencePersistent: %v", err)
+	}
+
+	ev, _, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read ended frame: %v", err)
+	}
+	if ev != "ended" {
+		t.Fatalf("event on evict: got %q want ended", ev)
+	}
+}
+
+func TestConferenceSSEStream_UnrelatedHouseholdGets404(t *testing.T) {
+	s := newLHEnv(t)
+	confID := startConference(t, s)
+
+	// Create a fourth user in a fourth household that owns a line but is
+	// NOT a conference member.
+	numD := nextPhone()
+	hwD := "conf-sse-d-" + numD
+	emailD := "conf-sse-d-" + numD + "@example.com"
+	hhNameD := "Conf SSE D " + numD
+	t.Cleanup(func() {
+		db := s.env.database.DB
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
+		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
+		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
+		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
+	})
+	userD, err := s.env.authStore.CreateUser(context.Background(), emailD, "Conf SSE D", nil)
+	if err != nil {
+		t.Fatalf("create user D: %v", err)
+	}
+	hhD, err := s.env.householdStore.Create(context.Background(), hhNameD, userD.ID)
+	if err != nil {
+		t.Fatalf("create household D: %v", err)
+	}
+	codeD, err := s.env.pairingStore.GenerateCode(context.Background(), hwD)
+	if err != nil {
+		t.Fatalf("gen code D: %v", err)
+	}
+	if _, _, err := s.env.pairingStore.ClaimDevice(context.Background(), codeD, numD, "Phone D", hhD.ID); err != nil {
+		t.Fatalf("claim D: %v", err)
+	}
+
+	client := authedClient(t, s, userD)
+	req, _ := http.NewRequest("GET", confStreamURL(s, confID), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unrelated user: got %d want 404", resp.StatusCode)
+	}
+}
+
+func TestConferenceSSEStream_EndedConferenceGets404(t *testing.T) {
+	s := newLHEnv(t)
+	confID := startConference(t, s)
+	if err := s.env.tracker.EndConferencePersistent(context.Background(), confID, "host_hangup"); err != nil {
+		t.Fatalf("EndConferencePersistent: %v", err)
+	}
+
+	client := authedClient(t, s, s.userA)
+	req, _ := http.NewRequest("GET", confStreamURL(s, confID), nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("ended conference: got %d want 404", resp.StatusCode)
 	}
 }

--- a/server/internal/web/sse_integration_test.go
+++ b/server/internal/web/sse_integration_test.go
@@ -290,34 +290,6 @@ func TestSSEStream_EndedCallGets404(t *testing.T) {
 	}
 }
 
-// startConference seeds two 2-party calls (host->A, host->B where host is
-// numA, A is numB, B is numC), then merges them into a conference. Returns
-// the conference UUID. Caller owns cleanup via t.Cleanup on any rows
-// created (newLHEnv already cleans up calls table).
-func startConference(t *testing.T, s lhSetup) uuid.UUID {
-	t.Helper()
-	ctx := context.Background()
-	tr := s.env.tracker
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
-		t.Fatalf("OnCallInitiated A->B: %v", err)
-	}
-	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
-		t.Fatalf("OnCallInitiated A->C: %v", err)
-	}
-	if err := tr.OnCallAnswered(ctx, s.numA, s.numB); err != nil {
-		t.Fatalf("OnCallAnswered A->B: %v", err)
-	}
-	if err := tr.OnCallAnswered(ctx, s.numA, s.numC); err != nil {
-		t.Fatalf("OnCallAnswered A->C: %v", err)
-	}
-	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
-	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
-	if err != nil {
-		t.Fatalf("CreateConferencePersistent: %v", err)
-	}
-	return conf.ID
-}
-
 // confStreamURL builds the SSE stream endpoint URL for a conference UUID.
 func confStreamURL(s lhSetup, confID uuid.UUID) string {
 	return s.env.srv.URL + "/api/conference/" + confID.String() + "/link-health/stream"
@@ -454,34 +426,7 @@ func TestConferenceSSEStream_UnrelatedHouseholdGets404(t *testing.T) {
 
 	// Create a fourth user in a fourth household that owns a line but is
 	// NOT a conference member.
-	numD := nextPhone()
-	hwD := "conf-sse-d-" + numD
-	emailD := "conf-sse-d-" + numD + "@example.com"
-	hhNameD := "Conf SSE D " + numD
-	t.Cleanup(func() {
-		db := s.env.database.DB
-		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwD)
-		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", numD)
-		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhNameD)
-		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhNameD)
-		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", emailD)
-		_, _ = db.Exec("DELETE FROM users WHERE email = $1", emailD)
-	})
-	userD, err := s.env.authStore.CreateUser(context.Background(), emailD, "Conf SSE D", nil)
-	if err != nil {
-		t.Fatalf("create user D: %v", err)
-	}
-	hhD, err := s.env.householdStore.Create(context.Background(), hhNameD, userD.ID)
-	if err != nil {
-		t.Fatalf("create household D: %v", err)
-	}
-	codeD, err := s.env.pairingStore.GenerateCode(context.Background(), hwD)
-	if err != nil {
-		t.Fatalf("gen code D: %v", err)
-	}
-	if _, _, err := s.env.pairingStore.ClaimDevice(context.Background(), codeD, numD, "Phone D", hhD.ID); err != nil {
-		t.Fatalf("claim D: %v", err)
-	}
+	userD := seedUnrelatedUser(t, s.env, "conf-sse-d")
 
 	client := authedClient(t, s, userD)
 	req, _ := http.NewRequest("GET", confStreamURL(s, confID), nil)

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2570,3 +2570,55 @@ body.dialup .phone-silent__text {
 .update-details--mobile > summary { display: inline-flex; align-items: center; gap: 4px; }
 .update-details--mobile .update-notes { max-width: none; margin-top: 6px; }
 
+
+/* --------- Conference observation deck: 3x3 edge matrix --------- */
+.deck-matrix {
+  display: grid;
+  grid-template-columns: auto repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 16px;
+}
+.deck-matrix__head {
+  padding: 4px 8px;
+  color: var(--ink-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.deck-matrix__cell {
+  border: 1px solid var(--rule-soft);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--paper-2);
+}
+.deck-matrix__cell--blank {
+  background: transparent;
+  border: 1px dashed var(--rule-soft);
+  opacity: 0.3;
+}
+.deck-matrix__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 0;
+}
+.deck-matrix__lbl {
+  font-size: 10px;
+  color: var(--ink-muted);
+}
+.deck-matrix__val {
+  font-size: 13px;
+  color: var(--ink);
+}
+@media (max-width: 640px) {
+  .deck-matrix {
+    grid-template-columns: 1fr;
+  }
+  .deck-matrix__head {
+    display: none;
+  }
+  .deck-matrix__cell--blank {
+    display: none;
+  }
+}

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1803,3 +1803,55 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
 .update-details--mobile > summary { display: inline-flex; align-items: center; gap: 4px; }
 .update-details--mobile .update-notes { max-width: none; margin-top: 6px; }
 
+
+/* --------- Conference observation deck: 3x3 edge matrix --------- */
+.deck-matrix {
+  display: grid;
+  grid-template-columns: auto repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 16px;
+}
+.deck-matrix__head {
+  padding: 4px 8px;
+  color: var(--ink-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.deck-matrix__cell {
+  border: 1px solid var(--rule-soft);
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: var(--paper-2);
+}
+.deck-matrix__cell--blank {
+  background: transparent;
+  border: 1px dashed var(--rule-soft);
+  opacity: 0.3;
+}
+.deck-matrix__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 0;
+}
+.deck-matrix__lbl {
+  font-size: 10px;
+  color: var(--ink-muted);
+}
+.deck-matrix__val {
+  font-size: 13px;
+  color: var(--ink);
+}
+@media (max-width: 640px) {
+  .deck-matrix {
+    grid-template-columns: 1fr;
+  }
+  .deck-matrix__head {
+    display: none;
+  }
+  .deck-matrix__cell--blank {
+    display: none;
+  }
+}

--- a/server/internal/web/templates/_conference-live-panel.html
+++ b/server/internal/web/templates/_conference-live-panel.html
@@ -1,22 +1,20 @@
 {{define "conference-live-panel"}}
-<div class="deck-panel__inner">
-  <div class="deck-matrix">
-    <div class="deck-matrix__head"></div>
-    {{range .Members}}<div class="deck-matrix__head label">to {{.DisplayName}}</div>{{end}}
-    {{range $row := .Members}}
-      <div class="deck-matrix__head label">from {{$row.DisplayName}}</div>
-      {{range $col := $.Members}}
-        {{if eq $row.Number $col.Number}}
-          <div class="deck-matrix__cell deck-matrix__cell--blank"></div>
-        {{else}}
-          {{$edge := edgeFor $.Edges $row.Number $col.Number}}
-          <div class="deck-matrix__cell">
-            {{template "deck-matrix-metrics" $edge}}
-          </div>
-        {{end}}
+<div class="deck-matrix">
+  <div class="deck-matrix__head"></div>
+  {{range .Members}}<div class="deck-matrix__head label">to {{.DisplayName}}</div>{{end}}
+  {{range $row := .Members}}
+    <div class="deck-matrix__head label">from {{$row.DisplayName}}</div>
+    {{range $col := $.Members}}
+      {{if eq $row.Number $col.Number}}
+        <div class="deck-matrix__cell deck-matrix__cell--blank"></div>
+      {{else}}
+        {{$edge := edgeFor $.Edges $row.Number $col.Number}}
+        <div class="deck-matrix__cell">
+          {{template "deck-matrix-metrics" $edge}}
+        </div>
       {{end}}
     {{end}}
-  </div>
+  {{end}}
 </div>
 {{end}}
 

--- a/server/internal/web/templates/_conference-live-panel.html
+++ b/server/internal/web/templates/_conference-live-panel.html
@@ -1,0 +1,36 @@
+{{define "conference-live-panel"}}
+<div class="deck-panel__inner">
+  <div class="deck-matrix">
+    <div class="deck-matrix__head"></div>
+    {{range .Members}}<div class="deck-matrix__head label">to {{.DisplayName}}</div>{{end}}
+    {{range $row := .Members}}
+      <div class="deck-matrix__head label">from {{$row.DisplayName}}</div>
+      {{range $col := $.Members}}
+        {{if eq $row.Number $col.Number}}
+          <div class="deck-matrix__cell deck-matrix__cell--blank"></div>
+        {{else}}
+          {{$edge := edgeFor $.Edges $row.Number $col.Number}}
+          <div class="deck-matrix__cell">
+            {{template "deck-matrix-metrics" $edge}}
+          </div>
+        {{end}}
+      {{end}}
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+{{define "deck-matrix-metrics"}}
+<div class="deck-matrix__row">
+  <span class="deck-matrix__lbl label">loss</span>
+  <span class="deck-matrix__val num">
+    {{if and . .Latest .Latest.LossPct}}{{printf "%.1f%%" (derefFloat32 .Latest.LossPct)}}{{else}}&mdash;{{end}}
+  </span>
+</div>
+<div class="deck-matrix__row">
+  <span class="deck-matrix__lbl label">jitter</span>
+  <span class="deck-matrix__val num">
+    {{if and . .Latest .Latest.JitterMs}}{{printf "%.0f ms" (derefFloat32 .Latest.JitterMs)}}{{else}}&mdash;{{end}}
+  </span>
+</div>
+{{end}}

--- a/server/internal/web/templates/calls.html
+++ b/server/internal/web/templates/calls.html
@@ -46,7 +46,7 @@
             </td>
             <td class="num">{{.Conference.CreatedAt.Format "Jan 2 15:04:05"}}</td>
             <td class="num">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&mdash;{{end}}</td>
-            <td></td>
+            <td class="r"><a href="/conference/live/{{.Conference.ID}}" aria-label="View conference details">Details &rarr;</a></td>
           </tr>
           {{else}}
           <tr>
@@ -93,6 +93,7 @@
           <span class="chip chip--conf"><span class="chip__dot"></span>3-way</span>
           <span class="num muted">{{.Conference.CreatedAt.Format "Jan 2 15:04:05"}}</span>
           {{if gt .Conference.DurationS 0}}<span class="num muted">· {{.Conference.DurationS}}s</span>{{end}}
+          <a href="/conference/live/{{.Conference.ID}}" style="margin-left: auto;" aria-label="View conference details">Details &rarr;</a>
         </div>
         {{else}}
         <div class="hstack num" style="font-size: 13px; color: var(--ink); margin-bottom: 6px;">

--- a/server/internal/web/templates/conference-live-detail.html
+++ b/server/internal/web/templates/conference-live-detail.html
@@ -1,7 +1,7 @@
-{{define "title"}}Live conference &mdash; {{len .Conf.Members}} parties{{end}}
+{{define "title"}}Live conference &mdash; {{len .Resp.Members}} parties{{end}}
 
 {{define "content"}}
-<div class="page deck" data-started-at="{{.Conf.CreatedAt.UnixMilli}}">
+<div class="page deck" data-started-at="{{.Resp.CreatedAt.UnixMilli}}">
   <header class="deck-header">
     <div class="deck-header__labels">
       <span class="deck-kicker label">live 3-way</span>
@@ -9,10 +9,10 @@
         {{range $i, $m := .Resp.Members}}{{if $i}} &harr; {{end}}{{$m.DisplayName}}{{end}}
       </h1>
       <div class="deck-meta">
-        <span class="deck-duration" data-duration-since="{{.Conf.CreatedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+        <span class="deck-duration" data-duration-since="{{.Resp.CreatedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
       </div>
     </div>
-    {{if .Ended}}
+    {{if .Resp.Ended}}
       <div class="deck-ended-chip">Ended</div>
     {{end}}
   </header>
@@ -28,8 +28,8 @@
   </div>
 
   <div id="conference-live-panel" class="deck-panel"
-       {{if not .Ended}}hx-ext="sse"
-       sse-connect="/api/conference/{{.Conf.ID}}/link-health/stream"
+       {{if not .Resp.Ended}}hx-ext="sse"
+       sse-connect="/api/conference/{{.Resp.ConfID}}/link-health/stream"
        sse-swap="sample,disconnect,ended"{{end}}>
     {{template "conference-live-panel" .Resp}}
   </div>

--- a/server/internal/web/templates/conference-live-detail.html
+++ b/server/internal/web/templates/conference-live-detail.html
@@ -1,0 +1,70 @@
+{{define "title"}}Live conference &mdash; {{len .Conf.Members}} parties{{end}}
+
+{{define "content"}}
+<div class="page deck" data-started-at="{{.Conf.CreatedAt.UnixMilli}}">
+  <header class="deck-header">
+    <div class="deck-header__labels">
+      <span class="deck-kicker label">live 3-way</span>
+      <h1 class="deck-title">
+        {{range $i, $m := .Resp.Members}}{{if $i}} &harr; {{end}}{{$m.DisplayName}}{{end}}
+      </h1>
+      <div class="deck-meta">
+        <span class="deck-duration" data-duration-since="{{.Conf.CreatedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+      </div>
+    </div>
+    {{if .Ended}}
+      <div class="deck-ended-chip">Ended</div>
+    {{end}}
+  </header>
+
+  <div class="deck-cards">
+    {{range .Resp.Members}}
+      <div class="deck-card{{if .IsHost}} deck-card--host{{end}}">
+        <div class="label">{{if .IsHost}}host{{else}}member{{end}}</div>
+        <div class="deck-card__name">{{.DisplayName}}</div>
+        <div class="deck-card__num num">{{.Number}}</div>
+      </div>
+    {{end}}
+  </div>
+
+  <div id="conference-live-panel" class="deck-panel"
+       {{if not .Ended}}hx-ext="sse"
+       sse-connect="/api/conference/{{.Conf.ID}}/link-health/stream"
+       sse-swap="sample,disconnect,ended"{{end}}>
+    {{template "conference-live-panel" .Resp}}
+  </div>
+
+  <p class="deck-disclaimer">
+    Bars show per-edge loss and jitter. Each member reports its own view of every other member.
+    The server sees the pipe, not the audio.
+  </p>
+</div>
+
+<script>
+  (function () {
+    var el = document.querySelector('.deck-duration');
+    if (!el) return;
+    var since = parseInt(el.getAttribute('data-duration-since'), 10);
+    if (!since) return;
+    function tick() {
+      if (!document.body.contains(el)) return;
+      var now = Date.now();
+      var s = Math.max(0, Math.floor((now - since) / 1000));
+      var h = Math.floor(s / 3600);
+      var m = Math.floor((s % 3600) / 60);
+      var sec = s % 60;
+      function pad(n) { return n < 10 ? '0' + n : String(n); }
+      el.textContent = (h > 0 ? h + ':' : '') + pad(m) + ':' + pad(sec);
+    }
+    tick();
+    var iv = setInterval(tick, 1000);
+
+    document.body.addEventListener('htmx:sseMessage', function (ev) {
+      if (ev.detail && (ev.detail.type === 'ended' || ev.detail.type === 'disconnect')) {
+        clearInterval(iv);
+        setTimeout(function () { location.reload(); }, 800);
+      }
+    });
+  })();
+</script>
+{{end}}

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 
 	"github.com/justinlindh/digits/server/internal/auth"
@@ -263,6 +264,70 @@ func recvMsg(t *testing.T, conn *websocket.Conn) *signaling.Message {
 		t.Fatalf("parse: %v", err)
 	}
 	return msg
+}
+
+// seedUnrelatedUser creates a fresh user + household + line owned by that
+// household, registers cleanup, and returns the user. Use when a test needs
+// a principal whose household owns no conference member line.
+func seedUnrelatedUser(t *testing.T, env callsTestEnv, label string) *auth.User {
+	t.Helper()
+	num := nextPhone()
+	hw := label + "-" + num
+	email := label + "-" + num + "@example.com"
+	hhName := label + " " + num
+	t.Cleanup(func() {
+		db := env.database.DB
+		_, _ = db.Exec("DELETE FROM devices WHERE hardware_id = $1", hw)
+		_, _ = db.Exec("DELETE FROM lines WHERE number = $1", num)
+		_, _ = db.Exec("DELETE FROM household_members WHERE household_id IN (SELECT id FROM households WHERE name = $1)", hhName)
+		_, _ = db.Exec("DELETE FROM households WHERE name = $1", hhName)
+		_, _ = db.Exec("DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE email = $1)", email)
+		_, _ = db.Exec("DELETE FROM users WHERE email = $1", email)
+	})
+	u, err := env.authStore.CreateUser(context.Background(), email, label, nil)
+	if err != nil {
+		t.Fatalf("seedUnrelatedUser %s: CreateUser: %v", label, err)
+	}
+	hh, err := env.householdStore.Create(context.Background(), hhName, u.ID)
+	if err != nil {
+		t.Fatalf("seedUnrelatedUser %s: Create household: %v", label, err)
+	}
+	code, err := env.pairingStore.GenerateCode(context.Background(), hw)
+	if err != nil {
+		t.Fatalf("seedUnrelatedUser %s: GenerateCode: %v", label, err)
+	}
+	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), code, num, "Phone "+label, hh.ID); err != nil {
+		t.Fatalf("seedUnrelatedUser %s: ClaimDevice: %v", label, err)
+	}
+	return u
+}
+
+// startConference seeds two 2-party calls (host->A, host->B where host is
+// numA, A is numB, B is numC), then merges them into a conference. Returns
+// the conference UUID. Caller owns cleanup via t.Cleanup on any rows
+// created (newLHEnv already cleans up calls table).
+func startConference(t *testing.T, s lhSetup) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	tr := s.env.tracker
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("OnCallInitiated A->B: %v", err)
+	}
+	if _, err := tr.OnCallInitiated(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("OnCallInitiated A->C: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, s.numA, s.numB); err != nil {
+		t.Fatalf("OnCallAnswered A->B: %v", err)
+	}
+	if err := tr.OnCallAnswered(ctx, s.numA, s.numC); err != nil {
+		t.Fatalf("OnCallAnswered A->C: %v", err)
+	}
+	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
+	if err != nil {
+		t.Fatalf("CreateConferencePersistent: %v", err)
+	}
+	return conf.ID
 }
 
 // testCookieJar is a minimal cookie jar that attaches a single cookie to all requests.


### PR DESCRIPTION
## What

Phase 3 of 4: read-only observation deck for 3-way conferences at
\`/conference/live/{uuid}\`.

- Page handler + template with N-member header, 3x3 edge matrix,
  duration ticker, SSE-driven per-sample updates. Ended conferences
  render a postmortem via DB readback.
- \`GET /api/conference/{uuid}/link-health\` returns the full 6-edge
  snapshot as JSON.
- \`GET /api/conference/{uuid}/link-health/stream\` SSE: initial matrix
  snapshot, per-RecordEdge sample events, ended event on
  EvictConference, periodic heartbeats.
- \`/calls\` conference rows link to \`/conference/live/{uuid}\`, closing
  the parity gap flagged in Phase 1.
- Dev-only \`POST /test-harness/start-conference\` for the Playwright
  suite.
- Matrix CSS lands in both intercom (digits.css) and dialup.css, with
  a single-column mobile collapse.

## Why

Phase 1/2 landed per-edge recording and persistence. Phase 3 makes it
visible. This PR is read-only; force-disconnect / kick is Phase 4.

## Auth

\`requireConferenceOwnership\` mirrors the 2-party \`requireCallEndpointOwnership\` privacy posture: the authenticated user must directly own
at least one member line. Linked households do NOT grant observation.

## Test plan

- [x] \`go test ./...\`
- [x] \`make test-integration\` -- new coverage: GetConferenceByID
  (active + ended), requireConferenceOwnership (5 cases), JSON
  endpoint happy path + unrelated-household 404 + DB readback
  fallback, SSE initial sample + sample-on-RecordEdge + ended-on-
  Evict + unrelated 404 + ended-conf 404, page render owner/ended/
  unknown-UUID, /calls conference-row link.
- [x] Playwright \`11-conference-live.spec.ts\` in both themes
  (requires a running dev server; tests skip otherwise).
- [x] \`golangci-lint run ./...\` clean.


## Screenshots

Intercom theme, active 3-way with linked-family display names:
![intercom active](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-260-intercom-active.png)

Dialup theme, active 3-way with per-edge loss and jitter:
![dialup active](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-260-dialup-active.png)

Dialup theme, ended conference (terminal state, no SSE wiring):
![dialup ended](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-260-dialup-ended.png)

`/calls` history with the conference row `Details` link (dialup theme):
![calls link](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-260-calls-link.png)

Link-health samples in these shots were injected directly into `call_link_health` for the screenshot; in production they flow from each Pi via `link_health` messages over the signaling socket.
