### PR TITLE
refactor(server): dedupe household fetches and consolidate chrome data (#280)

### DIFF
--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
@@ -24,10 +23,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	loc := time.UTC
-	if hh != nil {
-		loc = hh.Location()
-	}
+	loc := householdLocation(hh)
 	var entries []calls.HistoryEntry
 
 	// Scope call log to the user's household lines

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -22,7 +22,8 @@ type callsData struct {
 }
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
-	hhName, callHistory, hhDND, loc := h.householdContext(r)
+	hh := h.primaryHousehold(r)
+	hhName, callHistory, hhDND, loc := householdChrome(hh)
 	if !callHistory {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
@@ -31,33 +32,25 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 
 	// Scope call log to the user's household lines
 	user := auth.UserFromContext(r.Context())
-	if user != nil && h.lineStore != nil && h.householdStore != nil {
-		households, err := h.householdStore.GetForUser(r.Context(), user.ID)
+	if hh != nil && h.lineStore != nil {
+		lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("get households for user failed", "user_id", user.ID, "err", err)
+			slog.Error("list lines for household failed", "household_id", hh.ID, "err", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		if len(households) > 0 {
-			lines, err := h.lineStore.ListByHousehold(r.Context(), households[0].ID)
+		if len(lines) > 0 {
+			numbers := make([]string, len(lines))
+			for i, l := range lines {
+				numbers[i] = l.Number
+			}
+			hist, err := h.tracker.RecentHistoryForPhones(r.Context(), numbers, 100)
 			if err != nil {
-				slog.Error("list lines for household failed", "household_id", households[0].ID, "err", err)
+				slog.Error("query recent history failed", "err", err)
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			if len(lines) > 0 {
-				numbers := make([]string, len(lines))
-				for i, l := range lines {
-					numbers[i] = l.Number
-				}
-				hist, err := h.tracker.RecentHistoryForPhones(r.Context(), numbers, 100)
-				if err != nil {
-					slog.Error("query recent history failed", "err", err)
-					http.Error(w, "internal server error", http.StatusInternalServerError)
-					return
-				}
-				entries = hist
-			}
+			entries = hist
 		}
 	}
 	if entries == nil {
@@ -124,7 +117,7 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
+	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	data := callLiveDetailData{
 		Page:               "call-live",
 		Version:            version.Version,

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -5,28 +5,28 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type callsData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	Entries            []calls.HistoryEntry
-	User               *auth.User
+	chromeData
+	Entries []calls.HistoryEntry
+	User    *auth.User
 }
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 	hh := h.primaryHousehold(r)
-	hhName, callHistory, hhDND, loc := householdChrome(hh)
-	if !callHistory {
+	chrome := chromeFor("calls", hh)
+	if !chrome.CallHistoryEnabled {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
+	}
+	loc := time.UTC
+	if hh != nil {
+		loc = hh.Location()
 	}
 	var entries []calls.HistoryEntry
 
@@ -68,22 +68,18 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		entries[i].SortTime = entries[i].SortTime.In(loc)
 	}
 
-	renderWith(w, h.tmplCalls, layoutFor(r), callsData{Page: "calls", Version: version.Version, CallHistoryEnabled: callHistory, HouseholdName: hhName, HouseholdDND: hhDND, Entries: entries, User: user})
+	renderWith(w, h.tmplCalls, layoutFor(r), callsData{chromeData: chrome, Entries: entries, User: user})
 }
 
 
 type callLiveDetailData struct {
-	Page               string
-	Version            string
-	User               *auth.User
-	HouseholdName      string
-	HouseholdDND       bool
-	CallHistoryEnabled bool
-	Call               calls.Call
-	Caller             LinkHealthEndpointResp
-	Callee             LinkHealthEndpointResp
-	Ended              bool
-	ForceEndedBy       string
+	chromeData
+	User         *auth.User
+	Call         calls.Call
+	Caller       LinkHealthEndpointResp
+	Callee       LinkHealthEndpointResp
+	Ended        bool
+	ForceEndedBy string
 }
 
 // handleCallLiveDetail renders the observation-deck page for a specific call.
@@ -117,19 +113,14 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	data := callLiveDetailData{
-		Page:               "call-live",
-		Version:            version.Version,
-		User:               user,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		CallHistoryEnabled: callHistory,
-		Call:               call,
-		Caller:             callerEp,
-		Callee:             calleeEp,
-		Ended:              call.Status == "ended",
-		ForceEndedBy:       h.forceEndedLabel(r.Context(), call),
+		chromeData:   chromeFor("call-live", h.primaryHousehold(r)),
+		User:         user,
+		Call:         call,
+		Caller:       callerEp,
+		Callee:       calleeEp,
+		Ended:        call.Status == "ended",
+		ForceEndedBy: h.forceEndedLabel(r.Context(), call),
 	}
 
 	renderWith(w, h.tmplCallLiveDetail, layoutFor(r), data)

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -291,7 +291,7 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
 	_, isHostHH := ownedLines[conf.Host]
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
+	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	data := conferenceLiveDetailData{
 		Page:               "conference-live",
 		Version:            version.Version,

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -17,7 +17,6 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // ConferenceLinkHealthEdge is the per-directed-edge section of
@@ -260,14 +259,10 @@ func (h *Handler) renderConferenceLinkHealthPanel(resp ConferenceLinkHealthResp)
 
 // conferenceLiveDetailData is the render payload for conference-live-detail.html.
 type conferenceLiveDetailData struct {
-	Page               string
-	Version            string
-	User               *auth.User
-	HouseholdName      string
-	HouseholdDND       bool
-	CallHistoryEnabled bool
-	Resp               ConferenceLinkHealthResp
-	IsHostHousehold    bool
+	chromeData
+	User            *auth.User
+	Resp            ConferenceLinkHealthResp
+	IsHostHousehold bool
 }
 
 // handleConferenceLiveDetail renders the observation deck for a conference.
@@ -291,16 +286,11 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
 	_, isHostHH := ownedLines[conf.Host]
-	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	data := conferenceLiveDetailData{
-		Page:               "conference-live",
-		Version:            version.Version,
-		User:               user,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		CallHistoryEnabled: callHistory,
-		Resp:               resp,
-		IsHostHousehold:    isHostHH,
+		chromeData:      chromeFor("conference-live", h.primaryHousehold(r)),
+		User:            user,
+		Resp:            resp,
+		IsHostHousehold: isHostHH,
 	}
 	renderWith(w, h.tmplConferenceLiveDetail, layoutFor(r), data)
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -57,17 +57,16 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	active := h.tracker.Active()
-	ld := h.buildLinesData(r, "")
 	user := auth.UserFromContext(r.Context())
-	hhName, callHistoryEnabled, hhDND, loc := h.householdContext(r)
+	hh := h.primaryHousehold(r)
+	ld := h.buildLinesDataFor(r, hh, "")
+	hhName, callHistoryEnabled, hhDND, loc := householdChrome(hh)
 	now := time.Now().In(loc)
 
 	// Determine current household ID for linked-family lookup.
 	var householdID string
-	if h.householdStore != nil && user != nil {
-		if households, err := h.householdStore.GetForUser(r.Context(), user.ID); err == nil && len(households) > 0 {
-			householdID = households[0].ID
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 
 	// Build set of own line numbers for active-call resolution and for
@@ -298,7 +297,7 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	hhName, _, hhDND, _ := h.householdContext(r)
+	hhName, _, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
 		Page:          "connecting",
 		Version:       version.Version,

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -56,10 +56,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	hh := h.primaryHousehold(r)
 	ld := h.buildLinesDataFor(r, hh, "")
 	chrome := chromeFor("dashboard", hh)
-	loc := time.UTC
-	if hh != nil {
-		loc = hh.Location()
-	}
+	loc := householdLocation(hh)
 	now := time.Now().In(loc)
 
 	// Determine current household ID for linked-family lookup.

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -9,15 +9,10 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type dashboardData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
+	chromeData
 	Stats              dashStats
 	Lines              []lineRow
 	CallsTodayRecent   []callRow
@@ -60,7 +55,11 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	hh := h.primaryHousehold(r)
 	ld := h.buildLinesDataFor(r, hh, "")
-	hhName, callHistoryEnabled, hhDND, loc := householdChrome(hh)
+	chrome := chromeFor("dashboard", hh)
+	loc := time.UTC
+	if hh != nil {
+		loc = hh.Location()
+	}
 	now := time.Now().In(loc)
 
 	// Determine current household ID for linked-family lookup.
@@ -139,7 +138,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// not server-UTC.
 	var callsTodayRecent []callRow
 	var callsTodayTotalSec int
-	if callHistoryEnabled && len(ownNumbers) > 0 {
+	if chrome.CallHistoryEnabled && len(ownNumbers) > 0 {
 		recent, _ := h.tracker.RecentForPhones(ctx, ownNumbers, 20)
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 		for _, c := range recent {
@@ -170,11 +169,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := dashboardData{
-		Page:               "dashboard",
-		Version:            version.Version,
-		CallHistoryEnabled: callHistoryEnabled,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
+		chromeData: chrome,
 		Stats: dashStats{
 			TotalLines:  len(ld.Lines),
 			OnlineLines: countOnline(ld.Lines),
@@ -284,11 +279,8 @@ func fmtElapsed(d time.Duration) string {
 
 
 type connectingData struct {
-	Page          string
-	Version       string
-	HouseholdName string
-	HouseholdDND  bool
-	User          *auth.User
+	chromeData
+	User *auth.User
 }
 
 func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
@@ -297,12 +289,8 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	hhName, _, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
-		Page:          "connecting",
-		Version:       version.Version,
-		HouseholdName: hhName,
-		HouseholdDND:  hhDND,
-		User:          user,
+		chromeData: chromeFor("connecting", h.primaryHousehold(r)),
+		User:       user,
 	})
 }

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -227,15 +227,11 @@ func userDisplayLabel(u *auth.User) string {
 // householdNumbers returns the set of phone numbers belonging to the
 // authenticated user's household. Returns nil if the user has no household.
 func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
-	user := auth.UserFromContext(r.Context())
-	if user == nil || h.householdStore == nil {
+	hh := h.primaryHousehold(r)
+	if hh == nil {
 		return nil
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
-		return nil
-	}
-	lines, err := h.lineStore.ListByHousehold(r.Context(), households[0].ID)
+	lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	if err != nil {
 		return nil
 	}
@@ -246,25 +242,38 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 	return nums
 }
 
-// householdContext returns the household name, call-history flag, do-not-disturb flag, and timezone location for the current user.
-func (h *Handler) householdContext(r *http.Request) (name string, callHistory bool, dnd bool, loc *time.Location) {
+// primaryHousehold returns the first household the authenticated user belongs
+// to, or nil when the householdStore is unavailable, no user is on the context,
+// the lookup fails, or the user has no households.
+//
+// Handlers that need both the household fields and the household ID should
+// call this once at the top of the render and thread the *Household through
+// the helpers they invoke, instead of repeatedly calling GetForUser or
+// householdChrome.
+func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	if h.householdStore == nil {
-		return "", false, false, time.UTC
+		return nil
 	}
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		return "", false, false, time.UTC
+		return nil
 	}
 	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
 	if err != nil || len(households) == 0 {
-		return "", false, false, time.UTC
+		return nil
 	}
-	return households[0].Name, households[0].CallHistoryEnabled, households[0].DoNotDisturb, households[0].Location()
+	return households[0]
 }
 
-func (h *Handler) callHistoryEnabled(r *http.Request) bool {
-	_, ch, _, _ := h.householdContext(r)
-	return ch
+// householdChrome returns the chrome-bar fields (name, call-history flag,
+// do-not-disturb flag, timezone location) derived from hh. A nil hh yields
+// the empty-state defaults, so callers that resolved "no household" can
+// reuse this without a nil-check branch.
+func householdChrome(hh *household.Household) (name string, callHistory bool, dnd bool, loc *time.Location) {
+	if hh == nil {
+		return "", false, false, time.UTC
+	}
+	return hh.Name, hh.CallHistoryEnabled, hh.DoNotDisturb, hh.Location()
 }
 
 func jsonError(w http.ResponseWriter, msg string, code int) {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -249,8 +249,7 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 //
 // Handlers that need both the household fields and the household ID should
 // call this once at the top of the render and thread the *Household through
-// the helpers they invoke, instead of repeatedly calling GetForUser or
-// householdChrome.
+// the helpers they invoke, instead of repeatedly calling GetForUser.
 func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	if h.householdStore == nil {
 		return nil
@@ -266,15 +265,14 @@ func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	return households[0]
 }
 
-// householdChrome returns the chrome-bar fields (name, call-history flag,
-// do-not-disturb flag, timezone location) derived from hh. A nil hh yields
-// the empty-state defaults, so callers that resolved "no household" can
-// reuse this without a nil-check branch.
-func householdChrome(hh *household.Household) (name string, callHistory bool, dnd bool, loc *time.Location) {
+// householdLocation returns the household's timezone, or time.UTC when hh
+// is nil. Handlers use this to localize render-time timestamps without a
+// per-call nil check.
+func householdLocation(hh *household.Household) *time.Location {
 	if hh == nil {
-		return "", false, false, time.UTC
+		return time.UTC
 	}
-	return hh.Name, hh.CallHistoryEnabled, hh.DoNotDisturb, hh.Location()
+	return hh.Location()
 }
 
 // chromeData carries the fields every protected page exposes through the

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
+	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // requireLineOwnership looks up a line by its number and verifies the
@@ -274,6 +275,38 @@ func householdChrome(hh *household.Household) (name string, callHistory bool, dn
 		return "", false, false, time.UTC
 	}
 	return hh.Name, hh.CallHistoryEnabled, hh.DoNotDisturb, hh.Location()
+}
+
+// chromeData carries the fields every protected page exposes through the
+// layout chrome: the current page id, the build version, and household
+// flags consumed by the nav and header (household name, DND badge,
+// call-history availability). It is embedded in each page-data struct so
+// templates reach Page, Version, HouseholdName, HouseholdDND, and
+// CallHistoryEnabled by their promoted names. Adding a future chrome
+// field becomes a one-line change here rather than touching every page.
+type chromeData struct {
+	Page               string
+	Version            string
+	HouseholdName      string
+	HouseholdDND       bool
+	CallHistoryEnabled bool
+}
+
+// chromeFor builds a chromeData for the given page from the authenticated
+// user's primary household. A nil hh is fine: the chrome fields fall back
+// to their empty defaults, which the templates render as unauthenticated
+// chrome.
+func chromeFor(page string, hh *household.Household) chromeData {
+	c := chromeData{
+		Page:    page,
+		Version: version.Version,
+	}
+	if hh != nil {
+		c.HouseholdName = hh.Name
+		c.HouseholdDND = hh.DoNotDisturb
+		c.CallHistoryEnabled = hh.CallHistoryEnabled
+	}
+	return c
 }
 
 func jsonError(w http.ResponseWriter, msg string, code int) {

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -53,17 +53,16 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.primaryHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	data := linksData{
 		Page:               "links",
 		Version:            version.Version,
-		CallHistoryEnabled: h.callHistoryEnabled(r),
+		CallHistoryEnabled: myHousehold.CallHistoryEnabled,
 		HouseholdName:      myHousehold.Name,
 		HouseholdDND:       myHousehold.DoNotDisturb,
 		CreatedCode:        r.URL.Query().Get("created"),
@@ -101,12 +100,11 @@ func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) 
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.primaryHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	link, err := h.linkStore.CreateInvite(r.Context(), myHousehold.ID, user.ID)
 	if err != nil {
@@ -132,12 +130,11 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.primaryHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -9,24 +9,19 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type linksData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	LinkedFamilies     []linkedFamilyRow
-	PendingInvites     []linkRow
-	CreatedCode        string
-	Accepted           bool
-	Revoked            bool
-	Canceled           bool
-	Conflicts          string
-	Error              string
-	User               *auth.User
+	chromeData
+	LinkedFamilies []linkedFamilyRow
+	PendingInvites []linkRow
+	CreatedCode    string
+	Accepted       bool
+	Revoked        bool
+	Canceled       bool
+	Conflicts      string
+	Error          string
+	User           *auth.User
 }
 
 type linkedFamilyRow struct {
@@ -60,18 +55,14 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := linksData{
-		Page:               "links",
-		Version:            version.Version,
-		CallHistoryEnabled: myHousehold.CallHistoryEnabled,
-		HouseholdName:      myHousehold.Name,
-		HouseholdDND:       myHousehold.DoNotDisturb,
-		CreatedCode:        r.URL.Query().Get("created"),
-		Accepted:           r.URL.Query().Get("accepted") == "1",
-		Revoked:            r.URL.Query().Get("revoked") == "1",
-		Canceled:           r.URL.Query().Get("canceled") == "1",
-		Conflicts:          r.URL.Query().Get("conflicts"),
-		Error:              r.URL.Query().Get("error"),
-		User:               user,
+		chromeData:  chromeFor("links", myHousehold),
+		CreatedCode: r.URL.Query().Get("created"),
+		Accepted:    r.URL.Query().Get("accepted") == "1",
+		Revoked:     r.URL.Query().Get("revoked") == "1",
+		Canceled:    r.URL.Query().Get("canceled") == "1",
+		Conflicts:   r.URL.Query().Get("conflicts"),
+		Error:       r.URL.Query().Get("error"),
+		User:        user,
 	}
 
 	// Active links — build connected family directory

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -25,7 +25,7 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 	if user != nil && user.Name != "" {
 		suggested = user.Name + "'s Family"
 	}
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
+	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
 		Page:               "onboard",
 		Version:            version.Version,

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -6,17 +6,12 @@ import (
 	"strings"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type onboardData struct {
-	Page               string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	SuggestedName      string
-	Version            string
-	User               *auth.User
+	chromeData
+	SuggestedName string
+	User          *auth.User
 }
 
 func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
@@ -25,15 +20,10 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 	if user != nil && user.Name != "" {
 		suggested = user.Name + "'s Family"
 	}
-	hhName, callHistory, hhDND, _ := householdChrome(h.primaryHousehold(r))
 	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
-		Page:               "onboard",
-		Version:            version.Version,
-		CallHistoryEnabled: callHistory,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		SuggestedName:      suggested,
-		User:               user,
+		chromeData:    chromeFor("onboard", h.primaryHousehold(r)),
+		SuggestedName: suggested,
+		User:          user,
 	})
 }
 

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/device"
+	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
 	"github.com/justinlindh/digits/server/internal/signaling"
 	"github.com/justinlindh/digits/server/internal/updates"
@@ -50,6 +51,14 @@ type lineRow struct {
 }
 
 func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
+	return h.buildLinesDataFor(r, h.primaryHousehold(r), errMsg)
+}
+
+// buildLinesDataFor is buildLinesData with the primary household already
+// resolved. Use this when the caller has already fetched the household for
+// other purposes (e.g. chrome strip, household ID) to avoid a duplicate
+// GetForUser round-trip.
+func (h *Handler) buildLinesDataFor(r *http.Request, hh *household.Household, errMsg string) linesData {
 	var user *auth.User
 	if r != nil {
 		user = auth.UserFromContext(r.Context())
@@ -57,12 +66,9 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 
 	var lines []line.Line
 
-	// Scope to household if user has one and householdStore is available
-	if user != nil && h.householdStore != nil {
-		households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-		if err == nil && len(households) > 0 {
-			lines, _ = h.lineStore.ListByHousehold(r.Context(), households[0].ID)
-		}
+	// Scope to household if the user has one
+	if hh != nil {
+		lines, _ = h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	}
 
 	// If household lookup failed, show empty list rather than leaking all lines
@@ -102,7 +108,7 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 		}
 		rows[i] = row
 	}
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
+	hhName, callHistory, hhDND, _ := householdChrome(hh)
 	return linesData{
 		Page:                  "phones",
 		Version:               version.Version,
@@ -137,27 +143,22 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("name"))
 
 	// Get user's household to associate the new line
+	hh := h.primaryHousehold(r)
 	var householdID string
-	if h.householdStore != nil {
-		user := auth.UserFromContext(r.Context())
-		if user != nil {
-			households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-			if err == nil && len(households) > 0 {
-				householdID = households[0].ID
-			}
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 
 	if err := line.ValidateNumber(number); err != nil {
-		data := h.buildLinesData(r, err.Error())
+		data := h.buildLinesDataFor(r, hh, err.Error())
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	_, err := h.lineStore.Add(r.Context(), number, name, householdID)
-	data := h.buildLinesData(r, "")
+	data := h.buildLinesDataFor(r, hh, "")
 	if err != nil {
-		data = h.buildLinesData(r, err.Error())
+		data = h.buildLinesDataFor(r, hh, err.Error())
 	}
 
 	if isHTMX(r) {
@@ -180,41 +181,36 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
+	hh := h.primaryHousehold(r)
+
 	if err := line.ValidateNumber(number); err != nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesDataFor(r, hh, "")
 		data.PairError = "invalid phone number: " + err.Error()
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	if h.pairingStore == nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesDataFor(r, hh, "")
 		data.PairError = "pairing is not enabled"
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
-	// Get user's household
 	var householdID string
-	if h.householdStore != nil {
-		user := auth.UserFromContext(r.Context())
-		if user != nil {
-			households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-			if err == nil && len(households) > 0 {
-				householdID = households[0].ID
-			}
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 	if householdID == "" {
-		data := h.buildLinesData(r, "")
-		data.PairError = "no household found — please complete onboarding first"
+		data := h.buildLinesDataFor(r, hh, "")
+		data.PairError = "no household found. Please complete onboarding first."
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	token, hwID, err := h.pairingStore.ClaimDevice(r.Context(), code, number, name, householdID)
 	if err != nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesDataFor(r, hh, "")
 		data.PairError = err.Error()
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
@@ -298,7 +294,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
 
-	hhName, callHistory, hhDND, loc := h.householdContext(r)
+	hhName, callHistory, hhDND, loc := householdChrome(h.primaryHousehold(r))
 
 	if lastSeenAt != nil {
 		t := lastSeenAt.In(loc)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -281,7 +281,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hh := h.primaryHousehold(r)
-	_, _, _, loc := householdChrome(hh)
+	loc := householdLocation(hh)
 
 	if lastSeenAt != nil {
 		t := lastSeenAt.In(loc)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -15,7 +15,6 @@ import (
 	"github.com/justinlindh/digits/server/internal/line"
 	"github.com/justinlindh/digits/server/internal/signaling"
 	"github.com/justinlindh/digits/server/internal/updates"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type pairSuccess struct {
@@ -24,11 +23,7 @@ type pairSuccess struct {
 }
 
 type linesData struct {
-	Page                  string
-	Version               string
-	CallHistoryEnabled    bool
-	HouseholdName         string
-	HouseholdDND          bool
+	chromeData
 	Lines                 []lineRow
 	Error                 string
 	PairError             string
@@ -108,13 +103,8 @@ func (h *Handler) buildLinesDataFor(r *http.Request, hh *household.Household, er
 		}
 		rows[i] = row
 	}
-	hhName, callHistory, hhDND, _ := householdChrome(hh)
 	return linesData{
-		Page:                  "phones",
-		Version:               version.Version,
-		CallHistoryEnabled:    callHistory,
-		HouseholdName:         hhName,
-		HouseholdDND:          hhDND,
+		chromeData:            chromeFor("phones", hh),
 		Lines:                 rows,
 		Error:                 errMsg,
 		User:                  user,
@@ -232,11 +222,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 }
 
 type lineDetailData struct {
-	Page                  string
-	Version               string
-	CallHistoryEnabled    bool
-	HouseholdName         string
-	HouseholdDND          bool
+	chromeData
 	Line                  line.Line
 	Online                bool
 	Devices               []device.Device
@@ -294,7 +280,8 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
 
-	hhName, callHistory, hhDND, loc := householdChrome(h.primaryHousehold(r))
+	hh := h.primaryHousehold(r)
+	_, _, _, loc := householdChrome(hh)
 
 	if lastSeenAt != nil {
 		t := lastSeenAt.In(loc)
@@ -316,11 +303,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 
 	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
-		Page:                  "phones",
-		Version:               version.Version,
-		CallHistoryEnabled:    callHistory,
-		HouseholdName:         hhName,
-		HouseholdDND:          hhDND,
+		chromeData:            chromeFor("phones", hh),
 		Line:                  *ln,
 		Online:                online,
 		Devices:               devices,

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -7,33 +7,23 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/household"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type settingsData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdDND       bool
-	HouseholdName      string
-	User               *auth.User
-	Household          *household.Household
-	Saved              bool
+	chromeData
+	User      *auth.User
+	Household *household.Household
+	Saved     bool
 }
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	hh := h.primaryHousehold(r)
-	hhName, callHistory, dnd, _ := householdChrome(hh)
 	renderWith(w, h.tmplSettings, layoutFor(r), settingsData{
-		Page:               "settings",
-		Version:            version.Version,
-		CallHistoryEnabled: callHistory,
-		HouseholdDND:       dnd,
-		HouseholdName:      hhName,
-		User:               user,
-		Household:          hh,
-		Saved:              r.URL.Query().Get("saved") == "1",
+		chromeData: chromeFor("settings", hh),
+		User:       user,
+		Household:  hh,
+		Saved:      r.URL.Query().Get("saved") == "1",
 	})
 }
 

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -23,23 +23,12 @@ type settingsData struct {
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	var hh *household.Household
-	if user != nil && h.householdStore != nil {
-		households, _ := h.householdStore.GetForUser(r.Context(), user.ID)
-		if len(households) > 0 {
-			hh = households[0]
-		}
-	}
-	hhName := ""
-	dnd := false
-	if hh != nil {
-		hhName = hh.Name
-		dnd = hh.DoNotDisturb
-	}
+	hh := h.primaryHousehold(r)
+	hhName, callHistory, dnd, _ := householdChrome(hh)
 	renderWith(w, h.tmplSettings, layoutFor(r), settingsData{
 		Page:               "settings",
 		Version:            version.Version,
-		CallHistoryEnabled: h.callHistoryEnabled(r),
+		CallHistoryEnabled: callHistory,
 		HouseholdDND:       dnd,
 		HouseholdName:      hhName,
 		User:               user,
@@ -54,8 +43,8 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, _ := h.householdStore.GetForUser(r.Context(), user.ID)
-	if len(households) == 0 {
+	hh := h.primaryHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
@@ -65,8 +54,8 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
 	if name != "" {
-		if err := h.householdStore.UpdateName(r.Context(), households[0].ID, name); err != nil {
-			slog.Error("update household name failed", "household_id", households[0].ID, "err", err)
+		if err := h.householdStore.UpdateName(r.Context(), hh.ID, name); err != nil {
+			slog.Error("update household name failed", "household_id", hh.ID, "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
@@ -80,18 +69,13 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.primaryHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
-	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), households[0].ID, enabled); err != nil {
+	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), hh.ID, enabled); err != nil {
 		slog.Error("set call history failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
@@ -104,18 +88,13 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.primaryHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
-	householdID := households[0].ID
+	householdID := hh.ID
 	if err := h.householdStore.SetDoNotDisturb(r.Context(), householdID, enabled); err != nil {
 		slog.Error("set do not disturb failed", "err", err, "household_id", householdID)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
@@ -145,8 +124,8 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.primaryHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
@@ -156,7 +135,7 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 	}
 	tz := strings.TrimSpace(r.FormValue("timezone"))
 	if tz != "" {
-		if err := h.householdStore.SetTimezone(r.Context(), households[0].ID, tz); err != nil {
+		if err := h.householdStore.SetTimezone(r.Context(), hh.ID, tz); err != nil {
 			slog.Warn("set timezone failed", "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -238,7 +238,7 @@
       <form action="/settings/call-history" method="POST">
         <div class="hstack" style="align-items: flex-start; gap: 14px;">
           <label class="toggle" style="margin-top: 2px;">
-            <input type="checkbox" name="enabled" value="true" {{if .CallHistoryEnabled}}checked{{end}} onchange="this.form.submit()">
+            <input type="checkbox" name="enabled" value="true" {{if .Household.CallHistoryEnabled}}checked{{end}} onchange="this.form.submit()">
             <span class="toggle__track"></span>
           </label>
           <div>
@@ -262,7 +262,7 @@
       <form action="/settings/do-not-disturb" method="POST">
         <div class="hstack" style="align-items: flex-start; gap: 14px;">
           <label class="toggle" style="margin-top: 2px;">
-            <input type="checkbox" name="enabled" value="true" {{if .HouseholdDND}}checked{{end}} onchange="this.form.submit()">
+            <input type="checkbox" name="enabled" value="true" {{if .Household.DoNotDisturb}}checked{{end}} onchange="this.form.submit()">
             <span class="toggle__track"></span>
           </label>
           <div>
@@ -643,7 +643,7 @@
         <div class="am-plate__label">Privacy</div>
         <form action="/settings/call-history" method="POST" class="am-settings__toggle-row">
           <label class="am-settings__dip" aria-label="Call log">
-            <input type="checkbox" name="enabled" value="true" {{if .CallHistoryEnabled}}checked{{end}} onchange="this.form.submit()" class="am-settings__dip-input">
+            <input type="checkbox" name="enabled" value="true" {{if .Household.CallHistoryEnabled}}checked{{end}} onchange="this.form.submit()" class="am-settings__dip-input">
             <span class="am-settings__dip-body" aria-hidden="true">
               <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
               <span class="am-settings__dip-lever"></span>


### PR DESCRIPTION
## Summary

Addresses sub-issues 1 to 3 of #280 in a single refactor of the protected-page render path.

- **Dedupe GetForUser per render.** Each protected page previously issued 2 to 4 redundant `householdStore.GetForUser` calls because the chrome values (name, call-history flag, DND flag, timezone) were fetched independently. `handleDashboard` made roughly 4, `handleLinksGet`, `handleCalls`, and `handleSettings` made 2 each. Introduce `primaryHousehold(r)` as the single resolver, and thread the resulting `*household.Household` through each handler so chrome, line lookups, and downstream helpers share one fetch.
- **Embed `chromeData` in the nine page-data structs.** `dashboardData`, `linesData`, `lineDetailData`, `callsData`, `linksData`, `settingsData`, `onboardData`, `conferenceLiveDetailData`, `connectingData`, and `callLiveDetailData` all carried the same `Page`, `Version`, `CallHistoryEnabled`, `HouseholdName`, `HouseholdDND` quintuplet. They now embed a single `chromeData` struct populated by `chromeFor`. Templates keep reading `.Page`, `.Version`, `.HouseholdName`, `.HouseholdDND`, `.CallHistoryEnabled` through field promotion. Future chrome additions become a one-line change.
- **Settings form toggles read from `.Household` directly.** After commit 2 removed the duplicated fields from `settingsData`, point the privacy and do-not-disturb form checkboxes at `.Household.CallHistoryEnabled` and `.Household.DoNotDisturb`, which is the state they edit. Chrome remains for nav and header.

## Test plan

- [x] `make test` (fast tier) passes
- [x] `make test-integration` (needs Postgres service) passes
- [x] `golangci-lint run ./...` is clean
- [x] `go build ./...` clean
- [ ] Sanity render of `/`, `/phones`, `/calls`, `/links`, `/settings`, `/onboard`, `/connecting`, `/call/live/{id}`, `/conference/live/{uuid}` on dev or prod

No visible UI change: the chrome fields that drive the layout are populated the same way, from the same household, and the form toggles read the same booleans through a different path.