### PR TITLE
fix(digitsd): re-query firmware version after auto-update flash

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1415,10 +1415,22 @@ func main() {
 	// isn't quite awake yet at the instant the chip finishes booting). The
 	// goroutine sends the result on fwVersionCh so the main loop can update
 	// fwVersion/fwCommit without any shared-state synchronization.
+	//
+	// requeryInFlight dedupes overlapping calls. After an auto-update flash
+	// both afterFirmwareUpdated and the Pico's STATUS:READY message want to
+	// trigger a requery within the same second; the second call becomes a
+	// no-op and avoids a "channel full, dropping" warning. The flag clears
+	// when the goroutine returns, so a later genuine reboot starts fresh.
 	type fwVersionResult struct{ version, commit string }
 	fwVersionCh := make(chan fwVersionResult, 1)
+	var requeryInFlight atomic.Bool
 	requeryFirmware := func() {
+		if !requeryInFlight.CompareAndSwap(false, true) {
+			slog.Debug("pico: requery already in flight, skipping duplicate trigger")
+			return
+		}
 		go func() {
+			defer requeryInFlight.Store(false)
 			const attempts = 5
 			for attempt := 1; attempt <= attempts; attempt++ {
 				v, c, err := sp.QueryVersion()

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1171,7 +1171,7 @@ func triggerFactoryReset() {
 var updateInProgress atomic.Bool
 
 
-func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc) {
+func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc, afterFirmwareUpdated func()) {
 	if !updateInProgress.CompareAndSwap(false, true) {
 		slog.Info("updater: skipping -- another update is already in progress")
 		return
@@ -1238,6 +1238,9 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 				slog.Error("updater: firmware apply failed", "error", err)
 				reportStatus("failed", fmt.Sprintf("Firmware flash failed: %v", err))
 				return
+			}
+			if afterFirmwareUpdated != nil {
+				afterFirmwareUpdated()
 			}
 		}
 	}
@@ -1405,6 +1408,36 @@ func main() {
 		log.Fatalf("serial: %v", err)
 	}
 	defer func() { _ = sp.Close() }()
+
+	// Post-reboot firmware version results. STATUS:READY (external SWD flash
+	// or power cycle) and our own auto-update flow both invoke
+	// requeryFirmware to retry QueryVersion (the Pico's UART command loop
+	// isn't quite awake yet at the instant the chip finishes booting). The
+	// goroutine sends the result on fwVersionCh so the main loop can update
+	// fwVersion/fwCommit without any shared-state synchronization.
+	type fwVersionResult struct{ version, commit string }
+	fwVersionCh := make(chan fwVersionResult, 1)
+	requeryFirmware := func() {
+		go func() {
+			const attempts = 5
+			for attempt := 1; attempt <= attempts; attempt++ {
+				v, c, err := sp.QueryVersion()
+				if err == nil {
+					select {
+					case fwVersionCh <- fwVersionResult{version: v, commit: c}:
+					default:
+						slog.Warn("pico: version result channel full, dropping")
+					}
+					return
+				}
+				slog.Warn("pico: version query attempt failed", "attempt", attempt, "error", err)
+				if attempt < attempts {
+					time.Sleep(500 * time.Millisecond)
+				}
+			}
+			slog.Warn("pico: version query after reboot gave up")
+		}()
+	}
 
 	// POST: verify Pico is alive
 	postRetries := 3
@@ -1764,7 +1797,7 @@ func main() {
 
 	svcCodes.SetUpdateCallback(func() {
 		slog.Info("service code: *#UPDATE# (*#873283#) -- checking for updates")
-		go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion, "", "", flashCapable.Load(), nil)
+		go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion, "", "", flashCapable.Load(), nil, requeryFirmware)
 	})
 
 	svcCodes.SetFactoryResetCallback(func() {
@@ -1901,14 +1934,6 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
-	// Post-reboot firmware version results. STATUS:READY spawns a goroutine
-	// that retries QueryVersion (the Pico's UART command loop isn't quite
-	// awake yet at the instant it emits STATUS:READY). The goroutine sends
-	// the result here so the main loop can update fwVersion/fwCommit without
-	// any shared-state synchronization.
-	type fwVersionResult struct{ version, commit string }
-	fwVersionCh := make(chan fwVersionResult, 1)
-
 	// Main select loop
 	for {
 		select {
@@ -1997,25 +2022,7 @@ func main() {
 			// HOOK/KEY events would queue up or be dropped.
 			if event == "STATUS:READY" {
 				slog.Info("pico: detected reboot, re-querying firmware version")
-				go func() {
-					const attempts = 5
-					for attempt := 1; attempt <= attempts; attempt++ {
-						v, c, err := sp.QueryVersion()
-						if err == nil {
-							select {
-							case fwVersionCh <- fwVersionResult{version: v, commit: c}:
-							default:
-								slog.Warn("pico: version result channel full, dropping")
-							}
-							return
-						}
-						slog.Warn("pico: version query attempt failed", "attempt", attempt, "error", err)
-						if attempt < attempts {
-							time.Sleep(500 * time.Millisecond)
-						}
-					}
-					slog.Warn("pico: version query after reboot gave up")
-				}()
+				requeryFirmware()
 				continue
 			}
 
@@ -2237,7 +2244,7 @@ func main() {
 					})
 				}
 				go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion,
-					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable.Load(), statusReporter)
+					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable.Load(), statusReporter, requeryFirmware)
 
 			case sigclient.TypeFactoryReset:
 				slog.Info("factory reset: triggered by server")


### PR DESCRIPTION
## Summary
- After `ApplyFirmwareUpdate` succeeds in the auto-update flow, digitsd kept its stale cached `fwVersion`/`fwCommit` until manually restarted, so the webapp showed no version (or the previous version) until the next restart.
- Adds an `afterFirmwareUpdated` callback to `runTargetedUpdate`. Both call sites (signal-driven update from server, `*#UPDATE#` service code) pass a closure that spawns a retry-`QueryVersion` goroutine.
- Result lands on the existing `fwVersionCh`. Main loop picks it up, logs version change, updates flash-capability gate, re-sends `device_info` with the fresh version.
- Factored the goroutine body into `requeryFirmware` so the `STATUS:READY` handler shares the same code path.

## Background
PR #314 surfaced this: bench V2 unit (Digits 1) auto-updated to fw/v1.7.0 + pi/v1.15.0 cleanly, but webapp showed empty version until I manually `systemctl restart digitsd` on the device. Root cause was the post-flash refresh gap.

## Test plan
- [ ] `make pi-build` succeeds (verified locally)
- [ ] `make pi-test` passes (verified locally)
- [ ] `golangci-lint run ./...` clean (verified locally)
- [ ] Bench: trigger firmware update via webapp on Digits 1; observe `firmware version` log line update and webapp version refresh without restarting digitsd