### PR TITLE
chore(server): drop dead auth.NewStore, rename NewStoreFromDB to NewStore

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -110,7 +110,7 @@ func main() {
 	defer func() { _ = database.Close() }()
 
 	s := &stores{
-		auth:  auth.NewStoreFromDB(database.DB),
+		auth:  auth.NewStore(database.DB),
 		house: household.NewStore(database.DB),
 		link:  household.NewLinkStore(database.DB),
 		line:  line.NewStore(database),

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -90,7 +90,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Auth
-	authStore := auth.NewStoreFromDB(database.DB)
+	authStore := auth.NewStore(database.DB)
 	authStore.CookieDomain = cfg.CookieDomain
 
 	var emailSender email.Sender

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/device"
-	_ "github.com/lib/pq"
 )
 
 // ErrUserNotFound is returned by GetUserBy* when no matching row exists.
@@ -46,21 +45,8 @@ type Store struct {
 	CookieDomain string
 }
 
-// NewStore opens a new Postgres connection and returns a Store.
-func NewStore(databaseURL string) (*Store, error) {
-	db, err := sql.Open("postgres", databaseURL)
-	if err != nil {
-		return nil, err
-	}
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return &Store{db: db}, nil
-}
-
-// NewStoreFromDB wraps an existing *sql.DB (used when sharing a connection from db.Open).
-func NewStoreFromDB(db *sql.DB) *Store {
+// NewStore wraps an existing *sql.DB (shared with the rest of signald via db.Open).
+func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 

--- a/server/internal/auth/store_test.go
+++ b/server/internal/auth/store_test.go
@@ -26,7 +26,7 @@ func testDB(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("db.Open: %v", err)
 	}
-	s := NewStoreFromDB(database.DB)
+	s := NewStore(database.DB)
 	t.Cleanup(func() {
 		_, _ = database.DB.Exec("DELETE FROM sessions")
 		_, _ = database.DB.Exec("DELETE FROM magic_links")

--- a/server/internal/household/e2e_link_test.go
+++ b/server/internal/household/e2e_link_test.go
@@ -24,7 +24,7 @@ func TestE2EHouseholdLinkFlow(t *testing.T) {
 	}
 	defer func() { _ = database.Close() }()
 
-	authStore := auth.NewStoreFromDB(database.DB)
+	authStore := auth.NewStore(database.DB)
 	householdStore := NewStore(database.DB)
 	linkStore := NewLinkStore(database.DB)
 

--- a/server/internal/pairing/e2e_pairing_test.go
+++ b/server/internal/pairing/e2e_pairing_test.go
@@ -29,7 +29,7 @@ func TestE2EPairingFlow(t *testing.T) {
 	}
 	defer func() { _ = database.Close() }()
 
-	authStore := auth.NewStoreFromDB(database.DB)
+	authStore := auth.NewStore(database.DB)
 	householdStore := household.NewStore(database.DB)
 	pairingStore := NewStore(database.DB)
 

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -33,7 +33,7 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 	}
 	t.Cleanup(func() { _ = rawDB.Close() })
 
-	authStore := auth.NewStoreFromDB(rawDB)
+	authStore := auth.NewStore(rawDB)
 
 	// Google OAuth disabled (empty credentials)
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -134,7 +134,7 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	relay := signaling.NewRelay(hub, tracker, nil, nil)
 	relay.HealthStore = healthStore
 
-	authStore := auth.NewStoreFromDB(database.DB)
+	authStore := auth.NewStore(database.DB)
 	householdStore := household.NewStore(database.DB)
 	pairingStore := pairing.NewStore(database.DB)
 	linkStore := household.NewLinkStore(database.DB)


### PR DESCRIPTION
The URL-based `auth.NewStore(databaseURL string)` opened its own Postgres connection pool and had zero callers; every real caller threaded the shared `db.Open` connection through `NewStoreFromDB`. Delete the dead constructor and rename `NewStoreFromDB` to `NewStore` so `auth.Store` matches the convention used by `device`, `line`, `household`, and `pairing` (all take a shared `*sql.DB`). Pure rename on the caller side, no behavior change.