### PR TITLE
feat(server): live-update AM dashboard counters and clock via SSE

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/config"
+	"github.com/justinlindh/digits/server/internal/dashboard/events"
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/email"
@@ -62,6 +63,13 @@ func run(ctx context.Context) error {
 	householdStore := household.NewStore(database.DB)
 	pairingStore := pairing.NewStore(database.DB)
 	linkStore := household.NewLinkStore(database.DB)
+
+	// Dashboard pub/sub: hub.Register/Unregister and tracker.OnCall* notify
+	// this broadcaster so the /api/dashboard/stream SSE handler can re-render
+	// counters without polling.
+	dashEvents := events.New()
+	hub.SetDashboardEvents(dashEvents)
+	tracker.SetDashboardEvents(dashEvents)
 
 	// Link-health store with its own lifecycle; flusher runs until ctx is cancelled.
 	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled(cfg.LinkHealthFlushDisabled))
@@ -129,6 +137,7 @@ func run(ctx context.Context) error {
 		Tracker:        tracker,
 		Relay:          relay,
 		HealthStore:    healthStore,
+		DashEvents:     dashEvents,
 		AuthStore:      authStore,
 		AuthHandlers:   authHandlers,
 		GoogleAuth:     googleAuth,

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -78,12 +78,20 @@ type healthLifecycle interface {
 	EvictConference(confID uuid.UUID)
 }
 
+// dashNotifier is the subset of *dashboard/events.Broadcaster the Tracker
+// uses to wake dashboard SSE subscribers when active-call count changes.
+// Optional; nil disables notifications.
+type dashNotifier interface {
+	Notify()
+}
+
 type Tracker struct {
 	db          *db.Database
 	mu          sync.Mutex
 	active      map[string]*activeCall // "caller→callee" → call
 	conferences *ConferenceTracker
 	health      healthLifecycle
+	dashEvents  dashNotifier
 }
 
 func New(d *db.Database) *Tracker {
@@ -104,6 +112,15 @@ func (t *Tracker) Conferences() *ConferenceTracker {
 func (t *Tracker) SetHealthStore(h healthLifecycle) {
 	t.mu.Lock()
 	t.health = h
+	t.mu.Unlock()
+}
+
+// SetDashboardEvents registers an optional broadcaster that is signalled
+// whenever the active-call count changes. Wakes dashboard SSE subscribers.
+// Safe to call once at startup; subsequent calls overwrite.
+func (t *Tracker) SetDashboardEvents(b dashNotifier) {
+	t.mu.Lock()
+	t.dashEvents = b
 	t.mu.Unlock()
 }
 
@@ -128,10 +145,14 @@ func (t *Tracker) OnCallInitiated(ctx context.Context, from, to string) (int64, 
 		StartedAt: time.Now(),
 	}
 	h := t.health
+	d := t.dashEvents
 	t.mu.Unlock()
 
 	if h != nil {
 		h.Init(id)
+	}
+	if d != nil {
+		d.Notify()
 	}
 	return id, nil
 }
@@ -161,13 +182,18 @@ func (t *Tracker) OnCallEnded(ctx context.Context, caller, callee string) error 
 	} else if c, ok := t.active[key2]; ok {
 		id = c.ID
 	}
+	removed := id != 0
 	delete(t.active, key1)
 	delete(t.active, key2)
 	h := t.health
+	d := t.dashEvents
 	t.mu.Unlock()
 
 	if h != nil && id != 0 {
 		h.Evict(id)
+	}
+	if d != nil && removed {
+		d.Notify()
 	}
 
 	_, err := t.db.DB.ExecContext(ctx,
@@ -200,6 +226,8 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 		delete(t.active, key)
 	}
 	h := t.health
+	d := t.dashEvents
+	removedAny := len(toDelete) > 0
 	t.mu.Unlock()
 
 	if h != nil {
@@ -208,6 +236,9 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 				h.Evict(id)
 			}
 		}
+	}
+	if d != nil && removedAny {
+		d.Notify()
 	}
 
 	// End any open calls in the database

