### PR TITLE
fix(server): route AM htmx swap partials through partialFor

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -253,7 +253,6 @@ type lineDetailData struct {
 	PiUpdateNotes         []updates.Release
 	FirmwareUpdateNotes   []updates.Release
 	User                  *auth.User
-	Theme                 auth.Theme
 }
 
 func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
@@ -319,10 +318,6 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := auth.UserFromContext(r.Context())
-	var theme auth.Theme
-	if user != nil {
-		theme = user.Theme
-	}
 
 	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
 		Page:                  "phones",
@@ -342,7 +337,6 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		PiUpdateNotes:         piUpdateNotes,
 		FirmwareUpdateNotes:   firmwareUpdateNotes,
 		User:                  user,
-		Theme:                 theme,
 	})
 }
 
@@ -353,14 +347,9 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	}
 	online := h.hub.Get(number) != nil
 	if isHTMX(r) {
-		var theme auth.Theme
-		if u := auth.UserFromContext(r.Context()); u != nil {
-			theme = u.Theme
-		}
-		renderWith(w, h.tmplPhoneDetail, "phone-status", struct {
+		renderWith(w, h.tmplPhoneDetail, partialFor(r, "phone-status", "am-phone-status"), struct {
 			Online bool
-			Theme  auth.Theme
-		}{online, theme})
+		}{online})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -416,7 +405,7 @@ func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "missing voice_style", http.StatusBadRequest)
 		return
 	}
