### PR TITLE
feat(ci): expand GitHub squash-merge bullets for semantic-release

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -1,9 +1,20 @@
-// Firmware semantic-release config — full build with artifacts
+// Firmware semantic-release config: full build with artifacts.
+//
+// Uses tools/semantic-release-squash-expander instead of the standard
+// commit-analyzer / release-notes-generator pair so GitHub squash-merge
+// commits get expanded into their per-bullet virtual commits before scope
+// matching. Without this, a cross-component PR squashed under (e.g.) scope
+// "image" would never trigger this firmware-scoped release even if the
+// squash body contained "fix(firmware): ..." bullets.
+const path = require('path');
+const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+
 module.exports = {
   branches: ['main'],
   tagFormat: 'fw/v${version}',
   plugins: [
-    ['@semantic-release/commit-analyzer', {
+    [squashExpander, {
+      // Wrapped commit-analyzer options.
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.
@@ -13,15 +24,12 @@ module.exports = {
         { scope: '*firmware*', breaking: true, release: 'major' },
         { scope: '!*firmware*', release: false },
       ],
+      // Shared parser opts (analyzer + notes-generator both honor these).
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
-    }],
-    ['@semantic-release/release-notes-generator', {
+      // Wrapped release-notes-generator options.
       preset: 'conventionalcommits',
-      parserOpts: {
-        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
-      },
       writerOpts: {
         // Only include commits whose scope is or contains "firmware".
         // Multi-scope commits like fix(digitsd,firmware,server) are included.

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -1,9 +1,17 @@
-// Firmware semantic-release config — tag-only (no build toolchain available)
+// Firmware semantic-release config: tag-only (no build toolchain available).
+//
+// Uses tools/semantic-release-squash-expander instead of the standard
+// commit-analyzer / release-notes-generator pair so GitHub squash-merge
+// commits get expanded into their per-bullet virtual commits before scope
+// matching. See ./.releaserc-full.cjs for the rationale.
+const path = require('path');
+const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+
 module.exports = {
   branches: ['main'],
   tagFormat: 'fw/v${version}',
   plugins: [
-    ['@semantic-release/commit-analyzer', {
+    [squashExpander, {
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.
@@ -13,8 +21,6 @@ module.exports = {
         { scope: '*firmware*', breaking: true, release: 'major' },
         { scope: '!*firmware*', release: false },
       ],
-    }],
-    ['@semantic-release/release-notes-generator', {
       preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -1,9 +1,17 @@
-// Pi (digitsd) semantic-release config — runs from repo root
+// Pi (digitsd) semantic-release config: runs from repo root.
+//
+// Uses tools/semantic-release-squash-expander instead of the standard
+// commit-analyzer / release-notes-generator pair so GitHub squash-merge
+// commits get expanded into their per-bullet virtual commits before scope
+// matching. See firmware/.releaserc-full.cjs for the rationale.
+const path = require('path');
+const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+
 module.exports = {
   branches: ['main'],
   tagFormat: 'pi/v${version}',
   plugins: [
-    ['@semantic-release/commit-analyzer', {
+    [squashExpander, {
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.
@@ -13,11 +21,6 @@ module.exports = {
         { scope: '{*pi*,*digitsd*}', breaking: true, release: 'major' },
         { scope: '!{*pi*,*digitsd*}', release: false },
       ],
-      parserOpts: {
-        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
-      },
-    }],
-    ['@semantic-release/release-notes-generator', {
       preset: 'conventionalcommits',
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],

--- a/tools/semantic-release-squash-expander.cjs
+++ b/tools/semantic-release-squash-expander.cjs
@@ -1,0 +1,89 @@
+// semantic-release plugin that expands GitHub squash-merge commits into
+// virtual per-bullet commits before delegating to the standard
+// commit-analyzer and release-notes-generator plugins.
+//
+// GitHub formats a squash merge as one commit whose subject is the PR title
+// and whose body lists each original feature-branch commit as a bullet:
+//
+//   feat(image): V2 carrier board hardware bring-up (#308)
+//
+//   * fix(image): correct SWD pin number for V2 carrier
+//
+//   The OpenOCD bitbang config still had the V1 prototype pinout...
+//
+//   * feat(pi): add MONITOR mode to UART socket
+//
+//   ...
+//
+// The default conventional-commits parser only reads the squash commit's
+// subject line, which loses every per-commit type/scope. Scope-filtered
+// release configs (e.g. "scope: '*firmware*'") then see "no release" for
+// cross-component PRs whose squash subject scope matches no single
+// component.
+//
+// This plugin expands such squash commits into virtual commits so both the
+// release-decision and changelog-generation steps see the original per-
+// commit messages. Non-squash commits pass through unchanged.
+
+// A bullet's first line must look like a conventional-commit subject
+// (type, optional scope, optional !, colon, space, then text). We only
+// expand a body if at least one bullet matches; otherwise the bullets are
+// probably ordinary documentation list items.
+const CONVENTIONAL_SUBJECT = /^[a-z]+(?:\([\w*,!-]+\))?!?:\s+\S/;
+
+function splitSquashBullets(message) {
+    if (!message) return null;
+    const newlineIdx = message.indexOf("\n");
+    if (newlineIdx < 0) return null;
+    const body = message.slice(newlineIdx + 1);
+    // Split on lines that begin with "* " at column 0. The first chunk is
+    // everything before the first bullet (typically blank); discard it.
+    const parts = body.split(/^\* /m);
+    if (parts.length < 2) return null;
+    const bullets = parts.slice(1).map((p) => p.replace(/\s+$/, ""));
+    if (!bullets.some((b) => CONVENTIONAL_SUBJECT.test(b))) return null;
+    return bullets;
+}
+
+function expandCommits(commits) {
+    return commits.flatMap((commit) => {
+        const bullets = splitSquashBullets(commit.message);
+        if (!bullets) return [commit];
+        return bullets.map((bullet) => {
+            const lineBreak = bullet.indexOf("\n");
+            const subject = lineBreak < 0 ? bullet : bullet.slice(0, lineBreak);
+            const body =
+                lineBreak < 0 ? "" : bullet.slice(lineBreak + 1).replace(/^\n+/, "").replace(/\n+$/, "");
+            return {
+                ...commit,
+                header: subject,
+                subject: subject,
+                body,
+                message: body ? `${subject}\n\n${body}` : subject,
+            };
+        });
+    });
+}
+
+// The two real semantic-release plugins are required lazily so this file
+// can be unit-tested in environments where they are not installed.
+module.exports = {
+    async analyzeCommits(pluginConfig, context) {
+        const commitAnalyzer = require("@semantic-release/commit-analyzer");
+        return commitAnalyzer.analyzeCommits(pluginConfig, {
+            ...context,
+            commits: expandCommits(context.commits),
+        });
+    },
+    async generateNotes(pluginConfig, context) {
+        const releaseNotesGenerator = require("@semantic-release/release-notes-generator");
+        return releaseNotesGenerator.generateNotes(pluginConfig, {
+            ...context,
+            commits: expandCommits(context.commits),
+        });
+    },
+};
+
+// Exposed for unit testing.
+module.exports._expandCommits = expandCommits;
+module.exports._splitSquashBullets = splitSquashBullets;

--- a/tools/semantic-release-squash-expander.test.cjs
+++ b/tools/semantic-release-squash-expander.test.cjs
@@ -1,0 +1,105 @@
+// Smoke test for tools/semantic-release-squash-expander.cjs.
+// Run with: node tools/semantic-release-squash-expander.test.cjs
+
+const assert = require("assert");
+const { _expandCommits, _splitSquashBullets } = require("./semantic-release-squash-expander.cjs");
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`PASS ${name}`);
+    } catch (e) {
+        console.error(`FAIL ${name}`);
+        console.error(e);
+        process.exitCode = 1;
+    }
+}
+
+test("non-squash commit is left untouched", () => {
+    const commit = {
+        hash: "abc123",
+        message: "fix(server): handle NULL line_id\n\nDetail body line one.\nDetail body line two.",
+        subject: "fix(server): handle NULL line_id",
+        body: "Detail body line one.\nDetail body line two.",
+    };
+    const out = _expandCommits([commit]);
+    assert.deepStrictEqual(out, [commit]);
+});
+
+test("commit with bullets that are not conventional commits is left untouched", () => {
+    const commit = {
+        hash: "abc123",
+        message:
+            "docs: update README\n\nChanges:\n* Cleaned up the install steps\n* Added a troubleshooting section",
+    };
+    const out = _expandCommits([commit]);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].message, commit.message);
+});
+
+test("github squash with two bullets expands into two virtual commits", () => {
+    const commit = {
+        hash: "deadbeef",
+        author: { name: "Alice" },
+        message:
+            "feat(image): V2 carrier board hardware bring-up (#308)\n\n* fix(image): correct SWD pin number for V2 carrier\n\nThe OpenOCD bitbang config still had the V1 prototype pinout.\nDetails about the fix.\n\n* feat(pi): add MONITOR mode to UART socket\n\ndigits-pico-monitor used to stop digitsd to grab /dev/serial0.\n",
+    };
+    const out = _expandCommits([commit]);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].subject, "fix(image): correct SWD pin number for V2 carrier");
+    assert.strictEqual(out[0].header, "fix(image): correct SWD pin number for V2 carrier");
+    assert.strictEqual(
+        out[0].body,
+        "The OpenOCD bitbang config still had the V1 prototype pinout.\nDetails about the fix.",
+    );
+    assert.strictEqual(out[1].subject, "feat(pi): add MONITOR mode to UART socket");
+    assert.strictEqual(out[1].body, "digits-pico-monitor used to stop digitsd to grab /dev/serial0.");
+    // Non-message fields propagate (hash, author, etc.) so changelog links work.
+    assert.strictEqual(out[0].hash, "deadbeef");
+    assert.strictEqual(out[1].hash, "deadbeef");
+    assert.strictEqual(out[0].author.name, "Alice");
+});
+
+test("squash with single bullet still expands", () => {
+    const commit = {
+        hash: "1234",
+        message: "fix(server): minor (#42)\n\n* fix(server): handle NULL line_id\n\nbody",
+    };
+    const out = _expandCommits([commit]);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].subject, "fix(server): handle NULL line_id");
+    assert.strictEqual(out[0].body, "body");
+});
+
+test("split returns null for non-bullet body", () => {
+    assert.strictEqual(_splitSquashBullets("subject\n\nbody only"), null);
+    assert.strictEqual(_splitSquashBullets("subject only"), null);
+    assert.strictEqual(_splitSquashBullets(""), null);
+});
+
+test("split recognizes bare type without scope", () => {
+    const msg = "feat: cross-cutting (#9)\n\n* fix: nullguard\n\nfoo\n\n* feat: shiny\n\nbar";
+    const bullets = _splitSquashBullets(msg);
+    assert.strictEqual(bullets.length, 2);
+    assert.ok(bullets[0].startsWith("fix: nullguard"));
+    assert.ok(bullets[1].startsWith("feat: shiny"));
+});
+
+test("split recognizes breaking marker", () => {
+    const msg = "feat: rewrites (#9)\n\n* feat(api)!: drop v1 endpoint\n\nbody";
+    const bullets = _splitSquashBullets(msg);
+    assert.strictEqual(bullets.length, 1);
+    assert.ok(bullets[0].startsWith("feat(api)!: drop v1 endpoint"));
+});
+
+test("split recognizes multi-scope", () => {
+    const msg =
+        "feat(firmware,pi): re-anchor (#311)\n\n* feat(firmware,pi): re-anchor V2 release\n\nDetails";
+    const bullets = _splitSquashBullets(msg);
+    assert.strictEqual(bullets.length, 1);
+    assert.ok(bullets[0].startsWith("feat(firmware,pi): re-anchor V2 release"));
+});
+
+if (process.exitCode) {
+    process.exit(process.exitCode);
+}


### PR DESCRIPTION
## Summary

PR #308 squash-merged with title scope `image`, which matched neither `firmware/.releaserc-full.cjs`'s `*firmware*` filter nor `pi/.releaserc.cjs`'s `*pi*`/`*digitsd*` filter. Both Firmware Release and Pi Release workflows logged "no release" despite #308 shipping firmware and pi changes. PR #311 unblocks #308 specifically; this PR prevents recurrence.

GitHub's squash format actually preserves every original commit (subject + body) as `* `-prefixed bullets in the merge commit body. The default conventional-commits parser only reads the first subject line and ignores all that.

This adds `tools/semantic-release-squash-expander.cjs`, a thin wrapper around `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` that:
1. Inspects each commit message for GitHub's squash bullet format
2. If the body has bullets where at least one looks like a conventional commit, expands the squash into one virtual commit per bullet
3. Delegates to the standard plugins with the expanded list
4. Leaves non-squash commits untouched

Effect: trigger decision and changelog generation both see the original per-commit messages. Squash-merging stays the merge style. PR titles can be loose.

All three releaserc files (firmware-full, firmware-tagonly, pi) wired through the expander. Existing scope filters, release rules, and writerOpts transforms preserved exactly.

## Test plan

- [x] `node tools/semantic-release-squash-expander.test.cjs`: 8 smoke tests covering passthrough, expansion, edge cases (no scope, breaking marker, multi-scope, etc.)
- [x] `node -c` syntax check passes on all three releaserc files
- [ ] After merge: a future cross-component PR squash-merged with a single-scope title triggers the matching component releases via expanded body bullets