--- a/server/internal/calls/tracker_dashevents_test.go
+++ b/server/internal/calls/tracker_dashevents_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package calls
+
+// Tests that *Tracker calls SetDashboardEvents.Notify on the lifecycle
+// methods that change the active-call count: OnCallInitiated, OnCallEnded,
+// and ClearByNumber. The dashboard SSE handler relies on these wakes to
+// re-render counters without polling. Integration-tagged because the
+// Tracker methods exercised here run real SQL through the shared TEST_DATABASE_URL.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+type fakeNotifier struct {
+	count atomic.Int32
+}
+
+func (f *fakeNotifier) Notify() {
+	f.count.Add(1)
+}
+
+func (f *fakeNotifier) Count() int32 { return f.count.Load() }
+
+func TestTracker_SetDashboardEvents_OptionalAndOverwritable(t *testing.T) {
+	d := setupTestDB(t)
+	tr := New(d)
+	// nil notifier must be accepted without panic.
+	tr.SetDashboardEvents(nil)
+	n := &fakeNotifier{}
+	tr.SetDashboardEvents(n)
+	tr.SetDashboardEvents(n) // overwrite is fine
+}
+
+// TestTracker_NotifiesOnLifecycle exercises OnCallInitiated and OnCallEnded
+// against a real DB and verifies the broadcaster fires once per state change.
+// The dashboard SSE handler subscribes to those wakes to re-render the
+// ON CALL counter, so a missed Notify here means a stale UI in production.
+func TestTracker_NotifiesOnLifecycle(t *testing.T) {
+	d := setupTestDB(t)
+	tr := New(d)
+	n := &fakeNotifier{}
+	tr.SetDashboardEvents(n)
+
+	if _, err := tr.OnCallInitiated(context.Background(), "3140101", "3140102"); err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	if got := n.Count(); got != 1 {
+		t.Fatalf("after OnCallInitiated: got %d Notifies want 1", got)
+	}
+
+	if err := tr.OnCallEnded(context.Background(), "3140101", "3140102"); err != nil {
+		t.Fatalf("OnCallEnded: %v", err)
+	}
+	if got := n.Count(); got != 2 {
+		t.Fatalf("after OnCallEnded: got %d Notifies want 2", got)
+	}
+
+	// Idempotent end: nothing in the active map for this pair, so Notify
+	// must not fire again.
+	if err := tr.OnCallEnded(context.Background(), "3140101", "3140102"); err != nil {
+		t.Fatalf("idempotent OnCallEnded: %v", err)
+	}
+	if got := n.Count(); got != 2 {
+		t.Fatalf("no-op OnCallEnded must not Notify: got %d want 2", got)
+	}
+}
+
+func TestTracker_NotifiesOnClearByNumber(t *testing.T) {
+	d := setupTestDB(t)
+	tr := New(d)
+	n := &fakeNotifier{}
+	tr.SetDashboardEvents(n)
+
+	if _, err := tr.OnCallInitiated(context.Background(), "3140201", "3140202"); err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	// One wake from OnCallInitiated.
+	if got := n.Count(); got != 1 {
+		t.Fatalf("after Initiate: got %d want 1", got)
+	}
+
+	tr.ClearByNumber(context.Background(), "3140201")
+	if got := n.Count(); got != 2 {
+		t.Fatalf("after ClearByNumber: got %d want 2", got)
+	}
+
+	// Second clear hits no entries; must not wake.
+	tr.ClearByNumber(context.Background(), "3140201")
+	if got := n.Count(); got != 2 {
+		t.Fatalf("no-op Clear must not Notify: got %d want 2", got)
+	}
+}

