### PR TITLE
chore(server): collapse autodeploy.HealthPoller to a function type

### DIFF
--- a/server/cmd/autodeploy/main.go
+++ b/server/cmd/autodeploy/main.go
@@ -55,7 +55,7 @@ func main() {
 		Cfg:    cfg,
 		GH:     gh,
 		Runner: autodeploy.NewExecRunner(),
-		Health: autodeploy.DefaultHealthPoller(),
+		Health: autodeploy.PollHealth,
 		Mailer: mailer,
 		Store:  store,
 		Logger: logger,

--- a/server/internal/autodeploy/deploy.go
+++ b/server/internal/autodeploy/deploy.go
@@ -66,17 +66,9 @@ type Result struct {
 	Tag    string
 }
 
-type HealthPoller interface {
-	Poll(ctx context.Context, url, wantVersion string, interval time.Duration) error
-}
-
-type healthFn func(ctx context.Context, url, wantVersion string, interval time.Duration) error
-
-func (f healthFn) Poll(ctx context.Context, url, wantVersion string, interval time.Duration) error {
-	return f(ctx, url, wantVersion, interval)
-}
-
-func DefaultHealthPoller() HealthPoller { return healthFn(PollHealth) }
+// HealthPoller polls a /healthz endpoint until the reported version matches
+// wantVersion. Production wires this to PollHealth; tests substitute a stub.
+type HealthPoller func(ctx context.Context, url, wantVersion string, interval time.Duration) error
 
 type GitHubReleases interface {
 	LatestReleaseWithETag(ctx context.Context, repo, prefix, etag string) (Release, error)
@@ -256,7 +248,7 @@ func (d *Deployer) deployVersion(ctx context.Context, version string, healthTime
 	hctx, cancel := context.WithTimeout(ctx, healthTimeout)
 	defer cancel()
 	for _, u := range d.Cfg.HealthURLs {
-		if err := d.Health.Poll(hctx, u, version, 2*time.Second); err != nil {
+		if err := d.Health(hctx, u, version, 2*time.Second); err != nil {
 			return &stepError{Step: StepHealthcheck, Err: err}
 		}
 	}

--- a/server/internal/autodeploy/deploy_test.go
+++ b/server/internal/autodeploy/deploy_test.go
@@ -53,15 +53,13 @@ func (m *mockMailer) Send(to, subject, htmlBody string) error {
 	return m.err
 }
 
-type mockHealth struct {
-	errs map[string]error // keyed by wantVersion
-}
-
-func (m *mockHealth) Poll(ctx context.Context, url, wantVersion string, interval time.Duration) error {
-	if m.errs == nil {
-		return nil
+// mockHealth returns a HealthPoller that fails with errs[wantVersion] (if set)
+// and otherwise succeeds. Keyed by version so a single poller can model distinct
+// outcomes for the forward deploy vs. the revert that follows.
+func mockHealth(errs map[string]error) HealthPoller {
+	return func(ctx context.Context, url, wantVersion string, interval time.Duration) error {
+		return errs[wantVersion]
 	}
-	return m.errs[wantVersion]
 }
 
 type memStore struct{ s State }
@@ -87,7 +85,7 @@ func TestDeployNoop_SameTag(t *testing.T) {
 	d := &Deployer{
 		Cfg:    baseCfg(),
 		GH:     &mockGH{rel: Release{TagName: "server/v1.9.0", CommitSHA: "abc"}},
-		Runner: &mockRunner{}, Health: &mockHealth{}, Mailer: &mockMailer{},
+		Runner: &mockRunner{}, Health: mockHealth(nil), Mailer: &mockMailer{},
 		Store: &memStore{s: State{LastDeployedTag: "server/v1.9.0"}},
 		Now:   func() time.Time { return time.Unix(0, 0) },
 	}
@@ -104,7 +102,7 @@ func TestDeployNoop_NotModified(t *testing.T) {
 	d := &Deployer{
 		Cfg:    baseCfg(),
 		GH:     &mockGH{rel: Release{NotModified: true}},
-		Runner: &mockRunner{}, Health: &mockHealth{}, Mailer: &mockMailer{},
+		Runner: &mockRunner{}, Health: mockHealth(nil), Mailer: &mockMailer{},
 		Store:  &memStore{s: State{LastDeployedTag: "server/v1.9.0"}},
 		Now:    func() time.Time { return time.Unix(0, 0) },
 	}
@@ -124,7 +122,7 @@ func TestDeployHappyPath_NoGHCRToken_SkipsLogin(t *testing.T) {
 	d := &Deployer{
 		Cfg:    cfg,
 		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: &mockMailer{},
+		Runner: runner, Health: mockHealth(nil), Mailer: &mockMailer{},
 		Store: &memStore{s: State{LastDeployedTag: "server/v1.9.0"}},
 		Now:   func() time.Time { return time.Unix(1000, 0).UTC() },
 	}
@@ -158,7 +156,7 @@ func TestDeployHappyPath(t *testing.T) {
 	d := &Deployer{
 		Cfg:    baseCfg(),
 		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def", ETag: `W/"e"`}},
-		Runner: runner, Health: &mockHealth{}, Mailer: mailer,
+		Runner: runner, Health: mockHealth(nil), Mailer: mailer,
 		Store: store,
 		Now:   func() time.Time { return time.Unix(1000, 0).UTC() },
 	}
@@ -215,7 +213,7 @@ func TestDeploy_ImagesNotReady_SkipsAndExitsClean(t *testing.T) {
 	d := &Deployer{
 		Cfg:    baseCfg(),
 		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: mailer, Store: store,
+		Runner: runner, Health: mockHealth(nil), Mailer: mailer, Store: store,
 		Now: func() time.Time { return time.Unix(1000, 0).UTC() },
 	}
 	res, err := d.Run(context.Background())
@@ -257,7 +255,7 @@ func TestDeploy_LoginFails(t *testing.T) {
 	d := &Deployer{
 		Cfg: baseCfg(),
 		GH:  &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: mailer, Store: store,
+		Runner: runner, Health: mockHealth(nil), Mailer: mailer, Store: store,
 		Now: func() time.Time { return time.Unix(1000, 0).UTC() },
 	}
 	res, err := d.Run(context.Background())
@@ -291,7 +289,7 @@ func TestDeploy_HealthFails_RevertSucceeds(t *testing.T) {
 	runner := &mockRunner{}
 	mailer := &mockMailer{}
 	store := &memStore{s: State{LastDeployedTag: "server/v1.9.0"}}
-	health := &mockHealth{errs: map[string]error{"1.9.1": errors.New("timeout")}}
+	health := mockHealth(map[string]error{"1.9.1": errors.New("timeout")})
 	d := &Deployer{
 		Cfg: baseCfg(),
 		GH:  &mockGH{rel: Release{TagName: "server/v1.9.1", CommitSHA: "def"}},
@@ -328,10 +326,10 @@ func TestDeploy_HealthFails_RevertAlsoFails(t *testing.T) {
 	runner := &mockRunner{}
 	mailer := &mockMailer{}
 	store := &memStore{s: State{LastDeployedTag: "server/v1.9.0"}}
-	health := &mockHealth{errs: map[string]error{
+	health := mockHealth(map[string]error{
 		"1.9.1": errors.New("timeout"),
 		"1.9.0": errors.New("still broken"),
-	}}
+	})
 	d := &Deployer{
 		Cfg: baseCfg(),
 		GH:  &mockGH{rel: Release{TagName: "server/v1.9.1"}},
@@ -363,7 +361,7 @@ func TestDeploy_SpinProtection(t *testing.T) {
 	d := &Deployer{
 		Cfg:    baseCfg(),
 		GH:     &mockGH{rel: Release{TagName: "server/v1.9.1"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: &mockMailer{},
+		Runner: runner, Health: mockHealth(nil), Mailer: &mockMailer{},
 		Store: store,
 		Now:   func() time.Time { return time.Unix(1000, 0).UTC() },
 	}
@@ -393,7 +391,7 @@ func TestDeploy_EmailDebounce(t *testing.T) {
 	d := &Deployer{
 		Cfg: baseCfg(),
 		GH:  &mockGH{rel: Release{TagName: "server/v1.9.2"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: mailer, Store: store,
+		Runner: runner, Health: mockHealth(nil), Mailer: mailer, Store: store,
 		Now: func() time.Time { return now },
 	}
 	_, _ = d.Run(context.Background())
@@ -418,7 +416,7 @@ func TestDeploy_EmailAfterDebounceWindow(t *testing.T) {
 	d := &Deployer{
 		Cfg: baseCfg(),
 		GH:  &mockGH{rel: Release{TagName: "server/v1.9.2"}},
-		Runner: runner, Health: &mockHealth{}, Mailer: mailer, Store: store,
+		Runner: runner, Health: mockHealth(nil), Mailer: mailer, Store: store,
 		Now: func() time.Time { return now },
 	}
 	_, _ = d.Run(context.Background())


### PR DESCRIPTION
`HealthPoller` was a single-method interface backed by a `healthFn` adapter and a `DefaultHealthPoller()` factory to wrap the free `PollHealth` function. It has one production caller and one test stub. Swap the interface for a function type so `main.go` wires `Health: autodeploy.PollHealth` directly and the adapter plus factory disappear. Tests replace the `mockHealth` struct with a closure-returning helper, mechanical but cleaner.