### PR TITLE
feat(server): AM theme polish + remaining surfaces (phase 6 of 6)

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -253,6 +253,7 @@ type lineDetailData struct {
 	PiUpdateNotes         []updates.Release
 	FirmwareUpdateNotes   []updates.Release
 	User                  *auth.User
+	Theme                 auth.Theme
 }
 
 func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
@@ -318,6 +319,10 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := auth.UserFromContext(r.Context())
+	var theme auth.Theme
+	if user != nil {
+		theme = user.Theme
+	}
 
 	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
 		Page:                  "phones",
@@ -337,6 +342,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		PiUpdateNotes:         piUpdateNotes,
 		FirmwareUpdateNotes:   firmwareUpdateNotes,
 		User:                  user,
+		Theme:                 theme,
 	})
 }
 
@@ -347,7 +353,14 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	}
 	online := h.hub.Get(number) != nil
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhoneDetail, "phone-status", struct{ Online bool }{online})
+		var theme auth.Theme
+		if u := auth.UserFromContext(r.Context()); u != nil {
+			theme = u.Theme
+		}
+		renderWith(w, h.tmplPhoneDetail, "phone-status", struct {
+			Online bool
+			Theme  auth.Theme
+		}{online, theme})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -913,7 +913,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 /* === AM /phones/{number}: handset detail === */
 
-.am-handset { display: flex; flex-direction: column; gap: 18px; max-width: 1020px; }
+.am-handset { display: flex; flex-direction: column; gap: 18px; }
 
 /* Back-to-lines link, rendered as a cassette tab so it reads as in-idiom chrome. */
 .am-handset__back { align-self: flex-start; padding: 6px 14px; }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -911,6 +911,474 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
   .am-settings__kv-row { grid-template-columns: 1fr; gap: 4px; }
 }
 
