### PR TITLE
chore(digitsd): party-line log-noise cleanup (2 fixes)

### DIFF
--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -750,6 +750,12 @@ func (c *Controller) HandleConferenceConnect(confID, peer string, initiator bool
 func (c *Controller) HandleConferenceLeave(confID, peer, reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.confID == "" {
+		// Local conference state already cleared (host hangup tears down before
+		// the server's broadcast lands). Benign race; not an error.
+		slog.Info("conference: leave ignored, already torn down locally", "msg_conf_id", confID, "peer", peer, "reason", reason)
+		return
+	}
 	if c.confID != confID {
 		slog.Warn("conference: leave ignored, confID mismatch", "msg_conf_id", confID, "local_conf_id", c.confID, "peer", peer)
 		return
@@ -766,6 +772,13 @@ func (c *Controller) HandleConferenceLeave(confID, peer, reason string) {
 func (c *Controller) HandleConferenceEnd(confID, reason string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.confID == "" {
+		// Local conference state already cleared. Common host-hangup race:
+		// onHookOn tore down and cleared confID before the server's broadcast
+		// landed. Treat as benign; everything is already cleaned up locally.
+		slog.Info("conference: end ignored, already torn down locally", "msg_conf_id", confID, "reason", reason)
+		return
+	}
 	if c.confID != confID {
 		slog.Warn("conference: end ignored, confID mismatch", "msg_conf_id", confID, "local_conf_id", c.confID, "reason", reason)
 		return

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -1139,6 +1139,41 @@ func TestController_ConferenceEndFromIdleReturnsIdle(t *testing.T) {
 	}
 }
 
+// TestController_ConferenceLeaveAfterLocalTeardownIsBenign verifies that a
+// ConferenceLeave arriving after the host already cleared confID locally
+// returns silently without emitting Warn or invoking RemoveMeshPeer.
+func TestController_ConferenceLeaveAfterLocalTeardownIsBenign(t *testing.T) {
+	mock := &mockCallbacks{}
+	c := NewController(mock, "5550001")
+	defer c.Close()
+	// confID is "" by default, simulating the post-teardown state.
+
+	c.HandleConferenceLeave("conf-abc", "5550002", "hangup")
+
+	if mock.meshPeerRemoved("5550002") {
+		t.Fatalf("RemoveMeshPeer must not fire when local conference state is already cleared")
+	}
+}
+
+// TestController_ConferenceEndAfterLocalTeardownIsBenign verifies that a
+// ConferenceEnd arriving after the host already cleared confID locally
+// returns silently without invoking TearDownAllMeshPeers or HangupCall.
+func TestController_ConferenceEndAfterLocalTeardownIsBenign(t *testing.T) {
+	mock := &mockCallbacks{}
+	c := NewController(mock, "5550001")
+	defer c.Close()
+	// confID is "" by default, simulating the post-teardown state.
+
+	c.HandleConferenceEnd("conf-abc", "host_hangup")
+
+	if mock.allPeersTorndown() {
+		t.Fatalf("TearDownAllMeshPeers must not fire when local conference state is already cleared")
+	}
+	if mock.Hangups() != 0 {
+		t.Fatalf("HangupCall must not fire when local conference state is already cleared, got %d", mock.Hangups())
+	}
+}
+
 func TestController_ConferenceRejectedReturnsToConnected(t *testing.T) {
 	mock := &mockCallbacks{}
 	c := NewController(mock, "5550001")

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -180,6 +180,22 @@ func isUnsolicitedEvent(line string) bool {
 	}
 }
 
+// isFireAndForgetAck returns true for protocol acks the Pico emits in
+// response to fire-and-forget commands (HOOK:FLASH:ON/OFF, CALL:CONNECTED).
+// These have no waiting consumer on the Pi side. Without this filter they
+// fall through to the events channel and trigger spurious "unhandled event"
+// warnings for every call.
+func isFireAndForgetAck(line string) bool {
+	switch line {
+	case "HOOK:FLASH:ON", "HOOK:FLASH:OFF":
+		return true
+	case "CALL:CONNECTED:ACK", "CALL:CONNECTED:IGNORED":
+		return true
+	default:
+		return false
+	}
+}
+
 func (sp *SerialPort) readLoop() {
 	buf := make([]byte, 256)
 	var lineBuf strings.Builder
@@ -238,6 +254,13 @@ func (sp *SerialPort) readLoop() {
 						continue
 					default:
 					}
+				}
+
+				// Fire-and-forget acks have no waiting consumer; drop silently
+				// rather than routing to the events channel (which would fire
+				// "unhandled event" warnings on every call).
+				if isFireAndForgetAck(line) {
+					continue
 				}
 
 				// No pending command — deliver as event (shouldn't normally happen).

--- a/pi/digitsd/internal/phone/serial_test.go
+++ b/pi/digitsd/internal/phone/serial_test.go
@@ -49,3 +49,28 @@ func TestIsUnsolicitedEvent(t *testing.T) {
 		}
 	}
 }
+
+func TestIsFireAndForgetAck(t *testing.T) {
+	acks := []string{
+		"HOOK:FLASH:ON", "HOOK:FLASH:OFF",
+		"CALL:CONNECTED:ACK", "CALL:CONNECTED:IGNORED",
+	}
+	for _, msg := range acks {
+		if !isFireAndForgetAck(msg) {
+			t.Errorf("expected %q to be a fire-and-forget ack", msg)
+		}
+	}
+
+	notAcks := []string{
+		"HOOK:OFF", "HOOK:ON", "HOOK:FLASH",
+		"PONG", "STATUS:READY",
+		"RING:ACK", "RING:DONE",
+		"VERSION:1.0.0:abc1234",
+		"KEY:5", "DIAL:5551234", "FSM:IDLE",
+	}
+	for _, msg := range notAcks {
+		if isFireAndForgetAck(msg) {
+			t.Errorf("expected %q to NOT be a fire-and-forget ack", msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Two small log-quality fixes discovered during the party-line live debugging session that followed #276 (observability) and #277 (TEST:EVENT:HOOK:FLASH routing). Both are purely log noise, no behavior change.

### Fix 1: benign conference-teardown races now Info, not Warn
When the host hangs up its own conference, \`onHookOn\` tears down the local mesh and clears \`c.confID\` before the server's \`ConferenceEnd\` broadcast lands on the host (the server sends to all three members including the host). The host's \`HandleConferenceEnd\` then sees \`c.confID=""\` and the current confID-mismatch Warn fires on every single host-hangup teardown. Same race exists for a late \`ConferenceLeave\`.

Add an explicit \`c.confID == ""\` early return that logs Info (\"already torn down locally\") instead of Warn. Verified in live walk: #276 observability traced a clean 84ms host-hangup cascade end-to-end except for this one false-positive Warn on the host.

### Fix 2: fire-and-forget Pico ack filter
The Pico emits protocol acks for fire-and-forget commands that the Pi sends via \`SendFire\` (\`HOOK:FLASH:ON\`, \`HOOK:FLASH:OFF\`, \`CALL:CONNECTED:ACK\`, \`CALL:CONNECTED:IGNORED\`). No response channel is registered for these, so they fall through \`isUnsolicitedEvent\`'s default branch and land on the events channel, then trigger \`WARN phone: unhandled event\` for each one on every single call.

Add \`isFireAndForgetAck\` and filter matching lines after the pending-command check in the serial read loop.

## Test plan
- [x] \`go vet ./...\` + \`golangci-lint run ./...\` in \`pi/digitsd/\`: clean
- [x] New unit tests: \`TestController_ConferenceLeaveAfterLocalTeardownIsBenign\`, \`TestController_ConferenceEndAfterLocalTeardownIsBenign\`, \`TestIsFireAndForgetAck\`
- [x] \`go test ./...\` in \`pi/digitsd/\`: all pass
- [x] \`make build\` arm64 cross-compile: clean
- [ ] After deploy to 3 prototype phones: re-run host-hangup teardown (E.1) and confirm no \"confID mismatch\" Warn appears; re-run any 2-party call and confirm the three per-call \"unhandled event\" Warns are gone.