### PR TITLE
fix(ci): squash expander resolves wrapped plugins from caller

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -8,12 +8,20 @@
 // squash body contained "fix(firmware): ..." bullets.
 const path = require('path');
 const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+// The expander lives outside any project's node_modules and would fail to
+// resolve these otherwise; load them here where they're installed and pass
+// them through plugin options.
+const wrapped = {
+  commitAnalyzer: require('@semantic-release/commit-analyzer'),
+  releaseNotesGenerator: require('@semantic-release/release-notes-generator'),
+};
 
 module.exports = {
   branches: ['main'],
   tagFormat: 'fw/v${version}',
   plugins: [
     [squashExpander, {
+      _wrapped: wrapped,
       // Wrapped commit-analyzer options.
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -6,12 +6,17 @@
 // matching. See ./.releaserc-full.cjs for the rationale.
 const path = require('path');
 const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+const wrapped = {
+  commitAnalyzer: require('@semantic-release/commit-analyzer'),
+  releaseNotesGenerator: require('@semantic-release/release-notes-generator'),
+};
 
 module.exports = {
   branches: ['main'],
   tagFormat: 'fw/v${version}',
   plugins: [
     [squashExpander, {
+      _wrapped: wrapped,
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -6,12 +6,17 @@
 // matching. See firmware/.releaserc-full.cjs for the rationale.
 const path = require('path');
 const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+const wrapped = {
+  commitAnalyzer: require('@semantic-release/commit-analyzer'),
+  releaseNotesGenerator: require('@semantic-release/release-notes-generator'),
+};
 
 module.exports = {
   branches: ['main'],
   tagFormat: 'pi/v${version}',
   plugins: [
     [squashExpander, {
+      _wrapped: wrapped,
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.

--- a/tools/semantic-release-squash-expander.cjs
+++ b/tools/semantic-release-squash-expander.cjs
@@ -65,18 +65,34 @@ function expandCommits(commits) {
     });
 }
 
-// The two real semantic-release plugins are required lazily so this file
-// can be unit-tested in environments where they are not installed.
+// The wrapped plugins are passed in via pluginConfig._wrapped because this
+// file lives outside any project's node_modules: a bare require() from
+// here walks up only as far as repo-root, which is empty (semantic-release
+// installs into firmware/node_modules or pi/node_modules depending on the
+// release being run). The .releaserc that loads us is in the right place
+// to do the resolution and forwards the loaded modules through.
+function unwrap(pluginConfig, key) {
+    if (!pluginConfig._wrapped || !pluginConfig._wrapped[key]) {
+        throw new Error(
+            `semantic-release-squash-expander: pluginConfig._wrapped.${key} is required. ` +
+                "Have the calling .releaserc.cjs require('@semantic-release/" +
+                (key === "commitAnalyzer" ? "commit-analyzer" : "release-notes-generator") +
+                "') and pass it through plugin options.",
+        );
+    }
+    return pluginConfig._wrapped[key];
+}
+
 module.exports = {
     async analyzeCommits(pluginConfig, context) {
-        const commitAnalyzer = require("@semantic-release/commit-analyzer");
+        const commitAnalyzer = unwrap(pluginConfig, "commitAnalyzer");
         return commitAnalyzer.analyzeCommits(pluginConfig, {
             ...context,
             commits: expandCommits(context.commits),
         });
     },
     async generateNotes(pluginConfig, context) {
-        const releaseNotesGenerator = require("@semantic-release/release-notes-generator");
+        const releaseNotesGenerator = unwrap(pluginConfig, "releaseNotesGenerator");
         return releaseNotesGenerator.generateNotes(pluginConfig, {
             ...context,
             commits: expandCommits(context.commits),

--- a/tools/semantic-release-squash-expander.test.cjs
+++ b/tools/semantic-release-squash-expander.test.cjs
@@ -100,6 +100,68 @@ test("split recognizes multi-scope", () => {
     assert.ok(bullets[0].startsWith("feat(firmware,pi): re-anchor V2 release"));
 });
 
+// Wiring tests: mock the wrapped plugins via pluginConfig._wrapped and
+// verify that analyzeCommits / generateNotes forward an expanded commit
+// list and pass through return values.
+const expander = require("./semantic-release-squash-expander.cjs");
+
+test("analyzeCommits forwards expanded commits to wrapped commit-analyzer", async () => {
+    let receivedCommits = null;
+    const mockAnalyzer = {
+        async analyzeCommits(cfg, ctx) {
+            receivedCommits = ctx.commits;
+            return "minor";
+        },
+    };
+    const ctx = {
+        commits: [
+            {
+                hash: "deadbeef",
+                message:
+                    "feat(image): squash subject (#1)\n\n* fix(firmware): real fix\n\nbody one\n\n* feat(pi): real feat\n\nbody two",
+            },
+        ],
+    };
+    const out = await expander.analyzeCommits({ _wrapped: { commitAnalyzer: mockAnalyzer } }, ctx);
+    assert.strictEqual(out, "minor");
+    assert.strictEqual(receivedCommits.length, 2);
+    assert.strictEqual(receivedCommits[0].subject, "fix(firmware): real fix");
+    assert.strictEqual(receivedCommits[1].subject, "feat(pi): real feat");
+});
+
+test("generateNotes forwards expanded commits to wrapped notes-generator", async () => {
+    let receivedCommits = null;
+    const mockNotes = {
+        async generateNotes(cfg, ctx) {
+            receivedCommits = ctx.commits;
+            return "## Release Notes\n";
+        },
+    };
+    const ctx = {
+        commits: [
+            {
+                hash: "abc",
+                message: "feat: subj\n\n* fix(server): nullguard\n\nguarded the foo",
+            },
+        ],
+    };
+    const out = await expander.generateNotes({ _wrapped: { releaseNotesGenerator: mockNotes } }, ctx);
+    assert.strictEqual(out, "## Release Notes\n");
+    assert.strictEqual(receivedCommits.length, 1);
+    assert.strictEqual(receivedCommits[0].subject, "fix(server): nullguard");
+});
+
+test("missing _wrapped throws a helpful error", async () => {
+    await assert.rejects(
+        () => expander.analyzeCommits({}, { commits: [] }),
+        /pluginConfig\._wrapped\.commitAnalyzer is required/,
+    );
+    await assert.rejects(
+        () => expander.generateNotes({}, { commits: [] }),
+        /pluginConfig\._wrapped\.releaseNotesGenerator is required/,
+    );
+});
+
 if (process.exitCode) {
     process.exit(process.exitCode);
 }


### PR DESCRIPTION
## Summary

PR #312 landed the squash-merge expander but Firmware Release on the post-merge push failed:

```
Cannot find module '@semantic-release/commit-analyzer'
Require stack: tools/semantic-release-squash-expander.cjs
```

Pi Release worked because pi-release runs from repo root and `node_modules` was resolvable via Node's upward walk. Firmware Release runs from `firmware/` where `node_modules` lives in `firmware/node_modules`, which Node does not walk into from `tools/`.

Fix: each `.releaserc.cjs` resolves `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` from its own directory (where they ARE installed) and passes the loaded modules to the expander via `pluginConfig._wrapped`. The expander reads them from there with a helpful error if missing. No path resolution from `tools/` needed.

All three releaserc files updated. Smoke tests grow three more cases (forwarding via mocked `_wrapped`, helpful error when missing) for 11 passing tests total.

## Test plan

- [x] `node tools/semantic-release-squash-expander.test.cjs`: 11 PASS, 0 FAIL
- [x] `node -c` syntax check passes on all three releaserc files
- [ ] After merge: Firmware Release on the post-merge push completes without MODULE_NOT_FOUND