### PR TITLE
fix(digitsd): per-codec default volume so V2 first boot is audible

### DIFF
--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -30,6 +30,7 @@ type codecConfig struct {
 	MixerName       string // Volume mixer control name (PCM vs Lineout)
 	ALSAMin         int    // Volume range minimum
 	ALSAMax         int    // Volume range maximum
+	DefaultLevel    int    // First-boot volume level (0-9) when no /data/digits/volume exists
 }
 
 var (
@@ -60,6 +61,15 @@ func detectCodec() *codecConfig {
 				MixerName:      "PCM",
 				ALSAMin:        40,
 				ALSAMax:        115,
+				// V2 codec is noticeably quieter than V1 at the same level
+				// step. The TLV320AIC3104 PCM mixer drives the headphone amp
+				// through several attenuated stages (HP DAC at -19 dB, HP at
+				// +5 dB) so PCM needs to sit near the top of its range to
+				// reach a comfortable handset earpiece level. Level 8 maps
+				// to roughly -8 dB at PCM, which puts the earpiece at a
+				// telephone-normal SPL on first boot. Users can drop it
+				// later via *#*N service codes.
+				DefaultLevel: 8,
 			}
 			return
 		}
@@ -74,6 +84,8 @@ func detectCodec() *codecConfig {
 			MixerName:      "Lineout",
 			ALSAMin:        20,
 			ALSAMax:        58,
+			// V1 default unchanged from the historical hardcoded value.
+			DefaultLevel: 5,
 		}
 	})
 	return detectedCodec
@@ -93,6 +105,12 @@ func CodecMixerName() string { return detectCodec().MixerName }
 
 // CodecALSARange returns the min/max ALSA values for volume mapping.
 func CodecALSARange() (int, int) { c := detectCodec(); return c.ALSAMin, c.ALSAMax }
+
+// CodecDefaultVolumeLevel returns the volume level (0-9) to apply on first
+// boot when no persisted level exists. Calibrated per codec because the same
+// step on the V2 PCM mixer produces a much quieter handset output than on
+// V1 Lineout.
+func CodecDefaultVolumeLevel() int { return detectCodec().DefaultLevel }
 
 // Config holds ALSA device parameters.
 type Config struct {

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -208,7 +208,6 @@ func (h *ServiceCodeHandler) check() bool {
 const (
 	volumeFile     = "/data/digits/volume"
 	mixerStateFile = "/data/digits_mixer.state"
-	defaultVolume  = 5
 )
 
 // volumeToALSA converts a 0-9 volume level to ALSA value for the detected codec.
@@ -248,9 +247,12 @@ func SetVolume(level int) error {
 }
 
 // RestoreVolume loads the persisted volume level and applies it.
-// If no persisted level exists, applies defaultVolume (5).
+// If no persisted level exists, applies the codec-specific default returned
+// by audio.CodecDefaultVolumeLevel(). The default is calibrated per codec
+// because the same level step on the V2 TLV320AIC3104's PCM mixer produces
+// a noticeably quieter handset output than on V1's DA7212 Lineout.
 func RestoreVolume() {
-	level := defaultVolume
+	level := audio.CodecDefaultVolumeLevel()
 	data, err := os.ReadFile(volumeFile)
 	if err == nil {
 		var v int


### PR DESCRIPTION
## Summary

A fresh V2 image booted with audible-but-very-faint pairing voice because `RestoreVolume()` applied `defaultVolume = 5` regardless of codec. Level 5 maps very differently per codec because of their different ALSA mixer ranges:

| Codec | Mixer | Range | Level 5 ALSA | Approx dB |
|---|---|---|---|---|
| V1 DA7212 | Lineout | 20-58 | 41 | mid-range, audible |
| V2 TLV320AIC3104 | PCM | 40-115 | 81 | -23 dB, very faint |

On V2, PCM at -23 dB stacks on HP DAC -19 dB plus +5 dB HP amp for -37 dB at the handset earpiece. Audible if you're listening for it, easy to think it's silent.

Move the default into `codecConfig` as `DefaultLevel` and expose it via `audio.CodecDefaultVolumeLevel()`. `RestoreVolume` reads the per-codec value instead of the hardcoded constant.

V1 keeps level 5 unchanged. V2 gets level 8 (~ALSA 107, ~-8 dB at PCM), comparable perceived loudness to V1 through the handset earpiece. User-set volumes via `*#*N` service codes still persist and override.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/audio/... ./internal/phone/...` clean
- [x] `golangci-lint run ./...` clean
- [x] Manually verified on bench V2 unit: with PCM at 115 the spoken pairing code is clearly audible in the handset earpiece (was previously inaudible at default 81)
- [ ] After merge: a fresh V2 image flash boots loud enough to hear pairing voice without manual `amixer` intervention