### PR TITLE
chore(server): drop test-only LatestRelease wrapper

### DIFF
--- a/server/internal/autodeploy/github.go
+++ b/server/internal/autodeploy/github.go
@@ -41,14 +41,10 @@ type releaseJSON struct {
 	Prerelease      bool   `json:"prerelease"`
 }
 
-// LatestRelease returns the newest non-draft, non-prerelease release whose
-// tag_name starts with tagPrefix.
-func (c *GitHubClient) LatestRelease(ctx context.Context, repo, tagPrefix string) (Release, error) {
-	return c.LatestReleaseWithETag(ctx, repo, tagPrefix, "")
-}
-
-// LatestReleaseWithETag is like LatestRelease but sends If-None-Match so an
-// unchanged release list returns 304 and does not consume rate-limit budget.
+// LatestReleaseWithETag returns the newest non-draft, non-prerelease release
+// whose tag_name starts with tagPrefix. When priorETag is non-empty it is
+// sent as If-None-Match so an unchanged release list returns 304 and does
+// not consume rate-limit budget.
 func (c *GitHubClient) LatestReleaseWithETag(ctx context.Context, repo, tagPrefix, priorETag string) (Release, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases", c.base, repo)
 

--- a/server/internal/autodeploy/github_test.go
+++ b/server/internal/autodeploy/github_test.go
@@ -24,7 +24,7 @@ func TestLatestReleaseHappyPath(t *testing.T) {
 	defer srv.Close()
 
 	c := NewGitHubClient(srv.URL, "")
-	rel, err := c.LatestRelease(context.Background(), "owner/repo", "server/v")
+	rel, err := c.LatestReleaseWithETag(context.Background(), "owner/repo", "server/v", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestLatestReleaseSkipsDraftsAndPrereleases(t *testing.T) {
 	defer srv.Close()
 
 	c := NewGitHubClient(srv.URL, "")
-	rel, err := c.LatestRelease(context.Background(), "owner/repo", "server/v")
+	rel, err := c.LatestReleaseWithETag(context.Background(), "owner/repo", "server/v", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestLatestReleaseNoMatch(t *testing.T) {
 	defer srv.Close()
 
 	c := NewGitHubClient(srv.URL, "")
-	rel, err := c.LatestRelease(context.Background(), "owner/repo", "server/v")
+	rel, err := c.LatestReleaseWithETag(context.Background(), "owner/repo", "server/v", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func TestLatestReleaseHTTPErrors(t *testing.T) {
 			}))
 			defer srv.Close()
 			c := NewGitHubClient(srv.URL, "")
-			_, err := c.LatestRelease(context.Background(), "owner/repo", "server/v")
+			_, err := c.LatestReleaseWithETag(context.Background(), "owner/repo", "server/v", "")
 			if err == nil {
 				t.Fatal("expected error")
 			}


### PR DESCRIPTION
`GitHubClient.LatestRelease` only ever called `LatestReleaseWithETag(..., "")`, and the only callers were the four tests in `github_test.go`. Production code already uses `LatestReleaseWithETag` directly. Drop the wrapper, point the tests at the canonical method, and fold its docstring into the survivor so the exported surface matches the actual contract.