### PR TITLE
fix(image): order digitsd after sysinit and digits-first-boot

### DIFF
--- a/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digitsd.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=Digits Phone Daemon
-After=network-online.target sound.target
-Wants=network-online.target
+# Wait for sysinit and digits-first-boot before starting; digitsd's asset
+# extractor flips the rootfs rw/ro mid-boot, which races with first-boot's
+# own rw remount and causes first-boot's writes to fail with EROFS.
+# Wants= (soft) so a permanently-broken first-boot does not strand digitsd.
+After=network-online.target sound.target sysinit.target digits-first-boot.service
+Wants=network-online.target digits-first-boot.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary

Fixes a first-boot race that left dev devices with a fresh random
hostname on every reboot and the AP-fallback SSID stuck on the build
default. Symptoms surfaced while diagnosing PR #329 (the SSH host-key
symlink fix); SSH itself is unaffected.

## What was happening

`digits-first-boot.service` runs from `sysinit.target` and includes a
~17s `ssh-keygen -A` pass on Pi Zero 2 W. `digitsd.service` ran from
`multi-user.target` with `After=network-online.target sound.target`.
Neither of those waited on sysinit, so digitsd started while first-boot
was still mid-keygen. digitsd's asset extractor then performs its own
`sudo mount -o remount,rw / ; cp ; mount -o remount,ro /` cycle and
clobbered the rootfs back to RO while first-boot was still holding it
RW for its own writes. first-boot's `ssh-keygen` and `sed -i` then
failed with EROFS, the script exited before writing
`/data/.initialized`, and the same dance repeated next boot.

Boot journal excerpt (monotonic timestamps) showing the collision:

```
[11.33s] digits-first-boot: Remounting root filesystem read-write
[11.70s] digits-first-boot: Generating SSH host keys (ssh-keygen -A starts)
[21.38s] digitsd: sudo mount -o remount,rw /
[22.46s] digitsd: cp .../digits-first-boot.service
[24.49s] digitsd: sudo mount -o remount,ro /            <-- ROOTFS BACK TO RO
[25.03s] digitsd: sudo mount -o remount,ro /            <-- ditto
[28.86s] digits-first-boot: ssh-keygen RSA save failed: Read-only file system
[28.90s] digits-first-boot: sed: couldn't open temporary file: Read-only file system
[30.29s] systemd: digits-first-boot.service: Main process exited, status=4/NOPERMISSION
```

## Fix

Add `After=sysinit.target digits-first-boot.service` and a soft
`Wants=digits-first-boot.service` to `digitsd.service`. `Type=oneshot
RemainAfterExit=yes` on first-boot means systemd treats it as "active"
once `ExecStart` returns 0, so `After=` cleanly serializes digitsd
behind it. Soft `Wants=` rather than `Requires=` so a permanently
broken first-boot still lets digitsd come up; the device stays
recoverable.

The unit file is also embedded into the digitsd binary via `make embed`
(rsync from `pi/image/rootfs-overlay/`), so the same fix flows through
to OTA updates without a second edit.

## Out of scope

Option 3 from the design discussion (bake digitsd's runtime-extracted
assets at image build time so the asset extractor only fires on real
OTA version bumps) lands as a separate PR. The duplicate-source-of-
truth concern raised during review is mostly a non-issue today because
`internal/assets/embed/rootfs/` is gitignored and regenerated from
`rootfs-overlay/` by `make embed`; only the overlay file is committed.

## Test plan

- [ ] `make image-v2-flash` (dev image)
- [ ] Boot V2 unit, SSH in, confirm `/data/.initialized` exists with an ISO-8601 timestamp
- [ ] `cat /etc/hostname` and `grep ssid= /etc/hostapd/digits-ap.conf` both reflect the per-device ID
- [ ] `journalctl -b 0 -u digits-first-boot.service` exits 0 with "First-boot initialization complete"
- [ ] `journalctl -b 0 _SYSTEMD_UNIT=digits-first-boot.service _SYSTEMD_UNIT=digitsd.service -o short-monotonic` shows digitsd's first line strictly after first-boot's last line
- [ ] `journalctl -b 0 | grep -i 'read-only file system'` returns nothing from digitsd or first-boot
- [ ] Reboot. `/etc/hostname` is unchanged. first-boot is skipped via `ConditionPathExists`. No remount,rw|ro pairs in the journal.