### PR TITLE
fix(server): AM layout parity (DND indicator, focus color, nil guards)

### DIFF
--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -533,6 +533,9 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 }
 .am-shell__brand-slot { display: inline-flex; align-items: center; gap: 12px; padding-right: 8px; }
 .am-shell__household { margin-left: auto; font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--ink-muted); font-weight: 600; text-transform: uppercase; }
+.am-shell__dnd { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; padding: 4px 8px; border-radius: 4px; }
+.am-shell__dnd:hover, .am-shell__dnd:focus-visible { background: rgba(255,61,46,0.08); outline: none; }
+.am-shell__dnd-cap { font-size: 10px; letter-spacing: 0.18em; font-family: var(--font-led); }
 .am-shell__signout-form { margin: 0; }
 .am-key--nav { min-width: 0; min-height: 32px; padding: 4px 10px; }
 .am-shell__main { flex: 1; padding: 4px 36px 32px; }
@@ -1477,7 +1480,7 @@ body.am .deck-kick-confirm .deck-confirm__go {
   box-shadow: inset 0 2px 3px rgba(60,45,20,0.25);
 }
 .am input:focus, .am select:focus, .am textarea:focus {
-  outline: 2px solid var(--chip-blue);
+  outline: 2px solid rgba(255,165,32,0.55);
   outline-offset: 1px;
 }
 .am label { font-family: var(--font-body); font-size: 11px; font-weight: 600; color: var(--ink); }

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -1,7 +1,7 @@
 {{define "title"}}Overview{{end}}
 
 {{define "content"}}
-{{if eq .User.Theme "answering-machine"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
   {{template "dashboard-am" .}}
 {{else}}
 <div class="page">

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -34,6 +34,13 @@
 
     {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
 
+    {{if .HouseholdDND}}
+    <a href="/settings#do-not-disturb" class="am-shell__dnd" title="Household Do Not Disturb is on" aria-label="Do Not Disturb is on">
+      <span class="am-lamp am-lamp--on-red am-shell__dnd-lamp" aria-hidden="true"></span>
+      <span class="am-led am-led--red am-shell__dnd-cap">DND</span>
+    </a>
+    {{end}}
+
     <form class="am-shell__signout-form" method="POST" action="/auth/logout">
       <button class="am-key am-key--nav" type="submit">
         <span class="am-key__label">Sign out</span>

--- a/server/internal/web/templates/links.html
+++ b/server/internal/web/templates/links.html
@@ -1,7 +1,7 @@
 {{define "title"}}Connected families{{end}}
 
 {{define "content"}}
-{{if eq .User.Theme "answering-machine"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
   {{template "links-am" .}}
 {{else}}
 <div class="page" style="max-width: 900px;">

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -1,7 +1,7 @@
 {{define "title"}}Lines{{end}}
 
 {{define "content"}}
-{{if eq .User.Theme "answering-machine"}}
+{{if and .User (eq .User.Theme "answering-machine")}}
   {{template "phones-am" .}}
 {{else}}
 <div class="page">


### PR DESCRIPTION
## What

Three small parity gaps between AM and the other themes, found in the post-merge holistic review:

1. **DND indicator.** `layout-v2.html:21` and `layout-dialup.html:75` both render a red "Do Not Disturb" chip in the global chrome when `HouseholdDND` is set. `layout-answering-machine.html` had no such indicator, even though the data was already threaded through. Adds an `am-shell__dnd` lamp + LED cap linking to `/settings#do-not-disturb`.

2. **Focus outline color.** The global `.am input:focus, .am select:focus, .am textarea:focus` rule in `answering-machine.css` used `--chip-blue` while every other AM focus rule (`am-accept__input`, `am-settings__input`, `am-settings__select`, `am-cartridge:focus-within`, `am-settings__dip-input`) used amber. Unified to amber.

3. **Nil guard drift.** `phones.html`, `dashboard.html`, and `links.html` tested `.User.Theme` directly, while `settings.html`, `calls.html`, `phone-detail.html`, and `onboard.html` used `{{if and .User (eq .User.Theme ...)}}`. No current route panics, but the drift was inconsistent. Aligned all seven to the guarded form.

## Test

- `go build ./... && go test ./... && golangci-lint run ./...` all clean.