### PR TITLE
docs: add "definition of done" rule for substantial work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,16 @@ docs: update wiring notes
 
 **Style.** Go uses standard project layout, raw SQL with `database/sql` (no ORM), errors returned not panicked. Server web UI uses htmx + Tailwind, templates in `internal/web/templates/`. Firmware uses C with Pico SDK conventions.
 
+## Definition of done for substantial work
+
+Substantial = plan has 4+ tasks, PR touches 3+ files of non-trivial code, or work spans multiple sessions. Every plan for substantial work MUST end with a "phase close-out" task:
+
+1. Full test suite passes.
+2. Run `/simplify`; address genuine findings as a separate commit on the same branch. YAGNI-skip borderline ones with a one-line reason.
+3. Push; open or update the PR with inline screenshots if the change has a visual surface.
+
+Small fixes, docs, dep bumps, and typo PRs do not need this pass; their plans may omit the task.
+
 ## CI
 
 GitHub Actions workflows in `.github/workflows/`:


### PR DESCRIPTION
## Summary

Adds a short rule to CLAUDE.md codifying the end-of-phase close-out pass (full tests, `/simplify`, push with screenshots for visual changes) that we've been running by hand on recent multi-phase work.

Every plan for substantial work (4+ tasks, 3+ files of non-trivial code, or multi-session) must end with a "phase close-out" task. Small fixes, docs, dep bumps, and typo PRs are explicitly exempted.

Motivation: the `/simplify` pass has caught real reuse, quality, and efficiency issues on recent PRs (and once a visual regression via screenshot verification). Making it a first-class final task rather than an ad-hoc habit means it runs consistently.

## Test plan

- [x] Doc-only change; no code impact.