### PR TITLE
chore(server): replace mdash placeholders with ndash in templates

### DIFF
--- a/server/internal/web/templates/_call-live-panel.html
+++ b/server/internal/web/templates/_call-live-panel.html
@@ -27,7 +27,7 @@
         {{end}}
       {{end}}{{end}}
     </div>
-    <span class="deck-row__val num">{{if and . .LossPct}}{{printf "%.1f%%" (derefFloat32 .LossPct)}}{{else}}&mdash;{{end}}</span>
+    <span class="deck-row__val num">{{if and . .LossPct}}{{printf "%.1f%%" (derefFloat32 .LossPct)}}{{else}}&ndash;{{end}}</span>
   </div>
   <div class="deck-row">
     <span class="deck-row__lbl label">jitter</span>
@@ -38,7 +38,7 @@
         {{end}}
       {{end}}{{end}}
     </div>
-    <span class="deck-row__val num">{{if and . .JitterMs}}{{printf "%.0f ms" (derefFloat32 .JitterMs)}}{{else}}&mdash;{{end}}</span>
+    <span class="deck-row__val num">{{if and . .JitterMs}}{{printf "%.0f ms" (derefFloat32 .JitterMs)}}{{else}}&ndash;{{end}}</span>
   </div>
 </div>
 {{end}}
@@ -47,15 +47,15 @@
 <div class="deck-shared__row">
   <div class="deck-shared__item">
     <div class="label">round trip</div>
-    <div class="num">{{if and .Caller.Latest .Caller.Latest.RttMs}}{{printf "%.0f ms" (derefFloat32 .Caller.Latest.RttMs)}}{{else}}&mdash;{{end}}</div>
+    <div class="num">{{if and .Caller.Latest .Caller.Latest.RttMs}}{{printf "%.0f ms" (derefFloat32 .Caller.Latest.RttMs)}}{{else}}&ndash;{{end}}</div>
   </div>
   <div class="deck-shared__item">
     <div class="label">route</div>
-    <div class="num">{{with .Caller.Latest}}{{.ConnType}}{{else}}&mdash;{{end}}{{with .Callee.Latest}}{{with .ConnType}} · {{.}}{{end}}{{end}}</div>
+    <div class="num">{{with .Caller.Latest}}{{.ConnType}}{{else}}&ndash;{{end}}{{with .Callee.Latest}}{{with .ConnType}} · {{.}}{{end}}{{end}}</div>
   </div>
   <div class="deck-shared__item">
     <div class="label">bytes in / out</div>
-    <div class="num">{{with .Caller.Latest}}{{if .BytesIn}}{{humanBytes (derefInt64 .BytesIn)}}{{else}}&mdash;{{end}}{{else}}&mdash;{{end}} / {{with .Caller.Latest}}{{if .BytesOut}}{{humanBytes (derefInt64 .BytesOut)}}{{else}}&mdash;{{end}}{{else}}&mdash;{{end}}</div>
+    <div class="num">{{with .Caller.Latest}}{{if .BytesIn}}{{humanBytes (derefInt64 .BytesIn)}}{{else}}&ndash;{{end}}{{else}}&ndash;{{end}} / {{with .Caller.Latest}}{{if .BytesOut}}{{humanBytes (derefInt64 .BytesOut)}}{{else}}&ndash;{{end}}{{else}}&ndash;{{end}}</div>
   </div>
 </div>
 {{end}}

--- a/server/internal/web/templates/_conference-live-panel.html
+++ b/server/internal/web/templates/_conference-live-panel.html
@@ -22,13 +22,13 @@
 <div class="deck-matrix__row">
   <span class="deck-matrix__lbl label">loss</span>
   <span class="deck-matrix__val num">
-    {{if and . .Latest .Latest.LossPct}}{{printf "%.1f%%" (derefFloat32 .Latest.LossPct)}}{{else}}&mdash;{{end}}
+    {{if and . .Latest .Latest.LossPct}}{{printf "%.1f%%" (derefFloat32 .Latest.LossPct)}}{{else}}&ndash;{{end}}
   </span>
 </div>
 <div class="deck-matrix__row">
   <span class="deck-matrix__lbl label">jitter</span>
   <span class="deck-matrix__val num">
