### PR TITLE
fix(digitsd): keep dial tone responsive after volume / audio-test codes

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2010,17 +2010,11 @@ func main() {
 				if !easterEggs.AddKey(key) {
 					switch svcCodes.AddKey(key) {
 					case phone.ServiceCodeTerminal:
-						// Daemon is going down (shutdown, reboot, etc.); FSM
-						// state no longer matters. Reset to IDLE.
 						ctrl.Reset()
 						continue // skip forwarding to controller
 					case phone.ServiceCodeNonTerminal:
-						// User is still off-hook (volume, audio test) and the
-						// callback has restarted the dial-tone loop. Put the
-						// FSM back in DIALTONE so the next key press stops the
-						// resumed tone and starts dialing.
 						ctrl.ResetToDialtone()
-						continue // skip forwarding to controller
+						continue
 					}
 				}
 			}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2008,8 +2008,18 @@ func main() {
 				}
 				// Check easter eggs, then service codes
 				if !easterEggs.AddKey(key) {
-					if svcCodes.AddKey(key) {
+					switch svcCodes.AddKey(key) {
+					case phone.ServiceCodeTerminal:
+						// Daemon is going down (shutdown, reboot, etc.); FSM
+						// state no longer matters. Reset to IDLE.
 						ctrl.Reset()
+						continue // skip forwarding to controller
+					case phone.ServiceCodeNonTerminal:
+						// User is still off-hook (volume, audio test) and the
+						// callback has restarted the dial-tone loop. Put the
+						// FSM back in DIALTONE so the next key press stops the
+						// resumed tone and starts dialing.
+						ctrl.ResetToDialtone()
 						continue // skip forwarding to controller
 					}
 				}

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -171,11 +171,25 @@ func (c *Controller) IsCallActive() bool {
 }
 
 // Reset forces the controller back to IDLE with no pending digits.
-// Used after service codes to return the phone to a clean state.
+// Used after terminal service codes (shutdown, reboot, etc.) where the
+// daemon is going down and the FSM state no longer matters.
 func (c *Controller) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.state = StateIDLE
+	c.digits = ""
+}
+
+// ResetToDialtone forces the controller back to DIALTONE with no pending
+// digits. Used after non-terminal service codes (volume, audio test) where
+// the user is still off-hook and the callback has restarted the dial-tone
+// loop. The caller owns the tone; this method only updates FSM state, so
+// the next key press will correctly transition DIALTONE -> DIALING and
+// stop the tone.
+func (c *Controller) ResetToDialtone() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.state = StateDIALTONE
 	c.digits = ""
 }
 

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -181,11 +181,7 @@ func (c *Controller) Reset() {
 }
 
 // ResetToDialtone forces the controller back to DIALTONE with no pending
-// digits. Used after non-terminal service codes (volume, audio test) where
-// the user is still off-hook and the callback has restarted the dial-tone
-// loop. The caller owns the tone; this method only updates FSM state, so
-// the next key press will correctly transition DIALTONE -> DIALING and
-// stop the tone.
+// digits. Only updates FSM state; the caller owns the tone.
 func (c *Controller) ResetToDialtone() {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -1661,3 +1661,75 @@ func TestController_SetSilentModeIdleIsSideEffectFree(t *testing.T) {
 		t.Errorf("expected no callbacks while idle, got rings=%v leds=%v", cb.Rings(), cb.LEDs())
 	}
 }
