### PR TITLE
chore(server): dedupe user-fetch queries in auth store

### DIFF
--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -78,13 +78,13 @@ func (s *Store) CreateUser(ctx context.Context, email, name string, googleID *st
 	return u, nil
 }
 
-// GetUserByEmail looks up a user by email address.
-func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+const userSelectBase = `SELECT id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at FROM users WHERE `
+
+func (s *Store) queryUser(ctx context.Context, whereClause string, arg any) (*User, error) {
 	u := &User{}
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at FROM users WHERE email = $1`,
-		email,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
+	err := s.db.QueryRowContext(ctx, userSelectBase+whereClause, arg).Scan(
+		&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrUserNotFound
 	}
@@ -92,38 +92,21 @@ func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error)
 		return nil, err
 	}
 	return u, nil
+}
+
+// GetUserByEmail looks up a user by email address.
+func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error) {
+	return s.queryUser(ctx, `email = $1`, email)
 }
 
 // GetUserByGoogleID looks up a user by their Google OAuth subject ID.
 func (s *Store) GetUserByGoogleID(ctx context.Context, googleID string) (*User, error) {
-	u := &User{}
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at FROM users WHERE google_id = $1`,
-		googleID,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrUserNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return u, nil
+	return s.queryUser(ctx, `google_id = $1`, googleID)
 }
 
 // GetUserByID looks up a user by their UUID.
 func (s *Store) GetUserByID(ctx context.Context, id string) (*User, error) {
-	u := &User{}
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at FROM users WHERE id = $1`,
-		id,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrUserNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return u, nil
+	return s.queryUser(ctx, `id = $1`, id)
 }
 
 // UpdateLastLogin sets last_login_at to now for the given user.


### PR DESCRIPTION
`GetUserByEmail`, `GetUserByGoogleID`, and `GetUserByID` each repeated the same 9-column `SELECT`, `Scan`, and `ErrNoRows` mapping (three near-identical 14-line blocks). Extracted a private `queryUser` helper plus a `userSelectBase` constant so each public method reduces to a one-line delegation.

Same behavior; the column list now lives in one place, and a new lookup is two lines instead of fourteen.