+/* === AM /phones/{number}: handset detail === */
+
+.am-handset { display: flex; flex-direction: column; gap: 18px; max-width: 1020px; }
+
+/* Back-to-lines link, rendered as a cassette tab so it reads as in-idiom chrome. */
+.am-handset__back { align-self: flex-start; padding: 6px 14px; }
+
+/* Page header lamp + cap. The header plate is shared; the status cluster
+   on the right re-uses .am-page-header__well / __led / __cap with a small
+   inner gap for the lamp. */
+.am-handset__status-well { display: inline-flex; align-items: center; gap: 10px; padding: 10px 14px; }
+.am-handset__status-cap { font-size: 11px; letter-spacing: 0.22em; }
+
+/* Hero plate: silhouette framed like a cassette display window. A recessed
+   brass inset around the image, with a caption well underneath. */
+.am-handset__hero { padding: 20px 22px 18px; display: flex; flex-direction: column; align-items: center; gap: 14px; }
+.am-handset__hero-frame {
+  width: 100%;
+  max-width: 320px;
+  padding: 14px 18px 16px;
+  background: linear-gradient(180deg, #1a1812 0%, #24201a 100%);
+  border-radius: 6px;
+  box-shadow: inset 0 3px 6px rgba(0,0,0,0.65), 0 1px 0 rgba(255,255,255,0.4);
+  display: flex; align-items: center; justify-content: center;
+  position: relative;
+}
+.am-handset__hero-frame::before {
+  content: ''; position: absolute; inset: 6px; border: 1px solid rgba(255,165,32,0.22); border-radius: 4px; pointer-events: none;
+}
+.am-handset__hero-img { display: block; width: 100%; max-width: 220px; height: auto; filter: drop-shadow(0 4px 6px rgba(0,0,0,0.35)); }
+.am-handset__hero-caption { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.am-handset__hero-name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); letter-spacing: 0.04em; text-transform: uppercase; }
+.am-handset__hero-num { font-size: 18px; letter-spacing: 0.12em; }
+
+/* Two-column grid for the lower detail plates. Stacks on narrow viewports. */
+.am-handset__grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
+.am-handset__grid > * { min-width: 0; }
+
+.am-handset__plate { padding: 18px 20px 16px; display: flex; flex-direction: column; gap: 12px; }
+.am-handset__plate--wide { grid-column: 1 / -1; }
+.am-handset__plate--danger { border: 1px solid rgba(196,62,46,0.25); }
+
+/* Update notes list: tape-log style, each release in its own engraved card. */
+.am-handset__updates { display: flex; flex-direction: column; gap: 10px; }
+.am-handset__update-note {
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(100,80,40,0.25);
+  border-radius: 4px;
+  padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.am-handset__update-ver {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.08em; color: var(--ink);
+  text-transform: uppercase;
+}
+.am-handset__update-body { font-family: var(--font-body); font-size: 12px; color: var(--ink-soft); line-height: 1.5; }
+.am-handset__update-body p { margin: 0 0 4px; }
+.am-handset__update-body p:last-child { margin-bottom: 0; }
+.am-handset__update-body ul, .am-handset__update-body ol { margin: 0 0 4px; padding-left: 20px; }
+.am-handset__update-body code { font-family: var(--font-mono); font-size: 11px; }
+.am-handset__update-empty { margin: 0; font-style: italic; color: var(--ink-muted); font-size: 12px; }
+
+/* Actions plate: brass Save/Delete keys aligned left, with hint text. */
+.am-handset__actions { display: flex; flex-direction: column; gap: 10px; }
+.am-handset__actions-row { display: flex; gap: 10px; flex-wrap: wrap; }
+.am-handset__action-form { margin: 0; }
+.am-handset__action-desc { margin: 0 0 2px; line-height: 1.45; }
+
+/* Status lamp cluster used by the polled phone-status partial. Uses .am-lamp
+   variants for the indicator and .am-led variants for the cap word. */
+.am-handset__status { display: inline-flex; align-items: center; gap: 8px; }
+.am-handset__status-lamp { flex: 0 0 auto; }
+
+/* Mobile: stack columns, shrink hero, collapse grids. */
+@media (max-width: 780px) {
+  .am-handset__grid { grid-template-columns: 1fr; }
+  .am-handset__hero-frame { max-width: 240px; }
+  .am-handset__hero-img { max-width: 180px; }
+}
+
+/* === AM /calls: tape log === */
+
+.am-calls { display: flex; flex-direction: column; gap: 18px; }
+
+/* Header LIVE well: compact green-LED cluster showing auto-refresh heartbeat. */
+.am-calls__live-well { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; }
+.am-calls__live-cap { font-size: 11px; letter-spacing: 0.22em; }
+
+/* Tape plate: the roster plate that carries every log entry. htmx swaps this
+   element every 10s, so the header stays static. */
+.am-calls__tape { min-width: 0; }
+
+/* Entry row: LED time, caller/callee body, kind chip, duration, details link.
+   The grid template overrides the shared .am-roster__row default. */
+.am-calls__entry { grid-template-columns: 92px 1fr auto auto auto; align-items: center; padding: 10px 18px; }
+
+/* LED-amber time column, dot-matrix feel. */
+.am-calls__time { font-family: var(--font-led); font-weight: 700; font-size: 14px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); letter-spacing: 0.06em; }
+
+/* Body holds parties on top and meta (date + status word) underneath. */
+.am-calls__body { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.am-calls__parties { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-family: var(--font-mono); font-size: 13px; color: var(--ink); letter-spacing: 0.02em; }
+.am-calls__party { font-family: var(--font-mono); color: var(--ink); letter-spacing: 0.04em; }
+.am-calls__arrow { color: var(--ink-muted); font-family: var(--font-mono); }
+
+/* Multi-party row for conferences: inline wrap, phones separated by midpoints. */
+.am-calls__conf-parts { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; font-family: var(--font-mono); font-size: 13px; color: var(--ink); letter-spacing: 0.02em; }
+
+/* "from 3-way" inline badge for calls originating from a merged conference. */
+.am-calls__from-conf { font-family: var(--font-body); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--chip-blue); padding: 2px 6px; border: 1px solid rgba(42,86,128,0.4); border-radius: 3px; }
+
+/* Meta line: date plus per-call state word (ended/missed/ringing/...). */
+.am-calls__meta { display: flex; align-items: center; gap: 10px; font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); letter-spacing: 0.06em; }
+.am-calls__meta-state { text-transform: uppercase; letter-spacing: 0.16em; font-size: 9.5px; font-weight: 600; color: var(--ink-muted); }
+.am-calls__meta-state--connected { color: var(--led-green-dark); }
+.am-calls__meta-state--missed { color: var(--chip-red-dk); }
+.am-calls__meta-state--ringing { color: var(--led-amber-dim); }
+.am-calls__meta-state--initiated { color: var(--chip-blue); }
+
+/* Kind chip: REG for 2-party, 3-WAY for conferences. */
+.am-calls__status {
+  display: inline-flex; align-items: center; padding: 3px 9px;
+  background: var(--case-shade);
+  border-radius: 999px;
+  font-family: var(--font-body); font-size: 9.5px; font-weight: 600; letter-spacing: 0.18em;
+  color: #f4ebcb; text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+.am-calls__status--conf { background: linear-gradient(180deg, #4a84b4 0%, var(--chip-blue) 100%); }
+
+/* Right-aligned duration, monospace so columns line up visually. */
+.am-calls__duration { font-family: var(--font-mono); font-size: 12px; color: var(--ink-muted); letter-spacing: 0.04em; text-align: right; min-width: 44px; }
+
+.am-calls__details { font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase; color: var(--chip-blue); text-decoration: none; white-space: nowrap; }
+.am-calls__details:hover { color: var(--chip-red); }
+
+.am-calls__empty { padding: 18px 20px 20px; }
+
+/* Mobile: stack time + parties on top, push chip/duration/details onto a
+   second row so nothing clips at narrow widths. */
+@media (max-width: 780px) {
+  .am-calls__entry { grid-template-columns: 82px 1fr auto; grid-template-rows: auto auto; row-gap: 6px; padding: 10px 14px; }
+  .am-calls__duration { grid-column: 3; grid-row: 1; }
+  .am-calls__status { grid-column: 1 / 3; grid-row: 2; justify-self: start; }
+  .am-calls__details { grid-column: 3; grid-row: 2; }
+  .am-calls__body { grid-column: 2; grid-row: 1; }
+}
+
+/* === AM /onboard: welcome === */
+
+/* Centered wrapper: vertically centers the welcome plate in the main area so
+   first-run households see a single focused card, not a rail-aligned form. */
+.am-welcome { display: flex; justify-content: center; padding: 24px 16px; }
+
+/* Frame: bounded plate with cornered screws, a little wider than the accept
+   plate on /links so the long "family name" input has room to breathe. */
+.am-welcome__frame { width: 100%; max-width: 440px; padding: 26px 26px 22px; }
+
+/* Title: matches .am-title weight but bumped up for the primary headline. */
+.am-welcome__mark { font-family: var(--font-body); font-size: 18px; font-weight: 600; letter-spacing: 0.02em; color: var(--ink); margin: 0 0 4px; }
+
+/* Tagline sits under the title, shares .am-hint tone but keeps its own
+   bottom margin so the form doesn't hug the copy. */
+.am-welcome__tagline { margin: 0 0 16px; }
+
+/* Form: stacked label + input + full-width submit. Gaps match .am-settings
+   stacked forms so all AM forms feel like the same rack of controls. */
+.am-welcome__form { display: flex; flex-direction: column; gap: 12px; margin: 0; }
+.am-welcome__field { display: flex; flex-direction: column; gap: 6px; }
+
+/* Submit stretches to the plate edges for a clear primary action. */
+.am-welcome__submit { width: 100%; min-height: 44px; }
+
+/* === AM /calls/{id}/live: deck ===
+   Live 2-party and 3-way call pages ship the same shared .deck-* markup.
+   AM overlays the existing structure as a brass-framed tape-deck readout:
+   engraved header plate, LED-amber duration ticker, amber segment bars,
+   red STOP chicklet for End call, recessed cassette-window metrics plate. */
+
+body.am .deck { display: flex; flex-direction: column; gap: 16px; padding: 0; }
+
+body.am .deck-header {
+  display: flex; align-items: stretch; justify-content: space-between; gap: 14px;
+  padding: 14px 18px;
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 55%, var(--case-2) 100%);
+  border-radius: 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    inset 0 -1px 0 rgba(100,80,40,0.18),
+    0 1px 0 rgba(255,255,255,0.6),
+    0 2px 4px rgba(40,30,15,0.16);
+  border: 1px solid rgba(100,80,40,0.28);
+}
+body.am .deck-header__labels { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; min-width: 0; }
+body.am .deck-kicker {
+  display: inline-flex; align-items: center;
+  padding: 3px 10px;
+  background: linear-gradient(180deg, #e28a20 0%, #b86d10 100%);
+  color: #1a0f02;
+  border-radius: 2px;
+  font-family: var(--font-body); font-size: 9px; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255,220,160,0.55), 0 1px 0 rgba(60,30,5,0.4);
+}
+body.am .deck-title {
+  font-family: var(--font-body); font-style: normal;
+  font-size: 18px; font-weight: 600; letter-spacing: 0.02em; line-height: 1.2;
+  color: var(--ink); margin: 0;
+}
+body.am .deck-arrow { color: var(--case-dark); margin: 0 6px; font-weight: 500; }
+body.am .deck-meta { display: flex; align-items: center; gap: 12px; color: var(--ink-muted); font-size: 12px; }
+body.am .deck-duration {
+  font-family: var(--font-led);
+  font-size: 20px; font-weight: 700; letter-spacing: 0.08em;
+  color: var(--led-amber); text-shadow: 0 0 6px rgba(255,165,32,0.55);
+  padding: 4px 10px;
+  background: var(--led-bg);
+  border-radius: 3px;
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.7), 0 1px 0 rgba(255,255,255,0.35);
+  border: 1px solid var(--slot-edge);
+}
+body.am .deck-conn {
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+body.am .deck-kill {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  align-self: center;
+  min-width: 108px; min-height: 40px;
+  padding: 8px 16px;
+  background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%);
+  border: 1px solid var(--chip-red-dk);
+  border-radius: 5px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,200,180,0.6),
+    0 2px 0 var(--chip-red-dk),
+    0 3px 4px rgba(40,10,5,0.3);
+  color: #fff8f0;
+  font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 60ms;
+}
+body.am .deck-kill:hover { filter: brightness(1.04); }
+body.am .deck-kill:active { transform: translateY(2px); box-shadow: inset 0 2px 3px rgba(40,10,5,0.35); }
+
+body.am .deck-ended-chip {
+  align-self: center;
+  padding: 5px 12px;
+  background: var(--case-shade);
+  border-radius: 999px;
+  color: #f4ebcb;
+  font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+
+body.am .deck-cards {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 14px;
+}
+body.am .deck-card {
+  padding: 14px 16px 12px;
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border: 1px solid rgba(100,80,40,0.28);
+  border-radius: 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    0 1px 0 rgba(255,255,255,0.6),
+    0 2px 4px rgba(40,30,15,0.12);
+  position: relative;
+}
+body.am .deck-card::before { content: none; }
+body.am .deck-card .label {
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--label);
+}
+body.am .deck-card__name { font-family: var(--font-body); font-style: normal; font-size: 14px; font-weight: 600; color: var(--ink); margin-top: 6px; letter-spacing: 0.01em; }
+body.am .deck-card__num { font-family: var(--font-mono); font-size: 12px; color: var(--ink-muted); margin-top: 2px; letter-spacing: 0.04em; }
+body.am .deck-card--host { box-shadow: inset 0 0 0 1px rgba(255,165,32,0.35), inset 0 1px 0 rgba(255,255,255,0.7), 0 2px 4px rgba(40,30,15,0.12); }
+
+body.am .deck-panel {
+  padding: 14px 16px;
+  background: var(--led-bg);
+  border: 1px solid var(--slot-edge);
+  border-radius: 6px;
+  box-shadow: inset 0 3px 5px rgba(0,0,0,0.65), 0 1px 0 rgba(255,255,255,0.35);
+}
+body.am .deck-panel__inner { display: flex; flex-direction: column; gap: 12px; color: var(--tape-ink); }
+body.am .deck-panel__streams { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+body.am .deck-stream__head {
+  margin-bottom: 8px;
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase;
+  color: rgba(255,165,32,0.7);
+}
+body.am .deck-bars { display: flex; flex-direction: column; gap: 6px; }
+body.am .deck-row { display: grid; grid-template-columns: 60px 1fr 60px; gap: 8px; align-items: center; font-size: 11px; }
+body.am .deck-row__lbl {
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.2em; text-transform: uppercase;
+  color: rgba(232,218,168,0.65);
+}
+body.am .deck-row__val { font-family: var(--font-mono); font-size: 11px; color: var(--tape-ink); text-align: right; letter-spacing: 0.04em; }
+body.am .deck-bar {
+  display: flex; gap: 2px; height: 8px;
+  background: rgba(0,0,0,0.4);
+  border-radius: 2px;
+  padding: 1px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+body.am .deck-seg { flex: 1; background: transparent; border-radius: 1px; }
+body.am .deck-seg--on { background: var(--led-amber-dim); }
+body.am .deck-seg--on.deck-seg--warn { background: var(--led-amber); box-shadow: 0 0 3px rgba(255,165,32,0.55); }
+body.am .deck-seg--on.deck-seg--bad { background: var(--led-red); box-shadow: 0 0 3px rgba(255,61,46,0.6); }
+
+body.am .deck-shared {
+  border-top: 1px dashed rgba(255,165,32,0.18);
+  padding-top: 10px; margin-top: 2px;
+}
+body.am .deck-shared__row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+body.am .deck-shared__item .label {
+  display: block;
+  margin-bottom: 3px;
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.2em; text-transform: uppercase;
+  color: rgba(232,218,168,0.65);
+}
+body.am .deck-shared__item .num { font-family: var(--font-mono); font-size: 12px; color: var(--tape-ink); letter-spacing: 0.04em; }
+
+body.am .deck-disclaimer {
+  margin: 0; padding: 8px 4px 0;
+  font-family: var(--font-body); font-size: 11px; color: var(--ink-muted); font-style: italic; line-height: 1.5;
+  border: none;
+}
+
+body.am .deck-confirm {
+  padding: 0;
+  max-width: 440px;
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border: 1px solid rgba(100,80,40,0.3);
+  border-radius: 8px;
+  box-shadow: 0 8px 22px rgba(40,30,15,0.32);
+  color: var(--ink);
+}
+body.am .deck-confirm::backdrop { background: rgba(26,25,18,0.55); }
+body.am .deck-confirm__form { padding: 18px 20px 16px; }
+body.am .deck-confirm__title {
+  font-family: var(--font-body); font-style: normal;
+  font-size: 15px; font-weight: 600; letter-spacing: 0.01em; color: var(--ink);
+  margin: 0 0 10px;
+}
+body.am .deck-confirm__body { font-family: var(--font-body); font-size: 12px; color: var(--ink-soft); line-height: 1.5; margin: 0 0 16px; }
+body.am .deck-confirm__actions { display: flex; justify-content: flex-end; gap: 10px; padding: 0; }
+body.am .deck-confirm__cancel {
+  padding: 7px 14px;
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 5px;
+  color: var(--btn-label);
+  font-family: var(--font-body); font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 2px 0 var(--btn-press);
+}
+body.am .deck-confirm__cancel:active { transform: translateY(1px); box-shadow: inset 0 1px 2px rgba(60,45,20,0.3); }
+body.am .deck-confirm__go {
+  padding: 7px 16px;
+  background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%);
+  border: 1px solid var(--chip-red-dk);
+  border-radius: 5px;
+  color: #fff8f0;
+  font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255,200,180,0.55), 0 2px 0 var(--chip-red-dk);
+}
+body.am .deck-confirm__go:active { transform: translateY(1px); box-shadow: inset 0 1px 2px rgba(60,15,5,0.35); }
+
+body.am .deck-stale {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 8px 12px;
+  background: linear-gradient(180deg, #e05448 0%, var(--chip-red) 100%);
+  color: #fff8f0;
+  border: 1px solid var(--chip-red-dk);
+  border-radius: 5px;
+  font-family: var(--font-body); font-size: 11px; font-weight: 600; letter-spacing: 0.1em;
+  box-shadow: inset 0 1px 0 rgba(255,200,180,0.45);
+}
+body.am .deck-stale button {
+  padding: 4px 10px;
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 4px;
+  color: var(--btn-label);
+  font: inherit; font-weight: 600; letter-spacing: 0.12em;
+  cursor: pointer;
+}
+
+body.am .deck-ended {
+  padding: 14px; text-align: center;
+  font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); letter-spacing: 0.08em;
+}
+
+/* Conference deck: 3-way call matrix. Same markup family; override for
+   the brass-plate look with LED-well cells. */
+body.am .deck-matrix {
+  display: grid;
+  grid-template-columns: auto repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  padding: 16px;
+}
+body.am .deck-matrix__head {
+  padding: 4px 6px;
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.2em; text-transform: uppercase;
+  color: var(--ink-muted);
+}
+body.am .deck-matrix__cell {
+  padding: 10px 12px;
+  background: var(--led-bg);
+  border: 1px solid var(--slot-edge);
+  border-radius: 5px;
+  box-shadow: inset 0 2px 3px rgba(0,0,0,0.6);
+  color: var(--tape-ink);
+}
+body.am .deck-matrix__cell--blank {
+  background: transparent;
+  border: 1px dashed rgba(100,80,40,0.3);
+  box-shadow: none;
+  opacity: 0.4;
+}
+body.am .deck-matrix__row {
+  display: flex; justify-content: space-between; align-items: baseline; gap: 8px;
+  padding: 2px 0;
+}
+body.am .deck-matrix__lbl {
+  font-family: var(--font-body); font-size: 9px; font-weight: 600; letter-spacing: 0.2em; text-transform: uppercase;
+  color: rgba(232,218,168,0.65);
+}
+body.am .deck-matrix__val { font-family: var(--font-mono); font-size: 12px; color: var(--tape-ink); letter-spacing: 0.04em; }
+
+body.am .deck-card__kick {
+  margin-top: 10px;
+  padding: 5px 12px;
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+  border: 1px solid var(--btn-press);
+  border-radius: 4px;
+  color: var(--btn-label);
+  font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.55), 0 2px 0 var(--btn-press);
+}
+body.am .deck-card__kick:hover { filter: brightness(1.03); }
+body.am .deck-card__kick:active { transform: translateY(1px); box-shadow: inset 0 1px 2px rgba(60,45,20,0.3); }
+
+body.am .deck-kick-confirm .deck-confirm__go {
+  background: linear-gradient(180deg, #e28a20 0%, #b86d10 100%);
+  border-color: #6a3b05;
+  box-shadow: inset 0 1px 0 rgba(255,220,160,0.55), 0 2px 0 #6a3b05;
+  color: #1a0f02;
+}
+
+@media (max-width: 720px) {
+  body.am .deck-header { flex-direction: column; align-items: stretch; gap: 12px; }
+  body.am .deck-kill,
+  body.am .deck-ended-chip { align-self: flex-start; }
+  body.am .deck-cards,
+  body.am .deck-panel__streams,
+  body.am .deck-shared__row { grid-template-columns: 1fr; }
+  body.am .deck-matrix { grid-template-columns: 1fr; }
+  body.am .deck-matrix__head { display: none; }
+  body.am .deck-matrix__cell--blank { display: none; }
+}
+
 /* =========================================================================
    Shared-class shim: provides AM-palette defaults for the component classes
    used by the existing templates (dashboard.html, phones.html, etc.) so

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -250,6 +250,32 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-screw--br { position: absolute; bottom: 6px; right: 6px; }
 
 /* =========================================================================
+   Shared page scaffolding: header plate + roster list. Applied on /phones,
+   /links, /settings alongside any page-namespaced override class.
+   ========================================================================= */
+
+/* Header plate: engraved label stack on the left, LED well on the right. */
+.am-page-header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
+.am-page-header__info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.am-page-header__spacer { flex: 1; }
+.am-page-header__well { padding: 10px 14px; }
+.am-page-header__led { font-size: 22px; line-height: 1; }
+.am-page-header__cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
+
+/* Plate-scoped list: section label strip plus dashed-separated rows. Grid
+   column templates belong to the page-scoped override since each roster
+   (handsets, families, outbox) uses its own column count. */
+.am-roster { padding: 0; overflow: hidden; }
+.am-roster__head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
+.am-roster__row { display: grid; gap: 12px; border-bottom: 1px dashed rgba(100,80,40,0.2); }
+.am-roster__row:last-child { border-bottom: 0; }
+.am-roster__num { font-family: var(--font-led); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); }
+.am-roster__body { min-width: 0; }
+.am-roster__name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); }
+.am-roster__meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); letter-spacing: 0.06em; margin-top: 2px; }
+.am-roster__actions { display: inline-flex; gap: 6px; }
+
+/* =========================================================================
    Patchbay (Lines screen, phase 3)
    ========================================================================= */
 
