### PR TITLE
chore(image): bake digitsd's runtime assets at build time

### DIFF
--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -98,12 +98,9 @@ GOOS=linux GOARCH=arm64 go build \
     -o /digits/tools/build/digitsd \
     ./cmd/digitsd/
 
-# Cross-compile digits-setup (pure Go, no CGO needed)
-info "Cross-compiling digits-setup for aarch64..."
-cd /digits/pi/digits-setup
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
-    -o /digits/tools/build/digits-setup \
-    ./cmd/digits-setup/
+# digits-setup is cross-compiled by `make embed` on the host (see
+# pi/digitsd/Makefile) and lands on the rootfs via build-image.sh's
+# embed/rootfs/ rsync. Nothing to do here.
 
 # Cross-compile digits-recovery (pure Go, no CGO needed). build-image.sh reads
 # this from pi/digits-recovery/bin/ to match the local Makefile output path.

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -30,6 +30,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 OVERLAY_DIR="${REPO_DIR}/pi/image/rootfs-overlay"
+EMBED_DIR="${REPO_DIR}/pi/digitsd/internal/assets/embed"
+ASSET_MARKER_TOOL="${SCRIPT_DIR}/compute-asset-marker.py"
 PARTITION_SETUP="${REPO_DIR}/pi/image/partition-setup.sh"
 INIT_DATA="${REPO_DIR}/pi/image/init-data.sh"
 BUILD_DIR="${SCRIPT_DIR}/build"
@@ -622,6 +624,14 @@ install -m 755 "${BUILD_DIR}/digits-setup" "${ROOTFS_MNT}/usr/local/bin/digits-s
 info "Copying rootfs overlay..."
 rsync -a --no-owner --no-group "$OVERLAY_DIR/" "$ROOTFS_MNT/"
 
+# Layer the digitsd embed tree on top: same content as the overlay for shared
+# files (embed/rootfs/ is generated from rootfs-overlay/ by `make embed`,
+# minus a few build-time-only paths) plus digits-setup, which is cross-
+# compiled into embed only and would otherwise reach the rootfs only via
+# digitsd's runtime asset extractor on first boot.
+[[ -d "${EMBED_DIR}/rootfs" ]] || die "Embed dir not populated: ${EMBED_DIR}/rootfs (run 'make -C pi/digitsd embed')"
+rsync -a --no-owner --no-group "${EMBED_DIR}/rootfs/" "$ROOTFS_MNT/"
+
 # Make scripts executable
 chmod +x "${ROOTFS_MNT}/usr/local/bin/"* 2>/dev/null || true
 
@@ -702,6 +712,21 @@ if [[ "$PCB_MODE" == true ]]; then
 else
     bash "$INIT_DATA" "$DATA_MNT"
 fi
