### PR TITLE
fix(pi): drop V2 hook_inverted default, reconcile firmware polarity on startup

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1485,9 +1485,16 @@ func main() {
 	slog.Info("firmware capability", "version", fwVersion, "flash_capable", hookFlash)
 	sp.SetFlashEnabled(hookFlash)
 
-	// Configure hook inversion for PCB carrier boards
-	if postOk && cfg.HookInverted {
-		const hookInvertCmd = "HOOK:INVERT:ON"
+	// Reconcile hook polarity with the firmware on every startup. The Pico
+	// retains whichever invert state was last set across a Pi reboot (only
+	// loses it on Pico power loss), so removing hook_inverted from config
+	// would otherwise leave a stale HOOK:INVERT:ON in effect. Send the
+	// matching command for either direction every time.
+	if postOk {
+		hookInvertCmd := "HOOK:INVERT:OFF"
+		if cfg.HookInverted {
+			hookInvertCmd = "HOOK:INVERT:ON"
+		}
 		var hookOk bool
 		for i := 1; i <= 3; i++ {
 			resp, err := sp.SendCommand(hookInvertCmd, 2*time.Second)
@@ -1500,7 +1507,7 @@ func main() {
 			time.Sleep(500 * time.Millisecond)
 		}
 		if !hookOk {
-			log.Fatal("hook invert: failed after 3 attempts — refusing to run with wrong hook polarity")
+			log.Fatalf("hook invert: failed after 3 attempts, refusing to run with possibly wrong hook polarity")
 		}
 	}
 

--- a/pi/image/init-data.sh
+++ b/pi/image/init-data.sh
@@ -88,20 +88,15 @@ install -d -m 755 -o root -g root "${MOUNT_POINT}/ssh"
 
 CONFIG_JSON="${MOUNT_POINT}/digits/config.json"
 if [[ ! -f "$CONFIG_JSON" ]]; then
+    # Both V1 and V2 use the firmware's non-inverted hook polarity. V2 used
+    # to ship hook_inverted=true here as a workaround for the GP10/GP20 pin
+    # mismatch (firmware was reading a floating GP10 pulled HIGH and the
+    # invert flipped that to look like the right state). The firmware fix
+    # in fc3f4b62 routes V2 to GP20 and SW1 closes to GND on cradle, so
+    # non-inverted is correct for both boards. Setting hook_inverted here
+    # would reverse it.
     info "Creating placeholder config.json..."
-    if [[ "$PCB_MODE" == true ]]; then
-        info "  PCB mode: setting hook_inverted=true"
-        cat > "$CONFIG_JSON" << 'EOF'
-{
-  "server_url": "wss://app.digits.family/ws",
-  "pairing_code": "",
-  "wifi_ssid": "",
-  "wifi_configured": false,
-  "hook_inverted": true
-}
-EOF
-    else
-        cat > "$CONFIG_JSON" << 'EOF'
+    cat > "$CONFIG_JSON" << 'EOF'
 {
   "server_url": "wss://app.digits.family/ws",
   "pairing_code": "",
@@ -109,7 +104,6 @@ EOF
   "wifi_configured": false
 }
 EOF
-    fi
     chmod 644 "$CONFIG_JSON"
 fi
 

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -145,8 +145,11 @@ warn() { echo "WARNING: $*" >&2; }
 
 # Dev mode: pass --dev to enable SSH + default user for debugging
 # PCB mode: pass --pcb to target the V2 carrier board. Enables the onboard
-# TLV320AIC3104 codec overlay and sets hook_inverted. Without --pcb, the image
-# is built for V1/prototype hardware (Codec Zero HAT, non-inverted hook).
+# TLV320AIC3104 codec overlay, the GPCLK0 MCLK service, and the V2 mixer
+# state. Without --pcb, the image is built for V1/prototype hardware
+# (Codec Zero HAT). Both V1 and V2 use the firmware's non-inverted hook
+# polarity; the previous --pcb flip of hook_inverted was a workaround for
+# a since-fixed firmware pin mismatch.
 DEV_MODE=false
 PCB_MODE=false
 while [[ "${1:-}" == --* ]]; do
@@ -157,7 +160,7 @@ while [[ "${1:-}" == --* ]]; do
             ;;
         --pcb)
             PCB_MODE=true
-            info "PCB MODE: hook_inverted will be set in config.json"
+            info "PCB MODE: V2 carrier board (codec overlay, GPCLK0, V2 mixer state)"
             ;;
         *)
             die "Unknown flag: $1"


### PR DESCRIPTION
## Summary

A fresh V2 SD-card flash booted with inverted hook polarity (dial tone playing when handset on cradle, silence off-cradle). Two combined bugs:

**1. Stale `hook_inverted: true` in `init-data.sh`'s `--pcb` branch.** That default was a workaround for the pre-fc3f4b62 firmware reading a floating GP10 (held HIGH by internal pullup, looked like permanent off-hook); the invert flipped it back. Once the firmware was routed to GP20 where SW1 actually closes to GND on cradle press, the non-inverted default became correct, but init-data.sh kept asserting the obsolete invert.

**2. digitsd only sent `HOOK:INVERT:ON`, never `HOOK:INVERT:OFF`.** The Pico retains its invert state across Pi reboots (loses it only on Pico power loss). Removing `hook_inverted` from config did not actually clear the invert in firmware until the chip power-cycled. digitsd now reconciles in both directions on every startup.

Both V1 and V2 hookswitch use the same firmware non-inverted default. The previous `--pcb` flip was a workaround that outlived its cause.

## Test plan

- [x] `go build`, `go vet`, `go test ./...`, `golangci-lint run ./...` all clean
- [x] Bench V2 unit: with `hook_inverted` removed and `HOOK:INVERT:OFF` sent, on-cradle reads `HOOK:ON` (silence) and off-cradle reads `HOOK:OFF` (dial tone), matching V2 SW1 schematic
- [ ] After merge: a fresh V2 image flash boots with correct hook polarity out of the box