### PR TITLE
fix(image): bake SSH host key symlinks into rootfs at build time

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -1138,21 +1138,28 @@ if [[ "$DEV_MODE" == true ]]; then
 PasswordAuthentication yes
 SSHDEV
 
-    # Create SSH host keys directory on /data (writable)
+    # Create SSH host keys directory on /data (writable) and pre-generate
+    # the host keys on the host (not in chroot).
     mkdir -p "${DATA_MNT}/ssh"
-
-    # Write a tmpfiles rule so SSH host keys live on /data
-    mkdir -p "${ROOTFS_MNT}/etc/tmpfiles.d"
-    cat > "${ROOTFS_MNT}/etc/tmpfiles.d/digits-ssh.conf" << 'SSHCONF'
-L /etc/ssh/ssh_host_rsa_key - - - - /data/ssh/ssh_host_rsa_key
-L /etc/ssh/ssh_host_ed25519_key - - - - /data/ssh/ssh_host_ed25519_key
-SSHCONF
-
-    # Pre-generate SSH host keys on the HOST (not in chroot)
     ssh-keygen -t rsa -b 4096 -f "${DATA_MNT}/ssh/ssh_host_rsa_key" -N '' -q
     ssh-keygen -t ed25519 -f "${DATA_MNT}/ssh/ssh_host_ed25519_key" -N '' -q
 
-    info "DEV MODE: SSH enabled — user 'dev', password 'digits', passwordless sudo"
+    # Bake /etc/ssh/ssh_host_*_key symlinks into the rootfs so sshd can find
+    # the keys at /data/ssh/. The rootfs is mounted read-only at boot, so
+    # systemd-tmpfiles cannot create these symlinks at runtime; they must
+    # exist on disk before first boot.
+    ln -sf /data/ssh/ssh_host_rsa_key         "${ROOTFS_MNT}/etc/ssh/ssh_host_rsa_key"
+    ln -sf /data/ssh/ssh_host_rsa_key.pub     "${ROOTFS_MNT}/etc/ssh/ssh_host_rsa_key.pub"
+    ln -sf /data/ssh/ssh_host_ed25519_key     "${ROOTFS_MNT}/etc/ssh/ssh_host_ed25519_key"
+    ln -sf /data/ssh/ssh_host_ed25519_key.pub "${ROOTFS_MNT}/etc/ssh/ssh_host_ed25519_key.pub"
+
+    # Raspbian's regenerate_ssh_host_keys.service tries to ssh-keygen into
+    # the RO /etc/ssh and leaves stale zero-byte ssh_host_*_key.XXXX files
+    # behind. We supply our own keys above; mask the service so it does not
+    # race with sshd or pollute /etc/ssh.
+    hostside_mask_service "$ROOTFS_MNT" "regenerate_ssh_host_keys.service"
+
+    info "DEV MODE: SSH enabled, user 'dev', password 'digits', passwordless sudo"
 fi
 
 # ── step 23: final cleanup (host-side) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Dev images had SSH disabled at runtime. The `--dev` flow installed a
`systemd-tmpfiles` rule to create `/etc/ssh/ssh_host_*_key` symlinks at boot,
pointing at the host keys baked into `/data/ssh/`. But `systemd-tmpfiles-setup`
runs early in sysinit while the rootfs is still mounted read-only, so the
`L` directives failed:

```
systemd-tmpfiles[353]: Failed to create symlink '/etc/ssh/ssh_host_rsa_key': Read-only file system
```

`sshd.service` then started without host keys, hit OpenSSH's "no hostkeys
available" exit, retried 5 times in under 2 seconds, and was permanently
disabled for the rest of the boot:

```
sshd: no hostkeys available -- exiting
ssh.service: Start request repeated too quickly.
```

This affected every `make image-v2-dev` / `make image-v2-flash` build.

## Fix

Pre-create the symlinks on the build chroot (`tools/build-image.sh`), where
the rootfs is writable. They land on disk and `sshd` resolves them through
to `/data/ssh/...` at runtime regardless of the rootfs RO state. Also mask
Raspbian's `regenerate_ssh_host_keys.service`, which has the same
write-into-RO-`/etc/ssh` problem and leaves stale zero-byte
`ssh_host_*_key.XXXX` files behind.

## Verification

- Hot-applied the same symlink + mask fix to a built SD card, booted V2
  device, confirmed SSH login works (`dev@digits-XXXX`, `ssh.service active`,
  digitsd ready, Pico firmware responding via UART, V2 codec detected).
- Rebuild + reflash to confirm the builder produces a working image
  out-of-the-box is the next step (will exercise the patched code path).

## Test plan

- [ ] `make image-v2-flash` (dev image)
- [ ] Power on V2 unit, confirm `sshpass -p digits ssh dev@<ip>` works
- [ ] `journalctl -u ssh` shows successful start, no "Start request repeated too quickly"
- [ ] No `ssh_host_*_key.XXXX` cruft in `/etc/ssh/`