+
+// TestController_Reset verifies Reset() drops back to IDLE with no digits.
+func TestController_Reset(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:5")
+	if c.State() != StateDIALING {
+		t.Fatalf("setup: expected DIALING, got %s", c.State())
+	}
+
+	c.Reset()
+	if c.State() != StateIDLE {
+		t.Errorf("expected IDLE after Reset, got %s", c.State())
+	}
+	if c.digits != "" {
+		t.Errorf("expected empty digits after Reset, got %q", c.digits)
+	}
+}
+
+// TestController_ResetToDialtone_NextKeyStopsTone is the regression test for
+// the volume-code dialtone bug: after entering *#*N, the daemon callback
+// restarts the dial-tone loop, and the FSM was being forced to IDLE which
+// silently ignored every subsequent key press, leaving the resumed dial tone
+// playing forever.
+//
+// Now ResetToDialtone() puts the FSM back in DIALTONE so the next key press
+// transitions to DIALING and emits SendTone(STOP) just like the initial
+// off-hook sequence.
+func TestController_ResetToDialtone_NextKeyStopsTone(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := NewController(cb, "")
+
+	// Simulate user picking up and typing partial code; controller is now in
+	// DIALING with some buffered digits.
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:*")
+	c.HandleEvent("KEY:#")
+	c.HandleEvent("KEY:*")
+	if c.State() != StateDIALING {
+		t.Fatalf("setup: expected DIALING, got %s", c.State())
+	}
+
+	// Volume code matched in main.go: callback restarted dial tone loop, and
+	// the event loop calls ResetToDialtone() instead of Reset().
+	c.ResetToDialtone()
+	if c.State() != StateDIALTONE {
+		t.Fatalf("expected DIALTONE after ResetToDialtone, got %s", c.State())
+	}
+	if c.digits != "" {
+		t.Errorf("expected empty digits after ResetToDialtone, got %q", c.digits)
+	}
+
+	// Snapshot tone count, then press a key. The FSM must transition back to
+	// DIALING and emit STOP so the resumed dial-tone loop is silenced.
+	tonesBefore := len(cb.Tones())
+	c.HandleEvent("KEY:7")
+	if c.State() != StateDIALING {
+		t.Fatalf("expected DIALING after key press in DIALTONE, got %s", c.State())
+	}
+	tones := cb.Tones()
+	if len(tones) <= tonesBefore {
+		t.Fatal("expected SendTone(STOP) on first key after ResetToDialtone")
+	}
+	if last := tones[len(tones)-1]; last != ToneStop {
+		t.Errorf("expected last tone to be STOP, got %q", last)
+	}
+	if c.digits != "7" {
+		t.Errorf("expected digits=%q after key, got %q", "7", c.digits)
+	}
+}

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -11,25 +11,15 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 )
 
-// ServiceCodeResult is the outcome of feeding a key into ServiceCodeHandler.AddKey.
-// It tells the caller whether a code matched and, if so, whether the user is
-// still expected to be off-hook and using the phone afterwards (non-terminal
-// codes like volume) or whether the daemon is shutting down / rebooting
-// (terminal codes).
+// ServiceCodeResult tells the caller whether a service code matched and
+// whether the daemon is shutting down afterwards (terminal) or the user
+// remains off-hook (non-terminal).
 type ServiceCodeResult int
 
 const (
-	// ServiceCodeNone means no code matched on this key.
-	ServiceCodeNone ServiceCodeResult = iota
-	// ServiceCodeTerminal means a code matched and the daemon is going down
-	// (shutdown, reboot, setup, repair, factory reset, update). The caller
-	// should put the FSM in IDLE since state no longer matters.
-	ServiceCodeTerminal
-	// ServiceCodeNonTerminal means a code matched but the user is still
-	// off-hook and expected to keep using the phone (volume, audio test).
-	// The caller should put the FSM back in DIALTONE so the next key press
-	// stops the resumed dial tone and starts dialing.
-	ServiceCodeNonTerminal
+	ServiceCodeNone        ServiceCodeResult = iota
+	ServiceCodeTerminal                      // daemon going down
+	ServiceCodeNonTerminal                   // user still off-hook
 )
 
 // ServiceCodeHandler processes hidden service codes entered via the keypad.

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -11,6 +11,27 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 )
 
