### PR TITLE
fix(image): rebuild firmware on image build, reflash Pico on version mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: help server server-test pi-build pi-test firmware firmware-local stage-firmware image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
+.PHONY: help server server-test pi-build pi-test firmware firmware-local fetch-tags stage-firmware image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
+
+# Refresh tags from origin so version derivation in firmware and pi-build
+# resolves to the latest published release, not whatever the local clone
+# last fetched. Offline-tolerant: a failed fetch is silent and the build
+# falls back to whatever's already in .git.
+fetch-tags:
+	@git fetch --tags --quiet 2>/dev/null || true
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -16,7 +23,7 @@ server-run: ## Build and run the signaling server
 
 # ── Pi Daemon ────────────────────────────────────────────────────────────────
 
-pi-build: ## Cross-compile digitsd for aarch64
+pi-build: fetch-tags ## Cross-compile digitsd for aarch64
 	$(MAKE) -C pi/digitsd build
 
 pi-test: ## Run digitsd tests (host architecture)
@@ -24,7 +31,7 @@ pi-test: ## Run digitsd tests (host architecture)
 
 # ── Firmware ─────────────────────────────────────────────────────────────────
 
-firmware: ## Build Pico firmware (Docker, no host toolchain needed)
+firmware: fetch-tags ## Build Pico firmware (Docker, no host toolchain needed)
 	$(MAKE) -C firmware build
 
 firmware-local: ## Build Pico firmware on host (requires arm-none-eabi-gcc + Pico SDK)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help server server-test pi-build pi-test firmware firmware-local image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
+.PHONY: help server server-test pi-build pi-test firmware firmware-local stage-firmware image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -30,18 +30,28 @@ firmware: ## Build Pico firmware (Docker, no host toolchain needed)
 firmware-local: ## Build Pico firmware on host (requires arm-none-eabi-gcc + Pico SDK)
 	$(MAKE) -C firmware build-local
 
+# Mirror firmware/Makefile's DIGITS_VERSION derivation so the .version file we
+# stage matches the version string the firmware reports over UART after boot.
+DIGITS_FW_VERSION ?= $(shell git describe --tags --always --dirty --match 'fw/v*' 2>/dev/null | sed 's|^fw/v||')
+
+stage-firmware: firmware ## Build firmware and stage it at tools/build/firmware.elf for image bundling
+	@mkdir -p tools/build
+	@cp firmware/build/docker/digits.elf tools/build/firmware.elf
+	@printf '%s\n' '$(DIGITS_FW_VERSION)' > tools/build/firmware.elf.version
+	@echo "==> staged firmware $(DIGITS_FW_VERSION) -> tools/build/firmware.elf"
+
 # ── Pi SD Card Image ─────────────────────────────────────────────────────────
 
-image: ## Build Pi SD card image for V1/prototype hardware (Codec Zero HAT)
+image: stage-firmware ## Build Pi SD card image for V1/prototype hardware (Codec Zero HAT)
 	./pi/image/build-docker.sh
 
-image-dev: ## Build V1/prototype image with SSH enabled (Docker)
+image-dev: stage-firmware ## Build V1/prototype image with SSH enabled (Docker)
 	./pi/image/build-docker.sh --dev
 
-image-v2: ## Build Pi SD card image for V2 carrier board (onboard codec)
+image-v2: stage-firmware ## Build Pi SD card image for V2 carrier board (onboard codec)
 	./pi/image/build-docker.sh --pcb
 
-image-v2-dev: ## Build V2 carrier board image with SSH enabled (Docker)
+image-v2-dev: stage-firmware ## Build V2 carrier board image with SSH enabled (Docker)
 	./pi/image/build-docker.sh --dev --pcb
 
 # Default flash glob: newest of any variant. flash-v1 / flash-v2 narrow it.

--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -3,7 +3,8 @@ PI_HOST    ?= digits@<pi-ip>
 PI_DIR      = ~/digits/digitsd
 BUILDER_IMG = digitsd-builder
 
