### PR TITLE
refactor(server): eager-init Hub.updateStatus, drop redundant nil checks

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -40,8 +40,9 @@ type Hub struct {
 
 func NewHub() *Hub {
 	return &Hub{
-		conns:   make(map[string]*Conn),
-		hwConns: make(map[string]*Conn),
+		conns:        make(map[string]*Conn),
+		hwConns:      make(map[string]*Conn),
+		updateStatus: make(map[string]*UpdateStatusSnapshot),
 	}
 }
 
@@ -163,9 +164,6 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 func (h *Hub) SetUpdateStatus(number, status, detail string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.updateStatus == nil {
-		h.updateStatus = make(map[string]*UpdateStatusSnapshot)
-	}
 	h.updateStatus[number] = &UpdateStatusSnapshot{
 		Status:    status,
 		Detail:    detail,
@@ -177,9 +175,6 @@ func (h *Hub) SetUpdateStatus(number, status, detail string) {
 func (h *Hub) GetUpdateStatus(number string) *UpdateStatusSnapshot {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	if h.updateStatus == nil {
-		return nil
-	}
 	return h.updateStatus[number]
 }
 
@@ -187,9 +182,7 @@ func (h *Hub) GetUpdateStatus(number string) *UpdateStatusSnapshot {
 func (h *Hub) ClearUpdateStatus(number string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.updateStatus != nil {
-		delete(h.updateStatus, number)
-	}
+	delete(h.updateStatus, number)
 }
 
 // UpdateDeviceInfo sets version info for a connected phone under the write lock.


### PR DESCRIPTION
`NewHub` eagerly initializes `conns` and `hwConns` but lazy-initialized `updateStatus`, leaving `SetUpdateStatus` to fault it in. Initialize all three maps the same way and drop the three nil guards: in `Get` and `Clear` they were dead code (Go nil maps return the zero value on read and accept `delete` as a no-op), and in `Set` the lazy fault-in is no longer needed.

`NewHub` is the only constructor; no other code path produces a `*Hub`. No behavior change.