@@ -536,13 +562,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 .am-links { display: flex; flex-direction: column; gap: 18px; }
 
-/* Header plate: directory label + LED count well */
-.am-links__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
-.am-links__header-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.am-links__header-spacer { flex: 1; }
-.am-links__header-well { padding: 10px 14px; }
-.am-links__header-led { font-size: 22px; line-height: 1; }
-.am-links__header-cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
+/* Header plate uses the shared .am-page-header primitives. */
 
 /* Label-maker + Accept pair: two plates side by side */
 .am-links__pair { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: start; }
@@ -601,23 +621,14 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-accept__input:focus { outline: 1px solid rgba(255,165,32,0.55); outline-offset: 1px; }
 .am-accept__submit { min-width: 80px; }
 
-/* Station directory: numbered roster of linked families */
-.am-directory { padding: 0; overflow: hidden; }
-.am-directory__head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
-.am-directory__row {
-  display: grid;
-  grid-template-columns: 28px 14px 1fr auto;
-  gap: 12px;
-  align-items: start;
-  padding: 12px 18px;
-  border-bottom: 1px dashed rgba(100,80,40,0.2);
-}
-.am-directory__row:last-child { border-bottom: 0; }
-.am-directory__num { font-family: var(--font-led); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); line-height: 1.4; }
+/* Station directory: numbered roster of linked families. Shared .am-roster
+   primitives supply the wrapper, head, row, num, body, name, meta, and
+   actions; page-scoped rules below cover the per-page overrides and the
+   unique chip-row/lamp accents. */
+.am-directory__row { grid-template-columns: 28px 14px 1fr auto; align-items: start; padding: 12px 18px; }
+.am-directory__num { line-height: 1.4; }
 .am-directory__lamp { margin-top: 6px; }
