### PR TITLE
chore(server,digitsd,firmware): log party-line lifecycle events

### DIFF
--- a/firmware/src/hook.c
+++ b/firmware/src/hook.c
@@ -1,5 +1,7 @@
 #include "hook.h"
 
+#include <stdio.h>
+
 #include "hardware/gpio.h"
 #include "pico/time.h"
 
@@ -117,6 +119,7 @@ void hook_poll(void) {
                     // immediately (see comment above).
                     s_flash_pending = true;
                     s_flash_start = get_absolute_time();
+                    printf("HOOK:FLASH:WINDOW_OPEN\n");
                 } else {
                     // Flash disabled: hangup is instantaneous.
                     s_event = HOOK_EVENT_ON;
@@ -131,8 +134,10 @@ void hook_poll(void) {
                     s_flash_pending = false;
                     if (on_ms >= FLASH_MIN_MS && on_ms <= FLASH_MAX_MS) {
                         s_event = HOOK_EVENT_FLASH;
+                    } else {
+                        // Under FLASH_MIN_MS: contact bounce, suppress.
+                        printf("HOOK:FLASH:REJECT:BOUNCE on_ms=%lld\n", on_ms);
                     }
-                    // Under FLASH_MIN_MS: contact bounce, suppress.
                 } else {
                     // Normal pickup from committed on-hook state.
                     s_event = HOOK_EVENT_OFF;
@@ -149,6 +154,7 @@ void hook_poll(void) {
         if (on_ms > FLASH_MAX_MS) {
             s_flash_pending = false;
             s_event = HOOK_EVENT_ON;
+            printf("HOOK:FLASH:REJECT:TIMEOUT on_ms=%lld\n", on_ms);
         }
     }
 }

--- a/pi/digitsd/cmd/digitsd/linkhealth.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
@@ -20,6 +21,7 @@ type sigSender interface {
 // prior reporter for this peer before spawning a fresh one).
 func (d *daemonCallbacks) meshReporterOnConnected(pm *owebrtc.PeerManager, peerPhone string) func(webrtc.PeerConnectionState) {
 	return func(state webrtc.PeerConnectionState) {
+		slog.Info("conference: mesh PC state", "phone", peerPhone, "state", state.String())
 		if state != webrtc.PeerConnectionStateConnected {
 			return
 		}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -583,6 +583,7 @@ func (d *daemonCallbacks) RequestConferenceMerge(held, active string) {
 	d.mu.Lock()
 	sig := d.sig
 	d.mu.Unlock()
+	slog.Info("conference: sending ConferenceMerge to server", "held", held, "active", active)
 	sendSignal(sig, &sigclient.Message{
 		Type:       sigclient.TypeConferenceMerge,
 		HeldPeer:   held,
@@ -625,13 +626,19 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 	// would race against the remote track arriving.
 	webrtcCh := d.mixer.AddWebRTCSource(phone)
 	pm.OnRemoteTrack = func(track *webrtc.TrackRemote) {
+		slog.Info("conference: remote track attached (initiator)", "phone", phone)
 		go func() {
 			defer recoverGoroutine("conf-remote-track-" + phone)
+			gotFirst := false
 			for {
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
 					slog.Info("conference: remote track ended", "phone", phone)
 					return
+				}
+				if !gotFirst {
+					slog.Info("conference: first RTP packet received", "phone", phone)
+					gotFirst = true
 				}
 				// pm owns its own decoder — safe to call concurrently with other peers.
 				pcm, err := pm.Decode(pkt.Payload)
@@ -692,6 +699,7 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 }
 
 func (d *daemonCallbacks) RemoveMeshPeer(phone string) {
+	slog.Info("conference: removing mesh peer", "phone", phone)
 	d.mu.Lock()
 	mesh := d.mesh
 	if cancel, ok := d.meshReporterCancels[phone]; ok {
@@ -708,15 +716,20 @@ func (d *daemonCallbacks) RemoveMeshPeer(phone string) {
 func (d *daemonCallbacks) TearDownAllMeshPeers() {
 	d.mu.Lock()
 	mesh := d.mesh
+	var peers []string
+	if mesh != nil {
+		peers = mesh.ActivePeers()
+	}
 	for phone, cancel := range d.meshReporterCancels {
 		cancel()
 		delete(d.meshReporterCancels, phone)
 	}
 	d.mu.Unlock()
+	slog.Info("conference: tearing down all mesh peers", "count", len(peers), "peers", peers)
 	if mesh == nil {
 		return
 	}
-	for _, p := range mesh.ActivePeers() {
+	for _, p := range peers {
 		d.mixer.RemoveWebRTCSource(p)
 	}
 	mesh.CloseAll()
@@ -742,13 +755,19 @@ func (d *daemonCallbacks) setupMeshResponder(peer, offerSDP, confID string) (str
 	// Wire remote audio track BEFORE AcceptOffer so pion cannot miss it.
 	webrtcCh := d.mixer.AddWebRTCSource(peer)
 	pm.OnRemoteTrack = func(track *webrtc.TrackRemote) {
+		slog.Info("conference: remote track attached (responder)", "phone", peer)
 		go func() {
 			defer recoverGoroutine("conf-remote-track-" + peer)
+			gotFirst := false
 			for {
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
 					slog.Info("conference: remote track ended (responder)", "phone", peer)
 					return
+				}
+				if !gotFirst {
+					slog.Info("conference: first RTP packet received (responder)", "phone", peer)
+					gotFirst = true
 				}
 				// pm owns its own decoder — safe to call concurrently with other peers.
 				pcm, err := pm.Decode(pkt.Payload)

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -317,6 +317,7 @@ func (c *Controller) onKey(digit string) {
 		}
 	case StateADD_DIALTONE:
 		// First key during add-dial: stop the second dial tone, start collecting.
+		slog.Info("phone: ADD_DIALTONE -> ADD_DIALING", "digit", digit)
 		c.state = StateADD_DIALING
 		c.digits = digit
 		c.cb.SendTone(ToneStop)
@@ -434,6 +435,7 @@ func (c *Controller) dialThirdParty(number string) {
 		return
 	}
 
+	slog.Info("phone: ADD_DIALING -> ADD_CALLING", "adding", number)
 	c.addingPeer = number
 	c.digits = ""
 	c.state = StateADD_CALLING
@@ -474,6 +476,7 @@ func (c *Controller) onSignalAnswer(sender string) {
 			slog.Info("phone: answer from unexpected peer in ADD_CALLING", "from", sender, "adding", c.addingPeer)
 			return
 		}
+		slog.Info("phone: ADD_CALLING -> ADD_PRIVATE", "adding", c.addingPeer)
 		c.state = StateADD_PRIVATE
 		c.cb.SendTone(ToneStop)
 	default:
@@ -626,8 +629,10 @@ func (c *Controller) HandleHookFlash(activePeer string) {
 // onHookFlash dispatches the HOOK:FLASH event per 90s residential TWC semantics.
 // Called with c.mu already held.
 func (c *Controller) onHookFlash(activePeer string) {
+	slog.Info("phone: HOOK:FLASH received", "state", c.state, "conf_id", c.confID, "is_host", c.isConfHost, "active_peer", activePeer)
 	// Non-host in an active conference: flash is a no-op (historical accuracy).
 	if c.confID != "" && !c.isConfHost {
+		slog.Info("phone: HOOK:FLASH no-op (non-host in conference)", "conf_id", c.confID)
 		return
 	}
 	switch c.state {
@@ -643,12 +648,14 @@ func (c *Controller) onHookFlash(activePeer string) {
 		c.abortAdd()
 	case StateCONFERENCE_MERGED:
 		// No-op in v1 (no second add, no drop-last-party).
+		slog.Info("phone: HOOK:FLASH no-op (CONFERENCE_MERGED, v1)")
 	default:
-		// Any other state: no-op.
+		slog.Info("phone: HOOK:FLASH no-op (unhandled state)", "state", c.state)
 	}
 }
 
 func (c *Controller) enterAddDialtone(activePeer string) {
+	slog.Info("phone: CONNECTED -> ADD_DIALTONE", "held", activePeer)
 	c.heldPeer = activePeer
 	c.state = StateADD_DIALTONE
 	if c.heldPeer != "" {
@@ -659,6 +666,7 @@ func (c *Controller) enterAddDialtone(activePeer string) {
 }
 
 func (c *Controller) abortAdd() {
+	slog.Info("phone: abortAdd -> CONNECTED", "from_state", c.state, "held", c.heldPeer, "adding", c.addingPeer)
 	c.cb.SendTone(ToneStop)
 	// Tear down the added peer if one exists. Most paths into ADD_INTERCEPT
 	// already did this (busy/error/hangup handlers all call TearDownPeer
@@ -678,6 +686,7 @@ func (c *Controller) abortAdd() {
 }
 
 func (c *Controller) abortAddCalling() {
+	slog.Info("phone: abortAddCalling -> CONNECTED", "held", c.heldPeer, "adding", c.addingPeer)
 	c.cb.SendTone(ToneStop)
 	if c.addingPeer != "" {
 		c.cb.TearDownPeer(c.addingPeer)
@@ -691,6 +700,7 @@ func (c *Controller) abortAddCalling() {
 }
 
 func (c *Controller) requestMerge() {
+	slog.Info("phone: ADD_PRIVATE -> CONFERENCE_MERGED, requesting merge", "held", c.heldPeer, "adding", c.addingPeer)
 	if c.heldPeer != "" {
 		c.cb.MutePeer(c.heldPeer, false)
 	}
@@ -741,8 +751,10 @@ func (c *Controller) HandleConferenceLeave(confID, peer, reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.confID != confID {
+		slog.Warn("conference: leave ignored, confID mismatch", "msg_conf_id", confID, "local_conf_id", c.confID, "peer", peer)
 		return
 	}
+	slog.Info("conference: member left", "conf_id", confID, "peer", peer, "reason", reason)
 	c.cb.RemoveMeshPeer(peer)
 }
 
@@ -755,8 +767,10 @@ func (c *Controller) HandleConferenceEnd(confID, reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.confID != confID {
+		slog.Warn("conference: end ignored, confID mismatch", "msg_conf_id", confID, "local_conf_id", c.confID, "reason", reason)
 		return
 	}
+	slog.Info("conference: end received", "conf_id", confID, "reason", reason, "state", c.state, "is_host", c.isConfHost)
 	c.cb.TearDownAllMeshPeers()
 	c.cb.HangupCall()
 
@@ -796,9 +810,11 @@ func (c *Controller) HandleConferenceRejected(confID, reason string) {
 	// that case we can't cross-check IDs, which is why the mismatch guard
 	// only fires when both IDs are known and differ.
 	if c.confID != "" && confID != "" && c.confID != confID {
+		slog.Warn("conference: rejection ignored, confID mismatch", "msg_conf_id", confID, "local_conf_id", c.confID, "reason", reason)
 		return
 	}
 	if c.state != StateCONFERENCE_MERGED {
+		slog.Warn("conference: rejection ignored, not in CONFERENCE_MERGED", "state", c.state, "reason", reason)
 		return // probably stale; ignore
 	}
 	// ToneIntercept is the SIT triple-beep tone used for merge-failed intercept,

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -220,6 +220,9 @@ func (sp *SerialPort) readLoop() {
 						sp.logger.Warn("HOOK:FLASH received but firmware is not flash-capable; ignoring")
 						continue
 					}
+					if line == "HOOK:FLASH" {
+						sp.logger.Info("HOOK:FLASH forwarded from firmware")
+					}
 					select {
 					case sp.events <- line:
 					default:

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -459,6 +459,7 @@ func (t *Tracker) CreateConferencePersistent(ctx context.Context, host string, o
 	if h != nil {
 		h.InitConference(conf.ID)
 	}
+	slog.Info("conference: persisted", "conf_id", conf.ID.String(), "host", host, "originating_call_id", originatingCallID, "added_members", addedMembers)
 	return conf, nil
 }
 
@@ -494,6 +495,7 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 	if h != nil {
 		h.EvictConference(confID)
 	}
+	slog.Info("conference: end persisted", "conf_id", confID.String(), "reason", reason)
 	return nil
 }
 
@@ -512,6 +514,7 @@ func (t *Tracker) RecordKick(ctx context.Context, confID uuid.UUID, kickedPhone,
 	if err != nil {
 		return fmt.Errorf("record kick: %w", err)
 	}
+	slog.Info("conference: kick audited", "conf_id", confID.String(), "kicked", kickedPhone, "by_user", userID)
 	return nil
 }
 
@@ -625,6 +628,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 	if h != nil && ended {
 		h.EvictConference(confID)
 	}
+	slog.Info("conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining, "ended", ended)
 	return remaining, ended, nil
 }
 

--- a/server/internal/signaling/conference.go
+++ b/server/internal/signaling/conference.go
@@ -12,9 +12,11 @@ import (
 func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Message) {
 	held := msg.HeldPeer
 	active := msg.ActivePeer
+	slog.Info("conference: merge requested", "host", host, "held", held, "active", active)
 
 	// 1. Validate: host is in both calls.
 	if !r.Tracker.InCall(ctx, host, held) || !r.Tracker.InCall(ctx, host, active) {
+		slog.Warn("conference: merge rejected", "host", host, "reason", "host_not_in_both_calls", "held", held, "active", active)
 		r.sendRejection(ctx, host, msg.ConfID, "host_not_in_both_calls")
 		return
 	}
@@ -22,6 +24,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	// 2. Validate: neither added member is already in a conference.
 	for _, p := range []string{held, active} {
 		if r.Tracker.Conferences().IsBusy(p) {
+			slog.Warn("conference: merge rejected", "host", host, "reason", "member_already_in_conference", "busy_member", p)
 			r.sendRejection(ctx, host, msg.ConfID, "member_already_in_conference")
 			return
 		}
@@ -30,6 +33,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	// 3. Look up the originating call id (A-held).
 	callID := r.Tracker.CallIDForPair(ctx, host, held)
 	if callID == 0 {
+		slog.Warn("conference: merge rejected", "host", host, "reason", "call_id_unknown", "held", held)
 		r.sendRejection(ctx, host, msg.ConfID, "call_id_unknown")
 		return
 	}
@@ -40,6 +44,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 		r.sendRejection(ctx, host, msg.ConfID, "create_failed")
 		return
 	}
+	slog.Info("conference: created", "conf_id", conf.ID.String(), "host", host, "held", held, "active", active, "originating_call_id", callID)
 
 	// 4. Notify all three members of the membership snapshot.
 	members := []ConferenceMemberInfo{
@@ -49,24 +54,32 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	}
 	memberMsg := &Message{Type: TypeConferenceMember, ConfID: conf.ID.String(), Members: members}
 	for _, m := range members {
-		_ = r.Hub.SendTo(m.Phone, memberMsg)
+		if err := r.Hub.SendTo(m.Phone, memberMsg); err != nil {
+			slog.Warn("conference: ConferenceMember send failed", "conf_id", conf.ID.String(), "to", m.Phone, "err", err)
+		}
 	}
+	slog.Info("conference: ConferenceMember broadcast", "conf_id", conf.ID.String(), "members", len(members))
 
 	// 5. Instruct held and active peers to open a peer connection to each other.
 	//    Deterministic tiebreak: numerically smaller phone number is the initiator.
 	heldIsInitiator := held < active
-	_ = r.Hub.SendTo(held, &Message{
+	if err := r.Hub.SendTo(held, &Message{
 		Type:      TypeConferenceConnect,
 		ConfID:    conf.ID.String(),
 		Peer:      active,
 		Initiator: heldIsInitiator,
-	})
-	_ = r.Hub.SendTo(active, &Message{
+	}); err != nil {
+		slog.Warn("conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", held, "err", err)
+	}
+	if err := r.Hub.SendTo(active, &Message{
 		Type:      TypeConferenceConnect,
 		ConfID:    conf.ID.String(),
 		Peer:      held,
 		Initiator: !heldIsInitiator,
-	})
+	}); err != nil {
+		slog.Warn("conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", active, "err", err)
+	}
+	slog.Info("conference: ConferenceConnect dispatched", "conf_id", conf.ID.String(), "held", held, "active", active, "held_is_initiator", heldIsInitiator)
 }
 
 func (r *Relay) sendRejection(ctx context.Context, host, confID, reason string) {
@@ -82,26 +95,33 @@ func (r *Relay) endConference(ctx context.Context, confID uuid.UUID, reason stri
 	if conf == nil {
 		// Already ended (e.g. a second caller triggers endConference after a
 		// member drop already ended it). No members to notify.
+		slog.Info("conference: end skipped, already ended", "conf_id", confID.String(), "reason", reason)
 		return
 	}
+	slog.Info("conference: ending", "conf_id", confID.String(), "reason", reason, "members", len(conf.Members))
 	if err := r.Tracker.EndConferencePersistent(ctx, confID, reason); err != nil {
 		slog.Error("end conference persist", "err", err)
 	}
 	for p := range conf.Members {
-		_ = r.Hub.SendTo(p, &Message{
+		if err := r.Hub.SendTo(p, &Message{
 			Type:   TypeConferenceEnd,
 			ConfID: confID.String(),
 			Reason: reason,
-		})
+		}); err != nil {
+			slog.Warn("conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
+		}
 	}
+	slog.Info("conference: ConferenceEnd broadcast", "conf_id", confID.String(), "reason", reason)
 }
 
 func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, phone, reason string) {
 	conf := r.Tracker.Conferences().Snapshot(confID)
 	if conf == nil {
 		// Already ended; nothing to drop or notify.
+		slog.Info("conference: drop skipped, already ended", "conf_id", confID.String(), "phone", phone, "reason", reason)
 		return
 	}
+	slog.Info("conference: drop member", "conf_id", confID.String(), "phone", phone, "reason", reason)
 	var others []string
 	for p := range conf.Members {
 		if p != phone {
@@ -115,22 +135,28 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 	}
 
 	for _, p := range others {
-		_ = r.Hub.SendTo(p, &Message{
+		if err := r.Hub.SendTo(p, &Message{
 			Type:   TypeConferenceLeave,
 			ConfID: confID.String(),
 			Peer:   phone,
 			Reason: reason,
-		})
+		}); err != nil {
+			slog.Warn("conference: ConferenceLeave send failed", "conf_id", confID.String(), "to", p, "err", err)
+		}
 	}
+	slog.Info("conference: ConferenceLeave broadcast", "conf_id", confID.String(), "left", phone, "notified", others)
 	// v1: any drop ends the conference; notify remaining members explicitly so
 	// client controllers know to fully tear down (not just drop the leaver).
 	for _, p := range remaining {
-		_ = r.Hub.SendTo(p, &Message{
+		if err := r.Hub.SendTo(p, &Message{
 			Type:   TypeConferenceEnd,
 			ConfID: confID.String(),
 			Reason: "member_left",
-		})
+		}); err != nil {
+			slog.Warn("conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
+		}
 	}
+	slog.Info("conference: ConferenceEnd broadcast after drop", "conf_id", confID.String(), "remaining", remaining)
 }
 
 // KickMember drops a member from the conference and notifies the kicked
@@ -143,6 +169,7 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 // Reason is logged on the kicked phone's ConferenceEnd message; callers
 // may pass any human-friendly string (e.g., "kicked by <display name>").
 func (r *Relay) KickMember(ctx context.Context, confID uuid.UUID, kickedPhone, reason string) {
+	slog.Info("conference: kick member", "conf_id", confID.String(), "kicked", kickedPhone, "reason", reason)
 	// Notify the kicked phone first so it starts tearing down before the
 	// drop cascade reassigns the surviving pair to a continuation call.
 	// Non-member or unregistered phones get a no-op send; the caller is
@@ -152,7 +179,7 @@ func (r *Relay) KickMember(ctx context.Context, confID uuid.UUID, kickedPhone, r
 		ConfID: confID.String(),
 		Reason: reason,
 	}); err != nil {
-		slog.Debug("kick: send ConferenceEnd to kicked phone failed", "phone", kickedPhone, "err", err)
+		slog.Warn("conference: kick ConferenceEnd send to kicked phone failed", "conf_id", confID.String(), "phone", kickedPhone, "err", err)
 	}
 	r.dropMemberFromConference(ctx, confID, kickedPhone, reason)
 }


### PR DESCRIPTION
## Summary
- Adds Info/Warn logs at every connect and disconnect event across the 3-way party-line flow so live debugging on the prototype devices can trace the full chain from firmware hook flash, through digitsd state transitions and mesh signaling, into server persistence, and back out to the other phones' mesh teardown.
- No behavior change. Pure observability: new log lines plus promotion of two previously swallowed errors (mesh send failures) from Debug to Warn so they surface in prod logs.
- Motivated by a live debugging session where the entire merge path was silent in logs: onHookFlash, enterAddDialtone, abortAdd, abortAddCalling, requestMerge, RequestConferenceMerge send, server receipt, server validation rejections, CreateConferencePersistent success, ConferenceMember/Connect/Leave/End broadcasts, RemoveMeshPeer, TearDownAllMeshPeers, HandleConferenceLeave/End, and every mesh PC state transition. All silent. Failures looked identical to "nothing happened."

### Coverage added
- **firmware/hook.c:** flash window open, bounce-below-100ms reject, timeout-above-600ms reject.
- **digitsd serial.go:** HOOK:FLASH forwarded through the capability gate.
- **digitsd controller.go:** onHookFlash entry with state + conf role + active peer; non-host and CONFERENCE_MERGED no-ops; all ADD_* transitions; HandleConferenceLeave/End/Rejected entry and confID-mismatch early returns.
- **digitsd main.go + linkhealth.go:** RequestConferenceMerge send; mesh PC state on every transition (not just Connected); remote track attached; first RTP packet; RemoveMeshPeer; TearDownAllMeshPeers.
- **server signaling/conference.go:** merge receipt; each rejection branch with reason; all four broadcasts (Member, Connect, Leave, End) with per-recipient Warn on send failure; kick entry.
- **server calls/tracker.go:** success logs for CreateConferencePersistent, EndConferencePersistent, DropMemberPersistent, RecordKick.

## Test plan
- [x] \`golangci-lint run ./...\` in \`server/\` and \`pi/digitsd/\`: 0 issues
- [x] \`go test ./...\` in \`server/\` and \`pi/digitsd/\`: all pass
- [x] \`make firmware\`: clean build via Docker
- [x] \`make build\` in \`pi/digitsd/\` (arm64 cross): clean
- [x] \`make build\` in \`server/\`: clean
- [ ] Deploy to 3 prototype phones and prod server, walk through a full party-line flow (A dials B, A flashes, A dials C, C answers, A flashes to merge, various teardown paths) and confirm each expected log line fires on the expected device.