### PR TITLE
chore(server): drop dead turn.CredentialGenerator.Verify

### DIFF
--- a/server/internal/turn/credentials.go
+++ b/server/internal/turn/credentials.go
@@ -5,8 +5,6 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -41,26 +39,6 @@ func (g *CredentialGenerator) Generate(identifier string) Credentials {
 		Username:   username,
 		Credential: credential,
 	}
-}
-
-// Verify checks that the credential is valid for the given username and has not expired.
-func (g *CredentialGenerator) Verify(username, credential string) bool {
-	parts := strings.SplitN(username, ":", 2)
-	if len(parts) < 2 {
-		return false
-	}
-
-	expiry, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return false
-	}
-
-	if time.Now().Unix() > expiry {
-		return false
-	}
-
-	expected := g.computeHMAC(username)
-	return hmac.Equal([]byte(credential), []byte(expected))
 }
 
 func (g *CredentialGenerator) computeHMAC(data string) string {

--- a/server/internal/turn/credentials_test.go
+++ b/server/internal/turn/credentials_test.go
@@ -1,6 +1,9 @@
 package turn
 
 import (
+	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -9,32 +12,30 @@ func TestGenerateCredentials(t *testing.T) {
 	gen := NewCredentialGenerator("supersecret", 24*time.Hour)
 	creds := gen.Generate("user@digits")
 
-	if creds.Username == "" {
-		t.Error("expected non-empty username")
+	// Username encodes the expiry as the first colon-separated field so
+	// coturn can parse it; the identifier follows. Validate both halves.
+	before := time.Now().Unix()
+	parts := strings.SplitN(creds.Username, ":", 2)
+	if len(parts) != 2 {
+		t.Fatalf("username %q is not <expiry>:<identifier>", creds.Username)
 	}
+	var expiry int64
+	if _, err := fmt.Sscanf(parts[0], "%d", &expiry); err != nil {
+		t.Fatalf("expiry not an int: %v", err)
+	}
+	if expiry < before+23*3600 {
+		t.Errorf("expiry %d is less than ~23h in the future (before=%d)", expiry, before)
+	}
+	if parts[1] != "user@digits" {
+		t.Errorf("identifier=%q, want user@digits", parts[1])
+	}
+
+	// Credential must be non-empty base64; coturn verifies it itself using
+	// the shared secret, so we only check that we emitted well-formed data.
 	if creds.Credential == "" {
-		t.Error("expected non-empty credential")
+		t.Fatal("expected non-empty credential")
 	}
-	if !gen.Verify(creds.Username, creds.Credential) {
-		t.Error("expected Verify to return true for freshly generated credentials")
-	}
-}
-
-func TestVerify_TamperedCredential(t *testing.T) {
-	gen := NewCredentialGenerator("supersecret", 24*time.Hour)
-	creds := gen.Generate("user@digits")
-
-	if gen.Verify(creds.Username, "tampered-credential-xyz") {
-		t.Error("expected Verify to return false for tampered credential")
-	}
-}
-
-func TestVerify_ExpiredCredential(t *testing.T) {
-	// Negative TTL puts expiry in the past
-	gen := NewCredentialGenerator("supersecret", -time.Hour)
-	creds := gen.Generate("user@digits")
-
-	if gen.Verify(creds.Username, creds.Credential) {
-		t.Error("expected Verify to return false for expired credential")
+	if _, err := base64.StdEncoding.DecodeString(creds.Credential); err != nil {
+		t.Errorf("credential is not valid base64: %v", err)
 	}
 }


### PR DESCRIPTION
coturn validates TURN REST credentials itself using the shared secret; signald never calls `Verify` in production. Delete the dead method plus the two Verify-only tests, and tighten `TestGenerateCredentials` to check the ephemeral-TURN username format (`EXPIRY:IDENTIFIER`) and credential base64 shape directly rather than relying on a local round-trip check.