### PR TITLE
test(server): extend e2e coverage to the answering-machine theme

### DIFF
--- a/server/e2e/tests/08-theme.spec.ts
+++ b/server/e2e/tests/08-theme.spec.ts
@@ -152,9 +152,11 @@ for (const theme of ['intercom', 'dialup', 'answering-machine'] as Theme[]) {
         // Layout must match the theme we set.
         expect(await getLayout(page)).toBe(layoutForTheme(theme));
 
-        // Body contains no visible 500 / crash indicator.
+        // Body contains no visible 500 / crash indicator. Word-boundary on
+        // the bare "500" keeps the AM chrome brand "Digits 2500" from
+        // triggering a false positive.
         const body = (await page.textContent('body')) ?? '';
-        expect(body).not.toMatch(/500|internal server error/i);
+        expect(body).not.toMatch(/\b500\b|internal server error/i);
 
         // The AM theme replaces page-level h1s with LED plates and am-title
         // headers, so the heading-copy assertion only applies to the two

--- a/server/e2e/tests/08-theme.spec.ts
+++ b/server/e2e/tests/08-theme.spec.ts
@@ -68,6 +68,27 @@ test.describe('Theme switcher', () => {
     await expect(page.locator('.dialup-channels a', { hasText: /welcome/i })).toBeVisible();
   });
 
+  test('theme "answering-machine" renders layout-am (shell + LED chrome)', async ({ page }) => {
+    try {
+      await setTheme(page.request, 'answering-machine');
+    } catch (e) {
+      test.skip(true, `setTheme failed: ${(e as Error).message}`);
+      return;
+    }
+
+    await page.goto('/');
+    if (isAuthOrOnboard(page.url())) {
+      test.skip(true, 'No authenticated session or needs onboarding');
+      return;
+    }
+
+    expect(await getLayout(page)).toBe('am');
+    await expect(page.locator('body.am')).toHaveCount(1);
+    await expect(page.locator('.am-shell')).toBeVisible();
+    // AM nav tabs mirror the rail nav but with am-tab styling.
+    await expect(page.locator('.am-tabs a.am-tab', { hasText: /overview/i })).toBeVisible();
+  });
+
   test('POST /settings/theme round-trips and settings page reflects the new theme', async ({ page }) => {
     await page.goto('/settings');
     if (isAuthOrOnboard(page.url())) {
@@ -102,7 +123,7 @@ const CORE_PAGES = [
   { path: '/settings', h1: /^Settings$/ },
 ];
 
-for (const theme of ['intercom', 'dialup'] as Theme[]) {
+for (const theme of ['intercom', 'dialup', 'answering-machine'] as Theme[]) {
   test.describe(`core pages render under theme "${theme}"`, () => {
     test.beforeEach(async ({ page }) => {
       // Skip the whole group if we can't establish a session.
@@ -135,12 +156,15 @@ for (const theme of ['intercom', 'dialup'] as Theme[]) {
         const body = (await page.textContent('body')) ?? '';
         expect(body).not.toMatch(/500|internal server error/i);
 
-        // h1 matches expected copy (loose match so theme-specific framing
-        // doesn't break the assertion).
-        const heading = page.locator('h1').first();
-        await expect(heading).toBeVisible();
-        const text = ((await heading.textContent()) ?? '').trim();
-        expect(text).toMatch(h1);
+        // The AM theme replaces page-level h1s with LED plates and am-title
+        // headers, so the heading-copy assertion only applies to the two
+        // themes that still render a conventional h1 at the top of each page.
+        if (theme !== 'answering-machine') {
+          const heading = page.locator('h1').first();
+          await expect(heading).toBeVisible();
+          const text = ((await heading.textContent()) ?? '').trim();
+          expect(text).toMatch(h1);
+        }
       });
     }
   });

--- a/server/e2e/tests/helpers.ts
+++ b/server/e2e/tests/helpers.ts
@@ -42,22 +42,27 @@ export async function navigateTo(page: Page, path: string): Promise<boolean> {
 }
 
 /**
- * Theme identifiers. Match auth.ThemeIntercom / auth.ThemeDialup in the server.
+ * Theme identifiers. Match auth.ThemeIntercom / auth.ThemeDialup /
+ * auth.ThemeAnsweringMachine in the server.
  */
-export type Theme = 'intercom' | 'dialup';
+export type Theme = 'intercom' | 'dialup' | 'answering-machine';
 
 /**
  * Layout identifiers, one per layout template.
  *   'v2'     -> layout-v2.html (top rail, brass accent) used by theme 'intercom'
  *   'dialup' -> layout-dialup.html (channels sidebar) used by theme 'dialup'
+ *   'am'     -> layout-answering-machine.html (am-shell chrome, LED displays)
+ *               used by theme 'answering-machine'
  */
-export type Layout = 'v2' | 'dialup';
+export type Layout = 'v2' | 'dialup' | 'am';
 
 /**
  * Sniff which layout template rendered the current page by looking for the
  * layout-specific root element. Returns the active layout.
  */
 export async function getLayout(page: Page): Promise<Layout> {
+  const am = await page.locator('body.am').count();
+  if (am > 0) return 'am';
   const dialup = await page.locator('.dialup-window').count();
   if (dialup > 0) return 'dialup';
   return 'v2';
@@ -67,7 +72,9 @@ export async function getLayout(page: Page): Promise<Layout> {
  * Map a theme value to the layout it renders with.
  */
 export function layoutForTheme(theme: Theme): Layout {
-  return theme === 'dialup' ? 'dialup' : 'v2';
+  if (theme === 'answering-machine') return 'am';
+  if (theme === 'dialup') return 'dialup';
+  return 'v2';
 }
 
 /**


### PR DESCRIPTION
## What

Extends the Playwright e2e suite to cover the Answering Machine theme. Previously the per-theme smoke loop looped only `['intercom', 'dialup']`, so any regression specific to the AM layout would pass CI unnoticed.

- `helpers.ts`: `Theme` union now includes `'answering-machine'`; `Layout` union adds `'am'`. `getLayout()` detects the AM root via `body.am` (set by `layout-answering-machine.html`) before falling back to dialup / v2. `layoutForTheme()` maps the new theme to the new layout.
- `08-theme.spec.ts`: adds a standalone theme-switcher assertion for AM (shell chrome + tabs visible) parallel to the dialup one. Adds `'answering-machine'` to the per-theme `CORE_PAGES` loop.

## One compatibility note

AM pages replace page-level `h1`s with LED plates and `am-title` headers, so the heading-copy assertion in the `CORE_PAGES` loop is gated to the two themes that still render an h1. Per-theme layout + no-500 assertions still apply to all three.

## Test

`npx tsc --noEmit` clean in `server/e2e/`. The actual Playwright run needs the dev stack up (`make dev-up`) and is run via `make e2e`.