-	h.updateLineSetting(w, r, "voice-style-section", func(s *line.Settings) {
+	h.updateLineSetting(w, r, "voice-style-section", "am-voice-style-section", func(s *line.Settings) {
 		s.VoiceStyle = raw
 	})
 }
@@ -427,17 +416,17 @@ func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	silent := strings.TrimSpace(r.FormValue("silent_mode")) == "on"
-	h.updateLineSetting(w, r, "silent-mode-section", func(s *line.Settings) {
+	h.updateLineSetting(w, r, "silent-mode-section", "am-silent-mode-section", func(s *line.Settings) {
 		s.SilentMode = silent
 	})
 }
 
 // updateLineSetting applies a mutation to the Settings of the line identified
 // by the {number} path value, persists and pushes it if anything changed, and
-// then renders the named template partial (or redirects to the phone detail
+// then renders the theme-appropriate partial (or redirects to the phone detail
 // page for non-htmx callers). Handlers are expected to have already called
 // ParseForm and extracted the field they need before invoking this helper.
-func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, partial string, mutate func(*line.Settings)) {
+func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, intercom, am string, mutate func(*line.Settings)) {
 	number := r.PathValue("number")
 	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
@@ -462,7 +451,7 @@ func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, part
 		ln.Settings = next
 	}
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhoneDetail, partial, struct {
+		renderWith(w, h.tmplPhoneDetail, partialFor(r, intercom, am), struct {
 			Line line.Line
 		}{Line: *ln})
 		return

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -550,6 +550,63 @@
 </div>
 {{end}}
 
+{{define "am-voice-style-section"}}
+<div id="voice-style-section">
+  <form hx-post="/phones/{{.Line.Number}}/voice-style"
+        hx-target="#voice-style-section"
+        hx-swap="outerHTML"
+        class="am-settings__form am-settings__form--stack">
+    <label class="am-cartridge {{if eq .Line.Settings.VoiceStyle "copper"}}am-cartridge--selected{{end}}">
+      <input type="radio" name="voice_style" value="copper" {{if eq .Line.Settings.VoiceStyle "copper"}}checked{{end}}>
+      <span class="am-cartridge__body">
+        <span class="am-cartridge__name">Copper wire</span>
+        <span class="am-cartridge__desc">Warm vintage POTS sound. Narrow 300 to 3400 Hz band, like the old phone network.</span>
+      </span>
+      <span class="am-cartridge__lamp" aria-hidden="true"></span>
+    </label>
+    <label class="am-cartridge {{if eq .Line.Settings.VoiceStyle "modern"}}am-cartridge--selected{{end}}">
+      <input type="radio" name="voice_style" value="modern" {{if eq .Line.Settings.VoiceStyle "modern"}}checked{{end}}>
+      <span class="am-cartridge__body">
+        <span class="am-cartridge__name">Modern HD</span>
+        <span class="am-cartridge__desc">Full-range clean audio. No coloration, maximum clarity.</span>
+      </span>
+      <span class="am-cartridge__lamp" aria-hidden="true"></span>
+    </label>
+    <button type="submit" class="am-key am-settings__submit">
+      <span class="am-key__symbol">&#x25B6;</span>
+      <span class="am-key__label">Save</span>
+    </button>
+  </form>
+</div>
+{{end}}
+
+{{define "am-silent-mode-section"}}
+<div id="silent-mode-section">
+  <form hx-post="/phones/{{.Line.Number}}/silent-mode"
+        hx-target="#silent-mode-section"
+        hx-swap="outerHTML"
+        class="am-settings__toggle-row">
+    <label class="am-settings__dip" aria-label="Silent mode">
+      <input type="checkbox" name="silent_mode" value="on"
+             {{if .Line.Settings.SilentMode}}checked{{end}}
+             onchange="this.form.requestSubmit()"
+             class="am-settings__dip-input">
+      <span class="am-settings__dip-body" aria-hidden="true">
+        <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
+        <span class="am-settings__dip-lever"></span>
+        <span class="am-settings__dip-label am-settings__dip-label--off">0</span>
+      </span>
+    </label>
+    <div class="am-settings__toggle-info">
+      <div class="am-label am-settings__toggle-title">Silent mode</div>
+      <p class="am-hint am-settings__toggle-desc">
+        Incoming calls won't ring. The light still flashes and you can still answer.
+      </p>
+    </div>
+  </form>
+</div>
+{{end}}
+
 {{define "phone-detail-am"}}
 <div class="am-handset">
 
@@ -570,7 +627,7 @@
             hx-get="/phones/{{.Line.Number}}/online"
             hx-trigger="every 10s"
             hx-swap="innerHTML">
-        {{template "phone-status" .}}
+        {{template "am-phone-status" .}}
       </span>
     </div>
   </div>
@@ -648,12 +705,12 @@
 
     <section class="am-plate am-handset__plate">
       <span class="am-plate__label">Voice style</span>
-      {{template "voice-style-section" .}}
+      {{template "am-voice-style-section" .}}
     </section>
 
     <section class="am-plate am-handset__plate">
       <span class="am-plate__label">Ringer</span>
-      {{template "silent-mode-section" .}}
+      {{template "am-silent-mode-section" .}}
     </section>
 
     {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
@@ -700,23 +757,23 @@
 {{end}}
 
 {{define "phone-status"}}
-{{if eq .Theme "answering-machine"}}
-  {{if .Online}}
-  <span class="am-handset__status" data-online="true">
-    <span class="am-lamp am-lamp--on-green am-handset__status-lamp" aria-hidden="true"></span>
-    <span class="am-led am-led--green am-handset__status-cap">ONLINE</span>
-  </span>
-  {{else}}
-  <span class="am-handset__status" data-online="false">
-    <span class="am-lamp am-handset__status-lamp" aria-hidden="true"></span>
-    <span class="am-led am-led--dim am-handset__status-cap">OFFLINE</span>
-  </span>
-  {{end}}
+{{if .Online}}
+<span class="chip chip--on" data-online="true"><span class="chip__dot"></span>online</span>
 {{else}}
-  {{if .Online}}
-  <span class="chip chip--on" data-online="true"><span class="chip__dot"></span>online</span>
-  {{else}}
-  <span class="chip" data-online="false"><span class="chip__dot"></span>offline</span>
-  {{end}}
+<span class="chip" data-online="false"><span class="chip__dot"></span>offline</span>
+{{end}}
+{{end}}
+
+{{define "am-phone-status"}}
+{{if .Online}}
+<span class="am-handset__status" data-online="true">
+  <span class="am-lamp am-lamp--on-green am-handset__status-lamp" aria-hidden="true"></span>
+  <span class="am-led am-led--green am-handset__status-cap">ONLINE</span>
+</span>
+{{else}}
+<span class="am-handset__status" data-online="false">
+  <span class="am-lamp am-handset__status-lamp" aria-hidden="true"></span>
+  <span class="am-led am-led--dim am-handset__status-cap">OFFLINE</span>
+</span>
 {{end}}
 {{end}}


### PR DESCRIPTION
## What

Fixes the intercom-styled partials leaking into the AM theme on `/phones/{n}` after an htmx swap (and on initial render too, since the top-of-page online chip was intercom-shaped in AM context).

- Adds `am-voice-style-section`, `am-silent-mode-section`, `am-phone-status` defines in `phone-detail.html`, using the existing `am-cartridge`/`am-settings__dip`/`am-handset__status` primitives so the AM plate is internally consistent.
- Routes `updateLineSetting` and `handlePhoneOnline` through `partialFor(r, intercom, am)` instead of a single hardcoded partial name.
- Drops the now-unused `.Theme` field from `lineDetailData` and the anonymous struct in `handlePhoneOnline`.

## Why

Found in the post-merge holistic review of the 6-phase AM theme work. Phase 6 introduced the split-partial pattern for `phones-table`/`am-phones-table`, but `phone-detail` retained a single-partial-with-inline-theme-branching shape, meaning a Save re-rendered intercom classes inside the AM plate.

## Test

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean.