### PR TITLE
fix(server): wait for ?saved=1 in DnD e2e helper to fix navigation race

### DIFF
--- a/server/e2e/tests/10-do-not-disturb.spec.ts
+++ b/server/e2e/tests/10-do-not-disturb.spec.ts
@@ -70,8 +70,11 @@ async function setDoNotDisturb(page: Page, target: 'on' | 'off'): Promise<void> 
   );
   await checkbox.setChecked(target === 'on', { force: true });
   await wait;
-  // The handler returns 303 to /settings?saved=1; wait for that landing page.
-  await page.waitForURL((u) => u.toString().includes('/settings'));
+  // The handler returns 303 to /settings?saved=1. The page started at
+  // /settings#do-not-disturb, so a plain "/settings" check resolves
+  // immediately against the current URL and lets the next goto race the
+  // in-flight redirect; require the ?saved=1 query the handler appends.
+  await page.waitForURL((u) => u.toString().includes('/settings?saved=1'));
 }
 
 const SURFACES = ['/', '/phones', '/links', '/settings'];


### PR DESCRIPTION
## Summary

The `setDoNotDisturb` helper in `server/e2e/tests/10-do-not-disturb.spec.ts` has a navigation race that produces:

```
page.goto: Navigation to "http://localhost:8080/" is interrupted by
another navigation to "http://localhost:8080/settings?saved=1"
```

### Root cause

The helper loads `/settings#do-not-disturb`, toggles the auto-submitting checkbox (`onchange="this.form.submit()"` at `server/internal/web/templates/settings.html:262`), then waits via:

1. `waitForResponse(POST /settings/do-not-disturb)`: waits for the 303 response.
2. `waitForURL((u) => u.toString().includes('/settings'))`: matches the *current* URL `/settings#do-not-disturb` immediately.

The browser's redirect-following (303 to `/settings?saved=1`) is still in flight when the helper returns, so the next `page.goto('/')` collides with it.

### Fix

Tighten the predicate to require `?saved=1` (only present on the post-redirect landing page). The handler at `server/internal/web/handler_settings.go:101,109` is the only path that appends this query.

### Impact

- 6 of the last 50 Server E2E runs failed; 100% of those failures are this exact test on this exact line.
- All four call sites of `setDoNotDisturb` (lines 91, 109, 116, 151 pre-fix) are at risk and benefit from a single fix in the helper.
- Cherry-picked from commit `89535b54` which existed on `holistic/2026-04-25-leftover-emdashes` but was dropped during the squash-merge of #309.

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] CI Server E2E green on this PR.
- [ ] Re-run a couple of times on this PR to confirm stability across timing variance.