### PR TITLE
chore(server): drop unused version.String helper

### DIFF
--- a/server/internal/version/version.go
+++ b/server/internal/version/version.go
@@ -1,16 +1,9 @@
 // Package version provides build-time version info for the digits server.
 package version
 
-import "fmt"
-
 // These are set at build time via -ldflags.
 // Example: go build -ldflags "-X .../version.Version=1.2.3 -X .../version.Commit=abc123"
 var (
 	Version = "dev"
 	Commit  = "unknown"
 )
-
-// String returns a human-readable version string.
-func String() string {
-	return fmt.Sprintf("%s (%s)", Version, Commit)
-}


### PR DESCRIPTION
`server/internal/version` exported a `String()` helper that no package imports or calls. Deleting the function and its `fmt` import; the identically named helper in `pi/digitsd/internal/version` is still used by `digitsd` startup logging and is untouched.

Verified with `rg -n 'version\.String' server/` (no hits) and `go build ./...` + `go test ./...` in `server/` both clean.