-.am-directory__body { min-width: 0; }
-.am-directory__name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); letter-spacing: 0.02em; }
-.am-directory__meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); letter-spacing: 0.06em; margin-top: 2px; }
+.am-directory__name { letter-spacing: 0.02em; }
 .am-directory__lines { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
 .am-directory__line {
   display: inline-flex; align-items: baseline; gap: 6px;
@@ -629,21 +640,11 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 }
 .am-directory__line-name { font-family: var(--font-body); color: var(--ink); font-weight: 600; }
 .am-directory__line-num { font-family: var(--font-mono); color: var(--ink-muted); letter-spacing: 0.04em; }
-.am-directory__actions { display: inline-flex; gap: 6px; }
 .am-directory__empty { padding: 14px 18px 16px; }
 
-/* Outbox: thin strip of pending invites */
-.am-outbox { padding: 0; overflow: hidden; }
-.am-outbox__head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
-.am-outbox__row {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 14px;
-  align-items: center;
-  padding: 10px 18px;
-  border-bottom: 1px dashed rgba(100,80,40,0.2);
-}
-.am-outbox__row:last-child { border-bottom: 0; }
+/* Outbox: thin strip of pending invites. Shares .am-roster wrapper + head;
+   the row uses its own 3-column grid with a wider gap. */
+.am-outbox__row { grid-template-columns: auto 1fr auto; gap: 14px; align-items: center; padding: 10px 18px; }
 .am-outbox__code {
   font-family: var(--font-mono); font-size: 14px; font-weight: 500;
   color: var(--label); letter-spacing: 0.2em;
@@ -663,13 +664,10 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 .am-settings { max-width: 1020px; display: flex; flex-direction: column; gap: 18px; }
 
-/* Header plate: label + engraved email in an LED well (mirrors .am-phones__header / .am-links__header) */
-.am-settings__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
-.am-settings__header-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.am-settings__header-spacer { flex: 1; }
-.am-settings__header-well { padding: 10px 14px; max-width: 320px; overflow: hidden; }
+/* Header plate uses the shared .am-page-header primitives. The well clips
+   long emails and the LED downsizes to fit wrapping text. */
+.am-settings__header-well { max-width: 320px; overflow: hidden; }
 .am-settings__header-led { font-size: 14px; line-height: 1.2; word-break: break-all; }
-.am-settings__header-cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
 
 /* Two-column layout: sticky TOC + plate stack */
 .am-settings__layout {
@@ -1185,13 +1183,8 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 .am-phones { display: flex; flex-direction: column; gap: 18px; }
 
-/* Header plate: patched count LED + patch-new chicklet */
-.am-phones__header { display: flex; align-items: center; gap: 18px; padding: 16px 22px; flex-wrap: wrap; }
-.am-phones__header-info { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.am-phones__header-spacer { flex: 1; }
-.am-phones__header-well { padding: 10px 14px; }
-.am-phones__header-led { font-size: 22px; line-height: 1; }
-.am-phones__header-cap { font-size: 9px; letter-spacing: 0.2em; margin-top: 2px; }
+/* Header plate: patched count LED + patch-new chicklet. Uses the shared
+   .am-page-header primitives; no page-specific overrides needed. */
 
 /* Patchbay rail wrapper on this page. The inner .am-patchbay__rail grid
    is defined in the patchbay primitives section. */
@@ -1200,21 +1193,19 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 
 /* Two-column body: roster (wider) + pair panel (narrower) */
 .am-phones__body { display: grid; grid-template-columns: 1.35fr 1fr; gap: 18px; align-items: start; }
-.am-phones__roster { padding: 0; overflow: hidden; min-width: 0; }
-.am-phones__roster-head { padding: 14px 18px 8px; border-bottom: 1px solid rgba(100,80,40,0.2); }
 
-/* Roster rows. Dashed separator between rows; no border on last. */
-.am-phones__row { display: grid; grid-template-columns: 28px 14px 1fr auto auto; gap: 12px; align-items: center; padding: 10px 18px; border-bottom: 1px dashed rgba(100,80,40,0.2); }
-.am-phones__row:last-child { border-bottom: 0; }
-.am-phones__row-num { font-family: var(--font-led); font-size: 18px; color: var(--led-amber); text-shadow: 0 0 4px rgba(255,165,32,0.4); }
-.am-phones__row-body { min-width: 0; }
-.am-phones__row-name { font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--ink); }
+/* Handset roster: sits inside the narrower 2-col body, so needs min-width: 0
+   on top of the shared .am-roster padding and overflow. */
+.am-phones__roster { min-width: 0; }
+
+/* Roster row column template is page-specific: 28px num, 14px lamp, 1fr body,
+   two auto slots (caption + actions). Shared .am-roster__row supplies the
+   grid display, gap, and dashed separator. */
+.am-phones__row { grid-template-columns: 28px 14px 1fr auto auto; align-items: center; padding: 10px 18px; }
 .am-phones__row-name a { color: inherit; text-decoration: none; }
 .am-phones__row-name a:hover { color: var(--chip-blue); }
 .am-phones__empty { padding: 14px 18px; }
 .am-phones__row-num-caption { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); letter-spacing: 0.04em; }
-.am-phones__row-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); letter-spacing: 0.06em; margin-top: 2px; }
-.am-phones__row-actions { display: inline-flex; gap: 6px; }
 .am-phones__row--edit { display: flex; align-items: center; gap: 10px; }
 .am-phones__edit-form { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
 .am-phones__edit-input { flex: 1; min-width: 0; padding: 6px 10px; font: 13px/1 var(--font-body); color: var(--ink); background: rgba(0,0,0,0.12); border: 1px solid rgba(100,80,40,0.35); border-radius: 4px; }

--- a/server/internal/web/templates/call-live-detail.html
+++ b/server/internal/web/templates/call-live-detail.html
@@ -19,7 +19,7 @@
       </div>
     {{else}}
       <button class="deck-kill" type="button" onclick="document.getElementById('deck-confirm').showModal()">
-        {{if eq .User.Theme "dialup"}}◉ Disconnect{{else}}End call{{end}}
+        {{if eq .User.Theme "answering-machine"}}&#9632; Stop{{else if eq .User.Theme "dialup"}}◉ Disconnect{{else}}End call{{end}}
       </button>
     {{end}}
   </header>
@@ -48,7 +48,7 @@
     <dialog id="deck-confirm" class="deck-confirm">
       <form method="dialog" class="deck-confirm__form">
         <h2 class="deck-confirm__title">
-          {{if eq .User.Theme "dialup"}}Disconnect call?{{else}}End this call?{{end}}
+          {{if eq .User.Theme "answering-machine"}}Stop this session?{{else if eq .User.Theme "dialup"}}Disconnect call?{{else}}End this call?{{end}}
         </h2>
         <p class="deck-confirm__body">
           The server sends a hangup signal to both handsets. The call will drop within a second or two.
@@ -60,7 +60,7 @@
                   hx-post="/api/call/{{.Call.ID}}/disconnect"
                   hx-swap="none"
                   onclick="document.getElementById('deck-confirm').close()">
-            {{if eq .User.Theme "dialup"}}Disconnect{{else}}End call{{end}}
+            {{if eq .User.Theme "answering-machine"}}&#9632; Stop{{else if eq .User.Theme "dialup"}}Disconnect{{else}}End call{{end}}
           </button>
         </div>
       </form>

--- a/server/internal/web/templates/calls.html
+++ b/server/internal/web/templates/calls.html
@@ -1,6 +1,9 @@
 {{define "title"}}Call log{{end}}
 
 {{define "content"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
+  {{template "calls-am" .}}
+{{else}}
 <div class="page">
 
   <header class="page__head">
@@ -126,6 +129,74 @@
     </div>
     {{end}}
   </section>
+
+  {{template "page-footer" .}}
+
+</div>
+{{end}}
+{{end}}
+
+{{define "calls-am"}}
+<div class="am-calls">
+
+  <div class="am-plate am-page-header">
+    <div class="am-page-header__info">
+      <span class="am-label">Call log</span>
+      <span class="am-title">{{len .Entries}} entr{{if eq (len .Entries) 1}}y{{else}}ies{{end}}</span>
+    </div>
+    <div class="am-page-header__spacer"></div>
+    <div class="am-well am-page-header__well am-calls__live-well">
+      <span class="am-lamp am-lamp--on-green am-calls__live-lamp" aria-hidden="true"></span>
+      <div class="am-led am-led--green am-calls__live-cap">LIVE</div>
+    </div>
+  </div>
+
+  <div class="am-plate am-roster am-calls__tape"
+       hx-get="/calls"
+       hx-trigger="every 10s"
+       hx-swap="outerHTML"
+       hx-select=".am-calls__tape">
+    <div class="am-roster__head"><span class="am-label">Tape log</span></div>
+    {{if .Entries}}
+    {{range .Entries}}
+    {{if .IsConference}}
+    <div class="am-roster__row am-calls__entry am-calls__entry--conf">
+      <span class="am-calls__time">{{.Conference.CreatedAt.Format "15:04:05"}}</span>
+      <div class="am-calls__body">
+        <div class="am-calls__conf-parts">
+          {{range $i, $m := .Conference.Members}}{{if $i}}<span class="am-calls__arrow" aria-hidden="true">&#183;</span>{{end}}<span class="am-calls__party">{{fmtPhone $m}}</span>{{end}}
+        </div>
+        <div class="am-calls__meta">{{.Conference.CreatedAt.Format "Jan 2"}}</div>
+      </div>
+      <span class="am-calls__status am-calls__status--conf">3-WAY</span>
+      <span class="am-calls__duration">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&mdash;{{end}}</span>
+      <a class="am-calls__details" href="/conference/live/{{.Conference.ID}}" aria-label="View conference details">Details &rarr;</a>
+    </div>
+    {{else}}
+    <div class="am-roster__row am-calls__entry am-calls__entry--reg">
+      <span class="am-calls__time">{{.Call.StartedAt.Format "15:04:05"}}</span>
+      <div class="am-calls__body">
+        <div class="am-calls__parties">
+          <span class="am-calls__party">{{fmtPhone .Call.Caller}}</span>
+          <span class="am-calls__arrow" aria-hidden="true">&rarr;</span>
+          <span class="am-calls__party">{{fmtPhone .Call.Callee}}</span>
+          {{if .Call.OriginatingConferenceID}}<span class="am-calls__from-conf">from 3-way</span>{{end}}
+        </div>
+        <div class="am-calls__meta">
+          <span class="am-calls__meta-date">{{.Call.StartedAt.Format "Jan 2"}}</span>
+          <span class="am-calls__meta-state am-calls__meta-state--{{.Call.Status}}">{{.Call.Status}}</span>
+        </div>
+      </div>
+      <span class="am-calls__status am-calls__status--reg">REG</span>
+      <span class="am-calls__duration">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&mdash;{{end}}</span>
+      <a class="am-calls__details" href="/call/live/{{.Call.ID}}" aria-label="View call details">Details &rarr;</a>
+    </div>
+    {{end}}
+    {{end}}
+    {{else}}
+    <div class="am-calls__empty am-hint">No calls on the tape yet. New entries appear here as they happen.</div>
+    {{end}}
+  </div>
 
   {{template "page-footer" .}}
 

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -209,15 +209,15 @@
   {{if .Revoked}}<div class="banner banner--warn">Family disconnected.</div>{{end}}
   {{if .Canceled}}<div class="banner banner--warn">Invite canceled.</div>{{end}}
 
-  <div class="am-plate am-links__header">
-    <div class="am-links__header-info">
+  <div class="am-plate am-page-header">
+    <div class="am-page-header__info">
       <span class="am-label">Station directory</span>
       <span class="am-title">{{len .LinkedFamilies}} household{{if ne (len .LinkedFamilies) 1}}s{{end}} connected</span>
     </div>
-    <div class="am-links__header-spacer"></div>
-    <div class="am-well am-links__header-well">
-      <div class="am-led am-links__header-led">{{printf "%02d" (len .LinkedFamilies)}}</div>
-      <div class="am-led am-led--dim am-links__header-cap">Connected</div>
+    <div class="am-page-header__spacer"></div>
+    <div class="am-well am-page-header__well">
+      <div class="am-led am-page-header__led">{{printf "%02d" (len .LinkedFamilies)}}</div>
+      <div class="am-led am-led--dim am-page-header__cap">Connected</div>
     </div>
   </div>
 
@@ -257,16 +257,16 @@
 
   </div>
 
-  <div class="am-plate am-directory">
-    <div class="am-directory__head"><span class="am-label">Stations</span></div>
+  <div class="am-plate am-roster">
+    <div class="am-roster__head"><span class="am-label">Stations</span></div>
     {{if .LinkedFamilies}}
     {{range $i, $f := .LinkedFamilies}}
-    <div class="am-directory__row" id="family-{{$f.ID}}">
-      <span class="am-directory__num">{{printf "%02d" (inc $i)}}</span>
+    <div class="am-roster__row am-directory__row" id="family-{{$f.ID}}">
+      <span class="am-roster__num am-directory__num">{{printf "%02d" (inc $i)}}</span>
       <span class="am-lamp am-lamp--on-green am-directory__lamp"></span>
-      <div class="am-directory__body">
-        <div class="am-directory__name">{{$f.Name}}</div>
-        <div class="am-directory__meta">
+      <div class="am-roster__body">
+        <div class="am-roster__name am-directory__name">{{$f.Name}}</div>
+        <div class="am-roster__meta">
           {{if $f.AcceptedAt}}Since {{$f.AcceptedAt.Format "Jan 2, 2006"}} &middot; {{end}}{{len $f.Lines}} line{{if ne (len $f.Lines) 1}}s{{end}}
         </div>
         {{if $f.Lines}}
@@ -280,7 +280,7 @@
         </div>
         {{end}}
       </div>
-      <div class="am-directory__actions">
+      <div class="am-roster__actions">
         <button type="button"
           data-confirm
           data-confirm-action="/links/{{$f.ID}}/revoke"
@@ -297,10 +297,10 @@
   </div>
 
   {{if .PendingInvites}}
-  <div class="am-plate am-outbox">
-    <div class="am-outbox__head"><span class="am-label">Outbox</span></div>
+  <div class="am-plate am-roster">
+    <div class="am-roster__head"><span class="am-label">Outbox</span></div>
     {{range .PendingInvites}}
-    <div class="am-outbox__row">
+    <div class="am-roster__row am-outbox__row">
       <span class="am-outbox__code">{{.InviteCode}}</span>
       <span class="am-outbox__date">Printed {{.CreatedAt.Format "Jan 2, 2006"}}</span>
       <button type="button"

--- a/server/internal/web/templates/onboard.html
+++ b/server/internal/web/templates/onboard.html
@@ -1,6 +1,9 @@
 {{define "title"}}Welcome to Digits{{end}}
 
 {{define "content"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
+  {{template "onboard-am" .}}
+{{else}}
 <div class="auth">
   <div class="auth__frame">
 
@@ -21,6 +24,39 @@
       </form>
     </div>
 
+  </div>
+</div>
+{{end}}
+{{end}}
+
+{{define "onboard-am"}}
+<div class="am-welcome">
+  <div class="am-plate am-plate--screws am-welcome__frame">
+    <span class="am-screw am-screw--tl"></span>
+    <span class="am-screw am-screw--tr"></span>
+    <span class="am-screw am-screw--bl"></span>
+    <span class="am-screw am-screw--br"></span>
+
+    <div class="am-plate__label">New household</div>
+
+    <h1 class="am-welcome__mark">Cue the tape.</h1>
+    <p class="am-hint am-welcome__tagline">Name your household to set up the answering machine. You can rename it later in Settings.</p>
+
+    <form action="/onboard" method="POST" class="am-welcome__form">
+      <div class="am-welcome__field">
+        <label for="name" class="am-label">Family name</label>
+        <input type="text" id="name" name="name" required
+          value="{{.SuggestedName}}"
+          placeholder="THE SMITH FAMILY"
+          class="am-accept__input"
+          autocomplete="off"
+          autofocus>
+      </div>
+      <button type="submit" class="am-key am-welcome__submit">
+        <span class="am-key__symbol">&#x25CF;</span>
+        <span class="am-key__label">Record household</span>
+      </button>
+    </form>
   </div>
 </div>
 {{end}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1,6 +1,9 @@
 {{define "title"}}{{.Line.Name}}{{end}}
 
 {{define "content"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
+  {{template "phone-detail-am" .}}
+{{else}}
 <div class="page">
 
   <div style="margin-bottom: 10px;">
@@ -499,6 +502,7 @@
 
 </div>
 {{end}}
+{{end}}
 
 {{define "voice-style-section"}}
 <div id="voice-style-section">
@@ -546,10 +550,173 @@
 </div>
 {{end}}
 
+{{define "phone-detail-am"}}
+<div class="am-handset">
+
+  <a href="/phones" class="am-tab am-handset__back" aria-label="Back to lines">&larr; Lines</a>
+
+  <div class="am-plate am-page-header">
+    <div class="am-page-header__info">
+      <span class="am-label">Handset detail</span>
+      <span class="am-title">{{.Line.Name}}</span>
+    </div>
+    <div class="am-page-header__spacer"></div>
+    <div class="am-well am-page-header__well">
+      <div class="am-led am-page-header__led">{{fmtPhone .Line.Number}}</div>
+      <div class="am-led am-led--dim am-page-header__cap">LINE</div>
+    </div>
+    <div class="am-well am-page-header__well am-handset__status-well">
+      <span id="status-badge"
+            hx-get="/phones/{{.Line.Number}}/online"
+            hx-trigger="every 10s"
+            hx-swap="innerHTML">
+        {{template "phone-status" .}}
+      </span>
+    </div>
+  </div>
+
+  <script>
+  document.getElementById('status-badge').addEventListener('htmx:afterSwap', function(evt) {
+    var newOnline = evt.target.querySelector('[data-online]').getAttribute('data-online') === 'true';
+    var prev = this.dataset.prevOnline === 'true';
+    if (this.dataset.prevOnline !== undefined && newOnline !== prev) { location.reload(); return; }
+    this.dataset.prevOnline = newOnline;
+  });
+  (function() {
+    var badge = document.getElementById('status-badge');
+    var span = badge.querySelector('[data-online]');
+    if (span) badge.dataset.prevOnline = span.getAttribute('data-online');
+  })();
+  </script>
+
+  <section class="am-plate am-handset__hero">
+    <span class="am-plate__label">Handset</span>
+    <div class="am-handset__hero-frame">
+      <img class="am-handset__hero-img" src="/static/images/phone-silhouette.png" alt="Desk phone">
+    </div>
+    <div class="am-handset__hero-caption">
+      <span class="am-handset__hero-name">{{.Line.Name}}</span>
+      <span class="am-led am-handset__hero-num">{{fmtPhone .Line.Number}}</span>
+    </div>
+  </section>
+
+  <div class="am-handset__grid">
+
+    <section class="am-plate am-handset__plate">
+      <span class="am-plate__label">Details</span>
+      <dl class="am-settings__kv">
+        <div class="am-settings__kv-row">
+          <dt class="am-settings__kv-key am-label">Number</dt>
+          <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{fmtPhone .Line.Number}}</span></dd>
+        </div>
+        <div class="am-settings__kv-row">
+          <dt class="am-settings__kv-key am-label">Name</dt>
+          <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.Line.Name}}</span></dd>
+        </div>
+        <div class="am-settings__kv-row">
+          <dt class="am-settings__kv-key am-label">Added</dt>
+          <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.Line.CreatedAt.Format "Jan 2, 2006"}}</span></dd>
+        </div>
+        {{if .Devices}}
+        <div class="am-settings__kv-row">
+          <dt class="am-settings__kv-key am-label">Paired</dt>
+          <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{len .Devices}} device{{if ne (len .Devices) 1}}s{{end}}</span></dd>
+        </div>
+        {{end}}
+        {{if .DeviceInfo}}
+          {{if .DeviceInfo.PiVersion}}
+          <div class="am-settings__kv-row">
+            <dt class="am-settings__kv-key am-label">Pi</dt>
+            <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.PiVersion}}{{if .DeviceInfo.PiCommit}} &middot; {{.DeviceInfo.PiCommit}}{{end}}</span></dd>
+          </div>
+          {{end}}
+          {{if .DeviceInfo.FirmwareVersion}}
+          <div class="am-settings__kv-row">
+            <dt class="am-settings__kv-key am-label">Firmware</dt>
+            <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.FirmwareVersion}}{{if .DeviceInfo.FirmwareCommit}} &middot; {{.DeviceInfo.FirmwareCommit}}{{end}}{{if .DeviceInfo.FlashCapable}} &middot; SWD{{end}}</span></dd>
+          </div>
+          {{end}}
+        {{end}}
+        {{if .LastSeenAt}}
+        <div class="am-settings__kv-row">
+          <dt class="am-settings__kv-key am-label">Last seen</dt>
+          <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}</span></dd>
+        </div>
+        {{end}}
+      </dl>
+    </section>
+
+    <section class="am-plate am-handset__plate">
+      <span class="am-plate__label">Voice style</span>
+      {{template "voice-style-section" .}}
+    </section>
+
+    <section class="am-plate am-handset__plate">
+      <span class="am-plate__label">Ringer</span>
+      {{template "silent-mode-section" .}}
+    </section>
+
+    {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
+    <section class="am-plate am-handset__plate am-handset__plate--wide">
+      <span class="am-plate__label">Update notes</span>
+      <div class="am-handset__updates">
+        {{range .PiUpdateNotes}}
+        <article class="am-handset__update-note">
+          <span class="am-handset__update-ver">pi {{.Version}}</span>
+          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
+        </article>
+        {{end}}
+        {{range .FirmwareUpdateNotes}}
+        <article class="am-handset__update-note">
+          <span class="am-handset__update-ver">fw {{.Version}}</span>
+          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
+        </article>
+        {{end}}
+      </div>
+    </section>
+    {{end}}
+
+    <section class="am-plate am-handset__plate am-handset__plate--wide am-handset__plate--danger am-handset__actions">
+      <span class="am-plate__label">Actions</span>
+      <p class="am-hint am-handset__action-desc">Removing a handset is permanent. The device will need to be re-paired to come back online.</p>
+      <div class="am-handset__actions-row">
+        <form class="am-handset__action-form"
+              method="POST"
+              action="/phones/{{.Line.Number}}/delete"
+              onsubmit="return confirm('Delete line {{.Line.Name}} ({{fmtPhone .Line.Number}})? This cannot be undone.')">
+          <button type="submit" class="am-key am-key--red">
+            <span class="am-key__symbol">&#x2716;</span>
+            <span class="am-key__label">Delete line</span>
+          </button>
+        </form>
+      </div>
+    </section>
+
+  </div>
+
+  {{template "page-footer" .}}
+
+</div>
+{{end}}
+
 {{define "phone-status"}}
-{{if .Online}}
-  <span class="chip chip--on" data-online="true"><span class="chip__dot"></span>online</span>
+{{if eq .Theme "answering-machine"}}
+  {{if .Online}}
+  <span class="am-handset__status" data-online="true">
+    <span class="am-lamp am-lamp--on-green am-handset__status-lamp" aria-hidden="true"></span>
+    <span class="am-led am-led--green am-handset__status-cap">ONLINE</span>
+  </span>
+  {{else}}
+  <span class="am-handset__status" data-online="false">
+    <span class="am-lamp am-handset__status-lamp" aria-hidden="true"></span>
+    <span class="am-led am-led--dim am-handset__status-cap">OFFLINE</span>
+  </span>
+  {{end}}
 {{else}}
+  {{if .Online}}
+  <span class="chip chip--on" data-online="true"><span class="chip__dot"></span>online</span>
+  {{else}}
   <span class="chip" data-online="false"><span class="chip__dot"></span>offline</span>
+  {{end}}
 {{end}}
 {{end}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -392,17 +392,17 @@
 {{end}}
 
 {{define "am-phones-table"}}
-<div class="am-plate am-phones__roster" id="phones-table">
-  <div class="am-phones__roster-head"><span class="am-label">Handsets</span></div>
+<div class="am-plate am-roster am-phones__roster" id="phones-table">
+  <div class="am-roster__head"><span class="am-label">Handsets</span></div>
   {{if .Lines}}
   {{range $i, $l := .Lines}}
-  <div class="am-phones__row">
-    <span class="am-phones__row-num">{{printf "%02d" (inc $i)}}</span>
+  <div class="am-roster__row am-phones__row">
+    <span class="am-roster__num">{{printf "%02d" (inc $i)}}</span>
     <span class="am-lamp{{if $l.OnCall}} am-lamp--on-red{{else if $l.Online}} am-lamp--on-green{{end}}"></span>
-    <div class="am-phones__row-body">
-      <div class="am-phones__row-name"><a href="/phones/{{$l.Line.Number}}">{{$l.Line.Name}}</a></div>
+    <div class="am-roster__body">
+      <div class="am-roster__name am-phones__row-name"><a href="/phones/{{$l.Line.Number}}">{{$l.Line.Name}}</a></div>
       <div class="am-phones__row-num-caption">{{fmtPhone $l.Line.Number}}</div>
-      <div class="am-phones__row-meta">
+      <div class="am-roster__meta">
         {{if $l.OnCall}}IN SESSION
         {{else if $l.Online}}ONLINE{{if and $l.DeviceInfo $l.DeviceInfo.FirmwareVersion}} &middot; FW {{$l.DeviceInfo.FirmwareVersion}}{{end}}
         {{else}}OFFLINE
@@ -410,7 +410,7 @@
         {{if $l.Line.Settings.SilentMode}} &middot; SILENT{{end}}
       </div>
     </div>
-    <div class="am-phones__row-actions">
+    <div class="am-roster__actions">
       <button class="am-tab" hx-get="/phones/{{$l.Line.Number}}/edit" hx-target="closest .am-phones__row" hx-swap="outerHTML">Edit</button>
       <button class="am-tab" hx-post="/phones/{{$l.Line.Number}}/delete" hx-target="#phones-table" hx-swap="outerHTML" hx-confirm="Delete {{$l.Line.Name}}?">Delete</button>
     </div>
@@ -423,8 +423,8 @@
 {{end}}
 
 {{define "am-phone-edit-row"}}
-<div class="am-phones__row am-phones__row--edit">
-  <span class="am-phones__row-num">{{fmtPhone .Line.Number}}</span>
+<div class="am-roster__row am-phones__row am-phones__row--edit">
+  <span class="am-roster__num">{{fmtPhone .Line.Number}}</span>
   <form hx-post="/phones/{{.Line.Number}}/edit" hx-target="#phones-table" hx-swap="outerHTML" class="am-phones__edit-form">
     <input type="text" name="name" value="{{.Line.Name}}" class="am-phones__edit-input" autofocus>
     <button type="submit" class="am-tab">Save</button>
@@ -448,15 +448,15 @@
   </div>
   {{end}}
 
-  <div class="am-plate am-phones__header">
-    <div class="am-phones__header-info">
+  <div class="am-plate am-page-header">
+    <div class="am-page-header__info">
       <span class="am-label">Patchbay</span>
       <span class="am-title">{{len .Lines}} line{{if ne (len .Lines) 1}}s{{end}} paired</span>
     </div>
-    <div class="am-phones__header-spacer"></div>
-    <div class="am-well am-phones__header-well">
-      <div class="am-led am-phones__header-led">{{printf "%02d" (len .Lines)}}</div>
-      <div class="am-led am-led--dim am-phones__header-cap">PAIRED</div>
+    <div class="am-page-header__spacer"></div>
+    <div class="am-well am-page-header__well">
+      <div class="am-led am-page-header__led">{{printf "%02d" (len .Lines)}}</div>
+      <div class="am-led am-led--dim am-page-header__cap">PAIRED</div>
     </div>
     <a class="am-key" href="#pair-new"><span class="am-key__symbol">+</span><span class="am-key__label">Patch new</span></a>
   </div>

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -519,15 +519,15 @@
   <div class="banner banner--ok">Settings saved.</div>
   {{end}}
 
-  <div class="am-plate am-settings__header">
-    <div class="am-settings__header-info">
+  <div class="am-plate am-page-header">
+    <div class="am-page-header__info">
       <span class="am-label">Service menu</span>
       <span class="am-title">Settings</span>
     </div>
-    <div class="am-settings__header-spacer"></div>
-    <div class="am-well am-settings__header-well">
-      <div class="am-led am-settings__header-led">{{.User.Email}}</div>
-      <div class="am-led am-led--dim am-settings__header-cap">Signed&nbsp;in</div>
+    <div class="am-page-header__spacer"></div>
+    <div class="am-well am-page-header__well am-settings__header-well">
+      <div class="am-led am-page-header__led am-settings__header-led">{{.User.Email}}</div>
+      <div class="am-led am-led--dim am-page-header__cap">Signed&nbsp;in</div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

Final phase of the Answering Machine theme. Three commits:

1. **Primitive consolidation** (refactor, zero visible change). Extract `.am-page-header__*` from the duplicated `.am-phones__header*` / `.am-links__header*` / `.am-settings__header*` clusters; extract `.am-roster__*` from `.am-phones__row*` / `.am-directory__*`.
2. **Remaining surfaces reskinned.** `/calls`, `/phones/{number}`, `/onboard`, `/calls/{id}/live` deck (plus `/conference/live/{id}` via the same CSS overlay).
3. **Width fix on `.am-handset`.** Dropped the `max-width: 1020px` cap so phone-detail fills the shell padding zone like the other AM pages. Same pattern as the `.am-links` fix from PR #283.

`/auth/login` is intentionally skipped: `loginTmpl` is rendered with a bespoke handler that hard-codes `layout-v2.html` and passes a data map without `User`, so theme is not reachable there. Fix would require Go changes; out of scope.

## Screenshots

Call log (empty state; auto-refresh LIVE indicator on the right):

![AM calls](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-polish-calls.png)

Handset detail (post width-fix; header status plate, cassette-window hero, KV detail plate with LED-amber values, voice style, delete action plate):

![AM phone detail](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-polish-phone-detail-v2.png)

Onboard welcome (brass plate with corner screws, "Cue the tape." headline, Record household brass key):

![AM onboard](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-polish-onboard.png)

## Details by surface

**`/calls` (calls-am)**
- Header plate with LIVE indicator (green lamp + "LIVE" cap). Auto-refresh htmx scoped to `.am-calls__tape` body only; header stays static.
- Tape-log rows: LED-amber time column, caller/callee in monospace with arrow glyph, status chip (REG/3-WAY), duration right-aligned.
- Conference entries render as multi-party rows.
- Per-call status (connected/missed/ringing/initiated/ended) tints the meta line via `.am-calls__meta-state--<status>` variants.

**`/phones/{number}` (phone-detail-am)**
- Page header with brass title and amber-LED status lamp (ONLINE/OFFLINE/IN SESSION) updated by the existing 10s htmx poll. `lineDetailData` now carries `.Theme` so the `phone-status` partial renders the matching markup on poll responses.
- Cassette-window hero plate frames the phone silhouette image with LED-amber caption.
- Details plate uses `.am-settings__kv*` primitives (reused, not duplicated) for Number/Name/Added/Firmware/Pi/Last seen rows.
- Update notes render as tape-log cards under Firmware and Pi when new releases are available.
- Delete action in its own danger-framed plate with `.am-key--red` chicklet.
- Voice-style and silent-mode forms delegate to the existing htmx partials (which render into AM shim CSS without handler changes).
- Width matches the other AM pages after the 1020px cap was dropped.

**`/onboard` (onboard-am)**
- Brass plate with `.am-plate--screws` corner treatment.
- "NEW HOUSEHOLD" engraved label, "Cue the tape." headline.
- LED-amber input (reusing `.am-accept__input`), "Record household" brass key with record-dot glyph.

**`/calls/{id}/live` + `/conference/live/{id}` (CSS overlay)**
- No template fork. All `.deck-*` selectors get AM overrides under `body.am`.
- LED-amber duration ticker in an inset well. Kicker rendered as engraved brass strip. Metrics panel as a recessed cassette readout with amber segment bars. Stop button in `--chip-red`.
- Template adds AM glyph swaps on three theme-conditional sites (header Stop button, confirm title, confirm primary).
- Conference matrix (`.deck-matrix*`) and host card (`.deck-card--host`) get AM treatment too.

## Reviewer loop

Internal spec + code-quality reviews ran before commit. Findings folded in:
- Removed 23 dead `.am-handset__*` stubs that the implementer had left as "future wiring." YAGNI. Shared shims cover the voice-style/silent-mode forms under AM palette already.
- No em dashes introduced (pre-existing em dashes in untouched content grandfathered).
- No new unused selectors (`.am-welcome__*` 6/6 used, `.am-calls__*` all used via dynamic `{{.Call.Status}}` class interpolation, `.am-handset__*` pruned).

## Test plan

- [x] `go build -o bin/signald ./cmd/signald/`
- [x] `go test ./internal/web/ ./internal/auth/`
- [x] `golangci-lint run ./internal/web/... ./internal/auth/...`
- [x] Dev server visual check: all 4 prior AM pages still render pixel-equivalent post-consolidation. New surfaces render on-theme at full width.
- [x] No regressions to intercom or dialup: intercom branches unchanged, dialup untouched.

## What this closes out

Answering Machine theme coverage is complete across every in-nav page, the phone detail surface, the live call deck, the conference deck, and the onboard gateway. `/auth/login` remains intercom-themed by necessity.