### PR TITLE
fix(server): stop emailing invite code back to inviter

### DIFF
--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -48,21 +48,6 @@ func MagicLinkEmail(link string) (subject, body string) {
 	return
 }
 
-// HouseholdInviteEmail returns subject and HTML body for a household link invite notification.
-func HouseholdInviteEmail(householdName, inviteCode, baseURL string) (subject, body string) {
-	subject = fmt.Sprintf("Digits: Invite to link with %s", householdName)
-	content := fmt.Sprintf(`<h2 style="color:#e6edf3; margin:0 0 16px 0; font-size:20px;">Household Link Invite</h2>
-  <p style="color:#8b949e; font-size:14px; margin:0 0 16px 0;">You&#39;ve been invited to link your household with <strong>%s</strong> on Digits.</p>
-  <div style="background:#0d1117; border:1px solid #21262d; border-radius:8px; padding:16px; margin:16px 0; text-align:center;">
-    <p style="color:#8b949e; font-size:12px; margin:0 0 8px;">Your invite code:</p>
-    <p style="font-family:monospace; font-size:24px; letter-spacing:4px; color:#58a6ff; margin:0;">%s</p>
-  </div>
-  <p style="color:#8b949e; font-size:14px; margin:0;">Enter this code at <a href="%s/links" style="color:#58a6ff;">%s/links</a> to connect your families.</p>`,
-		householdName, inviteCode, baseURL, baseURL)
-	body = brandedWrap(content)
-	return
-}
-
 // ContactInviteEmail returns subject and HTML body for a contact invite notification.
 func ContactInviteEmail(fromPhoneName, toPhoneName, baseURL string) (subject, body string) {
 	subject = fmt.Sprintf("Digits: Contact request for %s", toPhoneName)

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -21,19 +21,6 @@ func TestMagicLinkEmailContainsBranding(t *testing.T) {
 	}
 }
 
-func TestHouseholdInviteEmailContainsBranding(t *testing.T) {
-	_, body := HouseholdInviteEmail("Smith Family", "ABC123", "https://app.digits.family")
-	if !strings.Contains(body, "DIGITS") {
-		t.Fatal("body should contain branded header")
-	}
-	if !strings.Contains(body, "Smith Family") {
-		t.Fatal("body should mention household name")
-	}
-	if !strings.Contains(body, "ABC123") {
-		t.Fatal("body should contain invite code")
-	}
-}
-
 func TestContactInviteEmailContainsBranding(t *testing.T) {
 	_, body := ContactInviteEmail("Isaac's Phone", "Emma's Phone", "https://app.digits.family")
 	if !strings.Contains(body, "DIGITS") {
@@ -49,10 +36,9 @@ func TestContactInviteEmailContainsBranding(t *testing.T) {
 
 func TestAllEmailsHaveFooter(t *testing.T) {
 	_, body1 := MagicLinkEmail("https://example.com/link")
-	_, body2 := HouseholdInviteEmail("Test", "CODE", "https://example.com")
 	_, body3 := ContactInviteEmail("A", "B", "https://example.com")
 
-	for i, body := range []string{body1, body2, body3} {
+	for i, body := range []string{body1, body3} {
 		if !strings.Contains(body, "Digits — A phone for real conversations") || !strings.Contains(body, "Digits —") {
 			// Check for the key phrase, allowing for HTML entity encoding of em dash
 			if !strings.Contains(body, "A phone for real conversations") {

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/line"
 	"github.com/justinlindh/digits/server/internal/version"
 )
@@ -111,14 +110,6 @@ func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) 
 		slog.Error("create invite failed", "err", err)
 		http.Redirect(w, r, "/links?error="+err.Error(), http.StatusSeeOther)
 		return
-	}
-
-	// Send email notification to the creating user with the invite code
-	if h.emailSender != nil && user.Email != "" {
-		subj, body := email.HouseholdInviteEmail(myHousehold.Name, link.InviteCode, h.cfg.BaseURL)
-		if err := h.emailSender.Send(user.Email, subj, body); err != nil {
-			slog.Error("send invite email failed", "err", err)
-		}
 	}
 
 	http.Redirect(w, r, "/links?created="+link.InviteCode, http.StatusSeeOther)


### PR DESCRIPTION
## Summary

- The "Invite a friend" button on `/links` was emailing the generated household invite code to the clicker's own address. There's no form field for a friend's email and no column on `household_links` to store one, so the notification path was half-built.
- Drop the self-email from `handleLinksInvitePost` and the now-unused `HouseholdInviteEmail` template. The `/links` postcard panel already renders the code with copy instructing the inviter to share it manually.
- If we later decide to let users email the invite to a friend, it's a real feature (schema column for recipient, form input, public `/accept/:code` landing for friends without an account) rather than an accidental side effect of clicking a button.

## Test plan

- [x] `make build` from `server/`
- [x] `make test` from `server/` (all packages pass)
- [x] `golangci-lint run ./...` clean
- [ ] Manual: click "Invite a friend" on `/links`, confirm the postcard renders and no email is sent