### PR TITLE
docs: mention AM theme in CLAUDE.md and server/README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ make dev-seed    # re-runs the idempotent seeder only
 make dev-logs    # tails the DB container
 ```
 
-Defaults in `.env.dev.example` (committed); override by copying to `.env.dev` (gitignored). Sign in via `http://localhost:<port>/auth/dev-session?email=dev@digits.local`. The seeded user has `theme='dialup'` and is preloaded with three lines, two linked households, and one pending invite, so every surface (`/`, `/links`, `/phones`, `/calls`, `/settings`) renders with real data.
+Defaults in `.env.dev.example` (committed); override by copying to `.env.dev` (gitignored). Sign in via `http://localhost:<port>/auth/dev-session?email=dev@digits.local`. The seeded user has `theme='dialup'` and is preloaded with three lines, two linked households, and one pending invite, so every surface (`/`, `/links`, `/phones`, `/calls`, `/settings`) renders with real data. The app ships three themes: `intercom` (default), `dialup`, and `answering-machine`; switch at `/settings/theme`.
 
 When `DEV_MODE=true`, signald serves `/static/*` from disk (`internal/web/static/`), so CSS and JS edits show on reload. Template edits still require a restart.
 

--- a/server/README.md
+++ b/server/README.md
@@ -50,7 +50,7 @@ When the server prints `server started addr=:8080`, open the URL that `dev-seed`
 http://localhost:8080/auth/dev-session?email=dev@digits.local
 ```
 
-That endpoint is only mounted when `DEV_MODE=true`. It sets a session cookie and redirects to the dialup-themed dashboard.
+That endpoint is only mounted when `DEV_MODE=true`. It sets a session cookie and redirects to the dialup-themed dashboard. The app ships three themes: `intercom` (default), `dialup`, and `answering-machine`; switch at `/settings/theme`.
 
 ### Config
 
@@ -192,7 +192,7 @@ See `.env.example` for a starter config file.
 | `/api/active-calls`     | Active calls list                        |
 | `/internal/stats`       | Internal stats (requires `ADMIN_SECRET`) |
 
-The UI uses htmx for partial updates and Tailwind CSS for styling. Dark theme throughout.
+The UI uses htmx for partial updates and Tailwind CSS for styling. Three themes ship: `intercom` (default), `dialup`, and `answering-machine`; the per-user choice lives on `users.theme`.
 
 ## WebSocket Protocol
 

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -307,6 +307,3 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		User:          user,
 	})
 }
-
-// requireLineOwnership looks up a line by number and verifies the authenticated
-// user's household owns it. Returns the line on success, or nil after writing


### PR DESCRIPTION
## What

Two small gaps found during the holistic review:

1. Neither `CLAUDE.md` nor `server/README.md` mentioned the answering-machine theme. Both docs predated phase 1 and the mention never got added. Adds a one-line callout in each so new developers learn the theme exists and how to switch. Also corrects `server/README`'s stale "Dark theme throughout" claim (all three current themes are warm-palette light themes).
2. `handler_dashboard.go` had an orphan two-line doc comment at the very end, describing `requireLineOwnership` which actually lives in `handler_helpers.go`. The function moved long ago; only the abandoned comment stayed behind. Deleted.

## Test

- `go build ./... && go test ./... && golangci-lint run ./...` all clean.