-VERSION ?= dev
+PI_VERSION_RAW := $(shell git describe --tags --dirty --match 'pi/v*' 2>/dev/null)
+VERSION ?= $(if $(PI_VERSION_RAW),$(PI_VERSION_RAW:pi/v%=%),dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)$(shell git diff --quiet 2>/dev/null || echo -dirty)
 LDFLAGS  = -X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$(VERSION) \
            -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$(COMMIT)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1523,8 +1523,12 @@ func main() {
 		slog.Info("POST: PASS -- Pico UART healthy")
 	} else {
 		slog.Warn("POST: FAIL -- Pico not responding")
-		if newSp, ok := reflashPico(sp, *serialDev, serialLogger, "post-fail"); ok {
-			sp = newSp
+		// reflashPico closes the original sp before flashing and returns a
+		// freshly-opened port regardless of whether post-flash PING passed.
+		// Always take newSp; only the postOk flag is gated on success.
+		newSp, ok := reflashPico(sp, *serialDev, serialLogger, "post-fail")
+		sp = newSp
+		if ok {
 			postOk = true
 		}
 		if !postOk {
@@ -1551,8 +1555,9 @@ func main() {
 			slog.Warn("firmware version mismatch with bundled image",
 				"pico", fwVersion, "bundled", bundled,
 				"action", "auto-reflash")
-			if newSp, ok := reflashPico(sp, *serialDev, serialLogger, "version-mismatch"); ok {
-				sp = newSp
+			newSp, ok := reflashPico(sp, *serialDev, serialLogger, "version-mismatch")
+			sp = newSp
+			if ok {
 				if v, c, err := sp.QueryVersion(); err == nil {
 					fwVersion, fwCommit = v, c
 					slog.Info("firmware version after reflash", "version", fwVersion, "commit", fwCommit)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1133,16 +1133,14 @@ func (d *daemonCallbacks) SendRaw(cmd string) {
 const (
 	defaultFirmwarePath        = "/data/digits/firmware.elf"
 	defaultFirmwareVersionPath = "/data/digits/firmware.elf.version"
+	defaultFlashScript         = "/usr/local/bin/flash-pico.sh"
 	defaultSWDConfig           = "/usr/local/share/digits/swd/digits-swd.cfg"
 	defaultOpenOCD             = "/usr/bin/openocd"
 	pcbRevPath                 = "/etc/digits-pcb-rev"
 )
 
-// firmwareNeedsReflash decides whether the Pico's running firmware version
-// differs from what's bundled in the image at /data/digits/firmware.elf.
-// Both empty strings, or either side empty, return false: we only reflash
-// when we have a confident mismatch. The PING-fail path handles the
-// "Pico unresponsive" case separately.
+// firmwareNeedsReflash reports a confident version mismatch; either side
+// empty returns false (treated as "unknown, skip").
 func firmwareNeedsReflash(picoVersion, bundledVersion string) bool {
 	if picoVersion == "" || bundledVersion == "" {
 		return false
@@ -1150,9 +1148,6 @@ func firmwareNeedsReflash(picoVersion, bundledVersion string) bool {
 	return picoVersion != bundledVersion
 }
 
-// readBundledFirmwareVersion reads the version string written next to the
-// bundled firmware ELF at image-build time. Missing or unreadable file
-// returns "", which firmwareNeedsReflash treats as "skip the check."
 func readBundledFirmwareVersion() string {
 	data, err := os.ReadFile(defaultFirmwareVersionPath)
 	if err != nil {
@@ -1161,38 +1156,30 @@ func readBundledFirmwareVersion() string {
 	return strings.TrimSpace(string(data))
 }
 
-// reflashPico runs openocd to flash defaultFirmwarePath onto the Pico,
-// then closes & reopens the serial port and verifies PING. Returns the
-// reopened *phone.SerialPort and a bool indicating whether PING passed after
-// flash. Skips silently when the firmware ELF or openocd binary is
-// missing (returns the original sp, false). If the serial port can't be
-// reopened the process aborts -- there is no path forward without UART.
+// reflashPico delegates to flash-pico.sh (RESCUE retry, FLASHSIZE override,
+// PCB-rev marker write at 0x101FF000) and re-establishes the serial port.
+// Aborts on serial-reopen failure: nothing else digitsd does works without
+// UART. Returns the reopened port and whether the post-flash PING passed.
 func reflashPico(sp *phone.SerialPort, serialDev string, serialLogger *slog.Logger, reason string) (*phone.SerialPort, bool) {
 	if _, err := os.Stat(defaultFirmwarePath); err != nil {
 		slog.Info("reflash: no firmware at path, skipping", "path", defaultFirmwarePath, "reason", reason)
-		return sp, false
-	}
-	if _, err := os.Stat(defaultOpenOCD); err != nil {
-		slog.Warn("reflash: openocd not found", "path", defaultOpenOCD, "reason", reason)
 		return sp, false
 	}
 	slog.Info("reflash: starting", "path", defaultFirmwarePath, "reason", reason)
 	if err := sp.Close(); err != nil {
 		slog.Warn("reflash: close serial failed", "error", err)
 	}
-	cmd := exec.Command("sudo", defaultOpenOCD,
-		"-f", defaultSWDConfig,
-		"-f", "target/rp2040.cfg",
-		"-c", "rp2040.core0 configure -event reset-init {}",
-		"-c", fmt.Sprintf("program %s verify", defaultFirmwarePath),
-		"-c", "reset run",
-		"-c", "exit")
+	// SKIP_SERVICE_CONTROL=1 stops the script from systemctl-stopping us
+	// (we ARE digitsd) and from doing its own post-flash PING (we hold
+	// the serial port; we'll PING ourselves below).
+	cmd := exec.Command("setsid", "bash", defaultFlashScript, defaultFirmwarePath)
+	cmd.Env = append(os.Environ(), "SKIP_SERVICE_CONTROL=1")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		slog.Error("reflash: openocd failed", "error", err, "reason", reason)
+		slog.Error("reflash: flash script failed", "error", err, "reason", reason)
 	} else {
-		slog.Info("reflash: openocd succeeded", "reason", reason)
+		slog.Info("reflash: flash script succeeded", "reason", reason)
 	}
 	time.Sleep(2 * time.Second)
 	newSp, err := phone.OpenSerial(serialDev, 115200, serialLogger)
@@ -1556,12 +1543,9 @@ func main() {
 		}
 	}
 
-	// If the Pico is healthy but running an older firmware than the one
-	// bundled in this image, reflash so a re-flashed SD card actually
-	// updates the Pico instead of leaving stale firmware in place. The
-	// PING-fail path above only triggers when the Pico is silent; this
-	// covers the "responsive but out of date" case.
-	if postOk {
+	// A re-flashed SD card must overwrite stale Pico firmware; the PING-fail
+	// path doesn't fire when the Pico responds.
+	if postOk && fwVersion != "" {
 		bundled := readBundledFirmwareVersion()
 		if firmwareNeedsReflash(fwVersion, bundled) {
 			slog.Warn("firmware version mismatch with bundled image",

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1131,11 +1131,81 @@ func (d *daemonCallbacks) SendRaw(cmd string) {
 
 // Default paths for SWD flash infrastructure on the Pi.
 const (
-	defaultFirmwarePath = "/data/digits/firmware.elf"
-	defaultSWDConfig    = "/usr/local/share/digits/swd/digits-swd.cfg"
-	defaultOpenOCD      = "/usr/bin/openocd"
-	pcbRevPath          = "/etc/digits-pcb-rev"
+	defaultFirmwarePath        = "/data/digits/firmware.elf"
+	defaultFirmwareVersionPath = "/data/digits/firmware.elf.version"
+	defaultSWDConfig           = "/usr/local/share/digits/swd/digits-swd.cfg"
+	defaultOpenOCD             = "/usr/bin/openocd"
+	pcbRevPath                 = "/etc/digits-pcb-rev"
 )
+
+// firmwareNeedsReflash decides whether the Pico's running firmware version
+// differs from what's bundled in the image at /data/digits/firmware.elf.
+// Both empty strings, or either side empty, return false: we only reflash
+// when we have a confident mismatch. The PING-fail path handles the
+// "Pico unresponsive" case separately.
+func firmwareNeedsReflash(picoVersion, bundledVersion string) bool {
+	if picoVersion == "" || bundledVersion == "" {
+		return false
+	}
+	return picoVersion != bundledVersion
+}
+
+// readBundledFirmwareVersion reads the version string written next to the
+// bundled firmware ELF at image-build time. Missing or unreadable file
+// returns "", which firmwareNeedsReflash treats as "skip the check."
+func readBundledFirmwareVersion() string {
+	data, err := os.ReadFile(defaultFirmwareVersionPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// reflashPico runs openocd to flash defaultFirmwarePath onto the Pico,
+// then closes & reopens the serial port and verifies PING. Returns the
+// reopened *phone.SerialPort and a bool indicating whether PING passed after
+// flash. Skips silently when the firmware ELF or openocd binary is
+// missing (returns the original sp, false). If the serial port can't be
+// reopened the process aborts -- there is no path forward without UART.
+func reflashPico(sp *phone.SerialPort, serialDev string, serialLogger *slog.Logger, reason string) (*phone.SerialPort, bool) {
+	if _, err := os.Stat(defaultFirmwarePath); err != nil {
+		slog.Info("reflash: no firmware at path, skipping", "path", defaultFirmwarePath, "reason", reason)
+		return sp, false
+	}
+	if _, err := os.Stat(defaultOpenOCD); err != nil {
+		slog.Warn("reflash: openocd not found", "path", defaultOpenOCD, "reason", reason)
+		return sp, false
+	}
+	slog.Info("reflash: starting", "path", defaultFirmwarePath, "reason", reason)
+	if err := sp.Close(); err != nil {
+		slog.Warn("reflash: close serial failed", "error", err)
+	}
+	cmd := exec.Command("sudo", defaultOpenOCD,
+		"-f", defaultSWDConfig,
+		"-f", "target/rp2040.cfg",
+		"-c", "rp2040.core0 configure -event reset-init {}",
+		"-c", fmt.Sprintf("program %s verify", defaultFirmwarePath),
+		"-c", "reset run",
+		"-c", "exit")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		slog.Error("reflash: openocd failed", "error", err, "reason", reason)
+	} else {
+		slog.Info("reflash: openocd succeeded", "reason", reason)
+	}
+	time.Sleep(2 * time.Second)
+	newSp, err := phone.OpenSerial(serialDev, 115200, serialLogger)
+	if err != nil {
+		log.Fatalf("reflash: serial re-open failed: %v", err)
+	}
+	if err := newSp.Ping(); err != nil {
+		slog.Warn("reflash: PING failed after flash", "error", err, "reason", reason)
+		return newSp, false
+	}
+	slog.Info("reflash: PING PASS", "reason", reason)
+	return newSp, true
+}
 
 // readPCBRev returns the fab revision of the carrier board ("1", "2", ...)
 // stamped at image-build time. Defaults to "1" if the marker is missing or
@@ -1466,47 +1536,9 @@ func main() {
 		slog.Info("POST: PASS -- Pico UART healthy")
 	} else {
 		slog.Warn("POST: FAIL -- Pico not responding")
-		elfPath := defaultFirmwarePath
-		swdCfg := defaultSWDConfig
-		openocd := defaultOpenOCD
-		if _, errElf := os.Stat(elfPath); errElf == nil {
-			if _, errOcd := os.Stat(openocd); errOcd == nil {
-				slog.Info("POST: attempting auto-flash", "path", elfPath)
-				// Close serial port before SWD flash
-				if err := sp.Close(); err != nil {
-					slog.Warn("POST: close serial failed", "error", err)
-				}
-				cmd := exec.Command("sudo", openocd,
-					"-f", swdCfg,
-					"-f", "target/rp2040.cfg",
-					"-c", "rp2040.core0 configure -event reset-init {}",
-					"-c", fmt.Sprintf("program %s verify", elfPath),
-					"-c", "reset run",
-					"-c", "exit")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				if err := cmd.Run(); err != nil {
-					slog.Error("POST: auto-flash failed", "error", err)
-				} else {
-					slog.Info("POST: auto-flash succeeded")
-				}
-				// Re-open serial port
-				time.Sleep(2 * time.Second)
-				sp, err = phone.OpenSerial(*serialDev, 115200, serialLogger)
-				if err != nil {
-					log.Fatalf("serial re-open after flash: %v", err)
-				}
-				if err := sp.Ping(); err == nil {
-					slog.Info("POST: PASS after auto-flash")
-					postOk = true
-				} else {
-					slog.Warn("POST: FAIL after auto-flash", "error", err)
-				}
-			} else {
-				slog.Warn("POST: openocd not found", "path", openocd)
-			}
-		} else {
-			slog.Info("POST: no firmware at path, skipping auto-flash", "path", elfPath)
+		if newSp, ok := reflashPico(sp, *serialDev, serialLogger, "post-fail"); ok {
+			sp = newSp
+			postOk = true
 		}
 		if !postOk {
 			slog.Warn("POST: Continuing without Pico. Phone will not function.")
@@ -1521,6 +1553,30 @@ func main() {
 		} else {
 			fwVersion, fwCommit = v, c
 			slog.Info("firmware version", "version", fwVersion, "commit", fwCommit)
+		}
+	}
+
+	// If the Pico is healthy but running an older firmware than the one
+	// bundled in this image, reflash so a re-flashed SD card actually
+	// updates the Pico instead of leaving stale firmware in place. The
+	// PING-fail path above only triggers when the Pico is silent; this
+	// covers the "responsive but out of date" case.
+	if postOk {
+		bundled := readBundledFirmwareVersion()
+		if firmwareNeedsReflash(fwVersion, bundled) {
+			slog.Warn("firmware version mismatch with bundled image",
+				"pico", fwVersion, "bundled", bundled,
+				"action", "auto-reflash")
+			if newSp, ok := reflashPico(sp, *serialDev, serialLogger, "version-mismatch"); ok {
+				sp = newSp
+				if v, c, err := sp.QueryVersion(); err == nil {
+					fwVersion, fwCommit = v, c
+					slog.Info("firmware version after reflash", "version", fwVersion, "commit", fwCommit)
+				} else {
+					slog.Warn("firmware version query after reflash failed", "error", err)
+					fwVersion, fwCommit = "", ""
+				}
+			}
 		}
 	}
 

--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -7,6 +7,43 @@ import (
 	"testing"
 )
 
+func TestFirmwareNeedsReflash(t *testing.T) {
+	cases := []struct {
+		name    string
+		pico    string
+		bundled string
+		want    bool
+	}{
+		{"both empty", "", "", false},
+		{"pico empty", "", "1.7.0", false},
+		{"bundled empty (sidecar absent)", "1.7.0", "", false},
+		{"identical versions", "1.7.0", "1.7.0", false},
+		{"older pico than bundled", "1.5.0-69-g8fc14f5a-dirty", "1.7.0", true},
+		{"newer pico than bundled", "1.8.0", "1.7.0", true},
+		{"dirty bundled, clean pico", "1.7.0", "1.7.0-3-gabcd-dirty", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := firmwareNeedsReflash(tc.pico, tc.bundled)
+			if got != tc.want {
+				t.Errorf("firmwareNeedsReflash(%q, %q) = %v, want %v", tc.pico, tc.bundled, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadBundledFirmwareVersion_Missing(t *testing.T) {
+	// Default path almost certainly doesn't exist on the dev host. The
+	// function must return "" without erroring so firmwareNeedsReflash
+	// short-circuits to "no reflash needed."
+	if _, err := os.Stat(defaultFirmwareVersionPath); err == nil {
+		t.Skipf("%s exists on this host; skipping", defaultFirmwareVersionPath)
+	}
+	if got := readBundledFirmwareVersion(); got != "" {
+		t.Errorf("readBundledFirmwareVersion() with missing file = %q, want %q", got, "")
+	}
+}
+
 func TestWritePCMWav(t *testing.T) {
 	samples := []int16{0, 100, -100, 32767, -32768, 0}
 	dir := t.TempDir()

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -134,7 +134,7 @@ for r in json.load(sys.stdin):
     if [[ -z "$FW_TAG" ]]; then
         die "Could not determine latest fw/v* release tag from GitHub. Run 'make stage-firmware' first or check network."
     fi
-    FW_VERSION="${FW_TAG#fw/}"
+    FW_VERSION="${FW_TAG#fw/v}"
     FW_DOWNLOAD_URL="https://github.com/justinlindh/digits/releases/download/${FW_TAG}/firmware-${FW_VERSION}.elf"
     info "  Downloading firmware ${FW_VERSION}..."
     if ! curl -sfL -o "$FW_ELF" "$FW_DOWNLOAD_URL"; then

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -94,7 +94,17 @@ export CC=aarch64-linux-gnu-gcc
 export CGO_ENABLED=1
 export CGO_CFLAGS="-I/usr/aarch64-linux-gnu/include -I/usr/include"
 export CGO_LDFLAGS="-L/usr/lib/aarch64-linux-gnu"
+
+# Stamp pi_version / pi_commit so devices report a real version instead
+# of "dev". Tags were refreshed host-side by make fetch-tags before this
+# container ran; if no pi/v* tag exists, fall back to "dev".
+DIGITSD_VERSION=$(git -C /digits describe --tags --dirty --match 'pi/v*' 2>/dev/null | sed 's|^pi/v||')
+DIGITSD_VERSION=${DIGITSD_VERSION:-dev}
+DIGITSD_COMMIT=$(git -C /digits rev-parse --short HEAD 2>/dev/null || echo unknown)
+info "Stamping digitsd: version=$DIGITSD_VERSION commit=$DIGITSD_COMMIT"
 GOOS=linux GOARCH=arm64 go build \
+    -ldflags "-X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$DIGITSD_VERSION \
+              -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$DIGITSD_COMMIT" \
     -o /digits/tools/build/digitsd \
     ./cmd/digitsd/
 

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -111,27 +111,41 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/digits-recovery .
 
 info "Binaries ready in tools/build/"
 
-# Download latest firmware ELF from GitHub releases
-info "Downloading latest Pico firmware from GitHub releases..."
-FW_API_URL="https://api.github.com/repos/justinlindh/digits/releases"
-FW_TAG=$(curl -sf "$FW_API_URL" | python3 -c "
+# Pico firmware: prefer host-staged ELF (Makefile's stage-firmware target
+# rebuilds firmware/build/docker/digits.elf and copies it here). Fall back
+# to the latest fw/v* GitHub release only when the host didn't stage one,
+# e.g. someone calling build-docker.sh directly. Either way, an image
+# without firmware is a regression we don't ship.
+FW_ELF=/digits/tools/build/firmware.elf
+FW_VER_FILE=/digits/tools/build/firmware.elf.version
+if [[ -f "$FW_ELF" ]]; then
+    if [[ -f "$FW_VER_FILE" ]]; then
+        info "Using host-staged Pico firmware ($(tr -d '[:space:]' < "$FW_VER_FILE"))"
+    else
+        info "Using host-staged Pico firmware (no version file)"
+    fi
+else
+    info "Downloading latest Pico firmware from GitHub releases..."
+    FW_API_URL="https://api.github.com/repos/justinlindh/digits/releases"
+    FW_TAG=$(curl -sf "$FW_API_URL" | python3 -c "
 import json, sys
 for r in json.load(sys.stdin):
     if r['tag_name'].startswith('fw/'):
         print(r['tag_name']); break
 " 2>/dev/null || true)
-if [[ -n "$FW_TAG" ]]; then
+    if [[ -z "$FW_TAG" ]]; then
+        die "Could not determine latest fw/v* release tag from GitHub. Run 'make stage-firmware' first or check network."
+    fi
     FW_VERSION="${FW_TAG#fw/}"
     FW_DOWNLOAD_URL="https://github.com/justinlindh/digits/releases/download/${FW_TAG}/firmware-${FW_VERSION}.elf"
     info "  Downloading firmware ${FW_VERSION}..."
-    if curl -sfL -o /digits/tools/build/firmware.elf "$FW_DOWNLOAD_URL"; then
-        info "  Firmware downloaded: tools/build/firmware.elf"
-    else
-        echo "WARN: Failed to download firmware from $FW_DOWNLOAD_URL -- image will not include firmware" >&2
+    if ! curl -sfL -o "$FW_ELF" "$FW_DOWNLOAD_URL"; then
+        die "Failed to download firmware from $FW_DOWNLOAD_URL"
     fi
-else
-    echo "WARN: Could not determine latest firmware release tag -- image will not include firmware" >&2
+    printf '%s\n' "$FW_VERSION" > "$FW_VER_FILE"
+    info "  Firmware downloaded: tools/build/firmware.elf ($FW_VERSION)"
 fi
+[[ -f "$FW_ELF" ]] || die "Firmware ELF still missing at $FW_ELF after fetch"
 
 # Run the image builder in a working directory, then copy output back
 BUILD_WD="/build"

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -111,11 +111,9 @@ CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/digits-recovery .
 
 info "Binaries ready in tools/build/"
 
-# Pico firmware: prefer host-staged ELF (Makefile's stage-firmware target
-# rebuilds firmware/build/docker/digits.elf and copies it here). Fall back
-# to the latest fw/v* GitHub release only when the host didn't stage one,
-# e.g. someone calling build-docker.sh directly. Either way, an image
-# without firmware is a regression we don't ship.
+# An image without firmware is a regression we don't ship: prefer the
+# host-staged ELF (make stage-firmware), fall back to GitHub release,
+# die if neither is available.
 FW_ELF=/digits/tools/build/firmware.elf
 FW_VER_FILE=/digits/tools/build/firmware.elf.version
 if [[ -f "$FW_ELF" ]]; then

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -699,10 +699,8 @@ info "Copying Pico firmware to /data/digits/firmware.elf..."
 cp "$FW_ELF" "${DATA_MNT}/digits/firmware.elf"
 chown 999:992 "${DATA_MNT}/digits/firmware.elf"
 chmod 644 "${DATA_MNT}/digits/firmware.elf"
-# Sidecar version lets digitsd compare the bundled firmware to what the
-# Pico reports over UART and reflash on mismatch. Both stage-firmware and
-# entrypoint.sh's GitHub fallback always write one; digitsd treats an
-# absent file as "skip the check" rather than failing.
+# Sidecar version lets digitsd reflash on Pico/image mismatch; absent
+# file = skip the check (no failure).
 if [[ -f "$FW_VER" ]]; then
     cp "$FW_VER" "${DATA_MNT}/digits/firmware.elf.version"
     chown 999:992 "${DATA_MNT}/digits/firmware.elf.version"

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -693,13 +693,20 @@ fi
 # ── step 14a: copy Pico firmware to /data (host-side) ────────────────────────
 
 FW_ELF="${BUILD_DIR}/firmware.elf"
-if [[ -f "$FW_ELF" ]]; then
-    info "Copying Pico firmware to /data/digits/firmware.elf..."
-    cp "$FW_ELF" "${DATA_MNT}/digits/firmware.elf"
-    chown 999:992 "${DATA_MNT}/digits/firmware.elf"
-    chmod 644 "${DATA_MNT}/digits/firmware.elf"
-else
-    warn "No firmware.elf found in tools/build/ -- Pico will need OTA flash after first boot"
+FW_VER="${BUILD_DIR}/firmware.elf.version"
+[[ -f "$FW_ELF" ]] || die "Missing ${FW_ELF} -- entrypoint.sh should have staged it. Run 'make stage-firmware' on the host or rebuild via 'make image-v2-flash'."
+info "Copying Pico firmware to /data/digits/firmware.elf..."
+cp "$FW_ELF" "${DATA_MNT}/digits/firmware.elf"
+chown 999:992 "${DATA_MNT}/digits/firmware.elf"
+chmod 644 "${DATA_MNT}/digits/firmware.elf"
+# Sidecar version lets digitsd compare the bundled firmware to what the
+# Pico reports over UART and reflash on mismatch. Both stage-firmware and
+# entrypoint.sh's GitHub fallback always write one; digitsd treats an
+# absent file as "skip the check" rather than failing.
+if [[ -f "$FW_VER" ]]; then
+    cp "$FW_VER" "${DATA_MNT}/digits/firmware.elf.version"
+    chown 999:992 "${DATA_MNT}/digits/firmware.elf.version"
+    chmod 644 "${DATA_MNT}/digits/firmware.elf.version"
 fi
 
 # ── step 14b: copy mixer state to /data (host-side) ─────────────────────────


### PR DESCRIPTION
## What

Fix the chain that let a fresh V2 image flash boot with stale Pico firmware (1.5.0-69-dev) on a 1.7.0 image, leaving the firmware reading V1 GPIO numbers on V2 hardware:

- New `make stage-firmware` target rebuilds firmware locally and stages `tools/build/firmware.elf` + `firmware.elf.version` sidecar before the image is built. `image`, `image-dev`, `image-v2`, `image-v2-dev` (and therefore `image-v2-flash`) all depend on it.
- `pi/image/entrypoint.sh` prefers the host-staged ELF and only falls back to the latest `fw/v*` GitHub release when one isn't present. Both paths now `die` instead of `warn` on missing firmware.
- `tools/build-image.sh` dies if `firmware.elf` is absent and copies the version sidecar to `/data/digits/firmware.elf.version`.
- `digitsd` now reflashes the Pico when its reported `VERSION` differs from the bundled `firmware.elf.version`, even when PING succeeds. The PING-fail and version-mismatch reflash paths share a single helper that delegates to `flash-pico.sh` (RESCUE retry, FLASHSIZE override, and the PCB-rev marker write at 0x101FF000): all things the previous inline openocd call was missing.

## Why

`tools/build/firmware.elf` was missing in the broken bringup because `entrypoint.sh`'s GitHub fetch silently warned and continued on failure, and `make image-v2-flash` had no firmware-rebuild step of its own. The image then shipped without `/data/digits/firmware.elf`, so digitsd's auto-flash had nothing to flash even when the Pico's old firmware was in fact wrong for the board. Adding a local-rebuild path, failing loudly on missing artifacts, and reflashing on version mismatch together guarantee that a fresh `make image-v2-flash` produces a phone whose Pico ends up running the firmware in `HEAD`.

## Test plan

- [x] `go test ./...` in `pi/digitsd` (incl. new `TestFirmwareNeedsReflash` table tests + `TestReadBundledFirmwareVersion_Missing`)
- [x] `golangci-lint run ./...` clean in `pi/digitsd`
- [x] `bash -n` clean on `pi/image/entrypoint.sh` and `tools/build-image.sh`
- [x] `make -n stage-firmware` shows the expected `make -C firmware build` + `cp` + `printf` chain with the right version string
- [ ] (manual, next bringup) `make image-v2-flash` end-to-end on a fresh SD; confirm device boots with `fw_version=1.7.0` and `HOOK:OFF` events fire on handset lift
