### PR TITLE
fix(image): chown image-builder outputs back to host UID

### DIFF
--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -48,12 +48,17 @@ make -C "$REPO_DIR/pi/digitsd" embed
 info "Building digits-image-builder Docker image..."
 docker build -t digits-image-builder "$SCRIPT_DIR"
 
-# Set up volume mounts
+# Set up volume mounts. Pass the host UID/GID so entrypoint.sh can chown
+# the artifacts it writes back to the bind-mounted repo (tools/build/,
+# pi/digits-recovery/bin/, the output .img.gz). Without this, subsequent
+# host-side builds hit Permission denied when overwriting them.
 DOCKER_ARGS=(
     --rm --privileged
     -v "$REPO_DIR":/digits
     -v "$CACHE_VOLUME":/cache
     -w /digits
+    -e "HOST_UID=$(id -u)"
+    -e "HOST_GID=$(id -g)"
 )
 
 # If this is a git worktree, .git is a file pointing to the main repo's

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -163,3 +163,17 @@ bash /digits/tools/build-image.sh ${BUILD_FLAGS[@]+"${BUILD_FLAGS[@]}"} "$SOURCE
 
 # Copy the output image to the mounted repo (accessible from host)
 cp -v "$BUILD_WD"/digits-pi-*.img.gz /digits/
+
+# Hand artifacts back to the host UID. The container runs as root for
+# loop mounts and parted, so anything written under the bind-mounted
+# /digits ends up root-owned. That breaks the next host-side make run
+# (e.g. stage-firmware's cp into tools/build/). build-docker.sh passes
+# HOST_UID/HOST_GID so we can fix it here.
+if [[ -n "${HOST_UID:-}" && -n "${HOST_GID:-}" ]]; then
+    info "Restoring host ownership of build artifacts (${HOST_UID}:${HOST_GID})..."
+    chown -R "${HOST_UID}:${HOST_GID}" \
+        /digits/tools/build \
+        /digits/pi/digits-recovery/bin \
+        2>/dev/null || true
+    chown "${HOST_UID}:${HOST_GID}" /digits/digits-pi-*.img.gz 2>/dev/null || true
+fi


### PR DESCRIPTION
## What

The image-builder container runs Docker as root (loop mount + parted), so artifacts it writes under the bind-mounted `/digits` end up root-owned. The next host-side `make` run then hits `Permission denied`. Specifically, `make stage-firmware` (added in #334) can't `cp` into a root-owned `tools/build/`.

- `build-docker.sh` passes `HOST_UID` / `HOST_GID` into the container.
- `entrypoint.sh` chowns the host-visible outputs at the end: `tools/build/`, `pi/digits-recovery/bin/`, and the `digits-pi-*.img.gz` images dropped at the repo root.

## Why

Hit during the first end-to-end test of #334's `make image-v2-flash`. The firmware Docker build itself was already user-mode (`firmware/Makefile` passes `--user $(id -u):$(id -g)`), so `firmware/build/docker/digits.elf` is host-owned. Only the image-builder container was leaving root-owned files behind, and `stage-firmware` was the first user-mode write into `tools/build/` after years of root-mode writes.

Failures during chown are tolerated (`|| true`) so callers without `HOST_UID` set (someone running the container by hand without `build-docker.sh`) still succeed.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] (manual) `sudo chown -R $(id -u):$(id -g) tools/build` once, then run `make image-v2-flash`; on subsequent runs `tools/build/` stays user-owned without manual intervention
