### PR TITLE
docs: document repo-root image and flash Makefile targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,23 @@ make firmware-local   # builds on host (requires arm-none-eabi-gcc + Pico SDK)
 ./scripts/flash.sh    # copies UF2 to mounted Pico
 ```
 
+Pi OS image and SD card flash (from repo root):
+```
+make image            # build V1 (Codec Zero HAT) image via Docker
+make image-dev        # V1 image with SSH enabled
+make image-v2         # build V2 (carrier board) image
+make image-v2-dev     # V2 image with SSH enabled
+
+make flash            # flash newest image to auto-detected SD (override SD=/dev/sdX)
+make flash-v1         # flash newest V1 image
+make flash-v2         # flash newest V2 image
+
+make image-flash      # build V1 dev image AND flash in one shot
+make image-v2-flash   # build V2 dev image AND flash
+```
+
+The flash targets refuse to write to anything that isn't a block device. Override SD detection with `make flash-v2 SD=/dev/sdX`. `make help` lists every target with a one-line description.
+
 Test tiers, build tag syntax, env vars, and CI workflow names live in `server/TESTING.md`.
 
 ## Local dev server


### PR DESCRIPTION
## Summary

CLAUDE.md's Build and test section covered server, digitsd, and firmware Makefiles but omitted the top-level Makefile that orchestrates Pi OS image building and SD card flashing.

Adds a Pi OS image and SD card flash subsection enumerating `image`, `image-dev`, `image-v2`, `image-v2-dev`, `flash`, `flash-v1`, `flash-v2`, `image-flash`, `image-v2-flash` plus the `SD=/dev/sdX` override syntax and a pointer to `make help`.

Triggered by an agent looking for "build the V2 image and flash it" rediscovering `tools/build-image.sh` from scratch instead of just running `make image-v2-flash`.

## Test plan

- [x] CLAUDE.md change is documentation-only; renders as expected on GitHub