--- a/server/internal/dashboard/events/broadcaster.go
+++ b/server/internal/dashboard/events/broadcaster.go
@@ -1,0 +1,54 @@
+// Package events provides a tiny in-process pub/sub broadcaster used to
+// signal "dashboard state may have changed" without carrying any payload.
+//
+// Sources (calls.Tracker, signaling.Hub) call Notify after mutating
+// state. Each subscriber's channel has buffer size 1, and Notify performs
+// a non-blocking send: bursts of notifications coalesce into a single
+// pending wake, so subscribers see at most one signal per outstanding
+// state change. Subscribers re-snapshot their own view on wake.
+package events
+
+import "sync"
+
+// Broadcaster fans out content-free wake signals to subscribers.
+//
+// Zero value is not usable; use New.
+type Broadcaster struct {
+	mu   sync.Mutex
+	subs map[chan struct{}]struct{}
+}
+
+// New returns an empty Broadcaster ready for use.
+func New() *Broadcaster {
+	return &Broadcaster{subs: make(map[chan struct{}]struct{})}
+}
+
+// Subscribe registers a new subscriber and returns its receive channel
+// plus an unsubscribe function. The channel has buffer size 1; bursts of
+// Notify calls collapse into a single pending wake.
+func (b *Broadcaster) Subscribe() (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+	b.mu.Lock()
+	b.subs[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		delete(b.subs, ch)
+		b.mu.Unlock()
+	}
+}
+
+// Notify wakes every subscriber. Best-effort, non-blocking: if a
+// subscriber's buffer is full (a previous wake is already pending), the
+// send is dropped, and the subscriber will pick up the latest state on
+// its next loop iteration.
+func (b *Broadcaster) Notify() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/server/internal/dashboard/events/broadcaster_test.go
+++ b/server/internal/dashboard/events/broadcaster_test.go
@@ -1,0 +1,124 @@
+package events_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/dashboard/events"
+)
+
+func TestBroadcaster_NotifyDeliversToSingleSubscriber(t *testing.T) {
+	b := events.New()
+	ch, unsub := b.Subscribe()
+	t.Cleanup(unsub)
+
+	b.Notify()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("expected notification within 1s")
+	}
+}
+
+func TestBroadcaster_NotifyFanOutsToAllSubscribers(t *testing.T) {
+	b := events.New()
+	ch1, unsub1 := b.Subscribe()
+	t.Cleanup(unsub1)
+	ch2, unsub2 := b.Subscribe()
+	t.Cleanup(unsub2)
+
+	b.Notify()
+
+	for i, ch := range []<-chan struct{}{ch1, ch2} {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d did not receive notification", i)
+		}
+	}
+}
+
+func TestBroadcaster_UnsubscribeStopsDelivery(t *testing.T) {
+	b := events.New()
+	ch, unsub := b.Subscribe()
+	unsub()
+
+	b.Notify()
+
+	select {
+	case <-ch:
+		t.Fatal("expected no notification after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBroadcaster_NotifyCoalescesWhenBufferFull(t *testing.T) {
+	b := events.New()
+	ch, unsub := b.Subscribe()
+	t.Cleanup(unsub)
+
+	// First Notify fills the buffer-1 channel.
+	b.Notify()
+	// Subsequent Notifies must not block; they coalesce into the existing pending wake.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			b.Notify()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Notify blocked when subscriber buffer was full")
+	}
+
+	// Subscriber sees exactly one wake (coalesced).
+	<-ch
+	select {
+	case <-ch:
+		t.Fatal("expected coalesced single wake, got multiple")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBroadcaster_ConcurrentSubscribeNotifyUnsubscribe(t *testing.T) {
+	b := events.New()
+	var received int64
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch, unsub := b.Subscribe()
+			defer unsub()
+			deadline := time.After(200 * time.Millisecond)
+			for {
+				select {
+				case <-ch:
+					atomic.AddInt64(&received, 1)
+				case <-deadline:
+					return
+				}
+			}
+		}()
+	}
+
+	notifyDone := make(chan struct{})
+	go func() {
+		defer close(notifyDone)
+		for i := 0; i < 200; i++ {
+			b.Notify()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+	<-notifyDone
+	if atomic.LoadInt64(&received) == 0 {
+		t.Fatal("expected at least one delivered notification under concurrency")
+	}
+}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -31,11 +31,19 @@ type Conn struct {
 	FlashCapable    bool
 }
 
+// dashNotifier is the subset of *dashboard/events.Broadcaster the Hub uses
+// to wake dashboard SSE subscribers when the set of online lines changes.
+// Optional; nil disables notifications.
+type dashNotifier interface {
+	Notify()
+}
+
 type Hub struct {
 	mu           sync.RWMutex
 	conns        map[string]*Conn                 // phone number → connection
 	hwConns      map[string]*Conn                 // hardware ID → connection
 	updateStatus map[string]*UpdateStatusSnapshot // phone number → last update status
+	dashEvents   dashNotifier
 }
 
 func NewHub() *Hub {
@@ -46,9 +54,17 @@ func NewHub() *Hub {
 	}
 }
 
+// SetDashboardEvents registers an optional broadcaster that is signalled
+// whenever the set of online lines changes. Wakes dashboard SSE subscribers.
+// Safe to call once at startup; subsequent calls overwrite.
+func (h *Hub) SetDashboardEvents(b dashNotifier) {
+	h.mu.Lock()
+	h.dashEvents = b
+	h.mu.Unlock()
+}
+
 func (h *Hub) Register(number string, conn *Conn) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	// Close existing connection for this number if any
 	if old, ok := h.conns[number]; ok {
 		if old.WS != nil {
@@ -69,19 +85,34 @@ func (h *Hub) Register(number string, conn *Conn) {
 	if conn.HardwareID != "" {
 		h.hwConns[conn.HardwareID] = conn
 	}
+	d := h.dashEvents
+	h.mu.Unlock()
 	slog.Debug("hub registered", "number", number)
+
+	if d != nil {
+		d.Notify()
+	}
 }
 
 func (h *Hub) Unregister(number string, conn *Conn) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	var changed bool
 	if existing, ok := h.conns[number]; ok && existing == conn {
 		close(conn.Send)
 		delete(h.conns, number)
 		if conn.HardwareID != "" {
 			delete(h.hwConns, conn.HardwareID)
 		}
+		changed = true
+	}
+	d := h.dashEvents
+	h.mu.Unlock()
+
+	if changed {
 		slog.Debug("hub unregistered", "number", number)
+		if d != nil {
+			d.Notify()
+		}
 	}
 }
 

--- a/server/internal/signaling/hub_dashevents_test.go
+++ b/server/internal/signaling/hub_dashevents_test.go
@@ -1,0 +1,51 @@
+package signaling
+
+// Tests that *Hub.Register and *Hub.Unregister call into a registered
+// dashboard-events Notifier. The dashboard SSE handler depends on these
+// wakes to re-render the LINES ONLINE counter without polling the hub.
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+type fakeNotifier struct {
+	count atomic.Int32
+}
+
+func (f *fakeNotifier) Notify() {
+	f.count.Add(1)
+}
+
+func (f *fakeNotifier) Count() int32 { return f.count.Load() }
+
+func TestHub_DashEvents_NotifiesOnRegisterAndUnregister(t *testing.T) {
+	h := NewHub()
+	n := &fakeNotifier{}
+	h.SetDashboardEvents(n)
+
+	conn := &Conn{Send: make(chan []byte, 1)}
+	h.Register("+15550001", conn)
+	if got := n.Count(); got != 1 {
+		t.Fatalf("Register: got %d notifications want 1", got)
+	}
+
+	h.Unregister("+15550001", conn)
+	if got := n.Count(); got != 2 {
+		t.Fatalf("Unregister: got %d notifications want 2", got)
+	}
+
+	// Stale Unregister (different conn) must not wake: the line is already gone.
+	h.Unregister("+15550001", &Conn{Send: make(chan []byte, 1)})
+	if got := n.Count(); got != 2 {
+		t.Fatalf("stale Unregister must not Notify: got %d want 2", got)
+	}
+}
+
+func TestHub_DashEvents_NilSafe(t *testing.T) {
+	h := NewHub()
+	// No SetDashboardEvents call: Register and Unregister must not panic.
+	conn := &Conn{Send: make(chan []byte, 1)}
+	h.Register("+15550002", conn)
+	h.Unregister("+15550002", conn)
+}

--- a/server/internal/web/dashboard_sse_integration_test.go
+++ b/server/internal/web/dashboard_sse_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package web
+
+// Integration tests for GET /api/dashboard/stream, the SSE endpoint that
+// drives the AM-theme top-row counters and clock.
+//
+// Verified behaviours:
+//   - 200 with Content-Type: text/event-stream for an authenticated user
+//   - Initial "status" frame contains the household-scoped counters
+//   - Hub.Register fires another "status" frame
+//   - Tracker.OnCallInitiated fires another "status" frame
+//   - Unauthenticated requests are redirected
+//
+// Requires TEST_DATABASE_URL (skipped otherwise via setupHandler).
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/signaling"
+)
+
+func dashStreamURL(srv *httptest.Server) string {
+	return srv.URL + "/api/dashboard/stream"
+}
+
+func TestDashboardStream_InitialSnapshot(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	srv := httptest.NewServer(h.Router())
+	t.Cleanup(srv.Close)
+
+	// Seed a single line so OnlineLines is at least 1 in the initial frame.
+	_, _ = setupLineWithConn(t, h, database, hh, "+15551110001", "Kitchen")
+
+	req, err := http.NewRequest("GET", dashStreamURL(srv), nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type: got %q want text/event-stream", ct)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	ev, data, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read initial frame: %v", err)
+	}
+	if ev != "status" {
+		t.Fatalf("initial event: got %q want status", ev)
+	}
+	for _, want := range []string{"am-overview__top", "ON&middot;CALL", "LINES&middot;ONLINE", "FAMILIES", "LOCAL&middot;TIME"} {
+		if !strings.Contains(data, want) {
+			t.Fatalf("initial frame missing %q; data=%q", want, data)
+		}
+	}
+}
+
+func TestDashboardStream_HubRegisterTriggersFrame(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	srv := httptest.NewServer(h.Router())
+	t.Cleanup(srv.Close)
+
+	number := "+15551110010"
+	_, _ = setupLineWithConn(t, h, database, hh, number, "Kitchen")
+	// setupLineWithConn already registers a conn. Unregister so the test
+	// drives a fresh Register below and observes the resulting Notify.
+	h.Hub().Unregister(number, h.Hub().Get(number))
+
+	req, _ := http.NewRequest("GET", dashStreamURL(srv), nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	if _, _, err := readSSEFrame(t, ctx, sr); err != nil {
+		t.Fatalf("drain initial: %v", err)
+	}
+
+	// Give the handler goroutine time to reach Subscribe() after the
+	// initial flush. Same pattern as sse_integration_test.go.
+	time.Sleep(50 * time.Millisecond)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 1)}
+	h.Hub().Register(number, conn)
+	t.Cleanup(func() { h.Hub().Unregister(number, conn) })
+
+	ev, _, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read post-register frame: %v", err)
+	}
+	if ev != "status" {
+		t.Fatalf("post-register event: got %q want status", ev)
+	}
+}
+
+func TestDashboardStream_CallInitiatedTriggersFrame(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	srv := httptest.NewServer(h.Router())
+	t.Cleanup(srv.Close)
+
+	caller := "+15551110020"
+	callee := "+15551110021"
+	_, _ = setupLineWithConn(t, h, database, hh, caller, "Caller")
+
+	req, _ := http.NewRequest("GET", dashStreamURL(srv), nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	sr := newSSEReader(resp)
+
+	if _, _, err := readSSEFrame(t, ctx, sr); err != nil {
+		t.Fatalf("drain initial: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := h.tracker.OnCallInitiated(context.Background(), caller, callee); err != nil {
+		t.Fatalf("OnCallInitiated: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = h.tracker.OnCallEnded(context.Background(), caller, callee)
+		_, _ = database.DB.Exec("DELETE FROM calls WHERE caller = $1 OR callee = $1", caller)
+	})
+
+	ev, data, err := readSSEFrame(t, ctx, sr)
+	if err != nil {
+		t.Fatalf("read post-call frame: %v", err)
+	}
+	if ev != "status" {
+		t.Fatalf("post-call event: got %q want status", ev)
+	}
+	// One owned endpoint with an active call: ON CALL renders as "01".
+	if !strings.Contains(data, "01") {
+		t.Errorf("post-call frame missing ON CALL count of 01; data=%q", data)
+	}
+}
+
+func TestDashboardStream_AuthRequired(t *testing.T) {
+	h, _, _ := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(dashStreamURL(srv))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("unauthenticated stream returned 200; want redirect or 4xx")
+	}
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
+	"github.com/justinlindh/digits/server/internal/dashboard/events"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/household"
@@ -77,6 +78,7 @@ type Handler struct {
 	tracker     *calls.Tracker
 	relay       *signaling.Relay
 	healthStore *calls.HealthStore
+	dashEvents  *events.Broadcaster
 	// Per-page template sets to avoid {{define}} name conflicts
 	tmplDashboard      *template.Template
 	tmplPhones         *template.Template
@@ -90,6 +92,7 @@ type Handler struct {
 	tmplCallLiveDetail         *template.Template
 	tmplConferenceLivePanel    *template.Template
 	tmplConferenceLiveDetail   *template.Template
+	tmplDashboardAMStatus      *template.Template
 	cfg                HandlerConfig
 	// Auth
 	authStore    *auth.Store
@@ -153,6 +156,7 @@ type Deps struct {
 	Tracker        *calls.Tracker
 	Relay          *signaling.Relay
 	HealthStore    *calls.HealthStore
+	DashEvents     *events.Broadcaster
 	AuthStore      *auth.Store
 	AuthHandlers   *auth.Handlers
 	GoogleAuth     *auth.GoogleAuth
@@ -267,6 +271,15 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Merge the AM status partial so {{template "dashboard-am-status"}} resolves
+	// inside the dashboard page.
+	if _, err := tmplDashboard.ParseFS(templateFS, "templates/_dashboard-am-status.html"); err != nil {
+		return nil, fmt.Errorf("parse dashboard-am-status partial into dashboard: %w", err)
+	}
+	tmplDashboardAMStatus, err := template.New("dashboard-am-status").Funcs(funcMap).ParseFS(templateFS, "templates/_dashboard-am-status.html")
+	if err != nil {
+		return nil, fmt.Errorf("parse dashboard-am-status: %w", err)
+	}
 	tmplPhones, err := parsePage("phones.html")
 	if err != nil {
 		return nil, err
@@ -339,6 +352,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tracker:            deps.Tracker,
 		relay:              deps.Relay,
 		healthStore:        deps.HealthStore,
+		dashEvents:         deps.DashEvents,
 		tmplDashboard:      tmplDashboard,
 		tmplPhones:         tmplPhones,
 		tmplCalls:          tmplCalls,
@@ -351,6 +365,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplCallLiveDetail:         tmplCallLiveDetail,
 		tmplConferenceLivePanel:    tmplConferenceLivePanel,
 		tmplConferenceLiveDetail:   tmplConferenceLiveDetail,
+		tmplDashboardAMStatus:      tmplDashboardAMStatus,
 		cfg:                cfg,
 		authStore:          deps.AuthStore,
 		authHandlers:       deps.AuthHandlers,
@@ -456,6 +471,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /api/active-calls", h.handleAPIActiveCalls)
 	protected.HandleFunc("GET /call/live/{id}", h.handleCallLiveDetail)
 	protected.HandleFunc("GET /conference/live/{uuid}", h.handleConferenceLiveDetail)
+	protected.HandleFunc("GET /api/dashboard/stream", h.handleDashboardStream)
 	protected.HandleFunc("GET /api/call/{id}/link-health", h.handleCallLinkHealth)
 	protected.HandleFunc("GET /api/call/{id}/link-health/stream", h.handleCallLinkHealthStream)
 	protected.HandleFunc("GET /api/conference/{uuid}/link-health", h.handleConferenceLinkHealth)

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -22,6 +22,20 @@ type dashboardData struct {
 	ActiveLine         string
 	ActivePeer         string
 	ActiveElapsed      string
+	// Status is the subset rendered by the dashboard-am-status partial. The
+	// partial is also rendered by the /api/dashboard/stream SSE handler, so
+	// this struct is the contract between the page render and stream render.
+	Status dashStatusVM
+}
+
+// dashStatusVM is what the dashboard-am-status partial reads. Both the page
+// handler and the SSE handler populate it the same way so the partial output
+// is identical at render time and at every subsequent SSE swap.
+type dashStatusVM struct {
+	ActiveCalls    int
+	OnlineLines    int
+	LinkedFamilies int
+	Now            time.Time
 }
 
 type callRow struct {
@@ -165,13 +179,14 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	stats := dashStats{
+		TotalLines:  len(ld.Lines),
+		OnlineLines: countOnline(ld.Lines),
+		ActiveCalls: activeCount,
+	}
 	data := dashboardData{
-		chromeData: newChromeData("dashboard", user, hh),
-		Stats: dashStats{
-			TotalLines:  len(ld.Lines),
-			OnlineLines: countOnline(ld.Lines),
-			ActiveCalls: activeCount,
-		},
+		chromeData:         newChromeData("dashboard", user, hh),
+		Stats:              stats,
 		Lines:              ld.Lines,
 		CallsTodayRecent:   callsTodayRecent,
 		CallsTodayTotalMin: (callsTodayTotalSec + 30) / 60, // +30 to round to nearest minute
@@ -180,6 +195,12 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		ActiveLine:         activeLine,
 		ActivePeer:         activePeer,
 		ActiveElapsed:      activeElapsed,
+		Status: dashStatusVM{
+			ActiveCalls:    stats.ActiveCalls,
+			OnlineLines:    stats.OnlineLines,
+			LinkedFamilies: len(linkedFamilies),
+			Now:            now,
+		},
 	}
 	renderWith(w, h.tmplDashboard, layoutFor(r), data)
 }

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -124,6 +124,8 @@ func (h *Handler) computeDashStatus(r *http.Request, hh *household.Household) da
 	}
 	families := len(h.buildLinkedFamilies(r.Context(), householdID))
 
+	// Household.Location() is nil-safe and falls back to UTC, so we deliberately
+	// skip an explicit hh != nil guard here even though hh.ID above takes one.
 	return dashStatusVM{
 		ActiveCalls:    activeCount,
 		OnlineLines:    onlineCount,

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/household"
+)
+
+// dashTickInterval is how often the dashboard SSE handler re-renders even
+// when no Notify has fired. Two purposes: (a) the LOCAL TIME LED tracks
+// real time without needing per-second wakes, (b) the periodic frame doubles
+// as a keep-alive so proxies don't close idle streams.
+const dashTickInterval = 15 * time.Second
+
+// handleDashboardStream opens an SSE stream for the AM-theme top-row
+// counters and clock. Sends one initial "status" event with the current
+// snapshot, then a fresh snapshot on every Notify from the dashboard
+// broadcaster (call start/end, line online/offline) and at least once
+// per dashTickInterval so the clock advances.
+//
+// Auth: protected mux already gates this. Household scope is derived from
+// the user's primary household, mirroring handleDashboard.
+func (h *Handler) handleDashboardStream(w http.ResponseWriter, r *http.Request) {
+	if h.dashEvents == nil {
+		// Broadcaster not wired (test harness or misconfig); 404 keeps the
+		// surface invisible rather than serving a stream that never updates.
+		http.NotFound(w, r)
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.NotFound(w, r)
+		return
+	}
+	hh := h.primaryHousehold(r)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		slog.Error("dashboard SSE: ResponseWriter does not implement Flusher")
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	if err := h.writeDashStatus(w, flusher, r, hh); err != nil {
+		return
+	}
+
+	sub, unsub := h.dashEvents.Subscribe()
+	defer unsub()
+
+	tick := time.NewTicker(dashTickInterval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-sub:
+		case <-tick.C:
+		}
+		if err := h.writeDashStatus(w, flusher, r, hh); err != nil {
+			return
+		}
+	}
+}
+
+func (h *Handler) writeDashStatus(w http.ResponseWriter, flusher http.Flusher, r *http.Request, hh *household.Household) error {
+	vm := h.computeDashStatus(r, hh)
+	fragment, err := h.renderDashStatus(vm)
+	if err != nil {
+		slog.Error("dashboard SSE: render failed", "err", err)
+		return err
+	}
+	if err := writeSSE(w, "status", fragment); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+// computeDashStatus snapshots the household-scoped counters and the
+// household-local clock for the top-row partial. Same scoping rules as
+// handleDashboard: only the user's own lines count toward ON·CALL and
+// LINES·ONLINE; FAMILIES is the count of accepted household links.
+func (h *Handler) computeDashStatus(r *http.Request, hh *household.Household) dashStatusVM {
+	ld := h.buildLinesData(r, hh, "")
+
+	ownNums := make(map[string]struct{}, len(ld.Lines))
+	onlineCount := 0
+	for _, l := range ld.Lines {
+		ownNums[l.Line.Number] = struct{}{}
+		if l.Online {
+			onlineCount++
+		}
+	}
+
+	activeCount := 0
+	for _, pair := range h.tracker.Active() {
+		if _, ok := ownNums[pair.Caller]; ok {
+			activeCount++
+			continue
+		}
+		if _, ok := ownNums[pair.Callee]; ok {
+			activeCount++
+		}
+	}
+
+	var householdID string
+	if hh != nil {
+		householdID = hh.ID
+	}
+	families := len(h.buildLinkedFamilies(r.Context(), householdID))
+
+	return dashStatusVM{
+		ActiveCalls:    activeCount,
+		OnlineLines:    onlineCount,
+		LinkedFamilies: families,
+		Now:            time.Now().In(hh.Location()),
+	}
+}
+
+func (h *Handler) renderDashStatus(vm dashStatusVM) (string, error) {
+	var buf bytes.Buffer
+	if err := h.tmplDashboardAMStatus.ExecuteTemplate(&buf, "dashboard-am-status", vm); err != nil {
+		return "", fmt.Errorf("render dashboard-am-status: %w", err)
+	}
+	return strings.TrimRight(buf.String(), "\n"), nil
+}

--- a/server/internal/web/templates/_dashboard-am-status.html
+++ b/server/internal/web/templates/_dashboard-am-status.html
@@ -1,0 +1,58 @@
+{{define "dashboard-am-status"}}
+{{/* Top row: LED status display + indicator lamps cluster. Rendered once on
+     page load and re-rendered by GET /api/dashboard/stream on every state
+     change (call start/end, line online/offline) and at least once per
+     stream tick so the LOCAL TIME LED keeps up. */}}
+<div class="am-overview__top">
+
+  {{/* LED status plate */}}
+  <div class="am-plate am-plate--screws am-overview__status">
+    <div class="am-screw am-screw--tl"></div><div class="am-screw am-screw--tr"></div>
+    <div class="am-label am-overview__status-label">Status &middot; {{.Now.Format "Monday, January 2"}}</div>
+    <div class="am-well am-overview__led-well">
+      <div class="am-overview__led-group">
+        <div class="am-led am-overview__led-big">{{printf "%02d" .ActiveCalls}}</div>
+        <div class="am-led am-led--dim am-overview__led-caption">ON&middot;CALL</div>
+      </div>
+      <div class="am-overview__led-sep"></div>
+      <div class="am-overview__led-group">
+        <div class="am-led am-led--green am-overview__led-mid">{{.OnlineLines}}</div>
+        <div class="am-led am-led--dim am-overview__led-caption">LINES&middot;ONLINE</div>
+      </div>
+      <div class="am-overview__led-sep"></div>
+      <div class="am-overview__led-group">
+        <div class="am-led am-overview__led-mid">{{.LinkedFamilies}}</div>
+        <div class="am-led am-led--dim am-overview__led-caption">FAMILIES</div>
+      </div>
+      <div class="am-overview__led-spacer"></div>
+      <div class="am-overview__led-group am-overview__led-group--right">
+        <div class="am-led am-overview__led-time">{{.Now.Format "3:04pm"}}</div>
+        <div class="am-led am-led--dim am-overview__led-caption">LOCAL&middot;TIME</div>
+      </div>
+    </div>
+  </div>
+
+  {{/* Indicator lamps + REC-off cluster */}}
+  <div class="am-plate am-overview__indicators">
+    <div class="am-plate__label">Indicators</div>
+    <div class="am-overview__lamps">
+      <div class="am-overview__lamp">
+        <span class="am-lamp{{if gt .ActiveCalls 0}} am-lamp--on-red{{end}}"></span>
+        <span class="am-overview__lamp-label">Ringing</span>
+      </div>
+      <div class="am-overview__lamp">
+        <span class="am-lamp{{if gt .OnlineLines 0}} am-lamp--on-green{{end}}"></span>
+        <span class="am-overview__lamp-label">Online</span>
+      </div>
+      <div class="am-overview__lamp">
+        <span class="am-lamp{{if gt .LinkedFamilies 0}} am-lamp--on-amber{{end}}"></span>
+        <span class="am-overview__lamp-label">Paired</span>
+      </div>
+    </div>
+    <div class="am-overview__rec">
+      <div class="am-rec"><span class="am-lamp"></span><span class="am-rec__label">REC</span></div>
+      <div class="am-hint am-overview__rec-hint">This lamp is wired to nothing. Audio never reaches this box.</div>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/server/internal/web/templates/dashboard.html
+++ b/server/internal/web/templates/dashboard.html
@@ -90,58 +90,10 @@
 {{define "dashboard-am"}}
 <div class="am-overview">
 
-  {{/* Top row: LED status display + indicator lamps cluster */}}
-  <div class="am-overview__top">
-
-    {{/* LED status plate */}}
-    <div class="am-plate am-plate--screws am-overview__status">
-      <div class="am-screw am-screw--tl"></div><div class="am-screw am-screw--tr"></div>
-      <div class="am-label am-overview__status-label">Status &middot; {{.Now.Format "Monday, January 2"}}</div>
-      <div class="am-well am-overview__led-well">
-        <div class="am-overview__led-group">
-          <div class="am-led am-overview__led-big">{{printf "%02d" .Stats.ActiveCalls}}</div>
-          <div class="am-led am-led--dim am-overview__led-caption">ON&middot;CALL</div>
-        </div>
-        <div class="am-overview__led-sep"></div>
-        <div class="am-overview__led-group">
-          <div class="am-led am-led--green am-overview__led-mid">{{.Stats.OnlineLines}}</div>
-          <div class="am-led am-led--dim am-overview__led-caption">LINES&middot;ONLINE</div>
-        </div>
-        <div class="am-overview__led-sep"></div>
-        <div class="am-overview__led-group">
-          <div class="am-led am-overview__led-mid">{{len .LinkedFamilies}}</div>
-          <div class="am-led am-led--dim am-overview__led-caption">FAMILIES</div>
-        </div>
-        <div class="am-overview__led-spacer"></div>
-        <div class="am-overview__led-group am-overview__led-group--right">
-          <div class="am-led am-overview__led-time">{{.Now.Format "3:04pm"}}</div>
-          <div class="am-led am-led--dim am-overview__led-caption">LOCAL&middot;TIME</div>
-        </div>
-      </div>
-    </div>
-
-    {{/* Indicator lamps + REC-off cluster */}}
-    <div class="am-plate am-overview__indicators">
-      <div class="am-plate__label">Indicators</div>
-      <div class="am-overview__lamps">
-        <div class="am-overview__lamp">
-          <span class="am-lamp{{if gt .Stats.ActiveCalls 0}} am-lamp--on-red{{end}}"></span>
-          <span class="am-overview__lamp-label">Ringing</span>
-        </div>
-        <div class="am-overview__lamp">
-          <span class="am-lamp{{if gt .Stats.OnlineLines 0}} am-lamp--on-green{{end}}"></span>
-          <span class="am-overview__lamp-label">Online</span>
-        </div>
-        <div class="am-overview__lamp">
-          <span class="am-lamp{{if .LinkedFamilies}} am-lamp--on-amber{{end}}"></span>
-          <span class="am-overview__lamp-label">Paired</span>
-        </div>
-      </div>
-      <div class="am-overview__rec">
-        <div class="am-rec"><span class="am-lamp"></span><span class="am-rec__label">REC</span></div>
-        <div class="am-hint am-overview__rec-hint">This lamp is wired to nothing. Audio never reaches this box.</div>
-      </div>
-    </div>
+  {{/* Top row swaps live via SSE: counters tick on call start/end and
+       handset online/offline; LOCAL TIME advances at least every minute. */}}
+  <div id="am-dashboard-status" hx-ext="sse" sse-connect="/api/dashboard/stream" sse-swap="status">
+    {{template "dashboard-am-status" .Status}}
   </div>
 
   {{/* Main grid: active session + messages on the left, lines on the right */}}

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
+	"github.com/justinlindh/digits/server/internal/dashboard/events"
 	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/email"
@@ -131,6 +132,9 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	tracker := calls.New(database)
 	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled(true))
 	tracker.SetHealthStore(healthStore)
+	dashEvents := events.New()
+	hub.SetDashboardEvents(dashEvents)
+	tracker.SetDashboardEvents(dashEvents)
 	relay := signaling.NewRelay(hub, tracker, nil, nil)
 	relay.HealthStore = healthStore
 
@@ -153,6 +157,7 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 		Tracker:        tracker,
 		Relay:          relay,
 		HealthStore:    healthStore,
+		DashEvents:     dashEvents,
 		AuthStore:      authStore,
 		AuthHandlers:   authHandlers,
 		GoogleAuth:     googleAuth,


### PR DESCRIPTION
## Summary

- New `GET /api/dashboard/stream` SSE endpoint refreshes the answering-machine dashboard's top-row LED block (`ON CALL`, `LINES ONLINE`, `FAMILIES`, `LOCAL TIME`) live, no page reload.
- `calls.Tracker` and `signaling.Hub` notify a shared content-free broadcaster on call start/end and handset connect/disconnect; the SSE handler re-snapshots and re-renders on every wake plus a 15s tick that doubles as clock advance and keep-alive.
- The top-row partial is shared between the page render and the SSE swap so the rendered output is identical at every frame.

Closes #278.

## Scope

Per the issue's "out of scope" section, this PR only wires the AM theme's top-row counters and clock. Lines panel rows, today's calls list, and the active-session tape are unchanged. The SSE endpoint is generic (any future theme can opt in by wrapping its counter block in a swap container).

## Screenshots

Idle (no active calls, no handsets connected):

![idle](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/issue-278-am-counters-idle.png)

After `/test-harness/start-call` triggers a call without a page reload (`ON CALL` flips to `01`, `Ringing` lamp lights):

![active call](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/issue-278-am-counters-active-call.png)

## Test plan

- [x] `go test ./...` passes
- [x] `make test-integration` passes (new `tracker_dashevents_test.go`, `hub_dashevents_test.go`, `dashboard_sse_integration_test.go`)
- [x] `golangci-lint run ./...` clean
- [x] Manual verification on dev signald: AM dashboard renders, `ON CALL` LED ticks live on `/test-harness/start-call`, dialup and intercom dashboards unchanged