### PR TITLE
feat(server): add Answering Machine theme foundation (phase 1 of 6)

### DIFF
--- a/server/internal/auth/theme.go
+++ b/server/internal/auth/theme.go
@@ -4,11 +4,12 @@ package auth
 type Theme string
 
 const (
-	ThemeIntercom Theme = "intercom" // Home intercom (default)
-	ThemeDialup   Theme = "dialup"   // Dial-up online service 1997
+	ThemeIntercom         Theme = "intercom"          // Home intercom (default)
+	ThemeDialup           Theme = "dialup"            // Dial-up online service 1997
+	ThemeAnsweringMachine Theme = "answering-machine" // Beige plastic mid-90s answering machine
 )
 
 // Valid reports whether t is a recognized theme identifier.
 func (t Theme) Valid() bool {
-	return t == ThemeIntercom || t == ThemeDialup
+	return t == ThemeIntercom || t == ThemeDialup || t == ThemeAnsweringMachine
 }

--- a/server/internal/auth/theme_test.go
+++ b/server/internal/auth/theme_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import "testing"
+
+func TestThemeValid(t *testing.T) {
+	cases := []struct {
+		in   Theme
+		want bool
+	}{
+		{ThemeIntercom, true},
+		{ThemeDialup, true},
+		{ThemeAnsweringMachine, true},
+		{Theme(""), false},
+		{Theme("ledger"), false},
+	}
+	for _, c := range cases {
+		if got := c.in.Valid(); got != c.want {
+			t.Errorf("Theme(%q).Valid() = %v, want %v", string(c.in), got, c.want)
+		}
+	}
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -251,6 +251,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			"templates/_partials.html",
 			"templates/layout-v2.html",
 			"templates/layout-dialup.html",
+			"templates/layout-answering-machine.html",
 			"templates/"+page,
 		)
 	}

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -277,7 +277,7 @@ func renderWith(w http.ResponseWriter, t *template.Template, name string, data a
 }
 
 // layoutFor returns the layout template name for the current user's theme.
