### PR TITLE
fix(server): drop leftover prose em dashes in live-call/conference templates

### DIFF
--- a/server/e2e/tests/10-do-not-disturb.spec.ts
+++ b/server/e2e/tests/10-do-not-disturb.spec.ts
@@ -70,8 +70,11 @@ async function setDoNotDisturb(page: Page, target: 'on' | 'off'): Promise<void> 
   );
   await checkbox.setChecked(target === 'on', { force: true });
   await wait;
-  // The handler returns 303 to /settings?saved=1; wait for that landing page.
-  await page.waitForURL((u) => u.toString().includes('/settings'));
+  // The handler returns 303 to /settings?saved=1. The page started at
+  // /settings#do-not-disturb, so a plain "/settings" check resolves
+  // immediately against the current URL and lets the next goto race the
+  // in-flight redirect; require the ?saved=1 query the handler appends.
+  await page.waitForURL((u) => u.toString().includes('/settings?saved=1'));
 }
 
 const SURFACES = ['/', '/phones', '/links', '/settings'];

--- a/server/internal/web/templates/call-live-detail.html
+++ b/server/internal/web/templates/call-live-detail.html
@@ -52,7 +52,7 @@
         </h2>
         <p class="deck-confirm__body">
           The server sends a hangup signal to both handsets. The call will drop within a second or two.
-          The server does not touch audio &mdash; only the signaling channel.
+          The server does not touch audio: only the signaling channel.
         </p>
         <div class="deck-confirm__actions">
           <button type="button" class="deck-confirm__cancel" onclick="document.getElementById('deck-confirm').close()">Cancel</button>

--- a/server/internal/web/templates/conference-live-detail.html
+++ b/server/internal/web/templates/conference-live-detail.html
@@ -1,4 +1,4 @@
-{{define "title"}}Live conference &mdash; {{len .Resp.Members}} parties{{end}}
+{{define "title"}}Live conference: {{len .Resp.Members}} parties{{end}}
 
 {{define "content"}}
 <div class="page deck" data-started-at="{{.Resp.CreatedAt.UnixMilli}}">


### PR DESCRIPTION
## What

Replace the em-dash entity with a colon in two user-facing template strings:

- `conference-live-detail.html:1` browser-tab title: `Live conference: N parties`
- `call-live-detail.html:55` end-call confirmation modal copy: "The server does not touch audio: only the signaling channel."

## Why (cross-PR drift)

CLAUDE.md hard rule: no em dashes anywhere, including in-app copy.

PR #303 (mdash-to-ndash placeholders) explicitly carved these two prose-level em dashes out of scope and left them "for a separate, prose-level pass." PR #304 (chrome consolidation, em-dash cleanup) was that next pass and cleaned several em dashes in `phone-detail.html`, `layout-v2.html`, `layout-dialup.html`, and the `call-live-detail.html` title block, but did not revisit the two callouts PR #303 had named. Result: a documented gap was created and then closed around without actually being filled.

Both replacements use a colon, matching the pattern PR #304 already established on these same templates (e.g. `Live session: ...`).

## Test plan

- [x] `go build ./...` from `server/`
- [x] `go test ./internal/web/...` from `server/`
- [x] `rg mdash server/internal/web/templates/` returns nothing
- [ ] Visual spot check: open `/conference/live/{id}` browser tab title, click "End this call?" on `/call/live/{id}`