### PR TITLE
fix(server): contain radio-card input so phone detail stops scroll-jumping on mobile

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -246,6 +246,8 @@ type lineDetailData struct {
 	LatestFirmwareVersion string
 	PiReleases            []updates.Release
 	FWReleases            []updates.Release
+	PiUpdateNotes         []updates.Release
+	FirmwareUpdateNotes   []updates.Release
 	User                  *auth.User
 }
 
@@ -281,13 +283,15 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 
 	var latestPi, latestFw string
 	var piReleases, fwReleases []updates.Release
+	var idx *updates.ReleaseIndex
 	if h.Releases != nil {
-		if idx := h.Releases.ReleaseIndex(); idx != nil {
-			latestPi = idx.Pi.Latest
-			latestFw = idx.Firmware.Latest
-			piReleases = idx.SortedReleases(updates.ComponentPi)
-			fwReleases = idx.SortedReleases(updates.ComponentFirmware)
-		}
+		idx = h.Releases.ReleaseIndex()
+	}
+	if idx != nil {
+		latestPi = idx.Pi.Latest
+		latestFw = idx.Firmware.Latest
+		piReleases = idx.SortedReleases(updates.ComponentPi)
+		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
 
 	hhName, callHistory, loc := h.householdContext(r)
@@ -298,6 +302,16 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	devInfo := h.hub.DeviceInfo(number)
+
+	var piUpdateNotes, firmwareUpdateNotes []updates.Release
+	if idx != nil && devInfo != nil {
+		if latestPi != "" && devInfo.PiVersion != "" && updates.CompareSemver(devInfo.PiVersion, latestPi) < 0 {
+			piUpdateNotes = idx.RangeReleases(updates.ComponentPi, devInfo.PiVersion, latestPi)
+		}
+		if latestFw != "" && devInfo.FirmwareVersion != "" && updates.CompareSemver(devInfo.FirmwareVersion, latestFw) < 0 {
+			firmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, devInfo.FirmwareVersion, latestFw)
+		}
+	}
 
 	user := auth.UserFromContext(r.Context())
 
@@ -315,6 +329,8 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		LatestFirmwareVersion: latestFw,
 		PiReleases:            piReleases,
 		FWReleases:            fwReleases,
+		PiUpdateNotes:         piUpdateNotes,
+		FirmwareUpdateNotes:   firmwareUpdateNotes,
 		User:                  user,
 	})
 }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -710,6 +710,11 @@ body.dialup:not(.crt-all) .dialup-window {
   cursor: pointer;
   border-radius: 0;
   margin: 0;
+  /* Contain the visually-hidden absolute-positioned input; without this it
+     escapes to the initial containing block, expanding <html>'s scroll
+     height. Clicking the label then scrolls the window (not .dialup-main)
+     to the input, pushing the dialup window off screen. */
+  position: relative;
 }
 .radio-card + .radio-card { margin-top: 4px; }
 .radio-card:hover { background: var(--dialup-blue-light); }

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -112,7 +112,21 @@
                 </span>
                 {{if .DeviceInfo.PiCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.PiCommit}}</span>{{end}}
                 {{if and .LatestPiVersion (ne .DeviceInfo.PiVersion .LatestPiVersion)}}
+                  {{if .PiUpdateNotes}}
+                  <details class="update-details" style="display: inline-block;">
+                    <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</summary>
+                    <div class="update-notes">
+                      {{range .PiUpdateNotes}}
+                        <article class="update-note">
+                          <span class="update-note__version">pi {{.Version}}</span>
+                          {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+                        </article>
+                      {{end}}
+                    </div>
+                  </details>
+                  {{else}}
                   <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</span>
+                  {{end}}
                 {{else if .LatestPiVersion}}
                   <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
                 {{end}}
@@ -129,7 +143,21 @@
                   <span class="chip"><span class="chip__dot"></span>SWD</span>
                 {{end}}
                 {{if and .LatestFirmwareVersion (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion)}}
+                  {{if .FirmwareUpdateNotes}}
+                  <details class="update-details" style="display: inline-block;">
+                    <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</summary>
+                    <div class="update-notes">
+                      {{range .FirmwareUpdateNotes}}
+                        <article class="update-note">
+                          <span class="update-note__version">fw {{.Version}}</span>
+                          {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+                        </article>
+                      {{end}}
+                    </div>
+                  </details>
+                  {{else}}
                   <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</span>
+                  {{end}}
                 {{else if .LatestFirmwareVersion}}
                   <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
                 {{end}}


### PR DESCRIPTION
## What

Two changes to `/phones/<number>` on the retro (dialup) theme:

- **Bug fix:** adds `position: relative` to `.radio-card` in `dialup.css`. Without it the hidden absolute `<input>` inside each label escaped to the initial containing block, inflating `<html>`'s scrollHeight. Tapping a label focused the input and the browser's native scroll-to-focused-element scrolled `<html>`, which `<body>`'s `overflow: hidden` at 100vh then clipped out of view. `digits.css` already had this rule; only `dialup.css` was missing it.
- **Release notes on the chip:** wires the existing `/phones` list pattern into `/phones/<num>`. The `X.Y.Z available` chips next to Pi software and Firmware now expand into the already-styled `WHAT'S NEW!` panel, showing the range of release notes between installed and latest. Data was already loaded; the template just wasn't hooked up.

## Why

Reported bug: on mobile with retro theme, opening Update Pi software and tapping the `LATEST` chip scrolled the whole dialup window off screen, leaving only the teal backdrop. No way to recover without reload. Follow-up observation: the equivalent release-notes affordance exists on the phones list page but never made it to the detail page, which was an oversight.

## Bug repro (prod, mobile, retro theme)

After tapping `1.13.0 LATEST` inside Update Pi software the viewport showed only the dialup desktop backdrop:

![bug: viewport is entirely teal after tapping a radio-card label](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-262-bug-viewport-teal.png)

With the CSS fix injected and the same click repeated, content stays on screen:

![after fix: content stays visible](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-262-after-css-fix.png)

## Release notes chip (dev server, mobile, retro theme)

Chip collapsed (device at fw 1.2.0, latest 1.4.0):

![chip collapsed: 1.4.0 AVAILABLE](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-262-chip-closed.png)

Chip expanded into the `WHAT'S NEW!` panel (FW 1.4.0 + FW 1.3.0 notes):

![chip expanded: WHAT'S NEW panel](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-262-chip-whats-new.png)

## Test plan

- [x] `go test ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] Reproduced on prod mobile viewport: tapping `1.13.0 LATEST` scrolled `<html>` to 823px while `<body>` stayed clipped at 100vh, showing only teal
- [x] CSS-injected the fix on prod and re-ran the same click: `<html>` scrollHeight dropped from 2355 to 839 and content stayed on screen
- [x] Verified release-notes chip expansion end-to-end with `TEST_FAKE_UPDATES=1` + `POST /dev/seed-firmware?number=2480001&fw=1.2.0`; tapping the `1.4.0 AVAILABLE` chip on retro mobile viewport showed the `WHAT'S NEW!` panel with FW 1.4.0 and FW 1.3.0 notes