-// Falls back to direction C when no theme is set (unauthenticated or new user).
+// Falls back to the intercom layout when no theme is set (unauthenticated or new user).
 func layoutFor(r *http.Request) string {
 	if u := auth.UserFromContext(r.Context()); u != nil {
 		switch u.Theme {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -279,8 +279,13 @@ func renderWith(w http.ResponseWriter, t *template.Template, name string, data a
 // layoutFor returns the layout template name for the current user's theme.
 // Falls back to direction C when no theme is set (unauthenticated or new user).
 func layoutFor(r *http.Request) string {
-	if u := auth.UserFromContext(r.Context()); u != nil && u.Theme == auth.ThemeDialup {
-		return "layout-dialup.html"
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		switch u.Theme {
+		case auth.ThemeDialup:
+			return "layout-dialup.html"
+		case auth.ThemeAnsweringMachine:
+			return "layout-answering-machine.html"
+		}
 	}
 	return "layout-v2.html"
 }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -1,0 +1,725 @@
+/* =========================================================================
+   Answering Machine theme: beige plastic, chicklet buttons, LED segments.
+   Foundation stylesheet. Page-specific AM markup lands in later phases;
+   the "shared-class shim" section at the bottom gives every existing
+   template a readable look in AM palette until those phases reskin it.
+   ========================================================================= */
+
+@font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-400.woff2') format('woff2'); font-weight: 400; font-display: swap; }
+@font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-500.woff2') format('woff2'); font-weight: 500; font-display: swap; }
+@font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-600.woff2') format('woff2'); font-weight: 600; font-display: swap; }
+@font-face { font-family: 'JetBrains Mono'; src: url('/static/fonts/jetbrains-mono-400.woff2') format('woff2'); font-weight: 400; font-display: swap; }
+@font-face { font-family: 'JetBrains Mono'; src: url('/static/fonts/jetbrains-mono-500.woff2') format('woff2'); font-weight: 500; font-display: swap; }
+
+:root {
+  /* Injection-molded beige */
+  --case: #d6ccae;
+  --case-2: #c8bc97;
+  --case-shade: #a89974;
+  --case-light: #e8deb9;
+  --case-dark: #8c7f5e;
+  --slot: #1a1912;
+  --slot-edge: #2a2720;
+
+  /* Display */
+  --led-bg: #0a0d07;
+  --led-amber: #ffa520;
+  --led-amber-dim: #6b4612;
+  --led-green: #3dd94a;
+  --led-red: #ff3d2e;
+
+  /* Buttons */
+  --btn: #ded3b2;
+  --btn-top: #ede3c3;
+  --btn-bot: #b8ac88;
+  --btn-press: #9f9471;
+  --btn-label: #3a3528;
+
+  /* Accent plastic chips */
+  --chip-red: #c43e2e;
+  --chip-red-dk: #842516;
+  --chip-blue: #2a5680;
+  --chip-blue-dk: #16334d;
+
+  --ink: #2a2720;
+  --ink-soft: #524c3a;
+  --ink-muted: #7a7258;
+  --label: #0f0e0a;
+
+  --font-body: 'Inter Tight', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --font-led: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--ink); }
+body.am { background: #2a2520; min-height: 100vh; }
+
+/* App shell: the whole app is the machine's face. Applied to <main.am> in
+   layout-answering-machine.html so the injection-mold speckle covers the
+   whole content viewport regardless of page length. */
+.am {
+  position: relative;
+  background:
+    radial-gradient(ellipse at 30% 20%, var(--case-light) 0%, var(--case) 40%, var(--case-2) 100%),
+    repeating-radial-gradient(circle at 20% 30%, rgba(60,50,30,0.025) 0px, rgba(60,50,30,0.025) 1px, transparent 1px, transparent 4px),
+    repeating-radial-gradient(circle at 70% 70%, rgba(60,50,30,0.02) 0px, rgba(60,50,30,0.02) 1px, transparent 1px, transparent 5px);
+  box-sizing: border-box;
+  color: var(--ink);
+  font-family: var(--font-body);
+}
+.am *, .am *::before, .am *::after { box-sizing: border-box; }
+.am button { font: inherit; cursor: pointer; }
+.am button:not([class]) { background: none; border: none; padding: 0; color: inherit; }
+.am a { color: var(--ink); }
+.am a:hover { color: var(--chip-blue); }
+
+/* Molded seam down the right edge of the viewport */
+.am::before {
+  content: ''; position: absolute; top: 30px; bottom: 30px; right: 14px; width: 1px;
+  background: linear-gradient(180deg, transparent 0, rgba(60,50,30,0.22) 20%, rgba(60,50,30,0.22) 80%, transparent 100%);
+  pointer-events: none;
+}
+
+/* Branding: embossed label */
+.am__brand {
+  font-family: var(--font-body); font-weight: 600; font-size: 13px; letter-spacing: 0.18em;
+  color: rgba(30,25,15,0.45);
+  text-shadow: 0 1px 0 rgba(255,255,255,0.4);
+  text-transform: uppercase;
+}
+.am__brand small { display: block; font-weight: 400; font-size: 9px; letter-spacing: 0.22em; margin-top: 2px; color: rgba(30,25,15,0.35); }
+
+/* Speaker grille: decorative element, used sparingly */
+.am__grille { display: grid; grid-template-columns: repeat(12, 6px); gap: 5px; }
+.am__grille-slot { width: 6px; height: 22px; background: var(--slot); border-radius: 1px; box-shadow: inset 0 1px 0 rgba(0,0,0,0.8), inset 0 -1px 0 rgba(255,255,255,0.15); }
+
+/* Raised bezel panel ("plate" for grouping controls on the face) */
+.am-plate {
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border-radius: 10px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    inset 0 -1px 0 rgba(100,80,40,0.12),
+    0 1px 0 rgba(255,255,255,0.6),
+    0 2px 4px rgba(40,30,15,0.12);
+  padding: 14px 16px;
+  position: relative;
+}
+.am-plate__label {
+  position: absolute; top: -8px; left: 14px; background: var(--case); padding: 0 6px;
+  font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--label); font-weight: 600; text-transform: uppercase;
+}
+
+/* Recessed well (for LED displays, cassette slots, etc.) */
+.am-well {
+  background: var(--slot);
+  border-radius: 6px;
+  box-shadow:
+    inset 0 2px 4px rgba(0,0,0,0.7),
+    inset 0 -1px 0 rgba(255,255,255,0.05),
+    0 1px 0 rgba(255,255,255,0.4);
+  padding: 10px 14px;
+  color: var(--led-amber);
+  font-family: var(--font-led);
+}
+
+/* LED segment display */
+.am-led {
+  font-family: var(--font-led); font-weight: 700; color: var(--led-amber);
+  text-shadow: 0 0 6px rgba(255,165,32,0.55), 0 0 12px rgba(255,165,32,0.25);
+  letter-spacing: 0.1em;
+}
+.am-led--green { color: var(--led-green); text-shadow: 0 0 6px rgba(61,217,74,0.55), 0 0 12px rgba(61,217,74,0.25); }
+.am-led--red { color: var(--led-red); text-shadow: 0 0 6px rgba(255,61,46,0.5), 0 0 12px rgba(255,61,46,0.25); }
+.am-led--dim { color: var(--led-amber-dim); text-shadow: none; }
+
+/* Chicklet button: the iconic beige rectangle with a dome */
+.am-key {
+  display: inline-flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px;
+  padding: 8px 10px 6px;
+  min-width: 54px; min-height: 44px;
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 5px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.75),
+    inset 0 -1px 0 rgba(100,85,45,0.4),
+    0 2px 0 var(--btn-press),
+    0 3px 4px rgba(40,30,15,0.3);
+  color: var(--btn-label);
+  font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase;
+  cursor: pointer;
+  transition: all 60ms;
+  text-decoration: none;
+}
+.am-key:hover { background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 40%, var(--btn-bot) 100%); }
+.am-key:active { transform: translateY(2px); box-shadow: inset 0 1px 2px rgba(60,45,20,0.3), 0 0 0 rgba(0,0,0,0); }
+.am-key__symbol { font-size: 16px; font-weight: 500; line-height: 1; font-family: var(--font-led); letter-spacing: 0; color: var(--label); }
+.am-key__label { font-size: 8.5px; letter-spacing: 0.14em; color: var(--ink-soft); }
+.am-key--red { background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%); border-color: var(--chip-red-dk); color: #fff8f0; box-shadow: inset 0 1px 0 rgba(255,180,160,0.55), 0 2px 0 var(--chip-red-dk), 0 3px 4px rgba(40,10,5,0.3); }
+.am-key--red .am-key__symbol, .am-key--red .am-key__label { color: #fff8f0; }
+.am-key--blue { background: linear-gradient(180deg, #4a84b4 0%, var(--chip-blue) 100%); border-color: var(--chip-blue-dk); color: #f0f6fa; box-shadow: inset 0 1px 0 rgba(160,200,230,0.55), 0 2px 0 var(--chip-blue-dk), 0 3px 4px rgba(5,20,40,0.3); }
+.am-key--blue .am-key__symbol, .am-key--blue .am-key__label { color: #f0f6fa; }
+.am-key--wide { min-width: 100px; }
+.am-key--tall { min-height: 68px; padding-top: 12px; padding-bottom: 10px; }
+
+/* Status lamp: small round LED with glow ring */
+.am-lamp {
+  width: 11px; height: 11px; border-radius: 50%; display: inline-block;
+  background: radial-gradient(circle at 30% 30%, #40100a 0%, #1a0804 70%);
+  border: 1px solid #0a0504;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.08), 0 1px 0 rgba(255,255,255,0.3);
+  position: relative;
+}
+.am-lamp--on-red { background: radial-gradient(circle at 30% 30%, #ff7a6a 0%, var(--led-red) 60%, #8a1a10 100%); box-shadow: 0 0 8px rgba(255,61,46,0.7), 0 0 14px rgba(255,61,46,0.3), inset 0 1px 1px rgba(255,255,255,0.3); animation: amPulse 1.4s ease-in-out infinite; }
+.am-lamp--on-green { background: radial-gradient(circle at 30% 30%, #86ff8b 0%, var(--led-green) 60%, #1c7224 100%); box-shadow: 0 0 6px rgba(61,217,74,0.6), 0 0 12px rgba(61,217,74,0.25); }
+.am-lamp--on-amber { background: radial-gradient(circle at 30% 30%, #ffd080 0%, var(--led-amber) 60%, #9a5808 100%); box-shadow: 0 0 6px rgba(255,165,32,0.6), 0 0 12px rgba(255,165,32,0.25); }
+
+@keyframes amPulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(255,61,46,0.7), 0 0 14px rgba(255,61,46,0.3), inset 0 1px 1px rgba(255,255,255,0.3); }
+  50% { box-shadow: 0 0 4px rgba(255,61,46,0.3), 0 0 8px rgba(255,61,46,0.12), inset 0 1px 1px rgba(255,255,255,0.3); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .am-lamp--on-red { animation: none; }
+}
+
+/* Unlit REC lamp: stylized, with "REC" label, crossed out. The privacy thesis. */
+.am-rec {
+  display: inline-flex; align-items: center; gap: 8px; padding: 6px 12px 6px 10px;
+  background: linear-gradient(180deg, var(--case) 0%, var(--case-2) 100%);
+  border-radius: 999px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), inset 0 -1px 0 rgba(100,80,40,0.15);
+}
+.am-rec__label { font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.22em; color: var(--ink-muted); text-transform: uppercase; position: relative; }
+.am-rec__label::after { content: ''; position: absolute; left: -3px; right: -3px; top: 50%; height: 1.5px; background: var(--chip-red-dk); transform: rotate(-8deg); }
+
+/* Tape cassette visualization (active session indicator) */
+.am-tape {
+  background: #2a2720; border-radius: 4px; padding: 10px 14px;
+  display: grid; grid-template-columns: 26px 1fr 26px; gap: 10px; align-items: center;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.6), inset 0 -1px 0 rgba(255,255,255,0.05), 0 1px 0 rgba(255,255,255,0.4);
+  font-family: var(--font-mono); color: #cdbf92; font-size: 11.5px;
+  position: relative;
+}
+.am-tape__reel {
+  width: 26px; height: 26px; border-radius: 50%;
+  background: radial-gradient(circle, #1a1510 0%, #3a3225 40%, #1a1510 62%, #4a4030 70%, #1a1510 100%);
+  border: 1px solid #0f0c07; box-shadow: inset 0 0 4px rgba(0,0,0,0.6);
+  position: relative;
+  animation: amSpin 4s linear infinite;
+}
+.am-tape__reel::before { content: ''; position: absolute; inset: 10px; border-radius: 50%; background: #cdbf92; box-shadow: 0 0 0 1px #0f0c07; }
+.am-tape__reel::after { content: ''; position: absolute; inset: 12px; border-radius: 50%; background: #1a1510; }
+.am-tape--idle .am-tape__reel { animation: none; }
+@keyframes amSpin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .am-tape__reel { animation: none; }
+}
+.am-tape__tape { height: 4px; background: repeating-linear-gradient(90deg, #6a5c38 0 4px, #4a3f26 4px 8px); border-radius: 1px; }
+.am-tape__label { position: absolute; top: -7px; left: 12px; background: var(--case); padding: 0 5px; font-family: var(--font-body); font-size: 8px; letter-spacing: 0.2em; color: var(--label); font-weight: 600; text-transform: uppercase; }
+
+/* Text helpers. No text-shadow on 9px labels: the 1px emboss fringes at
+   that size and reads as blur. Shadow stays on larger display text. */
+.am-label { font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--label); font-weight: 600; text-transform: uppercase; }
+.am-title { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); letter-spacing: 0.02em; }
+.am-mono { font-family: var(--font-mono); color: var(--ink); }
+.am-muted { color: var(--ink-muted); }
+.am-hint { font-family: var(--font-body); font-size: 10.5px; color: var(--ink-muted); }
+
+/* Simple screw/pin decoration */
+.am-screw { width: 12px; height: 12px; border-radius: 50%; background: radial-gradient(circle at 30% 30%, #b8ac88 0%, #7a6f4a 100%); border: 1px solid #5a502f; box-shadow: inset 0 1px 0 rgba(255,255,255,0.4); position: relative; display: inline-block; }
+.am-screw::before { content: ''; position: absolute; inset: 3px; border-top: 1.2px solid #5a502f; transform: rotate(30deg); }
+
+/* Cassette-deck function tabs (primary nav) */
+.am-tabs { display: flex; gap: 2px; background: var(--case-dark); padding: 3px; border-radius: 6px; box-shadow: inset 0 2px 3px rgba(0,0,0,0.35); }
+.am-tab { padding: 7px 14px; font-family: var(--font-body); font-size: 10.5px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); background: transparent; border: none; border-radius: 4px; cursor: pointer; text-decoration: none; display: inline-flex; align-items: center; }
+.am-tab:hover { color: var(--ink); }
+.am-tab.is-active { background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%); color: var(--ink); box-shadow: inset 0 1px 0 rgba(255,255,255,0.7), 0 1px 0 rgba(255,255,255,0.3), 0 2px 3px rgba(40,30,15,0.3); }
+
+/* Messages list (activity stacks) */
+.am-msg { display: grid; grid-template-columns: 28px 1fr auto auto; gap: 14px; align-items: center; padding: 10px 14px; border-bottom: 1px dashed rgba(100,80,40,0.28); font-family: var(--font-body); font-size: 13px; }
+.am-msg:last-child { border-bottom: 0; }
+.am-msg__num { font-family: var(--font-led); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); }
+.am-msg__time { font-family: var(--font-mono); font-size: 12px; color: var(--ink-muted); letter-spacing: 0.04em; }
+.am-msg__dur { font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-muted); letter-spacing: 0.04em; }
+.am-msg__who { font-weight: 600; color: var(--ink); }
+.am-msg__room { color: var(--ink-soft); font-size: 12px; }
+
+/* Corner screws on the plate */
+.am-plate--screws { padding-top: 20px; }
+.am-screw--tl { position: absolute; top: 6px; left: 6px; }
+.am-screw--tr { position: absolute; top: 6px; right: 6px; }
+.am-screw--bl { position: absolute; bottom: 6px; left: 6px; }
+.am-screw--br { position: absolute; bottom: 6px; right: 6px; }
+
+/* =========================================================================
+   Patchbay (Lines screen, phase 3)
+   ========================================================================= */
+
+.am-patchbay {
+  background: linear-gradient(180deg, #1a1812 0%, #24201a 100%);
+  border-radius: 8px;
+  padding: 22px 24px;
+  box-shadow: inset 0 3px 6px rgba(0,0,0,0.6), 0 1px 0 rgba(255,255,255,0.4);
+  position: relative;
+}
+.am-patchbay__rail {
+  background: linear-gradient(180deg, #302b22 0%, #1a1812 100%);
+  border-radius: 4px;
+  padding: 14px 16px 18px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px 10px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.8), 0 1px 0 rgba(255,255,255,0.12);
+}
+.am-jack {
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  color: #d8caa0;
+  padding-top: 18px;
+  position: relative;
+}
+.am-jack__label-top {
+  font-family: var(--font-body); font-size: 9px; letter-spacing: 0.2em;
+  color: #f0e5c5; text-transform: uppercase; font-weight: 600;
+  order: 3;
+  background: rgba(10,8,4,0.55); padding: 2px 7px; border-radius: 2px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.06);
+}
+.am-jack__socket {
+  width: 52px; height: 52px; border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%,
+    #050301 0%, #050301 26%,
+    #3a3226 28%, #4a402e 32%,
+    #1a1610 38%, #2a251d 48%,
+    #12100a 100%);
+  box-shadow:
+    inset 0 2px 4px rgba(0,0,0,0.9),
+    inset 0 -1px 0 rgba(255,255,255,0.05),
+    0 1px 0 rgba(255,255,255,0.12);
+  position: relative;
+  display: flex; align-items: center; justify-content: center;
+}
+.am-jack__plug {
+  position: absolute; top: -14px; left: 50%; transform: translateX(-50%);
+  width: 14px; height: 60px; border-radius: 3px 3px 0 0;
+  background: linear-gradient(180deg,
+    #d8d4cc 0%, #d8d4cc 18%,
+    #18150f 20%, #18150f 24%,
+    #c8c4bc 26%, #c8c4bc 46%,
+    #18150f 48%, #18150f 52%,
+    #b8b4ac 54%);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.5), inset 1px 0 0 rgba(255,255,255,0.4), inset -1px 0 0 rgba(0,0,0,0.4);
+}
+.am-jack__plug::before {
+  content: ''; position: absolute; top: -6px; left: -2px; right: -2px; height: 10px; border-radius: 3px 3px 0 0;
+  background: linear-gradient(180deg, #d63826 0%, #a0201a 100%);
+  box-shadow: inset 0 1px 0 rgba(255,180,160,0.4), 0 1px 2px rgba(0,0,0,0.5);
+}
+.am-jack--unpatched .am-jack__plug { display: none; }
+.am-jack__label-bot {
+  font-family: var(--font-mono); font-size: 11px; color: #d8caa0; letter-spacing: 0.06em;
+}
+.am-jack__lamp { margin-top: 2px; }
+
+/* =========================================================================
+   Two-machine pairing (Families screen, phase 4)
+   ========================================================================= */
+
+.am-pair {
+  display: grid; grid-template-columns: 1fr 80px 1fr; gap: 20px; align-items: center;
+  padding: 20px 0;
+}
+.am-unit {
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 45%, var(--case-2) 100%);
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    inset 0 -2px 0 rgba(100,80,40,0.15),
+    0 2px 0 rgba(255,255,255,0.5),
+    0 4px 8px rgba(40,30,15,0.18);
+  position: relative;
+}
+.am-unit::after {
+  content: ''; position: absolute; top: 6px; left: 40%; right: 40%; height: 2px;
+  background: repeating-linear-gradient(90deg, transparent 0 3px, rgba(60,50,30,0.35) 3px 6px);
+  border-radius: 2px;
+}
+.am-unit__head {
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px;
+}
+.am-unit__name {
+  font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.02em;
+}
+.am-unit__sub { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); margin-top: 2px; }
+.am-unit__tag {
+  font-family: var(--font-body); font-size: 8.5px; font-weight: 600; letter-spacing: 0.2em;
+  text-transform: uppercase; padding: 3px 8px;
+  background: var(--case-shade); color: #f4ebcb; border-radius: 3px;
+}
+
+.am-cord { position: relative; height: 80px; }
+.am-cord svg { width: 100%; height: 100%; overflow: visible; }
+.am-cord__path {
+  stroke: #3a2016; stroke-width: 4; fill: none; stroke-linecap: round;
+  filter: drop-shadow(0 3px 3px rgba(0,0,0,0.25));
+}
+.am-cord__label {
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  background: var(--case); padding: 2px 8px; border-radius: 3px;
+  font-family: var(--font-body); font-size: 8.5px; font-weight: 600; letter-spacing: 0.22em;
+  color: var(--label); text-transform: uppercase; text-shadow: 0 1px 0 rgba(255,255,255,0.3);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), 0 1px 2px rgba(40,30,15,0.15);
+  white-space: nowrap;
+}
+
+/* =========================================================================
+   Back panel (Settings screen, phase 5)
+   ========================================================================= */
+
+.am-back {
+  background: linear-gradient(180deg, #9e936f 0%, #b0a47c 100%);
+  border-radius: 10px;
+  padding: 24px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.4), inset 0 -1px 0 rgba(60,45,20,0.25);
+  position: relative;
+}
+.am-back__sticker {
+  background: #f4e8c4;
+  border: 1px solid #a89774;
+  border-radius: 2px;
+  padding: 10px 14px;
+  font-family: var(--font-mono); font-size: 10.5px; color: #2a2318;
+  line-height: 1.5;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+  position: relative;
+}
+.am-back__sticker::before {
+  content: ''; position: absolute; inset: 3px; border: 1px dashed rgba(60,45,20,0.25); border-radius: 1px; pointer-events: none;
+}
+
+/* DIP switch bank */
+.am-dip {
+  background: #c43e2e;
+  border-radius: 4px;
+  padding: 10px 8px 8px;
+  display: inline-flex; flex-direction: column; gap: 0;
+  box-shadow: inset 0 1px 0 rgba(255,180,160,0.35), 0 2px 3px rgba(40,10,5,0.3);
+  position: relative;
+}
+.am-dip__label {
+  font-family: var(--font-body); font-size: 7.5px; letter-spacing: 0.2em; color: #fff0e8;
+  text-align: center; font-weight: 600; margin-bottom: 4px; text-transform: uppercase;
+}
+.am-dip__row { display: flex; gap: 4px; }
+.am-dip__sw {
+  width: 16px; height: 28px;
+  background: linear-gradient(180deg, #2a2520 0%, #14120e 100%);
+  border-radius: 2px;
+  position: relative; cursor: pointer;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.08), inset 0 -1px 1px rgba(0,0,0,0.4);
+}
+.am-dip__sw::before {
+  content: ''; position: absolute; left: 2px; right: 2px; height: 11px;
+  background: linear-gradient(180deg, #f4ebd0 0%, #c8b988 100%);
+  border-radius: 1px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), inset 0 -1px 0 rgba(100,80,40,0.4), 0 1px 2px rgba(0,0,0,0.4);
+  transition: top 120ms;
+}
+.am-dip__sw[data-on="true"]::before { top: 2px; }
+.am-dip__sw[data-on="false"]::before { top: 15px; }
+.am-dip__sw::after {
+  content: attr(data-n); position: absolute; bottom: -12px; left: 0; right: 0; text-align: center;
+  font-family: var(--font-mono); font-size: 8px; color: #fff0e8;
+}
+.am-dip__ends {
+  display: flex; justify-content: space-between; padding: 0 2px; margin-top: 4px;
+  font-family: var(--font-body); font-size: 7px; letter-spacing: 0.15em; color: #fff0e8; font-weight: 600;
+}
+
+/* Knob */
+.am-knob {
+  width: 72px; height: 72px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #f0e5c5 0%, #d6ccae 30%, #a89974 70%, #7a6d4c 100%);
+  box-shadow:
+    inset 0 2px 2px rgba(255,255,255,0.5),
+    inset 0 -2px 2px rgba(60,45,20,0.25),
+    0 3px 5px rgba(40,30,15,0.35);
+  position: relative;
+  display: flex; align-items: center; justify-content: center;
+}
+.am-knob::before {
+  content: ''; position: absolute; top: 6px; left: 50%; width: 3px; height: 16px;
+  background: var(--label); transform: translateX(-50%); border-radius: 1px;
+}
+.am-knob::after {
+  content: ''; position: absolute; inset: 8px; border-radius: 50%;
+  background: repeating-conic-gradient(from 0deg, rgba(60,45,20,0.18) 0deg 3deg, transparent 3deg 9deg);
+  mask: radial-gradient(circle, transparent 45%, black 46%, black 100%);
+  -webkit-mask: radial-gradient(circle, transparent 45%, black 46%, black 100%);
+}
+.am-knob-wrap { display: inline-flex; flex-direction: column; align-items: center; gap: 8px; }
+.am-knob__scale {
+  position: relative; width: 92px; height: 10px; margin-top: -4px;
+  font-family: var(--font-body); font-size: 8px; letter-spacing: 0.15em; color: var(--label); font-weight: 600;
+  display: flex; justify-content: space-between; text-transform: uppercase;
+}
+
+/* Chunky mechanical toggle */
+.am-toggle {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 4px 0;
+}
+.am-toggle__body {
+  width: 46px; height: 24px; border-radius: 3px;
+  background: linear-gradient(180deg, #2a2520 0%, #14120e 100%);
+  position: relative; cursor: pointer;
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.3);
+  padding: 3px;
+}
+.am-toggle__lever {
+  width: 20px; height: 18px;
+  background: linear-gradient(180deg, #f0e5c5 0%, #c8b988 60%, #8a7d58 100%);
+  border-radius: 2px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.5), inset 0 -1px 0 rgba(60,45,20,0.4), 0 1px 2px rgba(0,0,0,0.5);
+  transition: transform 120ms;
+}
+.am-toggle[data-on="true"] .am-toggle__lever { transform: translateX(20px); }
+.am-toggle__labels {
+  font-family: var(--font-body); font-size: 8.5px; letter-spacing: 0.2em; color: var(--label);
+  font-weight: 600; display: flex; gap: 8px; text-transform: uppercase;
+}
+.am-toggle__labels span.is-on { color: var(--chip-red); }
+
+/* Serial plate / sticker typography */
+.am-serial { font-family: var(--font-mono); font-size: 10.5px; color: #2a2318; letter-spacing: 0.05em; }
+.am-serial dt { display: inline; font-weight: 600; }
+.am-serial dd { display: inline; margin: 0 12px 0 4px; }
+.am-serial br + dt { display: inline; }
+
+/* =========================================================================
+   Layout chrome (used by layout-answering-machine.html)
+   ========================================================================= */
+
+.am-shell { display: flex; flex-direction: column; min-height: 100vh; }
+.am-shell__nav {
+  display: flex; align-items: center; gap: 14px;
+  padding: 22px 36px 18px;
+  flex-wrap: wrap;
+}
+.am-shell__brand-slot { display: inline-flex; align-items: center; gap: 12px; padding-right: 8px; }
+.am-shell__spacer { flex: 1; }
+.am-shell__household { font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--ink-muted); font-weight: 600; text-transform: uppercase; }
+.am-shell__signout { appearance: none; background: transparent; border: none; color: inherit; font: inherit; cursor: pointer; padding: 0; }
+.am-shell__main { flex: 1; padding: 4px 36px 32px; }
+
+/* Mobile nav toggle (hidden on desktop) */
+.am-shell__toggle { display: none; }
+
+@media (max-width: 720px) {
+  .am-shell__nav { padding: 18px 20px 14px; gap: 10px; }
+  .am-shell__main { padding: 4px 20px 24px; }
+  .am-shell__toggle {
+    display: inline-flex;
+    padding: 8px 14px;
+    font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink); background: var(--case);
+    border: 1px solid var(--btn-press); border-radius: 4px;
+    box-shadow: 0 1px 0 var(--btn-press), 0 2px 3px rgba(40,30,15,0.2);
+  }
+  .am-tabs { flex-wrap: wrap; width: 100%; order: 99; }
+  .am-tabs:not(.is-open) { display: none; }
+  .am-shell__household { font-size: 8px; }
+}
+
+/* =========================================================================
+   Shared-class shim: provides AM-palette defaults for the component classes
+   used by the existing templates (dashboard.html, phones.html, etc.) so
+   every page is coherent in Phase 1. Phases 2 to 5 reskin each page with
+   bespoke AM markup and can trim these defaults over time.
+   ========================================================================= */
+
+/* Page containers */
+.page { max-width: 1180px; margin: 0 auto; padding: 0; }
+.page__head { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 18px; flex-wrap: wrap; }
+.page__title { font-family: var(--font-body); font-size: 22px; font-weight: 600; letter-spacing: 0.01em; color: var(--ink); margin: 0; }
+.page__sub { font-family: var(--font-body); font-size: 12px; color: var(--ink-muted); }
+.page__foot { margin-top: 24px; padding-top: 14px; border-top: 1px dashed rgba(100,80,40,0.25); font-size: 12px; color: var(--ink-muted); }
+
+/* Panels use plate material */
+.panel {
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border-radius: 10px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    inset 0 -1px 0 rgba(100,80,40,0.12),
+    0 1px 0 rgba(255,255,255,0.6),
+    0 2px 4px rgba(40,30,15,0.12);
+  margin-bottom: 18px;
+  overflow: hidden;
+}
+.panel__head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; padding: 12px 16px 6px; border-bottom: 1px dashed rgba(100,80,40,0.25); }
+.panel__title { font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 0.02em; margin: 0; color: var(--ink); }
+.panel__title-sub { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); letter-spacing: 0.04em; }
+.panel__action { font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--chip-blue); text-decoration: none; }
+.panel__action:hover { color: var(--chip-red); }
+.panel__body { padding: 12px 16px 14px; }
+.panel__body--tight { padding: 8px 12px; }
+
+/* Chips: small status pills. Lamp-in-a-pill metaphor. */
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 10px 3px 8px;
+  background: var(--case-shade);
+  border-radius: 999px;
+  font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.12em;
+  color: #f4ebcb; text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+.chip__dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #40100a 0%, #1a0804 70%);
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.08);
+}
+.chip--live { background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%); }
+.chip--live .chip__dot { background: radial-gradient(circle at 30% 30%, #ff7a6a 0%, var(--led-red) 60%); box-shadow: 0 0 4px rgba(255,61,46,0.7); animation: amPulse 1.4s ease-in-out infinite; }
+.chip--on { background: linear-gradient(180deg, #4aae52 0%, #2b7d34 100%); }
+.chip--on .chip__dot { background: radial-gradient(circle at 30% 30%, #86ff8b 0%, var(--led-green) 60%); box-shadow: 0 0 4px rgba(61,217,74,0.55); }
+
+/* Buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 8px 14px;
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 5px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.75),
+    0 2px 0 var(--btn-press),
+    0 3px 4px rgba(40,30,15,0.3);
+  color: var(--btn-label);
+  font-family: var(--font-body); font-size: 11px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 60ms;
+}
+.btn:hover { filter: brightness(1.03); }
+.btn:active { transform: translateY(2px); box-shadow: inset 0 1px 2px rgba(60,45,20,0.3); }
+.btn:disabled, .btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+.btn--primary { background: linear-gradient(180deg, #4a84b4 0%, var(--chip-blue) 100%); border-color: var(--chip-blue-dk); color: #f0f6fa; box-shadow: inset 0 1px 0 rgba(160,200,230,0.55), 0 2px 0 var(--chip-blue-dk), 0 3px 4px rgba(5,20,40,0.3); }
+.btn--danger { background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%); border-color: var(--chip-red-dk); color: #fff8f0; box-shadow: inset 0 1px 0 rgba(255,180,160,0.55), 0 2px 0 var(--chip-red-dk), 0 3px 4px rgba(40,10,5,0.3); }
+.btn--ghost { background: transparent; box-shadow: none; color: var(--ink); border-color: rgba(100,80,40,0.35); }
+.btn--ghost:active { transform: none; box-shadow: none; }
+.btn--sm { padding: 5px 10px; font-size: 10px; }
+
+/* Form controls */
+.am input[type="text"],
+.am input[type="email"],
+.am input[type="password"],
+.am input[type="tel"],
+.am input[type="number"],
+.am input[type="search"],
+.am select,
+.am textarea {
+  background: #f4ebd0;
+  border: 1px solid var(--btn-press);
+  border-radius: 3px;
+  padding: 7px 10px;
+  font: inherit;
+  color: var(--ink);
+  box-shadow: inset 0 2px 3px rgba(60,45,20,0.25);
+}
+.am input:focus, .am select:focus, .am textarea:focus {
+  outline: 2px solid var(--chip-blue);
+  outline-offset: 1px;
+}
+.am label { font-family: var(--font-body); font-size: 11px; font-weight: 600; color: var(--ink); }
+
+/* Utilities used by templates */
+.num { font-family: var(--font-mono); letter-spacing: 0.04em; }
+.muted { color: var(--ink-muted); }
+.stack-md > * + * { margin-top: 12px; }
+.stack-sm > * + * { margin-top: 8px; }
+
+/* Rooms grid (dashboard) */
+.rooms { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 14px; margin-bottom: 20px; }
+.rooms__card {
+  display: block; text-decoration: none; color: var(--ink);
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.7), 0 1px 0 rgba(255,255,255,0.6), 0 2px 4px rgba(40,30,15,0.12);
+  transition: transform 80ms;
+}
+.rooms__card:hover { transform: translateY(-1px); }
+.rooms__card--live { outline: 1px solid var(--chip-red); }
+.rooms__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 6px; }
+.rooms__name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); }
+.rooms__num { font-family: var(--font-mono); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); letter-spacing: 0.06em; }
+.rooms__empty { grid-column: 1 / -1; padding: 18px; text-align: center; color: var(--ink-muted); background: rgba(255,255,255,0.25); border-radius: 8px; }
+.rooms__callout { margin-top: 10px; padding: 8px 10px; background: rgba(42,39,32,0.85); border-radius: 5px; color: #f0e5c5; font-family: var(--font-mono); font-size: 11px; display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.rooms__callout-kicker { font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.22em; color: #cdbf92; text-transform: uppercase; }
+.rooms__callout-name { color: #fff0d6; font-weight: 600; }
+.rooms__callout-elapsed { color: var(--led-amber); }
+
+/* Today list (dashboard) */
+.today-list { list-style: none; margin: 0; padding: 0; }
+.today-list__row { display: grid; grid-template-columns: 70px 20px 1fr auto; gap: 10px; align-items: baseline; padding: 8px 4px; border-bottom: 1px dashed rgba(100,80,40,0.25); font-size: 13px; }
+.today-list__row:last-child { border-bottom: none; }
+.today-list__time { color: var(--ink-muted); font-family: var(--font-mono); font-size: 12px; }
+.today-list__dir { font-family: var(--font-mono); }
+.today-list__dir--in { color: var(--led-green); }
+.today-list__dir--out { color: var(--led-amber); }
+.today-list__peer { color: var(--ink); }
+.today-list__dur { color: var(--ink-muted); font-family: var(--font-mono); font-size: 12px; }
+.today-list__empty { padding: 14px; color: var(--ink-muted); font-style: italic; text-align: center; }
+
+/* Theme picker cards (settings) */
+.theme-card {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.5), 0 2px 4px rgba(40,30,15,0.08);
+  transition: transform 80ms, box-shadow 80ms;
+}
+.theme-card:hover { transform: translateY(-1px); }
+.theme-card input[type="radio"] { margin: 0; accent-color: var(--chip-blue); }
+.theme-card__swatch { display: flex; gap: 2px; border-radius: 3px; overflow: hidden; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.15); }
+.theme-card__swatch-strip { width: 10px; height: 28px; }
+.theme-card__body { flex: 1; display: flex; flex-direction: column; gap: 2px; }
+.theme-card__name { font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--ink); letter-spacing: 0.02em; }
+.theme-card__desc { font-family: var(--font-body); font-size: 11px; color: var(--ink-muted); line-height: 1.4; }
+.theme-card--selected { border-color: var(--chip-blue); box-shadow: 0 0 0 2px rgba(42,86,128,0.25), 0 2px 4px rgba(40,30,15,0.08); }
+
+/* Radio card (settings, CRT mode etc) */
+.radio-card {
+  display: block; padding: 10px 12px;
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(100,80,40,0.3);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.radio-card input[type="radio"] { margin-right: 8px; accent-color: var(--chip-blue); }
+.radio-card__title { display: flex; align-items: center; gap: 6px; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--ink); }
+.radio-card__indicator { width: 8px; height: 8px; border-radius: 50%; background: var(--chip-blue); display: inline-block; }
+.radio-card__desc { font-family: var(--font-body); font-size: 11px; color: var(--ink-muted); margin: 4px 0 0 24px; line-height: 1.4; }
+.radio-card__meta { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--ink-muted); letter-spacing: 0.08em; }
+
+/* Settings nav anchor list */
+.settings-nav { list-style: none; padding: 0; margin: 0 0 18px; display: flex; flex-wrap: wrap; gap: 6px; }
+.settings-nav__item { display: inline-block; padding: 5px 10px; font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-muted); background: rgba(255,255,255,0.35); border-radius: 4px; text-decoration: none; }
+.settings-nav__item:hover { color: var(--ink); background: rgba(255,255,255,0.6); }
+
+/* Key-value list (used throughout settings) */
+.kv { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; font-size: 12px; }
+.kv__key { font-family: var(--font-body); font-weight: 600; color: var(--ink-muted); letter-spacing: 0.04em; }
+.kv__val { font-family: var(--font-body); color: var(--ink); }
+.kv__val--mono { font-family: var(--font-mono); letter-spacing: 0.04em; }
+
+/* Tables (calls, phones) */
+.t { width: 100%; border-collapse: collapse; font-size: 13px; }
+.t th, .t td { padding: 8px 10px; text-align: left; border-bottom: 1px dashed rgba(100,80,40,0.2); }
+.t th { font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); }
+.t td.num, .t th.num { font-family: var(--font-mono); color: var(--ink); letter-spacing: 0.04em; }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -5,7 +5,6 @@
    template a readable look in AM palette until those phases reskin it.
    ========================================================================= */
 
