### PR TITLE
feat(server): AM theme Families reskin (phase 4 of 6)

### DIFF
--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -540,7 +540,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-links__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
 .am-links__header-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .am-links__header-spacer { flex: 1; }
-.am-links__header-well { padding: 10px 14px; display: inline-flex; flex-direction: column; align-items: center; }
+.am-links__header-well { padding: 10px 14px; }
 .am-links__header-led { font-size: 22px; line-height: 1; }
 .am-links__header-cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
 

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -534,7 +534,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
    AM /links: Families
    ========================================================================= */
 
-.am-links { display: flex; flex-direction: column; gap: 18px; max-width: 960px; }
+.am-links { display: flex; flex-direction: column; gap: 18px; }
 
 /* Header plate: directory label + LED count well */
 .am-links__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -531,6 +531,135 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 }
 
 /* =========================================================================
+   AM /links: Families
+   ========================================================================= */
+
+.am-links { display: flex; flex-direction: column; gap: 18px; max-width: 960px; }
+
+/* Header plate: directory label + LED count well */
+.am-links__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
+.am-links__header-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.am-links__header-spacer { flex: 1; }
+.am-links__header-well { padding: 10px 14px; display: inline-flex; flex-direction: column; align-items: center; }
+.am-links__header-led { font-size: 22px; line-height: 1; }
+.am-links__header-cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
+
+/* Label-maker + Accept pair: two plates side by side */
+.am-links__pair { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
+
+.am-labelmaker { display: flex; flex-direction: column; gap: 12px; padding: 18px 20px 16px; }
+.am-labelmaker__hint { margin: 0; }
+.am-labelmaker__form { margin: 0; }
+.am-labelmaker__button { padding: 9px 18px; }
+
+/* Tape label: cassette-style cream card showing a freshly printed invite code */
+.am-tape-label {
+  background: #f4e8c4;
+  border: 1px solid #a89774;
+  border-radius: 3px;
+  padding: 12px 14px 14px;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.1), inset 0 1px 0 rgba(255,255,255,0.5);
+  position: relative;
+}
+.am-tape-label::before {
+  content: ''; position: absolute; inset: 4px; border: 1px dashed rgba(60,45,20,0.25); border-radius: 2px; pointer-events: none;
+}
+.am-tape-label__stripe {
+  display: inline-block;
+  font-family: var(--font-body); font-size: 8.5px; letter-spacing: 0.22em; font-weight: 600;
+  color: #fff0e8; background: var(--chip-red); padding: 2px 8px; border-radius: 2px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.am-tape-label__code {
+  font-family: var(--font-led); font-size: 28px; font-weight: 700;
+  color: #2a2318; letter-spacing: 0.18em;
+  user-select: all;
+  line-height: 1.1;
+}
+.am-tape-label__note { font-family: var(--font-body); font-size: 10.5px; color: #5a4f30; margin-top: 6px; }
+
+/* Accept plate: code entry + brass key */
+.am-accept { display: flex; flex-direction: column; gap: 12px; padding: 18px 20px 16px; }
+.am-accept__hint { margin: 0; }
+.am-accept__form { display: flex; gap: 10px; align-items: stretch; flex-wrap: wrap; }
+.am-accept__input {
+  flex: 1; min-width: 0;
+  background: var(--slot);
+  border: 1px solid var(--slot-edge);
+  border-radius: 3px;
+  padding: 10px 12px;
+  font-family: var(--font-led); font-size: 18px; font-weight: 700;
+  color: var(--led-amber);
+  text-shadow: 0 0 6px rgba(255,165,32,0.45);
+  letter-spacing: 0.18em;
+  text-align: center;
+  text-transform: uppercase;
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.4);
+}
+.am-accept__input::placeholder { color: var(--led-amber-dim); text-shadow: none; letter-spacing: 0.18em; }
+.am-accept__input:focus { outline: 1px solid rgba(255,165,32,0.55); outline-offset: 1px; }
+.am-accept__submit { min-width: 80px; }
+
+/* Station directory: numbered roster of linked families */
+.am-directory { padding: 0; overflow: hidden; }
+.am-directory__head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
+.am-directory__row {
+  display: grid;
+  grid-template-columns: 28px 14px 1fr auto;
+  gap: 12px;
+  align-items: start;
+  padding: 12px 18px;
+  border-bottom: 1px dashed rgba(100,80,40,0.2);
+}
+.am-directory__row:last-child { border-bottom: 0; }
+.am-directory__num { font-family: var(--font-led); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); line-height: 1.4; }
+.am-directory__lamp { margin-top: 6px; }
+.am-directory__body { min-width: 0; }
+.am-directory__name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); letter-spacing: 0.02em; }
+.am-directory__meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); letter-spacing: 0.06em; margin-top: 2px; }
+.am-directory__lines { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.am-directory__line {
+  display: inline-flex; align-items: baseline; gap: 6px;
+  padding: 3px 9px;
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(100,80,40,0.25);
+  border-radius: 3px;
+  font-size: 11px;
+}
+.am-directory__line-name { font-family: var(--font-body); color: var(--ink); font-weight: 600; }
+.am-directory__line-num { font-family: var(--font-mono); color: var(--ink-muted); letter-spacing: 0.04em; }
+.am-directory__actions { display: inline-flex; gap: 6px; }
+.am-directory__empty { padding: 14px 18px 16px; }
+
+/* Outbox: thin strip of pending invites */
+.am-outbox { padding: 0; overflow: hidden; }
+.am-outbox__head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
+.am-outbox__row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 10px 18px;
+  border-bottom: 1px dashed rgba(100,80,40,0.2);
+}
+.am-outbox__row:last-child { border-bottom: 0; }
+.am-outbox__code {
+  font-family: var(--font-mono); font-size: 14px; font-weight: 500;
+  color: var(--label); letter-spacing: 0.2em;
+}
+.am-outbox__date { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); letter-spacing: 0.04em; }
+
+/* Mobile: stack the label-maker/accept pair */
+@media (max-width: 780px) {
+  .am-links__pair { grid-template-columns: 1fr; }
+  .am-directory__row { grid-template-columns: 24px 14px 1fr; grid-template-rows: auto auto; row-gap: 8px; }
+  .am-directory__actions { grid-column: 1 / -1; justify-content: flex-end; }
+  .am-outbox__row { grid-template-columns: 1fr auto; row-gap: 4px; }
+  .am-outbox__date { grid-column: 1 / -1; }
+}
+
+/* =========================================================================
    Shared-class shim: provides AM-palette defaults for the component classes
    used by the existing templates (dashboard.html, phones.html, etc.) so
    every page is coherent in Phase 1. Phases 2 to 5 reskin each page with

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -246,7 +246,7 @@
 
       <form method="POST" action="/links/accept" class="am-accept__form">
         <input type="text" name="code" placeholder="ENTER CODE" required
-               class="am-accept__input"
+               class="am-accept__input" aria-label="Invite code"
                autocomplete="off" maxlength="8">
         <button type="submit" class="am-key am-accept__submit">
           <span class="am-key__symbol">&#x25B6;</span>

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -1,6 +1,9 @@
 {{define "title"}}Connected families{{end}}
 
 {{define "content"}}
+{{if eq .User.Theme "answering-machine"}}
+  {{template "links-am" .}}
+{{else}}
 <div class="page" style="max-width: 900px;">
 
   <header class="page__head">
@@ -192,6 +195,125 @@
   {{end}}
 
   {{template "page-footer" .}}
+
+</div>
+{{end}}
+{{end}}
+
+{{define "links-am"}}
+<div class="am-links">
+
+  {{if .Error}}<div class="banner banner--err">{{.Error}}</div>{{end}}
+  {{if .Accepted}}<div class="banner banner--ok">Family connected successfully.</div>{{end}}
+  {{if .Conflicts}}<div class="banner banner--warn">Number conflict: line numbers <strong>{{.Conflicts}}</strong> exist in both households. One family will need to change these numbers under Lines before calls can be placed.</div>{{end}}
+  {{if .Revoked}}<div class="banner banner--warn">Family disconnected.</div>{{end}}
+  {{if .Canceled}}<div class="banner banner--warn">Invite canceled.</div>{{end}}
+
+  <div class="am-plate am-links__header">
+    <div class="am-links__header-info">
+      <span class="am-label">Station directory</span>
+      <span class="am-title">{{len .LinkedFamilies}} household{{if ne (len .LinkedFamilies) 1}}s{{end}} connected</span>
+    </div>
+    <div class="am-links__header-spacer"></div>
+    <div class="am-well am-links__header-well">
+      <div class="am-led am-links__header-led">{{printf "%02d" (len .LinkedFamilies)}}</div>
+      <div class="am-led am-led--dim am-links__header-cap">Connected</div>
+    </div>
+  </div>
+
+  <div class="am-links__pair">
+
+    <div class="am-plate am-labelmaker">
+      <div class="am-plate__label">Make invite</div>
+      <p class="am-hint am-labelmaker__hint">Print a label to share with another family.</p>
+
+      {{if .CreatedCode}}
+      <div class="am-tape-label" role="note" aria-label="Invite label">
+        <div class="am-tape-label__stripe">Family code</div>
+        <div class="am-tape-label__code">{{.CreatedCode}}</div>
+        <div class="am-tape-label__note">Share this code. It expires when used.</div>
+      </div>
+      {{end}}
+
+      <form method="POST" action="/links/invite" class="am-labelmaker__form">
+        <button type="submit" class="am-tab am-labelmaker__button">{{if .CreatedCode}}Print another{{else}}Print invite{{end}}</button>
+      </form>
+    </div>
+
+    <div class="am-plate am-accept">
+      <div class="am-plate__label">Accept invite</div>
+      <p class="am-hint am-accept__hint">Enter a code shared by another family.</p>
+
+      <form method="POST" action="/links/accept" class="am-accept__form">
+        <input type="text" name="code" placeholder="ENTER CODE" required
+               class="am-accept__input"
+               autocomplete="off" maxlength="8">
+        <button type="submit" class="am-key am-accept__submit">
+          <span class="am-key__symbol">&#x25B6;</span>
+          <span class="am-key__label">Accept</span>
+        </button>
+      </form>
+    </div>
+
+  </div>
+
+  <div class="am-plate am-directory">
+    <div class="am-directory__head"><span class="am-label">Stations</span></div>
+    {{if .LinkedFamilies}}
+    {{range $i, $f := .LinkedFamilies}}
+    <div class="am-directory__row" id="family-{{$f.ID}}">
+      <span class="am-directory__num">{{printf "%02d" (inc $i)}}</span>
+      <span class="am-lamp am-lamp--on-green am-directory__lamp"></span>
+      <div class="am-directory__body">
+        <div class="am-directory__name">{{$f.Name}}</div>
+        <div class="am-directory__meta">
+          {{if $f.AcceptedAt}}Since {{$f.AcceptedAt.Format "Jan 2, 2006"}} &middot; {{end}}{{len $f.Lines}} line{{if ne (len $f.Lines) 1}}s{{end}}
+        </div>
+        {{if $f.Lines}}
+        <div class="am-directory__lines">
+          {{range $f.Lines}}
+          <span class="am-directory__line">
+            <span class="am-directory__line-name">{{.Name}}</span>
+            <span class="am-directory__line-num">{{fmtPhone .Number}}</span>
+          </span>
+          {{end}}
+        </div>
+        {{end}}
+      </div>
+      <div class="am-directory__actions">
+        <button type="button"
+          data-confirm
+          data-confirm-action="/links/{{$f.ID}}/revoke"
+          data-confirm-title="Disconnect from {{$f.Name}}?"
+          data-confirm-body="Calls between families will no longer be possible. You can reconnect later with a new invite."
+          data-confirm-submit="Disconnect"
+          class="am-tab">Disconnect</button>
+      </div>
+    </div>
+    {{end}}
+    {{else}}
+    <div class="am-directory__empty am-hint">No families connected. Print an invite label and share the code.</div>
+    {{end}}
+  </div>
+
+  {{if .PendingInvites}}
+  <div class="am-plate am-outbox">
+    <div class="am-outbox__head"><span class="am-label">Outbox</span></div>
+    {{range .PendingInvites}}
+    <div class="am-outbox__row">
+      <span class="am-outbox__code">{{.InviteCode}}</span>
+      <span class="am-outbox__date">Printed {{.CreatedAt.Format "Jan 2, 2006"}}</span>
+      <button type="button"
+        data-confirm
+        data-confirm-action="/links/{{.ID}}/revoke"
+        data-confirm-title="Cancel invite {{.InviteCode}}?"
+        data-confirm-body="The code will stop working immediately. You can generate a new invite anytime."
+        data-confirm-submit="Cancel invite"
+        class="am-tab">Cancel</button>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
 
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

Reskins `/links` for users on the `answering-machine` theme. The page now reads as the "station directory" on the AM base: brass plate header with an LED counter of connected households, a "label maker" plate for printing invite codes onto a skeuomorphic cassette-style label card, an accept-invite plate with an LED-well code input, a numbered directory plate listing each connected family with a green lamp and line chips, and an outbox strip for pending invites.

Scope stays narrow: no handler changes, no htmx partials (all forms are full-page POST + redirect), no changes to other themes. Intercom markup is preserved in the `{{else}}` branch.

## Screenshots

Station directory, accept-invite plate, and outbox:

![Families directory](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-families-directory-v2.png)

Tape-label card rendered after pressing "Print invite":

![Families tape label](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-families-tape-label-v2.png)

## Reviewer-loop changes folded in

- Dropped dead `.am-directory__disconnect` and `.am-outbox__action` BEM modifiers that had no CSS rule (visual styling comes from the co-applied `.am-tab`).
- Moved inline `style="text-transform: uppercase;"` on the accept input into the `.am-accept__input` CSS rule.
- Added `aria-label="Invite code"` to the accept input for WCAG 2.1 SC 3.3.2.
- Dropped redundant `display/flex-direction/align-items` from `.am-links__header-well`; inherited from co-applied `.am-well`.
- Dropped `max-width: 960px` from `.am-links` so the page body fills the shell padding zone like `.am-phones` and `.am-overview` (initial screenshots showed the body capped narrower than the nav bar; fixed).

Primitive-duplication nits (`.am-links__header*` vs `.am-phones__header*`, `.am-directory__*` vs `.am-phones__row*`) raised by code review. Skipped for this PR: extracting shared primitives from N=2 call sites risks the wrong abstraction; revisit after Phase 5 and Phase 6 land when the shared pattern is empirical.

## Test plan

- [x] `go build -o bin/signald ./cmd/signald/`
- [x] `go test ./internal/web/ ./internal/auth/`
- [x] `golangci-lint run ./internal/web/... ./internal/auth/...`
- [x] Dev server visual check on `/links` in AM theme: directory, label-maker, accept form, outbox, tape-label state, full-width layout match with other AM pages.
- [x] No regressions to intercom `/links`: intercom markup is in the `{{else}}` branch, unchanged.

## Flow coverage

Banners (error, accepted, conflicts, revoked, canceled), create invite (with tape-label card when code is set), accept invite, connected directory with per-family lines and disconnect, pending-invite outbox with cancel.