### PR TITLE
fix(server): consolidate page chrome, cut GetForUser N+1, clear em dashes

### DIFF
--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -86,11 +86,13 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 
 
 func (h *Handler) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
-	ld := h.buildLinesData(r, "")
-	nums := h.householdNumbers(r)
+	hh := h.primaryHousehold(r)
+	ld := h.buildLinesData(r, hh, "")
 
+	nums := make(map[string]bool, len(ld.Lines))
 	var onlineCount int
 	for _, row := range ld.Lines {
+		nums[row.Line.Number] = true
 		if row.Online {
 			onlineCount++
 		}

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -8,56 +8,42 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type callsData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	Entries            []calls.HistoryEntry
-	User               *auth.User
+	chromeData
+	Entries []calls.HistoryEntry
 }
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
-	hhName, callHistory, hhDND, loc := h.householdContext(r)
-	if !callHistory {
+	user := auth.UserFromContext(r.Context())
+	hh := h.primaryHousehold(r)
+	if hh == nil || !hh.CallHistoryEnabled {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	var entries []calls.HistoryEntry
+	loc := householdLocation(hh)
 
-	// Scope call log to the user's household lines
-	user := auth.UserFromContext(r.Context())
-	if user != nil && h.lineStore != nil && h.householdStore != nil {
-		households, err := h.householdStore.GetForUser(r.Context(), user.ID)
+	var entries []calls.HistoryEntry
+	if h.lineStore != nil {
+		lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("get households for user failed", "user_id", user.ID, "err", err)
+			slog.Error("list lines for household failed", "household_id", hh.ID, "err", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		if len(households) > 0 {
-			lines, err := h.lineStore.ListByHousehold(r.Context(), households[0].ID)
+		if len(lines) > 0 {
+			numbers := make([]string, len(lines))
+			for i, l := range lines {
+				numbers[i] = l.Number
+			}
+			hist, err := h.tracker.RecentHistoryForPhones(r.Context(), numbers, 100)
 			if err != nil {
-				slog.Error("list lines for household failed", "household_id", households[0].ID, "err", err)
+				slog.Error("query recent history failed", "err", err)
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
-			if len(lines) > 0 {
-				numbers := make([]string, len(lines))
-				for i, l := range lines {
-					numbers[i] = l.Number
-				}
-				hist, err := h.tracker.RecentHistoryForPhones(r.Context(), numbers, 100)
-				if err != nil {
-					slog.Error("query recent history failed", "err", err)
-					http.Error(w, "internal server error", http.StatusInternalServerError)
-					return
-				}
-				entries = hist
-			}
+			entries = hist
 		}
 	}
 	if entries == nil {
@@ -75,27 +61,24 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		entries[i].SortTime = entries[i].SortTime.In(loc)
 	}
 
-	renderWith(w, h.tmplCalls, layoutFor(r), callsData{Page: "calls", Version: version.Version, CallHistoryEnabled: callHistory, HouseholdName: hhName, HouseholdDND: hhDND, Entries: entries, User: user})
+	renderWith(w, h.tmplCalls, layoutFor(r), callsData{
+		chromeData: newChromeData("calls", user, hh),
+		Entries:    entries,
+	})
 }
 
-
 type callLiveDetailData struct {
-	Page               string
-	Version            string
-	User               *auth.User
-	HouseholdName      string
-	HouseholdDND       bool
-	CallHistoryEnabled bool
-	Call               calls.Call
-	Caller             LinkHealthEndpointResp
-	Callee             LinkHealthEndpointResp
-	Ended              bool
-	ForceEndedBy       string
+	chromeData
+	Call         calls.Call
+	Caller       LinkHealthEndpointResp
+	Callee       LinkHealthEndpointResp
+	Ended        bool
+	ForceEndedBy string
 }
 
 // handleCallLiveDetail renders the observation-deck page for a specific call.
 // Auth uses the same ownership check as the JSON endpoint. Ended calls are
-// NOT 404'd here — they render in terminal state with the last-known samples
+// NOT 404'd here; they render in terminal state with the last-known samples
 // from DB fallback, making the URL useful as a postmortem surface.
 func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
@@ -124,19 +107,13 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
 	data := callLiveDetailData{
-		Page:               "call-live",
-		Version:            version.Version,
-		User:               user,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		CallHistoryEnabled: callHistory,
-		Call:               call,
-		Caller:             callerEp,
-		Callee:             calleeEp,
-		Ended:              call.Status == "ended",
-		ForceEndedBy:       h.forceEndedLabel(r.Context(), call),
+		chromeData:   newChromeData("call-live", user, h.primaryHousehold(r)),
+		Call:         call,
+		Caller:       callerEp,
+		Callee:       calleeEp,
+		Ended:        call.Status == "ended",
+		ForceEndedBy: h.forceEndedLabel(r.Context(), call),
 	}
 
 	renderWith(w, h.tmplCallLiveDetail, layoutFor(r), data)

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -87,7 +87,7 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	call, ownedLines, _, ok := h.requireCallEndpointOwnership(w, r, callID)
+	call, ownedLines, hh, ok := h.requireCallEndpointOwnership(w, r, callID)
 	if !ok {
 		return
 	}
@@ -108,7 +108,7 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := callLiveDetailData{
-		chromeData:   newChromeData("call-live", user, h.primaryHousehold(r)),
+		chromeData:   newChromeData("call-live", user, hh),
 		Call:         call,
 		Caller:       callerEp,
 		Callee:       calleeEp,

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -58,8 +58,8 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 	}
 
 	var linkedIndex map[string]string
-	if primaryHH != "" {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	if primaryHH != nil {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
 	}
 
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
@@ -178,8 +178,8 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	flusher.Flush()
 
 	var linkedIndex map[string]string
-	if primaryHH != "" {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	if primaryHH != nil {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
 	}
 
 	// Subscribe FIRST so samples arriving between the initial snapshot and
@@ -279,14 +279,14 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	user := auth.UserFromContext(r.Context())
 
 	var linkedIndex map[string]string
-	if primaryHH != "" {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH))
+	if primaryHH != nil {
+		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
 	}
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
 	_, isHostHH := ownedLines[conf.Host]
 	data := conferenceLiveDetailData{
-		chromeData:      newChromeData("conference-live", user, h.primaryHousehold(r)),
+		chromeData:      newChromeData("conference-live", user, primaryHH),
 		Resp:            resp,
 		IsHostHousehold: isHostHH,
 	}

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -17,7 +17,6 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // ConferenceLinkHealthEdge is the per-directed-edge section of
@@ -260,14 +259,9 @@ func (h *Handler) renderConferenceLinkHealthPanel(resp ConferenceLinkHealthResp)
 
 // conferenceLiveDetailData is the render payload for conference-live-detail.html.
 type conferenceLiveDetailData struct {
-	Page               string
-	Version            string
-	User               *auth.User
-	HouseholdName      string
-	HouseholdDND       bool
-	CallHistoryEnabled bool
-	Resp               ConferenceLinkHealthResp
-	IsHostHousehold    bool
+	chromeData
+	Resp            ConferenceLinkHealthResp
+	IsHostHousehold bool
 }
 
 // handleConferenceLiveDetail renders the observation deck for a conference.
@@ -291,16 +285,10 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
 	_, isHostHH := ownedLines[conf.Host]
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
 	data := conferenceLiveDetailData{
-		Page:               "conference-live",
-		Version:            version.Version,
-		User:               user,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		CallHistoryEnabled: callHistory,
-		Resp:               resp,
-		IsHostHousehold:    isHostHH,
+		chromeData:      newChromeData("conference-live", user, h.primaryHousehold(r)),
+		Resp:            resp,
+		IsHostHousehold: isHostHH,
 	}
 	renderWith(w, h.tmplConferenceLiveDetail, layoutFor(r), data)
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -9,21 +9,15 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type dashboardData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
+	chromeData
 	Stats              dashStats
 	Lines              []lineRow
 	CallsTodayRecent   []callRow
 	CallsTodayTotalMin int
 	LinkedFamilies     []linkedFamilyRow
-	User               *auth.User
 	Now                time.Time
 	ActiveLine         string
 	ActivePeer         string
@@ -57,17 +51,18 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	active := h.tracker.Active()
-	ld := h.buildLinesData(r, "")
-	user := auth.UserFromContext(r.Context())
-	hhName, callHistoryEnabled, hhDND, loc := h.householdContext(r)
+	user := auth.UserFromContext(ctx)
+	hh := h.primaryHousehold(r)
+	ld := h.buildLinesData(r, hh, "")
+	loc := householdLocation(hh)
 	now := time.Now().In(loc)
+
+	callHistoryEnabled := hh != nil && hh.CallHistoryEnabled
 
 	// Determine current household ID for linked-family lookup.
 	var householdID string
-	if h.householdStore != nil && user != nil {
-		if households, err := h.householdStore.GetForUser(r.Context(), user.ID); err == nil && len(households) > 0 {
-			householdID = households[0].ID
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 
 	// Build set of own line numbers for active-call resolution and for
@@ -171,11 +166,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := dashboardData{
-		Page:               "dashboard",
-		Version:            version.Version,
-		CallHistoryEnabled: callHistoryEnabled,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
+		chromeData: newChromeData("dashboard", user, hh),
 		Stats: dashStats{
 			TotalLines:  len(ld.Lines),
 			OnlineLines: countOnline(ld.Lines),
@@ -185,7 +176,6 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		CallsTodayRecent:   callsTodayRecent,
 		CallsTodayTotalMin: (callsTodayTotalSec + 30) / 60, // +30 to round to nearest minute
 		LinkedFamilies:     linkedFamilies,
-		User:               user,
 		Now:                now,
 		ActiveLine:         activeLine,
 		ActivePeer:         activePeer,
@@ -285,11 +275,7 @@ func fmtElapsed(d time.Duration) string {
 
 
 type connectingData struct {
-	Page          string
-	Version       string
-	HouseholdName string
-	HouseholdDND  bool
-	User          *auth.User
+	chromeData
 }
 
 func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
@@ -298,12 +284,7 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	hhName, _, hhDND, _ := h.householdContext(r)
 	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
-		Page:          "connecting",
-		Version:       version.Version,
-		HouseholdName: hhName,
-		HouseholdDND:  hhDND,
-		User:          user,
+		chromeData: newChromeData("connecting", user, h.primaryHousehold(r)),
 	})
 }

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -14,11 +14,12 @@ import (
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
+	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // requireLineOwnership looks up a line by its number and verifies the
 // authenticated user's household owns it. Returns the line on success, or
-// nil after writing a 404 — unauthenticated, unknown, and unauthorized
+// nil after writing a 404. Unauthenticated, unknown, and unauthorized
 // responses are intentionally indistinguishable to avoid leaking whether a
 // given number exists.
 func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, number string) *line.Line {
@@ -61,8 +62,8 @@ func (h *Handler) requireLineOwnershipWithHousehold(w http.ResponseWriter, r *ht
 
 // ownedLinesForUser returns the lines owned by any household the user belongs
 // to, keyed by number, plus the primary household ID. Returns (nil, "", false)
-// if the user has no households or any lookup fails — caller writes 404, same
-// response shape as nonexistent.
+// if the user has no households or any lookup fails. Caller writes 404, the
+// same response shape as nonexistent.
 func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[string]*line.Line, string, bool) {
 	households, err := h.householdStore.GetForUser(ctx, user.ID)
 	if err != nil {
@@ -246,25 +247,81 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 	return nums
 }
 
-// householdContext returns the household name, call-history flag, do-not-disturb flag, and timezone location for the current user.
-func (h *Handler) householdContext(r *http.Request) (name string, callHistory bool, dnd bool, loc *time.Location) {
+// primaryHousehold returns the first household the authenticated user belongs
+// to, or nil when the user is unauthenticated, the store is not wired, lookup
+// fails, or the user has no households. This is the canonical single-query
+// lookup; page handlers should call it once at the top and thread the result
+// through helpers rather than re-querying per chrome field.
+func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	if h.householdStore == nil {
-		return "", false, false, time.UTC
+		return nil
 	}
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		return "", false, false, time.UTC
+		return nil
 	}
 	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
 	if err != nil || len(households) == 0 {
-		return "", false, false, time.UTC
+		return nil
 	}
-	return households[0].Name, households[0].CallHistoryEnabled, households[0].DoNotDisturb, households[0].Location()
+	return households[0]
 }
 
-func (h *Handler) callHistoryEnabled(r *http.Request) bool {
-	_, ch, _, _ := h.householdContext(r)
-	return ch
+// householdLocation returns the timezone location for a household, falling
+// back to UTC when hh is nil.
+func householdLocation(hh *household.Household) *time.Location {
+	if hh == nil {
+		return time.UTC
+	}
+	return hh.Location()
+}
+
+// chromeData is the set of fields every protected page-data struct shares for
+// rendering the layout chrome (sidebar, nav, DND chip, version pill). Embed
+// this in each page-data struct and populate via newChromeData. The
+// HouseholdName/HouseholdDND/CallHistoryEnabled methods read through the
+// Household pointer so there is one source of truth per request.
+type chromeData struct {
+	Page      string
+	Version   string
+	User      *auth.User
+	Household *household.Household
+}
+
+// HouseholdName returns the current user's household name, or "" when none.
+func (c chromeData) HouseholdName() string {
+	if c.Household == nil {
+		return ""
+	}
+	return c.Household.Name
+}
+
+// HouseholdDND returns the household-wide do-not-disturb flag.
+func (c chromeData) HouseholdDND() bool {
+	if c.Household == nil {
+		return false
+	}
+	return c.Household.DoNotDisturb
+}
+
+// CallHistoryEnabled returns whether the household has call history on.
+func (c chromeData) CallHistoryEnabled() bool {
+	if c.Household == nil {
+		return false
+	}
+	return c.Household.CallHistoryEnabled
+}
+
+// newChromeData builds the shared chrome payload for a page. Pass the page
+// slug (used for nav "is-active" matching), the authenticated user (may be
+// nil), and the user's primary household (may be nil).
+func newChromeData(page string, user *auth.User, hh *household.Household) chromeData {
+	return chromeData{
+		Page:      page,
+		Version:   version.Version,
+		User:      user,
+		Household: hh,
+	}
 }
 
 func jsonError(w http.ResponseWriter, msg string, code int) {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -61,31 +61,31 @@ func (h *Handler) requireLineOwnershipWithHousehold(w http.ResponseWriter, r *ht
 }
 
 // ownedLinesForUser returns the lines owned by any household the user belongs
-// to, keyed by number, plus the primary household ID. Returns (nil, "", false)
-// if the user has no households or any lookup fails. Caller writes 404, the
-// same response shape as nonexistent.
-func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[string]*line.Line, string, bool) {
+// to, keyed by number, plus the primary household. Returns (nil, nil, false)
+// if the user has no households or any lookup fails. Caller writes 404, same
+// response shape as nonexistent.
+func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[string]*line.Line, *household.Household, bool) {
 	households, err := h.householdStore.GetForUser(ctx, user.ID)
 	if err != nil {
 		slog.Error("link_health: list households failed", "user_id", user.ID, "err", err)
-		return nil, "", false
+		return nil, nil, false
 	}
 	if len(households) == 0 {
-		return nil, "", false
+		return nil, nil, false
 	}
 	lines := make(map[string]*line.Line)
 	for _, hh := range households {
 		hhLines, err := h.lineStore.ListByHousehold(ctx, hh.ID)
 		if err != nil {
 			slog.Error("link_health: list lines failed", "household_id", hh.ID, "err", err)
-			return nil, "", false
+			return nil, nil, false
 		}
 		for i := range hhLines {
 			ln := hhLines[i]
 			lines[ln.Number] = &ln
 		}
 	}
-	return lines, households[0].ID, true
+	return lines, households[0], true
 }
 
 // requireCallEndpointOwnership verifies the authenticated user owns either
@@ -98,11 +98,11 @@ func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[s
 // regardless of auth outcome, to avoid a timing side channel on call-id
 // enumeration. Linked households do NOT grant access to telemetry; only
 // direct household ownership of a call endpoint does.
-func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, map[string]*line.Line, string, bool) {
+func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Request, callID int64) (calls.Call, map[string]*line.Line, *household.Household, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, "", false
+		return calls.Call{}, nil, nil, false
 	}
 
 	// Always do both queries in the same order, regardless of miss reason.
@@ -112,18 +112,18 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 	if callErr != nil {
 		slog.Error("link_health: get call failed", "call_id", callID, "err", callErr)
 		http.NotFound(w, r)
-		return calls.Call{}, nil, "", false
+		return calls.Call{}, nil, nil, false
 	}
 	if !ok || call.ID == 0 {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, "", false
+		return calls.Call{}, nil, nil, false
 	}
 
 	_, ownsCaller := ownedLines[call.Caller]
 	_, ownsCallee := ownedLines[call.Callee]
 	if !ownsCaller && !ownsCallee {
 		http.NotFound(w, r)
-		return calls.Call{}, nil, "", false
+		return calls.Call{}, nil, nil, false
 	}
 	return call, ownedLines, primaryHH, true
 }
@@ -132,22 +132,22 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 // conference auth helpers share: snapshot the user's owned lines and fetch
 // the conference, both unconditionally, then 404 on any failure. Callers
 // layer their own ownership predicate on the returned (conf, ownedLines).
-func (h *Handler) loadConferenceForUser(w http.ResponseWriter, r *http.Request, confID uuid.UUID, errLog string) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
+func (h *Handler) loadConferenceForUser(w http.ResponseWriter, r *http.Request, confID uuid.UUID, errLog string) (*calls.ConferenceSummary, map[string]*line.Line, *household.Household, bool) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
 		http.NotFound(w, r)
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	ownedLines, primaryHH, ok := h.ownedLinesForUser(r.Context(), user)
 	conf, confErr := h.tracker.GetConferenceByID(r.Context(), confID)
 	if confErr != nil {
 		slog.Error(errLog+": get conference failed", "conf_id", confID, "err", confErr)
 		http.NotFound(w, r)
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	if !ok || conf == nil {
 		http.NotFound(w, r)
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	return conf, ownedLines, primaryHH, true
 }
@@ -162,10 +162,10 @@ func (h *Handler) loadConferenceForUser(w http.ResponseWriter, r *http.Request, 
 //
 // Mirrors requireCallEndpointOwnership's constant-time query sequence to
 // avoid a timing side channel on conference-id enumeration.
-func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
+func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, *household.Household, bool) {
 	conf, ownedLines, primaryHH, ok := h.loadConferenceForUser(w, r, confID, "conference_link_health")
 	if !ok {
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	for _, member := range conf.Members {
 		if _, owns := ownedLines[member]; owns {
@@ -173,7 +173,7 @@ func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Requ
 		}
 	}
 	http.NotFound(w, r)
-	return nil, nil, "", false
+	return nil, nil, nil, false
 }
 
 // requireConferenceHostOwnership verifies the authenticated user's
@@ -185,14 +185,14 @@ func (h *Handler) requireConferenceOwnership(w http.ResponseWriter, r *http.Requ
 // Query sequence matches requireCallEndpointOwnership and
 // requireConferenceOwnership to avoid a timing side channel on
 // conference-id enumeration.
-func (h *Handler) requireConferenceHostOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, string, bool) {
+func (h *Handler) requireConferenceHostOwnership(w http.ResponseWriter, r *http.Request, confID uuid.UUID) (*calls.ConferenceSummary, map[string]*line.Line, *household.Household, bool) {
 	conf, ownedLines, primaryHH, ok := h.loadConferenceForUser(w, r, confID, "conference_kick")
 	if !ok {
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	if _, owns := ownedLines[conf.Host]; !owns {
 		http.NotFound(w, r)
-		return nil, nil, "", false
+		return nil, nil, nil, false
 	}
 	return conf, ownedLines, primaryHH, true
 }
@@ -249,9 +249,7 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 
 // primaryHousehold returns the first household the authenticated user belongs
 // to, or nil when the user is unauthenticated, the store is not wired, lookup
-// fails, or the user has no households. This is the canonical single-query
-// lookup; page handlers should call it once at the top and thread the result
-// through helpers rather than re-querying per chrome field.
+// fails, or the user has no households.
 func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	if h.householdStore == nil {
 		return nil
@@ -276,11 +274,10 @@ func householdLocation(hh *household.Household) *time.Location {
 	return hh.Location()
 }
 
-// chromeData is the set of fields every protected page-data struct shares for
-// rendering the layout chrome (sidebar, nav, DND chip, version pill). Embed
-// this in each page-data struct and populate via newChromeData. The
+// chromeData holds the fields every protected page-data struct shares for
+// rendering the layout chrome (sidebar, nav, DND chip, version pill). The
 // HouseholdName/HouseholdDND/CallHistoryEnabled methods read through the
-// Household pointer so there is one source of truth per request.
+// Household pointer so templates hit one source of truth per request.
 type chromeData struct {
 	Page      string
 	Version   string
@@ -288,7 +285,6 @@ type chromeData struct {
 	Household *household.Household
 }
 
-// HouseholdName returns the current user's household name, or "" when none.
 func (c chromeData) HouseholdName() string {
 	if c.Household == nil {
 		return ""
@@ -296,7 +292,6 @@ func (c chromeData) HouseholdName() string {
 	return c.Household.Name
 }
 
-// HouseholdDND returns the household-wide do-not-disturb flag.
 func (c chromeData) HouseholdDND() bool {
 	if c.Household == nil {
 		return false
@@ -304,7 +299,6 @@ func (c chromeData) HouseholdDND() bool {
 	return c.Household.DoNotDisturb
 }
 
-// CallHistoryEnabled returns whether the household has call history on.
 func (c chromeData) CallHistoryEnabled() bool {
 	if c.Household == nil {
 		return false
@@ -312,9 +306,6 @@ func (c chromeData) CallHistoryEnabled() bool {
 	return c.Household.CallHistoryEnabled
 }
 
-// newChromeData builds the shared chrome payload for a page. Pass the page
-// slug (used for nav "is-active" matching), the authenticated user (may be
-// nil), and the user's primary household (may be nil).
 func newChromeData(page string, user *auth.User, hh *household.Household) chromeData {
 	return chromeData{
 		Page:      page,

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -74,8 +74,8 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	// their call log; the underlying auth check does not grant read access to
 	// calls the user was not part of.
 	var linkedIndex map[string]string
-	if primaryHH != "" {
-		linkedFamilies := h.buildLinkedFamilies(r.Context(), primaryHH)
+	if primaryHH != nil {
+		linkedFamilies := h.buildLinkedFamilies(r.Context(), primaryHH.ID)
 		linkedIndex = buildLinkedLineIndex(linkedFamilies)
 	}
 

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -63,7 +63,6 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 		Error:       r.URL.Query().Get("error"),
 	}
 
-	// Active links: build connected family directory
 	data.LinkedFamilies = h.buildLinkedFamilies(r.Context(), myHousehold.ID)
 
 	// Pending invites sent by this household

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -9,24 +9,18 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/line"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type linksData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	LinkedFamilies     []linkedFamilyRow
-	PendingInvites     []linkRow
-	CreatedCode        string
-	Accepted           bool
-	Revoked            bool
-	Canceled           bool
-	Conflicts          string
-	Error              string
-	User               *auth.User
+	chromeData
+	LinkedFamilies []linkedFamilyRow
+	PendingInvites []linkRow
+	CreatedCode    string
+	Accepted       bool
+	Revoked        bool
+	Canceled       bool
+	Conflicts      string
+	Error          string
 }
 
 type linkedFamilyRow struct {
@@ -53,29 +47,23 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.primaryHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	data := linksData{
-		Page:               "links",
-		Version:            version.Version,
-		CallHistoryEnabled: h.callHistoryEnabled(r),
-		HouseholdName:      myHousehold.Name,
-		HouseholdDND:       myHousehold.DoNotDisturb,
-		CreatedCode:        r.URL.Query().Get("created"),
-		Accepted:           r.URL.Query().Get("accepted") == "1",
-		Revoked:            r.URL.Query().Get("revoked") == "1",
-		Canceled:           r.URL.Query().Get("canceled") == "1",
-		Conflicts:          r.URL.Query().Get("conflicts"),
-		Error:              r.URL.Query().Get("error"),
-		User:               user,
+		chromeData:  newChromeData("links", user, myHousehold),
+		CreatedCode: r.URL.Query().Get("created"),
+		Accepted:    r.URL.Query().Get("accepted") == "1",
+		Revoked:     r.URL.Query().Get("revoked") == "1",
+		Canceled:    r.URL.Query().Get("canceled") == "1",
+		Conflicts:   r.URL.Query().Get("conflicts"),
+		Error:       r.URL.Query().Get("error"),
 	}
 
-	// Active links — build connected family directory
+	// Active links: build connected family directory
 	data.LinkedFamilies = h.buildLinkedFamilies(r.Context(), myHousehold.ID)
 
 	// Pending invites sent by this household

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -6,17 +6,11 @@ import (
 	"strings"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type onboardData struct {
-	Page               string
-	CallHistoryEnabled bool
-	HouseholdName      string
-	HouseholdDND       bool
-	SuggestedName      string
-	Version            string
-	User               *auth.User
+	chromeData
+	SuggestedName string
 }
 
 func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
@@ -25,15 +19,9 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 	if user != nil && user.Name != "" {
 		suggested = user.Name + "'s Family"
 	}
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
 	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
-		Page:               "onboard",
-		Version:            version.Version,
-		CallHistoryEnabled: callHistory,
-		HouseholdName:      hhName,
-		HouseholdDND:       hhDND,
-		SuggestedName:      suggested,
-		User:               user,
+		chromeData:    newChromeData("onboard", user, h.primaryHousehold(r)),
+		SuggestedName: suggested,
 	})
 }
 

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/device"
+	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
 	"github.com/justinlindh/digits/server/internal/signaling"
 	"github.com/justinlindh/digits/server/internal/updates"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type pairSuccess struct {
@@ -23,16 +23,11 @@ type pairSuccess struct {
 }
 
 type linesData struct {
-	Page                  string
-	Version               string
-	CallHistoryEnabled    bool
-	HouseholdName         string
-	HouseholdDND          bool
+	chromeData
 	Lines                 []lineRow
 	Error                 string
 	PairError             string
 	PairSuccess           *pairSuccess
-	User                  *auth.User
 	LatestPiVersion       string
 	LatestFirmwareVersion string
 }
@@ -49,22 +44,19 @@ type lineRow struct {
 	PiUpdateNotes       []updates.Release
 }
 
-func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
+// buildLinesData assembles the line-list page payload. Pass in hh (the user's
+// primary household, may be nil) so callers that already fetched it do not
+// round-trip again; lines are scoped to hh's household.
+func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMsg string) linesData {
 	var user *auth.User
 	if r != nil {
 		user = auth.UserFromContext(r.Context())
 	}
 
 	var lines []line.Line
-
-	// Scope to household if user has one and householdStore is available
-	if user != nil && h.householdStore != nil {
-		households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-		if err == nil && len(households) > 0 {
-			lines, _ = h.lineStore.ListByHousehold(r.Context(), households[0].ID)
-		}
+	if hh != nil && h.lineStore != nil {
+		lines, _ = h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	}
-
 	// If household lookup failed, show empty list rather than leaking all lines
 	if lines == nil {
 		lines = []line.Line{}
@@ -102,23 +94,17 @@ func (h *Handler) buildLinesData(r *http.Request, errMsg string) linesData {
 		}
 		rows[i] = row
 	}
-	hhName, callHistory, hhDND, _ := h.householdContext(r)
 	return linesData{
-		Page:                  "phones",
-		Version:               version.Version,
-		CallHistoryEnabled:    callHistory,
-		HouseholdName:         hhName,
-		HouseholdDND:          hhDND,
+		chromeData:            newChromeData("phones", user, hh),
 		Lines:                 rows,
 		Error:                 errMsg,
-		User:                  user,
 		LatestPiVersion:       latestPi,
 		LatestFirmwareVersion: latestFw,
 	}
 }
 
 func (h *Handler) handlePhonesGet(w http.ResponseWriter, r *http.Request) {
-	data := h.buildLinesData(r, "")
+	data := h.buildLinesData(r, h.primaryHousehold(r), "")
 	if pairedName := r.URL.Query().Get("paired"); pairedName != "" {
 		data.PairSuccess = &pairSuccess{
 			Name:            pairedName,
@@ -136,29 +122,24 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	// Get user's household to associate the new line
+	hh := h.primaryHousehold(r)
 	var householdID string
-	if h.householdStore != nil {
-		user := auth.UserFromContext(r.Context())
-		if user != nil {
-			households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-			if err == nil && len(households) > 0 {
-				householdID = households[0].ID
-			}
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 
 	if err := line.ValidateNumber(number); err != nil {
-		data := h.buildLinesData(r, err.Error())
+		data := h.buildLinesData(r, hh, err.Error())
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	_, err := h.lineStore.Add(r.Context(), number, name, householdID)
-	data := h.buildLinesData(r, "")
+	msg := ""
 	if err != nil {
-		data = h.buildLinesData(r, err.Error())
+		msg = err.Error()
 	}
+	data := h.buildLinesData(r, hh, msg)
 
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
@@ -180,41 +161,36 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
+	hh := h.primaryHousehold(r)
+
 	if err := line.ValidateNumber(number); err != nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesData(r, hh, "")
 		data.PairError = "invalid phone number: " + err.Error()
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	if h.pairingStore == nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesData(r, hh, "")
 		data.PairError = "pairing is not enabled"
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
-	// Get user's household
 	var householdID string
-	if h.householdStore != nil {
-		user := auth.UserFromContext(r.Context())
-		if user != nil {
-			households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-			if err == nil && len(households) > 0 {
-				householdID = households[0].ID
-			}
-		}
+	if hh != nil {
+		householdID = hh.ID
 	}
 	if householdID == "" {
-		data := h.buildLinesData(r, "")
-		data.PairError = "no household found — please complete onboarding first"
+		data := h.buildLinesData(r, hh, "")
+		data.PairError = "no household found: please complete onboarding first"
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
 	token, hwID, err := h.pairingStore.ClaimDevice(r.Context(), code, number, name, householdID)
 	if err != nil {
-		data := h.buildLinesData(r, "")
+		data := h.buildLinesData(r, hh, "")
 		data.PairError = err.Error()
 		renderWith(w, h.tmplPhones, layoutFor(r), data)
 		return
@@ -236,11 +212,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 }
 
 type lineDetailData struct {
-	Page                  string
-	Version               string
-	CallHistoryEnabled    bool
-	HouseholdName         string
-	HouseholdDND          bool
+	chromeData
 	Line                  line.Line
 	Online                bool
 	Devices               []device.Device
@@ -252,12 +224,11 @@ type lineDetailData struct {
 	FWReleases            []updates.Release
 	PiUpdateNotes         []updates.Release
 	FirmwareUpdateNotes   []updates.Release
-	User                  *auth.User
 }
 
 func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln := h.requireLineOwnership(w, r, number)
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -298,7 +269,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
 
-	hhName, callHistory, hhDND, loc := h.householdContext(r)
+	loc := householdLocation(hh)
 
 	if lastSeenAt != nil {
 		t := lastSeenAt.In(loc)
@@ -320,11 +291,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 
 	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
-		Page:                  "phones",
-		Version:               version.Version,
-		CallHistoryEnabled:    callHistory,
-		HouseholdName:         hhName,
-		HouseholdDND:          hhDND,
+		chromeData:            newChromeData("phones", user, hh),
 		Line:                  *ln,
 		Online:                online,
 		Devices:               devices,
@@ -336,7 +303,6 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		FWReleases:            fwReleases,
 		PiUpdateNotes:         piUpdateNotes,
 		FirmwareUpdateNotes:   firmwareUpdateNotes,
-		User:                  user,
 	})
 }
 
@@ -387,7 +353,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := h.buildLinesData(r, "")
+	data := h.buildLinesData(r, h.primaryHousehold(r), "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return
@@ -632,7 +598,7 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to delete line", http.StatusInternalServerError)
 		return
 	}
-	data := h.buildLinesData(r, "")
+	data := h.buildLinesData(r, h.primaryHousehold(r), "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -44,9 +44,9 @@ type lineRow struct {
 	PiUpdateNotes       []updates.Release
 }
 
-// buildLinesData assembles the line-list page payload. Pass in hh (the user's
-// primary household, may be nil) so callers that already fetched it do not
-// round-trip again; lines are scoped to hh's household.
+// buildLinesData assembles the line-list page payload. hh may be nil; when
+// nil or lookup fails the handler shows an empty list rather than leaking
+// every line on the server.
 func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMsg string) linesData {
 	var user *auth.User
 	if r != nil {
@@ -342,7 +342,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	ln := h.requireLineOwnership(w, r, number)
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -353,7 +353,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := h.buildLinesData(r, h.primaryHousehold(r), "")
+	data := h.buildLinesData(r, hh, "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return
@@ -589,7 +589,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln := h.requireLineOwnership(w, r, number)
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -598,7 +598,7 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to delete line", http.StatusInternalServerError)
 		return
 	}
-	data := h.buildLinesData(r, h.primaryHousehold(r), "")
+	data := h.buildLinesData(r, hh, "")
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -6,45 +6,19 @@ import (
 	"strings"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/household"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type settingsData struct {
-	Page               string
-	Version            string
-	CallHistoryEnabled bool
-	HouseholdDND       bool
-	HouseholdName      string
-	User               *auth.User
-	Household          *household.Household
-	Saved              bool
+	chromeData
+	Saved bool
 }
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	var hh *household.Household
-	if user != nil && h.householdStore != nil {
-		households, _ := h.householdStore.GetForUser(r.Context(), user.ID)
-		if len(households) > 0 {
-			hh = households[0]
-		}
-	}
-	hhName := ""
-	dnd := false
-	if hh != nil {
-		hhName = hh.Name
-		dnd = hh.DoNotDisturb
-	}
+	hh := h.primaryHousehold(r)
 	renderWith(w, h.tmplSettings, layoutFor(r), settingsData{
-		Page:               "settings",
-		Version:            version.Version,
-		CallHistoryEnabled: h.callHistoryEnabled(r),
-		HouseholdDND:       dnd,
-		HouseholdName:      hhName,
-		User:               user,
-		Household:          hh,
-		Saved:              r.URL.Query().Get("saved") == "1",
+		chromeData: newChromeData("settings", user, hh),
+		Saved:      r.URL.Query().Get("saved") == "1",
 	})
 }
 

--- a/server/internal/web/templates/call-live-detail.html
+++ b/server/internal/web/templates/call-live-detail.html
@@ -1,4 +1,4 @@
-{{define "title"}}Live session — {{.Caller.DisplayName}} &harr; {{.Callee.DisplayName}}{{end}}
+{{define "title"}}Live session: {{.Caller.DisplayName}} &harr; {{.Callee.DisplayName}}{{end}}
 
 {{define "content"}}
 <div class="page deck" data-started-at="{{.Call.StartedAt.UnixMilli}}">

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{{block "title" .}}Digits{{end}} — Digits</title>
+<title>{{block "title" .}}Digits{{end}} | Digits</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="stylesheet" href="/static/dialup.css">
 <script src="/static/htmx.min.js"></script>
@@ -19,7 +19,7 @@
   <div class="dialup-title">
     <div class="dialup-title__app">
       <span class="dialup-title__icon" aria-hidden="true"></span>
-      <span>Digits — {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span>
+      <span>Digits: {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span>
     </div>
     <div class="dialup-title__controls" aria-hidden="true">
       <span class="dialup-title__btn">_</span>

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{block "title" .}}Digits{{end}} — Digits</title>
+<title>{{block "title" .}}Digits{{end}} | Digits</title>
 <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
 <link rel="preload" href="/static/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="/static/fonts/inter-tight-500.woff2" as="font" type="font/woff2" crossorigin>

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -250,13 +250,13 @@
             </div>
           </details>
           {{else}}
-          <p class="muted" style="font-size: 12.5px; margin: 0;">Firmware updates require SWD wiring — flash via USB.</p>
+          <p class="muted" style="font-size: 12.5px; margin: 0;">Firmware updates require SWD wiring: flash via USB.</p>
           {{end}}
           {{end}}
 
           {{else}}
             {{if .Online}}
-            <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report — device is online but hasn't reported version info yet.</p>
+            <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report: device is online but hasn't reported version info yet.</p>
             <form method="POST" action="/phones/{{.Line.Number}}/update">
               <button type="submit" class="btn btn--primary">Check for updates</button>
             </form>
@@ -359,7 +359,7 @@
     .then(function(r) { return r.json(); })
     .then(function(data) {
       if (data.error) { showResult(prefix, 'failed', 'Failed to send: ' + data.error); return; }
-      if (progressText) progressText.textContent = 'Update triggered — waiting for device...';
+      if (progressText) progressText.textContent = 'Update triggered: waiting for device...';
       startPolling(prefix);
     })
     .catch(function(err) { showResult(prefix, 'failed', 'Network error: ' + err.message); });


### PR DESCRIPTION
## Summary

Addresses #280.

- **chromeData** holds the five fields every protected page-data struct shared (Page, Version, User, Household) with HouseholdName / HouseholdDND / CallHistoryEnabled exposed as methods that read through the embedded `*Household`. All nine page-data structs (dashboard, phones, phone-detail, calls, call-live, links, settings, onboard, conference-live, connecting) embed it, so future chrome fields are a one-line change instead of touching every handler.
- **primaryHousehold(r)** replaces `householdContext` + `callHistoryEnabled`; ownership helpers (`ownedLinesForUser`, `requireCallEndpointOwnership`, `requireConferenceOwnership`, `requireConferenceHostOwnership`) now return `*household.Household` so the household lookup their auth check already runs feeds back to the handler. Net GetForUser per page render:
  - Dashboard: 4 -> 1
  - Calls / Links / Settings: 2 -> 1
  - Phone-detail / call-live / conference-live: 2 -> 1
  - handlePhoneEditPost / handlePhoneDelete: 2 -> 1 (via `requireLineOwnershipWithHousehold`)
- **settingsData** no longer hand-copies HouseholdName / HouseholdDND / CallHistoryEnabled. Templates continue to read `.HouseholdName` (method on chromeData) for layout chrome and `.Household.Name` / `.Household.Timezone` for the edit form, both backed by the same `*Household` pointer.
- **Em dashes** in layout-v2, layout-dialup, phone-detail, call-live-detail are gone. A handful of stale em dashes in Go comments/error strings under server/internal/web/ that the pre-commit hook had grandfathered are also cleaned up in files this refactor touched.

## Test plan

- [x] `go test ./...` (unit)
- [x] `make test-integration` (integration, against Postgres)
- [x] `golangci-lint run ./...` (zero issues)
- [ ] Spot-check rendered chrome on `/`, `/phones`, `/calls`, `/links`, `/settings`, `/phones/{num}` in dev-up