### PR TITLE
fix(ci): chain release-groom from pi/fw release workflows

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -93,6 +93,9 @@ jobs:
   groom:
     needs: release
     if: needs.release.outputs.tag != ''
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/release-groom.yml
     with:
       tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.released_tag.outputs.tag }}
     defaults:
       run:
         working-directory: firmware
@@ -74,8 +76,24 @@ jobs:
             npx semantic-release --extends "$RELEASERC"
           fi
         env:
-          # Publish the release with ADMIN_PAT so that `release: published`
-          # fires downstream workflows (release-groom.yml). Releases created
-          # via the default GITHUB_TOKEN are suppressed by GitHub's recursive
-          # workflow prevention rule.
           GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+
+      - name: Detect released tag
+        id: released_tag
+        working-directory: ${{ github.workspace }}
+        run: |
+          tag=$(git tag --points-at HEAD | grep -E '^fw/v' | sort -V | tail -n1 || true)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [ -n "$tag" ]; then
+            echo "Released $tag"
+          else
+            echo "No firmware release was created"
+          fi
+
+  groom:
+    needs: release
+    if: needs.release.outputs.tag != ''
+    uses: ./.github/workflows/release-groom.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -100,6 +100,9 @@ jobs:
   groom:
     needs: release
     if: needs.release.outputs.tag != ''
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/release-groom.yml
     with:
       tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.released_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -82,8 +84,23 @@ jobs:
             npx semantic-release --extends ./pi/.releaserc.cjs
           fi
         env:
-          # Publish the release with ADMIN_PAT so that `release: published`
-          # fires downstream workflows (release-groom.yml). Releases created
-          # via the default GITHUB_TOKEN are suppressed by GitHub's recursive
-          # workflow prevention rule.
           GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+
+      - name: Detect released tag
+        id: released_tag
+        run: |
+          tag=$(git tag --points-at HEAD | grep -E '^pi/v' | sort -V | tail -n1 || true)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [ -n "$tag" ]; then
+            echo "Released $tag"
+          else
+            echo "No pi release was created"
+          fi
+
+  groom:
+    needs: release
+    if: needs.release.outputs.tag != ''
+    uses: ./.github/workflows/release-groom.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-groom.yml
+++ b/.github/workflows/release-groom.yml
@@ -1,8 +1,20 @@
 name: Groom Release Notes
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to groom (e.g. fw/v1.4.0).'
+        required: true
+        type: string
+      force:
+        description: 'Re-groom even if already groomed.'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
@@ -17,17 +29,13 @@ on:
 
 jobs:
   groom:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'fw/v') ||
-      startsWith(github.event.release.tag_name, 'pi/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     env:
-      TAG: ${{ github.event.release.tag_name || inputs.tag }}
-      FORCE: ${{ inputs.force || 'false' }}
+      TAG: ${{ inputs.tag }}
+      FORCE: ${{ inputs.force && 'true' || 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Replace the `release: published` trigger on `release-groom.yml` with direct chaining from `pi-release.yml` and `fw-release.yml` via `workflow_call`. The release jobs now detect the new tag with `git tag --points-at HEAD` after semantic-release and invoke the groom workflow through `needs` / `uses` / `secrets: inherit`.

## Why

The event-driven trigger was brittle. Each release workflow had to publish with `ADMIN_PAT` solely to bypass GitHub's recursive-workflow suppression, and grooming still quietly stopped firing for `pi/v1.12.1` and `pi/v1.13.0`, which shipped with raw commit-log bodies. Chaining directly removes the event plumbing and the reason for the PAT workaround, so the groom job runs (or fails visibly) in the same workflow as the release.

`workflow_dispatch` on `release-groom.yml` still works, so the two ungroomed releases can be backfilled by running the workflow manually with each tag after this merges.

## Test plan

- [ ] Merge and watch the next `pi/*` or `fw/*` release trigger both the release job and the chained groom job in one workflow run.
- [ ] Confirm the published release body starts with `<!-- groomed:v1 -->`.
- [ ] Run `Groom Release Notes` via `workflow_dispatch` against `pi/v1.12.1` and `pi/v1.13.0` to backfill.