### PR TITLE
chore(server): drop dead email.ContactInviteEmail template

### DIFF
--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -62,14 +62,3 @@ func HouseholdInviteEmail(householdName, inviteCode, baseURL string) (subject, b
 	body = brandedWrap(content)
 	return
 }
-
-// ContactInviteEmail returns subject and HTML body for a contact invite notification.
-func ContactInviteEmail(fromPhoneName, toPhoneName, baseURL string) (subject, body string) {
-	subject = fmt.Sprintf("Digits: Contact request for %s", toPhoneName)
-	content := fmt.Sprintf(`<h2 style="color:#e6edf3; margin:0 0 16px 0; font-size:20px;">New Contact Request</h2>
-  <p style="color:#8b949e; font-size:14px; margin:0 0 16px 0;"><strong>%s</strong> wants to add <strong>%s</strong> as a contact on Digits.</p>
-  <p style="color:#8b949e; font-size:14px; margin:0;">Review and respond at <a href="%s/contacts" style="color:#58a6ff;">%s/contacts</a>.</p>`,
-		fromPhoneName, toPhoneName, baseURL, baseURL)
-	body = brandedWrap(content)
-	return
-}

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -34,25 +34,11 @@ func TestHouseholdInviteEmailContainsBranding(t *testing.T) {
 	}
 }
 
-func TestContactInviteEmailContainsBranding(t *testing.T) {
-	_, body := ContactInviteEmail("Isaac's Phone", "Emma's Phone", "https://app.digits.family")
-	if !strings.Contains(body, "DIGITS") {
-		t.Fatal("body should contain branded header")
-	}
-	if !strings.Contains(body, "Isaac&#39;s Phone") || !strings.Contains(body, "Isaac's Phone") {
-		// Either escaped or unescaped is fine
-		if !strings.Contains(body, "Isaac") {
-			t.Fatal("body should mention from phone")
-		}
-	}
-}
-
 func TestAllEmailsHaveFooter(t *testing.T) {
 	_, body1 := MagicLinkEmail("https://example.com/link")
 	_, body2 := HouseholdInviteEmail("Test", "CODE", "https://example.com")
-	_, body3 := ContactInviteEmail("A", "B", "https://example.com")
 
-	for i, body := range []string{body1, body2, body3} {
+	for i, body := range []string{body1, body2} {
 		if !strings.Contains(body, "Digits — A phone for real conversations") || !strings.Contains(body, "Digits —") {
 			// Check for the key phrase, allowing for HTML entity encoding of em dash
 			if !strings.Contains(body, "A phone for real conversations") {


### PR DESCRIPTION
`ContactInviteEmail` points at `/contacts`, a page that doesn't exist and never has. No handler sends it, no feature wires it up. Delete the template and its branding test; the remaining templates keep their coverage and the footer test drops to the two senders that are actually wired up.