-    {{if and . .Latest .Latest.JitterMs}}{{printf "%.0f ms" (derefFloat32 .Latest.JitterMs)}}{{else}}&mdash;{{end}}
+    {{if and . .Latest .Latest.JitterMs}}{{printf "%.0f ms" (derefFloat32 .Latest.JitterMs)}}{{else}}&ndash;{{end}}
   </span>
 </div>
 {{end}}

--- a/server/internal/web/templates/calls.html
+++ b/server/internal/web/templates/calls.html
@@ -48,7 +48,7 @@
               <span class="chip chip--conf"><span class="chip__dot"></span>3-way</span>
             </td>
             <td class="num">{{.Conference.CreatedAt.Format "Jan 2 15:04:05"}}</td>
-            <td class="num">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&mdash;{{end}}</td>
+            <td class="num">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&ndash;{{end}}</td>
             <td class="r"><a href="/conference/live/{{.Conference.ID}}" aria-label="View conference details">Details &rarr;</a></td>
           </tr>
           {{else}}
@@ -74,7 +74,7 @@
               {{end}}
             </td>
             <td class="num">{{.Call.StartedAt.Format "Jan 2 15:04:05"}}</td>
-            <td class="num">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&mdash;{{end}}</td>
+            <td class="num">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&ndash;{{end}}</td>
             <td class="r"><a href="/call/live/{{.Call.ID}}" aria-label="View call details">Details &rarr;</a></td>
           </tr>
           {{end}}
@@ -169,7 +169,7 @@
         <div class="am-calls__meta">{{.Conference.CreatedAt.Format "Jan 2"}}</div>
       </div>
       <span class="am-calls__status am-calls__status--conf">3-WAY</span>
-      <span class="am-calls__duration">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&mdash;{{end}}</span>
+      <span class="am-calls__duration">{{if gt .Conference.DurationS 0}}{{.Conference.DurationS}}s{{else}}&ndash;{{end}}</span>
       <a class="am-calls__details" href="/conference/live/{{.Conference.ID}}" aria-label="View conference details">Details &rarr;</a>
     </div>
     {{else}}
@@ -188,7 +188,7 @@
         </div>
       </div>
       <span class="am-calls__status am-calls__status--reg">REG</span>
-      <span class="am-calls__duration">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&mdash;{{end}}</span>
+      <span class="am-calls__duration">{{if gt .Call.DurationS 0}}{{.Call.DurationS}}s{{else}}&ndash;{{end}}</span>
       <a class="am-calls__details" href="/call/live/{{.Call.ID}}" aria-label="View call details">Details &rarr;</a>
     </div>
     {{end}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -490,7 +490,7 @@
       <div class="am-jack am-jack--unpatched">
         <span class="am-jack__label-top">{{printf "%02d" (inc $i)}}</span>
         <div class="am-jack__socket"></div>
-        <span class="am-jack__label-bot">&mdash;</span>
+        <span class="am-jack__label-bot">&ndash;</span>
         <span class="am-jack__lamp am-lamp"></span>
       </div>
       {{end}}


### PR DESCRIPTION
## What

Replace the `mdash` HTML entity with `ndash` in four server templates wherever it is used as a "no value" placeholder: `_call-live-panel.html`, `_conference-live-panel.html`, `calls.html`, and `phones.html`.

## Why

CLAUDE.md has a hard rule: no em dashes anywhere, including in-app copy. Use a colon, period, comma, or restructure.

Cross-PR drift surfaced this during today's holistic review:

- #282 (AM theme Lines, phase 3) added the `mdash` entity as the empty-label marker on unpatched `am-jack` slots.
- #290 (AM theme polish, phase 6) added two more in `am-calls__duration` cells.

Both phases copied the same pattern that already lived in the intercom `calls.html` table and the `deck-*` live-call partials. Fixing only the new additions would leave the ambient pattern ready to be copied again by the next theme phase or the next empty-cell panel. This PR normalises every "no value" placeholder site at once so the next surface that needs one inherits the `ndash` entity instead.

## Scope

Intentionally limited to the "no value" placeholder pattern. Prose em dashes in `conference-live-detail.html` (the live-conference title separator) and `phone-detail.html` body copy need sentence-level restructuring rather than a mechanical entity swap, so they are out of scope here and left for a separate, prose-level pass.

## Test plan

- [x] `go build ./...` from `server/`
- [x] `go test ./internal/web/...` from `server/`
- [ ] Visual spot check: live call panel, live conference panel, call log, Lines page (intercom and AM themes)