### PR TITLE
fix(ci): swap release-groom to claude-code-base-action

### DIFF
--- a/.github/workflows/release-groom.yml
+++ b/.github/workflows/release-groom.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Groom notes with Claude
         if: steps.body.outputs.already_groomed != 'true'
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action/base-action@v1
         continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

The `claude-code-action@v1` step in `release-groom.yml` started failing on every release since 2026-04-26 with `Action failed with error: Unsupported event type: push`. SDK bump 0.2.117 -> 0.2.120 introduced an event-type allowlist that rejects `push`. Because `release-groom.yml` is invoked via `workflow_call` from `pi-release.yml` / `fw-release.yml` (both triggered by `push` to main), the called workflow inherits `push` as the event and the action exits 1.

`continue-on-error: true` makes the job report success, but the next step (`Update release body`) is gated on `steps.claude.outcome == 'success'`, so the raw conventional-commits body stays in the release.

Five releases shipped ungroomed: `pi/v1.14.0`, `pi/v1.14.1`, `pi/v1.14.2`, `fw/v1.6.0`, `pi/v1.15.0`.

Switching to `anthropics/claude-code-action/base-action@v1`, the lower-level subfolder of the same repo. Inputs are identical (`prompt`, `claude_args`, `claude_code_oauth_token`); same `@v1` release stream; no event-type gate. Subscription billing is preserved because the base action wraps the same Claude Code CLI and the same OAuth token (`sk-ant-oat01-...`) routes to Pro/Max quota the same way.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, run `gh workflow run release-groom.yml -f tag=pi/v1.15.0 -f force=true` and confirm the release body's first line becomes `<!-- groomed:v1 -->`
- [ ] Backfill the four other ungroomed 04-26 releases the same way
- [ ] Next organic pi/fw release groom job (push-triggered) succeeds end-to-end