### PR TITLE
refactor(server): make Household.Location nil-safe, drop wrapper helper

### DIFF
--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -180,8 +180,12 @@ func (s *Store) UpdateName(ctx context.Context, householdID, name string) error 
 }
 
 // Location returns the parsed *time.Location for this household's timezone.
-// Falls back to time.UTC if the timezone string is invalid.
+// Falls back to time.UTC if h is nil or the timezone string is invalid, so
+// callers without a household can still format timestamps without a guard.
 func (h *Household) Location() *time.Location {
+	if h == nil {
+		return time.UTC
+	}
 	loc, err := time.LoadLocation(h.Timezone)
 	if err != nil {
 		return time.UTC

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -250,6 +250,11 @@ func TestHouseholdLocation(t *testing.T) {
 	if loc3 != time.UTC {
 		t.Errorf("Location() for invalid timezone = %q, want UTC", loc3.String())
 	}
+
+	var nilHH *Household
+	if loc4 := nilHH.Location(); loc4 != time.UTC {
+		t.Errorf("Location() on nil receiver = %q, want UTC", loc4.String())
+	}
 }
 
 func TestUpdateName(t *testing.T) {

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -22,7 +22,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	loc := householdLocation(hh)
+	loc := hh.Location()
 
 	var entries []calls.HistoryEntry
 	if h.lineStore != nil {

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -54,7 +54,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(ctx)
 	hh := h.primaryHousehold(r)
 	ld := h.buildLinesData(r, hh, "")
-	loc := householdLocation(hh)
+	loc := hh.Location()
 	now := time.Now().In(loc)
 
 	callHistoryEnabled := hh != nil && hh.CallHistoryEnabled

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/auth"
@@ -263,15 +262,6 @@ func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 		return nil
 	}
 	return households[0]
-}
-
-// householdLocation returns the timezone location for a household, falling
-// back to UTC when hh is nil.
-func householdLocation(hh *household.Household) *time.Location {
-	if hh == nil {
-		return time.UTC
-	}
-	return hh.Location()
 }
 
 // chromeData holds the fields every protected page-data struct shares for

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -269,7 +269,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
 
-	loc := householdLocation(hh)
+	loc := hh.Location()
 
 	if lastSeenAt != nil {
 		t := lastSeenAt.In(loc)


### PR DESCRIPTION
## Summary
- The web layer had a `householdLocation(hh)` helper whose only job was to short-circuit to UTC when `hh` was nil before delegating to `Household.Location()`.
- Push the nil branch into the method itself so the fallback lives in one place and the three callers can write `hh.Location()` directly, matching the way nil households already flow through the chrome-data path.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (web suite + new nil-receiver assertion in `TestHouseholdLocation`; pre-existing root-only `TestLoadConfigOptionalTokenFileUnreadable` failure unrelated)