-@font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-400.woff2') format('woff2'); font-weight: 400; font-display: swap; }
 @font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-500.woff2') format('woff2'); font-weight: 500; font-display: swap; }
 @font-face { font-family: 'Inter Tight'; src: url('/static/fonts/inter-tight-600.woff2') format('woff2'); font-weight: 600; font-display: swap; }
 @font-face { font-family: 'JetBrains Mono'; src: url('/static/fonts/jetbrains-mono-400.woff2') format('woff2'); font-weight: 400; font-display: swap; }
@@ -52,12 +51,9 @@
 }
 
 html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--ink); }
-body.am { background: #2a2520; min-height: 100vh; }
 
-/* App shell: the whole app is the machine's face. Applied to <main.am> in
-   layout-answering-machine.html so the injection-mold speckle covers the
-   whole content viewport regardless of page length. */
 .am {
+  min-height: 100vh;
   position: relative;
   background:
     radial-gradient(ellipse at 30% 20%, var(--case-light) 0%, var(--case) 40%, var(--case-2) 100%),
@@ -67,7 +63,7 @@ body.am { background: #2a2520; min-height: 100vh; }
   color: var(--ink);
   font-family: var(--font-body);
 }
-.am *, .am *::before, .am *::after { box-sizing: border-box; }
+.am-shell, .am-shell *, .am-shell *::before, .am-shell *::after { box-sizing: border-box; }
 .am button { font: inherit; cursor: pointer; }
 .am button:not([class]) { background: none; border: none; padding: 0; color: inherit; }
 .am a { color: var(--ink); }
@@ -87,7 +83,7 @@ body.am { background: #2a2520; min-height: 100vh; }
   text-shadow: 0 1px 0 rgba(255,255,255,0.4);
   text-transform: uppercase;
 }
-.am__brand small { display: block; font-weight: 400; font-size: 9px; letter-spacing: 0.22em; margin-top: 2px; color: rgba(30,25,15,0.35); }
+.am__brand small { display: block; font-weight: 500; font-size: 9px; letter-spacing: 0.22em; margin-top: 2px; color: rgba(30,25,15,0.35); }
 
 /* Speaker grille: decorative element, used sparingly */
 .am__grille { display: grid; grid-template-columns: repeat(12, 6px); gap: 5px; }
@@ -494,7 +490,6 @@ body.am { background: #2a2520; min-height: 100vh; }
 .am-serial { font-family: var(--font-mono); font-size: 10.5px; color: #2a2318; letter-spacing: 0.05em; }
 .am-serial dt { display: inline; font-weight: 600; }
 .am-serial dd { display: inline; margin: 0 12px 0 4px; }
-.am-serial br + dt { display: inline; }
 
 /* =========================================================================
    Layout chrome (used by layout-answering-machine.html)
@@ -507,9 +502,9 @@ body.am { background: #2a2520; min-height: 100vh; }
   flex-wrap: wrap;
 }
 .am-shell__brand-slot { display: inline-flex; align-items: center; gap: 12px; padding-right: 8px; }
-.am-shell__spacer { flex: 1; }
-.am-shell__household { font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--ink-muted); font-weight: 600; text-transform: uppercase; }
-.am-shell__signout { appearance: none; background: transparent; border: none; color: inherit; font: inherit; cursor: pointer; padding: 0; }
+.am-shell__household { margin-left: auto; font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--ink-muted); font-weight: 600; text-transform: uppercase; }
+.am-shell__signout-form { margin: 0; }
+.am-key--nav { min-width: 0; min-height: 32px; padding: 4px 10px; }
 .am-shell__main { flex: 1; padding: 4px 36px 32px; }
 
 /* Mobile nav toggle (hidden on desktop) */

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{block "title" .}}Digits{{end}} · Digits</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+<link rel="preload" href="/static/fonts/inter-tight-500.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/static/fonts/jetbrains-mono-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/static/answering-machine.css">
+<script src="/static/htmx.min.js"></script>
+<script src="/static/sse.min.js"></script>
+</head>
+<body class="am">
+
+{{if ne .Page "login"}}
+<div class="am-shell">
+  <header class="am-shell__nav" aria-label="Primary">
+    <div class="am-shell__brand-slot">
+      <span class="am__brand">Digits 2500<small>Family Telephone System</small></span>
+    </div>
+
+    <button class="am-shell__toggle" type="button" aria-label="Toggle navigation" onclick="this.parentElement.querySelector('.am-tabs').classList.toggle('is-open')">Menu</button>
+
+    <nav class="am-tabs" aria-label="Sections">
+      <a class="am-tab {{if eq .Page "dashboard"}}is-active{{end}}" href="/">Overview</a>
+      <a class="am-tab {{if eq .Page "phones"}}is-active{{end}}" href="/phones">Lines</a>
+      <a class="am-tab {{if eq .Page "links"}}is-active{{end}}" href="/links">Families</a>
+      {{if .CallHistoryEnabled}}
+      <a class="am-tab {{if eq .Page "calls"}}is-active{{end}}" href="/calls">Calls</a>
+      {{end}}
+      <a class="am-tab {{if eq .Page "settings"}}is-active{{end}}" href="/settings">Settings</a>
+    </nav>
+
+    <div class="am-shell__spacer"></div>
+
+    {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
+
+    <form method="POST" action="/auth/logout" style="margin: 0;">
+      <button class="am-key" type="submit" style="min-width: 0; min-height: 32px; padding: 4px 10px;">
+        <span class="am-key__label">Sign out</span>
+      </button>
+    </form>
+  </header>
+
+  <main class="am-shell__main">
+    {{block "content" .}}{{end}}
+  </main>
+</div>
+{{else}}
+<main class="am-shell__main">
+  {{block "content" .}}{{end}}
+</main>
+{{end}}
+
+{{template "confirm-dialog" .}}
+
+</body>
+</html>

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -20,9 +20,9 @@
       <span class="am__brand">Digits 2500<small>Family Telephone System</small></span>
     </div>
 
-    <button class="am-shell__toggle" type="button" aria-label="Toggle navigation" onclick="this.parentElement.querySelector('.am-tabs').classList.toggle('is-open')">Menu</button>
+    <button class="am-shell__toggle" id="am-nav-toggle" type="button" aria-label="Toggle navigation" aria-controls="am-nav-tabs" aria-expanded="false">Menu</button>
 
-    <nav class="am-tabs" aria-label="Sections">
+    <nav class="am-tabs" id="am-nav-tabs" aria-label="Sections">
       <a class="am-tab {{if eq .Page "dashboard"}}is-active{{end}}" href="/">Overview</a>
       <a class="am-tab {{if eq .Page "phones"}}is-active{{end}}" href="/phones">Lines</a>
       <a class="am-tab {{if eq .Page "links"}}is-active{{end}}" href="/links">Families</a>
@@ -32,12 +32,10 @@
       <a class="am-tab {{if eq .Page "settings"}}is-active{{end}}" href="/settings">Settings</a>
     </nav>
 
-    <div class="am-shell__spacer"></div>
-
     {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
 
-    <form method="POST" action="/auth/logout" style="margin: 0;">
-      <button class="am-key" type="submit" style="min-width: 0; min-height: 32px; padding: 4px 10px;">
+    <form class="am-shell__signout-form" method="POST" action="/auth/logout">
+      <button class="am-key am-key--nav" type="submit">
         <span class="am-key__label">Sign out</span>
       </button>
     </form>
@@ -54,6 +52,20 @@
 {{end}}
 
 {{template "confirm-dialog" .}}
+
+{{if ne .Page "login"}}
+<script>
+(function () {
+  var toggle = document.getElementById('am-nav-toggle');
+  var tabs = document.getElementById('am-nav-tabs');
+  if (!toggle || !tabs) return;
+  toggle.addEventListener('click', function () {
+    var open = tabs.classList.toggle('is-open');
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  });
+})();
+</script>
+{{end}}
 
 </body>
 </html>

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -171,6 +171,18 @@
             <span class="theme-card__desc">Blue gradients, chunky 3D bevels, Tahoma, dial-up-era 'Welcome!' energy.</span>
           </span>
         </label>
+        <label class="theme-card {{if eq .User.Theme "answering-machine"}}theme-card--selected{{end}}">
+          <input type="radio" name="theme" value="answering-machine" {{if eq .User.Theme "answering-machine"}}checked{{end}}>
+          <span class="theme-card__swatch">
+            <span class="theme-card__swatch-strip" style="background: #d6ccae;"></span>
+            <span class="theme-card__swatch-strip" style="background: #1a1912;"></span>
+            <span class="theme-card__swatch-strip" style="background: #ffa520;"></span>
+          </span>
+          <span class="theme-card__body">
+            <span class="theme-card__name">Answering machine</span>
+            <span class="theme-card__desc">Beige injection-molded plastic, chicklet keys, amber LED readouts. The unlit REC lamp is the point.</span>
+          </span>
+        </label>
         <button type="submit" class="btn btn--primary">Save theme</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary

Phase 1 of 6 for the new Answering Machine theme: a beige mid-90s plastic answering-machine aesthetic for the webapp theme gallery. This PR lands only the foundation. It:

- Adds `ThemeAnsweringMachine` to the `auth.Theme` enum.
- Ships `static/answering-machine.css` (plates, wells, chicklet keys, status lamps, LED readouts, REC lamp, cassette tape, patchbay, machine-unit, cord, DIP, knob, mechanical toggle) plus shared-class shims so every existing template renders coherently on the AM palette.
- Adds `templates/layout-answering-machine.html` with brand plate, cassette-deck tabs, household label, sign-out chicklet, mobile menu.
- Routes the enum in `layoutFor()` and registers the new layout in `parsePage`.
- Adds a third theme card in `settings.html` with amber LED swatch strip.

Feature controls visible in the eventual mockups (household DND, per-line quiet hours, ring test, at-rest link health) are out of scope here; they are tracked as candidate features in #269, #270, #271, #272 and surface as visual placeholders until those ship.

## What this does not do

- Does not change the intercom or dialup themes.
- Does not reskin any page body. Phase 2 (dashboard), 3 (lines), 4 (families), 5 (settings) follow.
- Does not ship the patchbay, two-unit cord, DIP/knob UX, etc., as page content; the CSS primitives for them are present but unused by templates until their phase PRs.

## Test plan

- [x] `go test ./internal/auth/ ./internal/web/` passes.
- [x] `golangci-lint run ./internal/auth/... ./internal/web/...` reports 0 issues.
- [x] Local dev-server smoke test: signed in as the seeded `dev@digits.local`, switched theme to Answering machine via `POST /settings/theme`, confirmed `answering-machine.css`, `am-shell`, `am-tab`, and `Digits 2500` markers appear on `/`, `/phones`, `/links`, `/settings`.
- [x] `/auth/login` unauthenticated still loads the default layout (only `digits.css`, no AM markers). Login flow is untouched.
- [ ] Reviewer: `cd server && make dev-up` (set a free `SIGNALD_ADDR` if 8080 is taken), sign in, switch theme to Answering machine on `/settings`, click through every page to confirm the beige shell looks coherent.

## Screenshots

Foundation chrome only; per-page bespoke AM markup lands in phases 2 to 5.

Settings with theme picker (Answering machine selected):

![settings](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-273-am-settings.png)

Overview, top of page showing chrome and line cards:

![dashboard](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-273-am-dashboard.png)