+// ServiceCodeResult is the outcome of feeding a key into ServiceCodeHandler.AddKey.
+// It tells the caller whether a code matched and, if so, whether the user is
+// still expected to be off-hook and using the phone afterwards (non-terminal
+// codes like volume) or whether the daemon is shutting down / rebooting
+// (terminal codes).
+type ServiceCodeResult int
+
+const (
+	// ServiceCodeNone means no code matched on this key.
+	ServiceCodeNone ServiceCodeResult = iota
+	// ServiceCodeTerminal means a code matched and the daemon is going down
+	// (shutdown, reboot, setup, repair, factory reset, update). The caller
+	// should put the FSM in IDLE since state no longer matters.
+	ServiceCodeTerminal
+	// ServiceCodeNonTerminal means a code matched but the user is still
+	// off-hook and expected to keep using the phone (volume, audio test).
+	// The caller should put the FSM back in DIALTONE so the next key press
+	// stops the resumed dial tone and starts dialing.
+	ServiceCodeNonTerminal
+)
+
 // ServiceCodeHandler processes hidden service codes entered via the keypad.
 // Codes are detected from a rolling key buffer.
 //
@@ -87,8 +108,9 @@ func (h *ServiceCodeHandler) SetUpdateCallback(fn func()) {
 	h.onUpdate = fn
 }
 
-// AddKey processes a keypress. Returns true if a service code was triggered.
-func (h *ServiceCodeHandler) AddKey(key string) bool {
+// AddKey processes a keypress. Returns the kind of code that was triggered
+// (or ServiceCodeNone if the key extended the buffer without matching anything).
+func (h *ServiceCodeHandler) AddKey(key string) ServiceCodeResult {
 	h.buffer += key
 	if len(h.buffer) > bufferMaxLen {
 		h.buffer = h.buffer[len(h.buffer)-bufferMaxLen:]
@@ -101,7 +123,7 @@ func (h *ServiceCodeHandler) Reset() {
 	h.buffer = ""
 }
 
-func (h *ServiceCodeHandler) check() bool {
+func (h *ServiceCodeHandler) check() ServiceCodeResult {
 	// --- 9-character codes ---
 	if len(h.buffer) >= 9 {
 		last9 := h.buffer[len(h.buffer)-9:]
@@ -111,7 +133,7 @@ func (h *ServiceCodeHandler) check() bool {
 				go h.onUpdate()
 			}
 			h.buffer = ""
-			return true
+			return ServiceCodeTerminal
 		}
 	}
 
@@ -126,7 +148,7 @@ func (h *ServiceCodeHandler) check() bool {
 				go h.onFactoryReset()
 			}
 			h.buffer = ""
-			return true
+			return ServiceCodeTerminal
 		}
 		if last8 == "*#73887#" {
 			slog.Info("service code: *#73887# (*#SETUP#) -> Wi-Fi re-provisioning")
@@ -136,7 +158,7 @@ func (h *ServiceCodeHandler) check() bool {
 				slog.Info("service code: *#73887# triggered but no setup callback registered -- ignoring")
 			}
 			h.buffer = ""
-			return true
+			return ServiceCodeTerminal
 		}
 	}
 
@@ -151,14 +173,14 @@ func (h *ServiceCodeHandler) check() bool {
 				go h.onAudioTest()
 			}
 			h.buffer = ""
-			return true
+			return ServiceCodeNonTerminal
 		}
 	}
 
 	// --- 4-character codes ---
 
 	if len(h.buffer) < 4 {
-		return false
+		return ServiceCodeNone
 	}
 	last4 := h.buffer[len(h.buffer)-4:]
 
@@ -169,21 +191,21 @@ func (h *ServiceCodeHandler) check() bool {
 			go h.onRepair()
 		}
 		h.buffer = ""
-		return true
+		return ServiceCodeTerminal
 	case "*#*#":
 		slog.Info("service code: *#*# -> shutdown")
 		if h.onShutdown != nil {
 			go h.onShutdown()
 		}
 		h.buffer = ""
-		return true
+		return ServiceCodeTerminal
 	case "*##*":
 		slog.Info("service code: *##* -> reboot")
 		if h.onReboot != nil {
 			go h.onReboot()
 		}
 		h.buffer = ""
-		return true
+		return ServiceCodeTerminal
 	}
 
 	// Volume codes: *#*N where N is 0-9
@@ -196,11 +218,11 @@ func (h *ServiceCodeHandler) check() bool {
 				h.onVolume(level)
 			}
 			h.buffer = ""
-			return true
+			return ServiceCodeNonTerminal
 		}
 	}
 
