### PR TITLE
feat(server): AM theme dashboard reskin (phase 2 of 6)

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -235,6 +235,8 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			return segDesc{Lit: lit, Severity: sev}
 		},
 		"renderNotes": renderNotes,
+		"add":         func(a, b int) int { return a + b },
+		"lastLine":    func(i int, lines []lineRow) bool { return i == len(lines)-1 },
 		"edgeFor": func(edges []ConferenceLinkHealthEdge, from, peer string) *ConferenceLinkHealthEdge {
 			for i := range edges {
 				if edges[i].From == from && edges[i].Peer == peer {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -190,8 +190,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			}
 			return out
 		},
-		"add":      func(a, b int) int { return a + b },
-		"lastLine": func(i int, lines []lineRow) bool { return i == len(lines)-1 },
+		"inc": func(n int) int { return n + 1 },
 		"humanBytes": func(n int64) string {
 			switch {
 			case n > 1024*1024:

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -190,6 +190,8 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			}
 			return out
 		},
+		"add":      func(a, b int) int { return a + b },
+		"lastLine": func(i int, lines []lineRow) bool { return i == len(lines)-1 },
 		"humanBytes": func(n int64) string {
 			switch {
 			case n > 1024*1024:
@@ -235,8 +237,6 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			return segDesc{Lit: lit, Severity: sev}
 		},
 		"renderNotes": renderNotes,
-		"add":         func(a, b int) int { return a + b },
-		"lastLine":    func(i int, lines []lineRow) bool { return i == len(lines)-1 },
 		"edgeFor": func(edges []ConferenceLinkHealthEdge, from, peer string) *ConferenceLinkHealthEdge {
 			for i := range edges {
 				if edges[i].From == from && edges[i].Peer == peer {

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -23,6 +23,7 @@ type dashboardData struct {
 	CallsTodayTotalMin int
 	LinkedFamilies     []linkedFamilyRow
 	User               *auth.User
+	Now                time.Time
 }
 
 type callRow struct {
@@ -167,6 +168,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		CallsTodayTotalMin: (callsTodayTotalSec + 30) / 60, // +30 to round to nearest minute
 		LinkedFamilies:     linkedFamilies,
 		User:               user,
+		Now:                time.Now().In(loc),
 	}
 	renderWith(w, h.tmplDashboard, layoutFor(r), data)
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -24,6 +24,9 @@ type dashboardData struct {
 	LinkedFamilies     []linkedFamilyRow
 	User               *auth.User
 	Now                time.Time
+	ActiveLine         string
+	ActivePeer         string
+	ActiveElapsed      string
 }
 
 type callRow struct {
@@ -56,6 +59,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	ld := h.buildLinesData(r, "")
 	user := auth.UserFromContext(r.Context())
 	hhName, callHistoryEnabled, loc := h.householdContext(r)
+	now := time.Now().In(loc)
 
 	// Determine current household ID for linked-family lookup.
 	var householdID string
@@ -116,6 +120,19 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Pluck the first household-scoped active call for the AM dashboard's
+	// single session panel. Deterministic "first" by Lines order beats the
+	// silent "last" that a template-side scan would produce.
+	var activeLine, activePeer, activeElapsed string
+	for _, lr := range ld.Lines {
+		if lr.OnCall {
+			activeLine = lr.Line.Name
+			activePeer = lr.OnCallPeerName
+			activeElapsed = lr.OnCallElapsed
+			break
+		}
+	}
+
 	// Build today's call rows when history is enabled. Scoped to this
 	// household's own line numbers so one family never sees another's
 	// activity. "Today" is relative to the household's configured timezone,
@@ -124,7 +141,6 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	var callsTodayTotalSec int
 	if callHistoryEnabled && len(ownNumbers) > 0 {
 		recent, _ := h.tracker.RecentForPhones(ctx, ownNumbers, 20)
-		now := time.Now().In(loc)
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 		for _, c := range recent {
 			if !c.StartedAt.After(today) {
@@ -168,7 +184,10 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		CallsTodayTotalMin: (callsTodayTotalSec + 30) / 60, // +30 to round to nearest minute
 		LinkedFamilies:     linkedFamilies,
 		User:               user,
-		Now:                time.Now().In(loc),
+		Now:                now,
+		ActiveLine:         activeLine,
+		ActivePeer:         activePeer,
+		ActiveElapsed:      activeElapsed,
 	}
 	renderWith(w, h.tmplDashboard, layoutFor(r), data)
 }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -25,6 +25,7 @@
   --led-amber: #ffa520;
   --led-amber-dim: #6b4612;
   --led-green: #3dd94a;
+  --led-green-dark: #2b7d34;
   --led-red: #ff3d2e;
 
   /* Buttons */
@@ -779,7 +780,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-overview__line-num { font-size: 11px; }
 .am-overview__line-status { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; }
 .am-overview__line-status--live { color: var(--led-red); }
-.am-overview__line-status--online { color: #2b7d34; }
+.am-overview__line-status--online { color: var(--led-green-dark); }
 .am-overview__line-status--idle { color: var(--ink-muted); }
 
 /* Mobile: stack the top row and the main grid */

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -718,3 +718,76 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .t th, .t td { padding: 8px 10px; text-align: left; border-bottom: 1px dashed rgba(100,80,40,0.2); }
 .t th { font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-muted); }
 .t td.num, .t th.num { font-family: var(--font-mono); color: var(--ink); letter-spacing: 0.04em; }
+
+/* =========================================================================
+   Overview page layout (phase 2). Uses primitives from earlier sections;
+   adds only grid and composition rules specific to the dashboard.
+   ========================================================================= */
+
+.am-overview { display: flex; flex-direction: column; gap: 18px; }
+
+/* Top row: status LED plate (wide) + indicators cluster (narrow) */
+.am-overview__top { display: grid; grid-template-columns: 1fr 340px; gap: 18px; }
+.am-overview__status { padding: 18px 22px 16px; }
+.am-overview__status-label { margin-bottom: 10px; }
+.am-overview__indicators { position: relative; padding: 16px 18px 14px; }
+
+/* LED well. Row of LED groups separated by thin amber rules;
+   a spacer pushes LOCAL TIME to the right. */
+.am-overview__led-well { display: flex; align-items: center; gap: 20px; padding: 14px 18px; }
+.am-overview__led-group { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+.am-overview__led-group--right { align-items: flex-end; text-align: right; }
+.am-overview__led-sep { width: 1px; height: 48px; background: rgba(255,165,32,0.2); }
+.am-overview__led-spacer { flex: 1; }
+.am-overview__led-big { font-size: 44px; line-height: 1; }
+.am-overview__led-mid { font-size: 28px; line-height: 1; }
+.am-overview__led-time { font-size: 18px; line-height: 1; }
+.am-overview__led-caption { font-size: 9px; letter-spacing: 0.2em; }
+
+/* Indicator lamps cluster */
+.am-overview__lamps { display: flex; align-items: center; justify-content: space-around; padding-top: 6px; padding-bottom: 8px; }
+.am-overview__lamp { display: inline-flex; flex-direction: column; align-items: center; gap: 3px; }
+.am-overview__lamp-label { font-family: var(--font-body); font-size: 7.5px; letter-spacing: 0.18em; color: var(--label); text-transform: uppercase; font-weight: 600; }
+.am-overview__rec { margin-top: 12px; padding-top: 12px; border-top: 1px dashed rgba(100,80,40,0.3); display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+.am-overview__rec-hint { font-size: 10px; text-align: right; max-width: 180px; line-height: 1.3; }
+
+/* Main grid: wider messages column + narrower lines column */
+.am-overview__grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 18px; align-items: start; }
+.am-overview__messages { padding: 0; overflow: hidden; }
+.am-overview__lines { padding: 18px 16px 14px; }
+
+/* Active session header inside messages plate */
+.am-overview__session-head { display: flex; align-items: center; gap: 12px; padding: 14px 18px 10px; border-bottom: 1px solid rgba(100,80,40,0.2); }
+.am-overview__session-dot { font-size: 14px; }
+.am-overview__session-title { flex: 1; }
+.am-overview__session-elapsed { font-size: 11.5px; }
+.am-overview__session-tape { padding: 14px; }
+.am-overview__tape-caption { display: flex; justify-content: space-between; margin-bottom: 4px; color: #e8daa8; }
+
+.am-overview__messages-head { padding: 8px 18px 6px; display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+.am-overview__messages-sub { font-size: 11px; letter-spacing: 0.04em; }
+.am-overview__messages-list { padding: 0 4px 8px; }
+.am-overview__messages-empty { padding: 14px 18px 16px; }
+.am-overview__msg-row { display: flex; gap: 10px; align-items: baseline; }
+.am-overview__msg-meta { font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; margin-top: 2px; }
+
+/* Lines panel rows */
+.am-overview__line { display: grid; grid-template-columns: 16px 1fr auto; align-items: center; gap: 10px; padding: 8px 0; text-decoration: none; color: inherit; }
+.am-overview__line--bordered { border-bottom: 1px dashed rgba(100,80,40,0.2); }
+.am-overview__line-body { min-width: 0; }
+.am-overview__line-name { font-size: 12.5px; }
+.am-overview__line-num { font-size: 11px; }
+.am-overview__line-status { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; }
+.am-overview__line-status--live { color: var(--led-red); }
+.am-overview__line-status--online { color: #2b7d34; }
+.am-overview__line-status--idle { color: var(--ink-muted); }
+
+/* Mobile: stack the top row and the main grid */
+@media (max-width: 780px) {
+  .am-overview__top { grid-template-columns: 1fr; }
+  .am-overview__grid { grid-template-columns: 1fr; }
+  .am-overview__led-well { flex-wrap: wrap; gap: 14px; }
+  .am-overview__led-spacer { display: none; }
+  .am-overview__led-sep { display: none; }
+  .am-overview__led-group--right { align-items: flex-start; text-align: left; }
+}

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -773,8 +773,8 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-overview__msg-meta { font-size: 10.5px; letter-spacing: 0.14em; text-transform: uppercase; margin-top: 2px; }
 
 /* Lines panel rows */
-.am-overview__line { display: grid; grid-template-columns: 16px 1fr auto; align-items: center; gap: 10px; padding: 8px 0; text-decoration: none; color: inherit; }
-.am-overview__line--bordered { border-bottom: 1px dashed rgba(100,80,40,0.2); }
+.am-overview__line { display: grid; grid-template-columns: 16px 1fr auto; align-items: center; gap: 10px; padding: 8px 0; text-decoration: none; color: inherit; border-bottom: 1px dashed rgba(100,80,40,0.2); }
+.am-overview__line:last-child { border-bottom: 0; }
 .am-overview__line-body { min-width: 0; }
 .am-overview__line-name { font-size: 12.5px; }
 .am-overview__line-num { font-size: 11px; }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -27,6 +27,7 @@
   --led-green: #3dd94a;
   --led-green-dark: #2b7d34;
   --led-red: #ff3d2e;
+  --tape-ink: #e8daa8;
 
   /* Buttons */
   --btn: #ded3b2;
@@ -729,7 +730,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 /* Top row: status LED plate (wide) + indicators cluster (narrow) */
 .am-overview__top { display: grid; grid-template-columns: 1fr 340px; gap: 18px; }
-.am-overview__status { padding: 18px 22px 16px; }
+.am-overview__status { padding: 18px 22px 16px; min-width: 0; }
 .am-overview__status-label { margin-bottom: 10px; }
 .am-overview__indicators { position: relative; padding: 16px 18px 14px; }
 
@@ -763,7 +764,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-overview__session-title { flex: 1; }
 .am-overview__session-elapsed { font-size: 11.5px; }
 .am-overview__session-tape { padding: 14px; }
-.am-overview__tape-caption { display: flex; justify-content: space-between; margin-bottom: 4px; color: #e8daa8; }
+.am-overview__tape-caption { display: flex; justify-content: space-between; margin-bottom: 4px; color: var(--tape-ink); }
 
 .am-overview__messages-head { padding: 8px 18px 6px; display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
 .am-overview__messages-sub { font-size: 11px; letter-spacing: 0.04em; }

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -1,6 +1,9 @@
 {{define "title"}}Overview{{end}}
 
 {{define "content"}}
+{{if eq .User.Theme "answering-machine"}}
+  {{template "dashboard-am" .}}
+{{else}}
 <div class="page">
 
   <header class="page__head">
@@ -80,5 +83,150 @@
 
   {{template "page-footer" .}}
 
+</div>
+{{end}}
+{{end}}
+
+{{define "dashboard-am"}}
+<div class="am-overview">
+
+  {{/* Top row: LED status display + indicator lamps cluster */}}
+  <div class="am-overview__top">
+
+    {{/* LED status plate */}}
+    <div class="am-plate am-plate--screws am-overview__status">
+      <div class="am-screw am-screw--tl"></div><div class="am-screw am-screw--tr"></div>
+      <div class="am-label am-overview__status-label">Status &middot; {{.Now.Format "Monday, January 2"}}</div>
+      <div class="am-well am-overview__led-well">
+        <div class="am-overview__led-group">
+          <div class="am-led am-overview__led-big">{{printf "%02d" .Stats.ActiveCalls}}</div>
+          <div class="am-led am-led--dim am-overview__led-caption">ON&middot;CALL</div>
+        </div>
+        <div class="am-overview__led-sep"></div>
+        <div class="am-overview__led-group">
+          <div class="am-led am-led--green am-overview__led-mid">{{.Stats.OnlineLines}}</div>
+          <div class="am-led am-led--dim am-overview__led-caption">LINES&middot;ONLINE</div>
+        </div>
+        <div class="am-overview__led-sep"></div>
+        <div class="am-overview__led-group">
+          <div class="am-led am-overview__led-mid">{{len .LinkedFamilies}}</div>
+          <div class="am-led am-led--dim am-overview__led-caption">FAMILIES</div>
+        </div>
+        <div class="am-overview__led-spacer"></div>
+        <div class="am-overview__led-group am-overview__led-group--right">
+          <div class="am-led am-overview__led-time">{{.Now.Format "3:04pm"}}</div>
+          <div class="am-led am-led--dim am-overview__led-caption">LOCAL&middot;TIME</div>
+        </div>
+      </div>
+    </div>
+
+    {{/* Indicator lamps + REC-off cluster */}}
+    <div class="am-plate am-overview__indicators">
+      <div class="am-plate__label">Indicators</div>
+      <div class="am-overview__lamps">
+        <div class="am-overview__lamp">
+          <span class="am-lamp{{if gt .Stats.ActiveCalls 0}} am-lamp--on-red{{end}}"></span>
+          <span class="am-overview__lamp-label">Ringing</span>
+        </div>
+        <div class="am-overview__lamp">
+          <span class="am-lamp{{if gt .Stats.OnlineLines 0}} am-lamp--on-green{{end}}"></span>
+          <span class="am-overview__lamp-label">Online</span>
+        </div>
+        <div class="am-overview__lamp">
+          <span class="am-lamp{{if .LinkedFamilies}} am-lamp--on-amber{{end}}"></span>
+          <span class="am-overview__lamp-label">Paired</span>
+        </div>
+      </div>
+      <div class="am-overview__rec">
+        <div class="am-rec"><span class="am-lamp"></span><span class="am-rec__label">REC</span></div>
+        <div class="am-hint am-overview__rec-hint">This lamp is wired to nothing. Audio never reaches this box.</div>
+      </div>
+    </div>
+  </div>
+
+  {{/* Main grid: active session + messages on the left, lines on the right */}}
+  <div class="am-overview__grid">
+
+    {{/* LEFT column: active session (if any) + today's calls */}}
+    <div class="am-plate am-overview__messages">
+      {{$activeLine := ""}}{{$activePeer := ""}}{{$activeElapsed := ""}}
+      {{range .Lines}}{{if .OnCall}}{{$activeLine = .Line.Name}}{{$activePeer = .OnCallPeerName}}{{$activeElapsed = .OnCallElapsed}}{{end}}{{end}}
+
+      {{if $activeLine}}
+      <div class="am-overview__session-head">
+        <span class="am-led am-led--red am-overview__session-dot">&#9679;</span>
+        <span class="am-title am-overview__session-title">{{$activeLine}} is on a call with {{$activePeer}}</span>
+        {{if $activeElapsed}}<span class="am-mono am-muted am-overview__session-elapsed">{{$activeElapsed}} elapsed</span>{{end}}
+      </div>
+      <div class="am-overview__session-tape">
+        <div class="am-tape">
+          <span class="am-tape__label">Session</span>
+          <div class="am-tape__reel"></div>
+          <div>
+            <div class="am-overview__tape-caption">
+              <span>{{$activeLine}} &#8596; {{$activePeer}}</span>
+              <span>{{$activeElapsed}}</span>
+            </div>
+            <div class="am-tape__tape"></div>
+          </div>
+          <div class="am-tape__reel"></div>
+        </div>
+      </div>
+      {{end}}
+
+      <div class="am-overview__messages-head">
+        <span class="am-label">Today's calls</span>
+        {{if .CallHistoryEnabled}}<span class="am-mono am-muted am-overview__messages-sub">{{len .CallsTodayRecent}} call{{if ne (len .CallsTodayRecent) 1}}s{{end}} &middot; {{.CallsTodayTotalMin}} min total</span>{{end}}
+      </div>
+
+      {{if .CallHistoryEnabled}}
+        {{if .CallsTodayRecent}}
+        <div class="am-overview__messages-list">
+          {{range $i, $c := .CallsTodayRecent}}
+          <div class="am-msg">
+            <span class="am-msg__num">{{printf "%02d" (add $i 1)}}</span>
+            <div>
+              <div class="am-overview__msg-row">
+                <span class="am-msg__who">{{$c.PeerName}}</span>
+                <span class="am-msg__room">&middot; {{$c.LineName}}</span>
+              </div>
+              <div class="am-mono am-muted am-overview__msg-meta">{{if eq $c.Direction "in"}}Answered{{else}}Placed{{end}}</div>
+            </div>
+            <span class="am-msg__time">{{$c.StartedAt.Format "3:04 pm"}}</span>
+            <span class="am-msg__dur">{{fmtDuration $c.DurationS}}</span>
+          </div>
+          {{end}}
+        </div>
+        {{else}}
+        <div class="am-overview__messages-empty am-hint">No calls yet today.</div>
+        {{end}}
+      {{else}}
+        <div class="am-overview__messages-empty am-hint">Call history is off. The dashboard only shows the active session.</div>
+      {{end}}
+    </div>
+
+    {{/* RIGHT column: Lines panel */}}
+    <div class="am-plate am-overview__lines">
+      <div class="am-plate__label">Lines</div>
+      {{if .Lines}}
+        {{range $i, $l := .Lines}}
+        <a class="am-overview__line{{if not (lastLine $i $.Lines)}} am-overview__line--bordered{{end}}" href="{{if and $l.OnCall $l.OnCallID}}/call/live/{{$l.OnCallID}}{{else}}/phones/{{$l.Line.Number}}{{end}}">
+          <span class="am-lamp{{if $l.OnCall}} am-lamp--on-red{{else if $l.Online}} am-lamp--on-green{{end}}"></span>
+          <div class="am-overview__line-body">
+            <div class="am-title am-overview__line-name">{{$l.Line.Name}}</div>
+            <div class="am-mono am-muted am-overview__line-num">{{fmtPhone $l.Line.Number}}</div>
+          </div>
+          <span class="am-overview__line-status{{if $l.OnCall}} am-overview__line-status--live{{else if $l.Online}} am-overview__line-status--online{{else}} am-overview__line-status--idle{{end}}">
+            {{if $l.OnCall}}In session{{else if $l.Online}}Online{{else}}Idle{{end}}
+          </span>
+        </a>
+        {{end}}
+      {{else}}
+        <div class="am-hint">No lines paired. <a href="/phones">Pair a handset</a>.</div>
+      {{end}}
+    </div>
+  </div>
+
+  {{template "page-footer" .}}
 </div>
 {{end}}

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -149,14 +149,11 @@
 
     {{/* LEFT column: active session (if any) + today's calls */}}
     <div class="am-plate am-overview__messages">
-      {{$activeLine := ""}}{{$activePeer := ""}}{{$activeElapsed := ""}}
-      {{range .Lines}}{{if .OnCall}}{{$activeLine = .Line.Name}}{{$activePeer = .OnCallPeerName}}{{$activeElapsed = .OnCallElapsed}}{{end}}{{end}}
-
-      {{if $activeLine}}
+      {{if .ActiveLine}}
       <div class="am-overview__session-head">
         <span class="am-led am-led--red am-overview__session-dot">&#9679;</span>
-        <span class="am-title am-overview__session-title">{{$activeLine}} is on a call with {{$activePeer}}</span>
-        {{if $activeElapsed}}<span class="am-mono am-muted am-overview__session-elapsed">{{$activeElapsed}} elapsed</span>{{end}}
+        <span class="am-title am-overview__session-title">{{.ActiveLine}} is on a call with {{.ActivePeer}}</span>
+        {{if .ActiveElapsed}}<span class="am-mono am-muted am-overview__session-elapsed">{{.ActiveElapsed}} elapsed</span>{{end}}
       </div>
       <div class="am-overview__session-tape">
         <div class="am-tape">
@@ -164,8 +161,8 @@
           <div class="am-tape__reel"></div>
           <div>
             <div class="am-overview__tape-caption">
-              <span>{{$activeLine}} &#8596; {{$activePeer}}</span>
-              <span>{{$activeElapsed}}</span>
+              <span>{{.ActiveLine}} &#8596; {{.ActivePeer}}</span>
+              <span>{{.ActiveElapsed}}</span>
             </div>
             <div class="am-tape__tape"></div>
           </div>
@@ -184,7 +181,7 @@
         <div class="am-overview__messages-list">
           {{range $i, $c := .CallsTodayRecent}}
           <div class="am-msg">
-            <span class="am-msg__num">{{printf "%02d" (add $i 1)}}</span>
+            <span class="am-msg__num">{{printf "%02d" (inc $i)}}</span>
             <div>
               <div class="am-overview__msg-row">
                 <span class="am-msg__who">{{$c.PeerName}}</span>
@@ -209,8 +206,8 @@
     <div class="am-plate am-overview__lines">
       <div class="am-plate__label">Lines</div>
       {{if .Lines}}
-        {{range $i, $l := .Lines}}
-        <a class="am-overview__line{{if not (lastLine $i $.Lines)}} am-overview__line--bordered{{end}}" href="{{if and $l.OnCall $l.OnCallID}}/call/live/{{$l.OnCallID}}{{else}}/phones/{{$l.Line.Number}}{{end}}">
+        {{range $l := .Lines}}
+        <a class="am-overview__line" href="{{if and $l.OnCall $l.OnCallID}}/call/live/{{$l.OnCallID}}{{else}}/phones/{{$l.Line.Number}}{{end}}">
           <span class="am-lamp{{if $l.OnCall}} am-lamp--on-red{{else if $l.Online}} am-lamp--on-green{{end}}"></span>
           <div class="am-overview__line-body">
             <div class="am-title am-overview__line-name">{{$l.Line.Name}}</div>


### PR DESCRIPTION
## Summary

Phase 2 of 6 for the Answering Machine theme. Reskins the `/` Overview page with bespoke markup using the CSS primitives shipped in #273.

- **LED status header**: `NN ON CALL`, `N LINES ONLINE`, `N FAMILIES`, local time, in amber seven-seg-style LEDs with glow.
- **Indicator lamps cluster**: Ringing (red, pulses on active call), Online (green), Paired (amber). REC lamp below with the one authoritative privacy caption.
- **Active session cassette**: two spinning reels and a striped tape whenever a line is in session. Shows the first household-scoped active call deterministically.
- **Today's messages list** with LED-styled numbered entries.
- **Compact Lines panel** on the right, per-line lamps wired to OnCall (red), Online (green), Idle (dark).

All data-driven from existing `dashboardData` plus one new `Now` field for the local-time LED and three pre-computed active-session fields. No feature controls rendered (DND, quiet hours, ring test, at-rest link health): those remain candidate features tracked in #269–#272.

Phase close-out per CLAUDE.md > Definition of done:
- `/simplify` pass aggregated three fixes, landed as a separate commit:
  - Dropped the `lastLine` funcMap helper; the stylesheet already uses `:last-child` for identical effect in two other selectors. Removes a `lineRow` type dependency from the funcMap.
  - Hoisted the active-session scan from template into handler. Template was silently picking the LAST on-call line via a `{{range}}{{if .OnCall}}$var = ...{{end}}{{end}}` pattern; handler now picks the FIRST deterministically and the scan is testable from Go.
  - Single `now := time.Now().In(loc)` at the top of `handleDashboard`, reused for both the call-history day boundary and the `Now` field. Removes a latent second-boundary drift.
  - Renamed `add` funcMap helper to `inc` since its one caller is a 1-based counter.
- `go test ./...` passes. `golangci-lint run ./internal/auth/... ./internal/web/...` reports 0 issues.
- Local smoke test: confirmed idle + active-call paths render via agent-browser. Test call seeded through the existing `/test-harness/start-call` dev endpoint.

## What this does not do

- Does not reskin `/phones`, `/links`, `/settings`. Those are phases 3 to 5.
- Does not change the intercom or dialup dashboards.

## Screenshots

Idle (no active call):

![dashboard-idle](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-275-am-dashboard-idle.png)

Active call (Ringing lamp, cassette spinning, session header, Lines panel reflects in-session):

![dashboard-oncall](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-275-am-dashboard-oncall.png)