### PR TITLE
chore(digitsd): route TEST:EVENT:HOOK:FLASH through HandleHookFlash

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1072,7 +1072,13 @@ func (d *daemonCallbacks) HandleSocketCommand(cmd string) string {
 		event := cmd[11:]
 		slog.Info("test: injecting event", "event", event)
 		if d.ctrl != nil {
-			d.ctrl.HandleEvent(event)
+			// HOOK:FLASH has a dedicated dispatch that needs the active
+			// 2-party peer, mirroring the serial reader path in main.go.
+			if event == "HOOK:FLASH" {
+				d.ctrl.HandleHookFlash(d.currentPeer())
+			} else {
+				d.ctrl.HandleEvent(event)
+			}
 		}
 		return "OK"
 	}


### PR DESCRIPTION
## Summary
- The \`uart.sock\` TEST:EVENT handler routed every injected event through \`ctrl.HandleEvent\`, which doesn't recognize \`HOOK:FLASH\`. The flash has a dedicated dispatch path (\`ctrl.HandleHookFlash(activePeer)\`) that only the serial reader knew to invoke, so the whole party-line flash flow was unreachable via the debug socket.
- Mirror the serial reader's branch in \`main.go:1898\`: when the injected event is \`HOOK:FLASH\`, call \`HandleHookFlash(currentPeer())\`; otherwise \`HandleEvent\`.
- Gated by \`DIGITS_DEBUG=1\` like the rest of the TEST:EVENT surface, so prod behavior is unchanged.
- Context: #276 added observability logs for the party-line flow. This completes the debug-side picture by making the flow drivable over SSH via \`scripts/uart-term.sh\` without a physical hook-flash actuation on the handset.

## Test plan
- [x] \`go vet ./...\` in \`pi/digitsd/\`: clean
- [x] \`golangci-lint run ./...\` in \`pi/digitsd/\`: 0 issues
- [x] \`go test ./cmd/digitsd/...\`: pass
- [x] \`make build\` (arm64 cross) in \`pi/digitsd/\`: clean
- [ ] After deploy with \`DIGITS_DEBUG=1\` set: verify \`echo TEST:EVENT:HOOK:FLASH | socat - UNIX-CONNECT:/data/digits/uart.sock\` produces the new \`phone: HOOK:FLASH received\` log line added in #276.