### PR TITLE
chore(server): remove em dashes from web templates (#280)

### DIFF
--- a/server/internal/web/templates/call-live-detail.html
+++ b/server/internal/web/templates/call-live-detail.html
@@ -1,4 +1,4 @@
-{{define "title"}}Live session — {{.Caller.DisplayName}} &harr; {{.Callee.DisplayName}}{{end}}
+{{define "title"}}Live session: {{.Caller.DisplayName}} &harr; {{.Callee.DisplayName}}{{end}}
 
 {{define "content"}}
 <div class="page deck" data-started-at="{{.Call.StartedAt.UnixMilli}}">

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{block "title" .}}Digits{{end}} — Digits</title>
+<title>{{block "title" .}}Digits{{end}} : Digits</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="stylesheet" href="/static/dialup.css">
 <script src="/static/htmx.min.js"></script>
@@ -19,7 +19,7 @@
   <div class="dialup-title">
     <div class="dialup-title__app">
       <span class="dialup-title__icon" aria-hidden="true"></span>
-      <span>Digits — {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span>
+      <span>Digits: {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span>
     </div>
     <div class="dialup-title__controls" aria-hidden="true">
       <span class="dialup-title__btn">_</span>

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{block "title" .}}Digits{{end}} — Digits</title>
+<title>{{block "title" .}}Digits{{end}} : Digits</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="preload" href="/static/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="/static/fonts/inter-tight-500.woff2" as="font" type="font/woff2" crossorigin>

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -250,13 +250,13 @@
             </div>
           </details>
           {{else}}
-          <p class="muted" style="font-size: 12.5px; margin: 0;">Firmware updates require SWD wiring — flash via USB.</p>
+          <p class="muted" style="font-size: 12.5px; margin: 0;">Firmware updates require SWD wiring. Flash via USB.</p>
           {{end}}
           {{end}}
 
           {{else}}
             {{if .Online}}
-            <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report — device is online but hasn't reported version info yet.</p>
+            <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report: device is online but hasn't reported version info yet.</p>
             <form method="POST" action="/phones/{{.Line.Number}}/update">
               <button type="submit" class="btn btn--primary">Check for updates</button>
             </form>
@@ -359,7 +359,7 @@
     .then(function(r) { return r.json(); })
     .then(function(data) {
       if (data.error) { showResult(prefix, 'failed', 'Failed to send: ' + data.error); return; }
-      if (progressText) progressText.textContent = 'Update triggered — waiting for device...';
+      if (progressText) progressText.textContent = 'Update triggered: waiting for device...';
       startPolling(prefix);
     })
     .catch(function(err) { showResult(prefix, 'failed', 'Network error: ' + err.message); });


### PR DESCRIPTION
## Summary

Replaces pre-existing em dashes in four template files with colons or restructured copy. The pre-commit hook only blocks *new* em dashes, so these older ones have lived past it. Fixes sub-issue 4 of #280.

Six replacements across four files:

- `layout-v2.html` and `layout-dialup.html` title tags
- `layout-dialup.html` brand span in the title bar
- `phone-detail.html` firmware-SWD note, version-report wait copy, and update-triggered toast
- `call-live-detail.html` title

## Before / after

`layout-v2.html` and `layout-dialup.html` title:

Before: `{{block "title" .}}Digits{{end}} [emdash] Digits`
After: `{{block "title" .}}Digits{{end}} : Digits`

`layout-dialup.html` brand span:

Before: `<span>Digits [emdash] {{if .HouseholdName}}...{{else}}Phone Network{{end}}</span>`
After: `<span>Digits: {{if .HouseholdName}}...{{else}}Phone Network{{end}}</span>`

Verified with `rg` that zero em dashes remain in `server/internal/web/templates/`. `go build ./...` and `make test` both pass.

Refs #280.