+
+# Pre-write the asset-version marker so digitsd's first-boot Extract sees
+# matching marker and skips the rw/ro remount + asset-rewrite pass entirely.
+# The marker format must match Extractor.Extract's `currentVersion + ":" +
+# contentHash` (see pi/digitsd/internal/assets/assets.go); the helper script
+# mirrors the Go hashEmbeddedFS algorithm exactly. Image builds do not pass
+# a -ldflags override, so version.Version stays "dev" and we hardcode it.
+# OTA digitsd updates land with a different version string and a fresh hash,
+# so the runtime extractor takes over from there.
+info "Pre-writing asset-version marker..."
+ASSET_MARKER=$(python3 "$ASSET_MARKER_TOOL" "$EMBED_DIR" dev)
+echo "$ASSET_MARKER" > "${DATA_MNT}/digits/asset-version"
+chown 999:992 "${DATA_MNT}/digits/asset-version"
+chmod 644 "${DATA_MNT}/digits/asset-version"
+info "  marker: $ASSET_MARKER"
 
 # ── step 15b: populate recovery partition (host-side) ───────────────────────
 

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -380,7 +380,7 @@ hostside_mask_service() {
 [[ $EUID -eq 0 ]] || die "Must run as root (sudo $0 $*)"
 
 require_cmd losetup parted e2fsck resize2fs mkfs.ext4 \
-            qemu-aarch64-static gzip blkid rsync openssl zstd dtc
+            qemu-aarch64-static gzip blkid rsync openssl zstd dtc python3
 
 # Verify we're on x86_64
 [[ "$(uname -m)" == "x86_64" ]] || die "This script must run on x86_64 Linux"

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -10,7 +10,7 @@
 #   - x86_64 Linux host
 #   - qemu-user-static (for arm64 chroot — apt-get ONLY)
 #   - losetup, parted, e2fsck, resize2fs, mkfs.ext4
-#   - Cross-compiled binaries in tools/build/ (digitsd, digits-setup)
+#   - Cross-compiled digitsd in tools/build/ and embed dir populated via 'make -C pi/digitsd embed'
 #
 # Design principle:
 #   qemu-user chroot is ONLY used for apt-get operations. All other
@@ -390,8 +390,7 @@ INPUT_IMG="${1:-}"
 [[ -f "$INPUT_IMG" ]] || die "Input image not found: $INPUT_IMG"
 
 # Verify pre-built binaries exist
-[[ -f "${BUILD_DIR}/digitsd" ]]      || die "Missing ${BUILD_DIR}/digitsd -- run cross-compilation first (see README)"
-[[ -f "${BUILD_DIR}/digits-setup" ]] || die "Missing ${BUILD_DIR}/digits-setup -- run cross-compilation first (see README)"
+[[ -f "${BUILD_DIR}/digitsd" ]] || die "Missing ${BUILD_DIR}/digitsd -- run cross-compilation first (see README)"
 [[ -f "${REPO_DIR}/pi/digits-recovery/bin/digits-recovery" ]] || die "Missing pi/digits-recovery/bin/digits-recovery -- run pi/digits-recovery build first"
 
 # Verify overlay directory exists
@@ -616,7 +615,6 @@ hostside_add_to_groups "$ROOTFS_MNT" "digits" audio i2c
 info "Copying Digits binaries..."
 
 install -m 755 "${BUILD_DIR}/digitsd" "${ROOTFS_MNT}/usr/local/bin/digitsd"
-install -m 755 "${BUILD_DIR}/digits-setup" "${ROOTFS_MNT}/usr/local/bin/digits-setup"
 
 
 # ── step 13: copy rootfs overlay (host-side) ────────────────────────────────

--- a/tools/compute-asset-marker.py
+++ b/tools/compute-asset-marker.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Compute the asset-marker that digitsd writes to /data/digits/asset-version.
+
+Mirrors pi/digitsd/internal/assets/assets.go hashEmbeddedFS: walk rootfs/ and
+data/ under the embed dir, sort entries lexicographically by their full path,
+and compute SHA-256 over (path || NUL || data || NUL) for each entry.
+
+Used by tools/build-image.sh to pre-write the marker on the data partition so
+digitsd's first-boot Extract sees marker matches and skips the rootfs remount
++ rewrite pass. The runtime extraction path stays in place for OTA digitsd
+updates (which arrive with a different version string and a fresh hash).
+
+Usage: compute-asset-marker.py <embed-dir> [version]
+
+<embed-dir> contains rootfs/ and data/ subdirs (typically
+pi/digitsd/internal/assets/embed). Version defaults to "dev" because image
+builds do not pass a -ldflags override for version.Version.
+"""
+import hashlib
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("usage: compute-asset-marker.py <embed-dir> [version]")
+    embed_dir = sys.argv[1]
+    version = sys.argv[2] if len(sys.argv) > 2 else "dev"
+
+    entries: list[tuple[str, str]] = []
+    for prefix in ("rootfs", "data"):
+        prefix_path = os.path.join(embed_dir, prefix)
+        if not os.path.isdir(prefix_path):
+            continue
+        for root, _, files in os.walk(prefix_path):
+            for name in files:
+                full = os.path.join(root, name)
+                rel = os.path.relpath(full, embed_dir)
+                entries.append((rel, full))
+
+    entries.sort(key=lambda e: e[0])
+
+    h = hashlib.sha256()
+    for rel, full in entries:
+        h.update(rel.encode("utf-8"))
+        h.update(b"\x00")
+        with open(full, "rb") as fp:
+            h.update(fp.read())
+        h.update(b"\x00")
+
+    print(f"{version}:{h.hexdigest()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Follow-up to PR #330. Eliminates the digitsd-vs-first-boot rootfs flip race at its root by removing the need for digitsd to do any runtime asset extraction on a fresh-flashed image. The runtime path stays in place for OTA digitsd updates (new version string and fresh hash both miss the marker, so Extract still runs), but on a clean flash there is no version drift between the digitsd binary and its embedded assets, so there is also nothing to extract.

## What was happening

digitsd's `assets.Extractor.Extract` ran on every boot, hashed its embedded FS, compared against `/data/digits/asset-version`, and on mismatch did `sudo mount -o remount,rw / ; cp ... ; remount,ro /`. Fresh flashes never had a marker file, so the rewrite always ran on boot 1, then matched on boot 2+. PR #330 stopped that pass from racing with `digits-first-boot.service` by adding ordering, but the rewrite itself was still pure boot-time work that landed the same content the rsync layer below already put in place.

## Fix

Two pieces in `tools/build-image.sh`:

1. **Layer `embed/rootfs/` over the rootfs partition** at build time. embed/rootfs/ is generated from rootfs-overlay/ by `make embed`, so files shared between them are no-ops. The only meaningful addition is the cross-compiled `digits-setup` binary, which used to reach the rootfs only via the runtime extractor. Now it lands at flash time.
2. **Pre-write `/data/digits/asset-version`** with the same `version:hash` marker digitsd would compute on first boot. New helper `tools/compute-asset-marker.py` mirrors the Go `Extractor.hashEmbeddedFS` algorithm: sha256 over (sorted path || NUL || data || NUL) for every file in `embed/rootfs/` and `embed/data/`. Cross-checked against a Go reference impl reading the same embed dir; same hash byte-for-byte.

The recovery skeleton tar captures the pre-written marker (it is created from /data after we write asset-version), so factory resets also restore a state where digitsd skips extraction.

## Why this is `chore(image)` not `fix(image)`

Nothing was broken after PR #330 landed: digitsd's runtime extraction worked, just did unnecessary rewrites on every fresh flash. This removes a redundant boot-time step and shrinks the surface area for future races against any other startup work that touches the rootfs.

## Test plan

- [ ] `make image-v2-flash` (dev image)
- [ ] On boot 1, `journalctl -u digitsd | grep 'assets:'` shows `marker matches (version=dev hash=...), skipping extraction` (not `extracting assets for version dev`)
- [ ] `journalctl -b 0 | grep -E 'remount,(rw|ro)'` returns nothing from digitsd (only first-boot's pair, if first-boot still has hostapd sed)
- [ ] `/data/digits/asset-version` exists at flash time, owned by `digits:digits`, mode 644
- [ ] `/usr/local/bin/digits-setup` exists on the fresh rootfs (verifies the embed rsync worked)
- [ ] OTA regression check: bump digitsd `version.Version` and change one byte in any embedded asset, deploy via the updater, confirm the runtime extractor logs `extracting assets for version <new>` and writes the new marker
- [ ] Negative test: `sudo rm /data/digits/asset-version`, reboot, confirm runtime extractor reruns and rewrites the marker without breakage