-	return false
+	return ServiceCodeNone
 }
 
 

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -9,12 +9,12 @@ func TestServiceCodeShutdown(t *testing.T) {
 	// Don't set callbacks — we're just testing detection, not actual shutdown
 	h := NewServiceCodeHandler()
 	for _, k := range "*#*" {
-		if h.AddKey(string(k)) {
+		if h.AddKey(string(k)) != ServiceCodeNone {
 			t.Fatal("triggered too early")
 		}
 	}
-	if !h.AddKey("#") {
-		t.Error("*#*# should trigger")
+	if got := h.AddKey("#"); got != ServiceCodeTerminal {
+		t.Errorf("*#*# should trigger as terminal, got %v", got)
 	}
 }
 
@@ -23,8 +23,8 @@ func TestServiceCodeReboot(t *testing.T) {
 	for _, k := range "*##" {
 		h.AddKey(string(k))
 	}
-	if !h.AddKey("*") {
-		t.Error("*##* should trigger")
+	if got := h.AddKey("*"); got != ServiceCodeTerminal {
+		t.Errorf("*##* should trigger as terminal, got %v", got)
 	}
 }
 
@@ -36,8 +36,8 @@ func TestServiceCodeVolume(t *testing.T) {
 	for _, k := range "*#*" {
 		h.AddKey(string(k))
 	}
-	if !h.AddKey("5") {
-		t.Error("*#*5 should trigger")
+	if got := h.AddKey("5"); got != ServiceCodeNonTerminal {
+		t.Errorf("*#*5 should trigger as non-terminal, got %v", got)
 	}
 	if gotLevel != 5 {
 		t.Errorf("expected level 5, got %d", gotLevel)
@@ -52,10 +52,13 @@ func TestServiceCodeAudioTest(t *testing.T) {
 	var triggered bool
 	for i, k := range code {
 		result := h.AddKey(string(k))
-		if result && i < len(code)-1 {
+		if result != ServiceCodeNone && i < len(code)-1 {
 			t.Fatalf("triggered too early at index %d", i)
 		}
-		if result {
+		if result != ServiceCodeNone {
+			if result != ServiceCodeNonTerminal {
+				t.Errorf("audio test should be non-terminal, got %v", result)
+			}
 			triggered = true
 		}
 	}
@@ -72,8 +75,8 @@ func TestServiceCodeVolume8Works(t *testing.T) {
 	for _, k := range "*#*" {
 		h.AddKey(string(k))
 	}
-	if !h.AddKey("8") {
-		t.Error("*#*8 should trigger volume")
+	if got := h.AddKey("8"); got != ServiceCodeNonTerminal {
+		t.Errorf("*#*8 should trigger volume as non-terminal, got %v", got)
 	}
 	if gotLevel != 8 {
 		t.Errorf("expected level 8, got %d", gotLevel)
@@ -83,7 +86,7 @@ func TestServiceCodeVolume8Works(t *testing.T) {
 func TestServiceCodeNoMatch(t *testing.T) {
 	h := NewServiceCodeHandler()
 	for _, k := range "1234" {
-		if h.AddKey(string(k)) {
+		if h.AddKey(string(k)) != ServiceCodeNone {
 			t.Error("1234 should not trigger")
 		}
 	}
@@ -92,7 +95,7 @@ func TestServiceCodeNoMatch(t *testing.T) {
 func TestServiceCodeIncomplete(t *testing.T) {
 	h := NewServiceCodeHandler()
 	for _, k := range "*#*" {
-		if h.AddKey(string(k)) {
+		if h.AddKey(string(k)) != ServiceCodeNone {
 			t.Error("incomplete code should not trigger")
 		}
 	}
@@ -107,8 +110,8 @@ func TestServiceCodeAtEnd(t *testing.T) {
 	for _, k := range "*#*" {
 		h.AddKey(string(k))
 	}
-	if !h.AddKey("#") {
-		t.Error("*#*# at end of buffer should trigger")
+	if got := h.AddKey("#"); got != ServiceCodeTerminal {
+		t.Errorf("*#*# at end of buffer should trigger as terminal, got %v", got)
 	}
 }
 
@@ -119,7 +122,7 @@ func TestServiceCodeReset(t *testing.T) {
 	h.AddKey("*")
 	h.Reset()
 	// After reset, adding "#" should NOT complete *#*#
-	if h.AddKey("#") {
+	if h.AddKey("#") != ServiceCodeNone {
 		t.Error("should not trigger after reset")
 	}
 }
@@ -134,10 +137,13 @@ func TestServiceCodeSetup(t *testing.T) {
 	var triggered bool
 	for i, k := range code {
 		result := h.AddKey(string(k))
-		if result && i < len(code)-1 {
+		if result != ServiceCodeNone && i < len(code)-1 {
 			t.Fatalf("triggered too early at index %d", i)
 		}
-		if result {
+		if result != ServiceCodeNone {
+			if result != ServiceCodeTerminal {
+				t.Errorf("setup should be terminal, got %v", result)
+			}
 			triggered = true
 		}
 	}
@@ -159,7 +165,7 @@ func TestServiceCodeSetupNotTriggeredByPrefix(t *testing.T) {
 
 	// Type all but the last character
 	for _, k := range "*#73887" {
-		if h.AddKey(string(k)) {
+		if h.AddKey(string(k)) != ServiceCodeNone {
 			t.Error("should not trigger before final #")
 		}
 	}
@@ -180,7 +186,7 @@ func TestServiceCodeSetupAfterOtherKeys(t *testing.T) {
 	code := "*#73887#"
 	for i, k := range code {
 		result := h.AddKey(string(k))
-		if result && i == len(code)-1 {
+		if result != ServiceCodeNone && i == len(code)-1 {
 			triggered = true
 		}
 	}
@@ -211,7 +217,10 @@ func TestServiceCodeRepair(t *testing.T) {
 	var triggered bool
 	for i, k := range code {
 		result := h.AddKey(string(k))
-		if result && i == len(code)-1 {
+		if result != ServiceCodeNone && i == len(code)-1 {
+			if result != ServiceCodeTerminal {
+				t.Errorf("repair should be terminal, got %v", result)
+			}
 			triggered = true
 		}
 	}
@@ -234,7 +243,10 @@ func TestServiceCodeFactoryReset(t *testing.T) {
 	var triggered bool
 	for i, k := range code {
 		result := h.AddKey(string(k))
-		if result && i == len(code)-1 {
+		if result != ServiceCodeNone && i == len(code)-1 {
+			if result != ServiceCodeTerminal {
+				t.Errorf("factory reset should be terminal, got %v", result)
+			}
 			triggered = true
 		}
 	}


### PR DESCRIPTION
## Summary
- Volume codes (\`*#*N\`) and the audio-test code (\`*#8378#\`) left the FSM in \`StateIDLE\` while the daemon's callback restarted the dial-tone loop. Subsequent key presses were ignored by \`onKey\`'s IDLE branch, so the resumed dial tone played until the user hung up. Reported symptom: "I enter the key codes to change the volume but then it doesn't silence the dialtone after I keep pressing buttons."
- Distinguishes terminal codes (shutdown, reboot, setup, repair, factory reset, update) from non-terminal ones (volume, audio test). \`ServiceCodeHandler.AddKey\` now returns a \`ServiceCodeResult\` enum and the event loop dispatches to a new \`Controller.ResetToDialtone()\` (DIALTONE) for non-terminal, \`Reset()\` (IDLE) for terminal.

## Test plan
- [x] \`go test ./...\` passes in \`pi/digitsd\`
- [x] \`golangci-lint run ./...\` clean
- [x] \`go vet ./...\` clean
- [x] New \`TestController_ResetToDialtone_NextKeyStopsTone\` covers the exact bug: after \`ResetToDialtone()\`, the next \`KEY:\` event must transition DIALTONE -> DIALING and emit \`SendTone(STOP)\`
- [ ] Bench: pick up handset, dial \`*#*5\`, double-beep plays, dial tone resumes, press any digit -> tone stops and call attempt begins