### PR TITLE
fix(image): pre-render SWD config and keep dev SSH keys in skeleton

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -761,6 +761,22 @@ rm -rf "${DATA_MNT}/wifi/"*
 rm -rf "${DATA_MNT}/log/journal/"*
 rm -rf "${DATA_MNT}/ssh/"*
 
+# Re-populate /data/ssh with dev SSH host keys after the cleanup, so the
+# skeleton tar below captures them and factory reset still leaves SSH
+# working on dev images. The rootfs symlinks /etc/ssh/ssh_host_*_key
+# point at /data/ssh/* (created later in the dev block); a factory reset
+# wipes /data, restores it from this skeleton, then reboots into the
+# (unchanged) rootfs snapshot. Without these keys in the skeleton, the
+# symlinks resolve to nothing post-reset and sshd refuses to start.
+# Production images skip this entirely; they have no dev user, no
+# password auth, and no symlinks pointing at /data/ssh.
+if [[ "$DEV_MODE" == true ]]; then
+    info "  DEV MODE: pre-generating SSH host keys for skeleton..."
+    mkdir -p "${DATA_MNT}/ssh"
+    ssh-keygen -t rsa -b 4096 -f "${DATA_MNT}/ssh/ssh_host_rsa_key" -N '' -q
+    ssh-keygen -t ed25519 -f "${DATA_MNT}/ssh/ssh_host_ed25519_key" -N '' -q
+fi
+
 # Create compressed data skeleton archive
 info "  Creating data skeleton archive..."
 tar cf - -C "$DATA_MNT" . | zstd -T0 -o "${RECOVERY_MNT}/data-skeleton.tar.zst"
@@ -1175,11 +1191,9 @@ if [[ "$DEV_MODE" == true ]]; then
 PasswordAuthentication yes
 SSHDEV
 
-    # Create SSH host keys directory on /data (writable) and pre-generate
-    # the host keys on the host (not in chroot).
-    mkdir -p "${DATA_MNT}/ssh"
-    ssh-keygen -t rsa -b 4096 -f "${DATA_MNT}/ssh/ssh_host_rsa_key" -N '' -q
-    ssh-keygen -t ed25519 -f "${DATA_MNT}/ssh/ssh_host_ed25519_key" -N '' -q
+    # SSH host keys on /data/ssh/ were pre-generated earlier (right before
+    # the data-skeleton tar) so they get captured by the skeleton and
+    # survive factory reset. Just bake the symlinks here.
 
     # Bake /etc/ssh/ssh_host_*_key symlinks into the rootfs so sshd can find
     # the keys at /data/ssh/. The rootfs is mounted read-only at boot, so

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -642,6 +642,20 @@ if [[ "$PCB_MODE" == true ]]; then
 fi
 info "PCB rev marker: $(cat "${ROOTFS_MNT}/etc/digits-pcb-rev")"
 
+# Pre-render the active SWD config from the per-rev source. digitsd's startup
+# code at cmd/digitsd/main.go does the same byte-compare-and-write at runtime
+# as a self-heal path (so editing /etc/digits-pcb-rev or shipping a new rev
+# config via OTA still works without an asset-version bump), but on a fresh
+# flash that path triggers a rw/ro remount cycle to write a file we already
+# know the content of. Doing it here keeps digitsd's startup write-free.
+PCB_REV=$(cat "${ROOTFS_MNT}/etc/digits-pcb-rev")
+SWD_SRC="${ROOTFS_MNT}/usr/local/share/digits/swd/digits-swd-v${PCB_REV}.cfg"
+SWD_DST="${ROOTFS_MNT}/usr/local/share/digits/swd/digits-swd.cfg"
+[[ -f "$SWD_SRC" ]] || die "SWD config source not found: $SWD_SRC"
+cp "$SWD_SRC" "$SWD_DST"
+chmod 644 "$SWD_DST"
+info "SWD config: pre-rendered $(basename "$SWD_SRC") -> $(basename "$SWD_DST")"
+
 # ── step 13a: compile device-tree overlays (host-side) ──────────────────────
 # The FAT boot firmware loads compiled .dtbo binaries only; .dts sources in
 # /boot/firmware/overlays/ are ignored by the loader.


### PR DESCRIPTION
## Summary

Two related image-builder fixes that close out the remaining first-boot rootfs gotchas after PRs #329, #330, #331.

## 1. Pre-render the active SWD config

digitsd's startup at `cmd/digitsd/main.go:1372-1389` byte-compares `/usr/local/share/digits/swd/digits-swd.cfg` against the per-rev source matching `/etc/digits-pcb-rev` and re-renders on mismatch with a `sudo mount -o remount,rw / ; sudo cp ; sudo mount -o remount,ro /` cycle. The active cfg is not in `rootfs-overlay/`, so on every fresh flash the on-disk file is absent, the byte compare misses, and the rw/ro flip fires. Confirmed in the post-#331 reflash journal:

```
13:43:11 sudo: digits : COMMAND=/usr/bin/mount -o remount,rw /
13:43:11 sudo: digits : COMMAND=/usr/bin/mount -o remount,ro /
```

Decoupled from any race now (PR #330 ordering keeps it after first-boot completes), but it is still avoidable rootfs work.

Fix: pre-render at image build time, right after the existing pcb-rev marker stamp, reading the same `/etc/digits-pcb-rev` value the runtime path reads. The runtime byte-compare passes on first boot and the remount cycle is skipped. Runtime path stays in place as a self-heal fallback for OTA cfg updates and manual rev edits.

## 2. Keep dev SSH host keys in the data skeleton

While reviewing factory-reset behaviour for the SWD change, I noticed PR #329's dev SSH host keys would not survive a factory reset on dev images. Build order in `build-image.sh` was:

1. Pre-skeleton cleanup wipes `/data/ssh/*` (intentional, keeps skeleton free of device-specific state)
2. data-skeleton tar runs (captures empty `/data/ssh/`)
3. Dev block much later runs `ssh-keygen` into `/data/ssh/` (too late, skeleton already taken)

So fresh flashes worked (keys land at flash time) but factory reset on a dev unit would: restore `/data/ssh/` empty from the skeleton, leave the rootfs symlinks `/etc/ssh/ssh_host_*_key -> /data/ssh/*` in place from the snapshot, and sshd would refuse to start with `no hostkeys available`, exactly the failure mode #329 was meant to fix.

Fix: move the dev keygen to right after the cleanup and right before the tar, so the skeleton captures the dev-baked keys. Removed the duplicate keygen from the late dev block. Production images skip the new block (`DEV_MODE` false) and are unaffected: no SSH service, no dev user, no password auth, no symlinks pointing at `/data/ssh`.

## Test plan

- [ ] `make image-v2-flash` (V2 dev image)
- [ ] On boot 1, `journalctl -u digitsd | grep 'swd render:'` shows `swd render: already current pcb_rev=2` (not `installed config`)
- [ ] `journalctl -b 0 | grep 'remount,'` returns nothing from digitsd (only first-boot's pair)
- [ ] `cat /usr/local/share/digits/swd/digits-swd.cfg | head -3` matches `digits-swd-v2.cfg` byte-for-byte
- [ ] V1 build (`make image-flash`) renders from `digits-swd-v1.cfg` instead
- [ ] SWD self-heal: `sudo rm /usr/local/share/digits/swd/digits-swd.cfg`, restart digitsd, confirm it re-renders cleanly via the runtime path
- [ ] Factory reset SSH: trigger factory reset on a dev image, confirm SSH still works after the reset reboot (`sshpass -p digits ssh dev@<ip>` succeeds)