### PR TITLE
fix(ci): stop hard-wrapping groomed release notes

### DIFF
--- a/.github/release-voice.md
+++ b/.github/release-voice.md
@@ -20,6 +20,9 @@ boring about it on purpose.
 - No em-dashes. Regular hyphens or sentences only.
 - No per-item headings. Prose paragraphs, 1 to 4 total.
 - Cap at 120 words. Shorter is almost always better.
+- Do not hard-wrap paragraphs. Each paragraph is one continuous line in
+  the output, with a single blank line between paragraphs. Some renderers
+  treat soft newlines as visible line breaks.
 - Never include the sentinel line below in your output as prose; it is
   part of the output format, prepended exactly once at the start.
 
@@ -41,10 +44,7 @@ refactor(firmware): extract keypad ISR into separate file
 
 ## Output
 <!-- groomed:v1 -->
-A nerd in the nerd factory finally tracked down why the 4-key sometimes
-registered twice on fast taps. Knocked it out of the park. Also: the
-side tone, that thing where you heard yourself breathe into the
-receiver, is noticeably quieter. You're welcome.
+A nerd in the nerd factory finally tracked down why the 4-key sometimes registered twice on fast taps. Knocked it out of the park. Also: the side tone, that thing where you heard yourself breathe into the receiver, is noticeably quieter. You're welcome.
 
 ## Input commits
 feat(firmware): silent mode
@@ -53,10 +53,7 @@ chore(firmware): bump SDK version
 
 ## Output
 <!-- groomed:v1 -->
-Silent mode landed. Flip it on from the line settings and the ringer
-stays shut regardless of who's calling. While we were in there we
-fixed a slow-creep timing drift in the ringer pattern, so the bells
-now clang in the exact rhythm you remember.
+Silent mode landed. Flip it on from the line settings and the ringer stays shut regardless of who's calling. While we were in there we fixed a slow-creep timing drift in the ringer pattern, so the bells now clang in the exact rhythm you remember.
 
 ## Input commits
 chore(pi): bump kernel pinning
@@ -64,5 +61,4 @@ chore(pi): update base image
 
 ## Output
 <!-- groomed:v1 -->
-Under-the-hood tune-ups you will not notice. Everything still works. If
-anything, it works more.
+Under-the-hood tune-ups you will not notice. Everything still works. If anything, it works more.


### PR DESCRIPTION
## Summary

Mobile webapp view of release notes was rendering each paragraph as a staircase of forced line breaks (see PR #323's screenshot). Two compounding causes:

1. **Voice file examples were hard-wrapped at ~70 cols.** Claude faithfully imitated the format and produced bodies with soft newlines every ~70 chars.
2. **`server/internal/web/render.go:61` enables goldmark's `WithHardWraps`**, so every soft newline becomes a visible `<br>`. GitHub's CommonMark renderer collapses them to spaces, which is why this only showed up in the digits webapp.

Fixing the prompt is the right scope: hard-wrapping markdown source is presentational, fragile, and renderer-specific. Once the source is one paragraph per line, every consumer (GitHub, the digits webapp, copy-paste into Slack) renders the same.

## Changes

- Unwrap the three example outputs in `.github/release-voice.md`
- Add an explicit "do not hard-wrap paragraphs" rule under Hard rules with a one-line note about why

## Test plan

- [ ] CI green
- [ ] After merge, re-groom the five 04-26 releases (`pi/v1.14.0`, `pi/v1.14.1`, `pi/v1.14.2`, `fw/v1.6.0`, `pi/v1.15.0`) with `force=true`
- [ ] Confirm the rendered notes in the digits webapp flow as continuous paragraphs