### PR TITLE
fix(digitsd): poll PING after reflash so first POST cleanly passes

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1186,12 +1186,37 @@ func reflashPico(sp *phone.SerialPort, serialDev string, serialLogger *slog.Logg
 	if err != nil {
 		log.Fatalf("reflash: serial re-open failed: %v", err)
 	}
-	if err := newSp.Ping(); err != nil {
-		slog.Warn("reflash: PING failed after flash", "error", err, "reason", reason)
+	// A virgin Pico needs to cold-boot the freshly written firmware before
+	// it can answer PING; flash-pico.sh's own sleeps don't always cover
+	// it. Poll Ping() until deadline so the first POST after reflash
+	// reads PASS instead of "Phone will not function." Ping itself has a
+	// 2 s timeout, so a 10 s ceiling allows ~4 attempts.
+	if pingErr := pollPing(newSp.Ping, 10*time.Second, 500*time.Millisecond); pingErr != nil {
+		slog.Warn("reflash: PING failed after flash", "error", pingErr, "reason", reason)
 		return newSp, false
 	}
 	slog.Info("reflash: PING PASS", "reason", reason)
 	return newSp, true
+}
+
+// pollPing retries ping() until it succeeds or deadline elapses, returning
+// the last error on timeout. interval is the gap between attempts; the
+// caller's ping function carries its own timeout. Decoupled from
+// *phone.SerialPort so it can be unit-tested with a fake.
+func pollPing(ping func() error, deadline, interval time.Duration) error {
+	end := time.Now().Add(deadline)
+	var lastErr error
+	for {
+		if err := ping(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(end) {
+			return lastErr
+		}
+		time.Sleep(interval)
+	}
 }
 
 // readPCBRev returns the fab revision of the carrier board ("1", "2", ...)

--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -2,10 +2,57 @@ package main
 
 import (
 	"encoding/binary"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+func TestPollPing_Immediate(t *testing.T) {
+	calls := 0
+	err := pollPing(func() error { calls++; return nil }, 5*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("pollPing returned error on immediate success: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 ping, got %d", calls)
+	}
+}
+
+func TestPollPing_SucceedsOnRetry(t *testing.T) {
+	calls := 0
+	err := pollPing(func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("not ready")
+		}
+		return nil
+	}, 5*time.Second, 1*time.Millisecond)
+	if err != nil {
+		t.Fatalf("pollPing returned error after retry success: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 pings, got %d", calls)
+	}
+}
+
+func TestPollPing_Deadline(t *testing.T) {
+	calls := 0
+	want := errors.New("never ready")
+	start := time.Now()
+	err := pollPing(func() error { calls++; return want }, 50*time.Millisecond, 10*time.Millisecond)
+	elapsed := time.Since(start)
+	if !errors.Is(err, want) {
+		t.Errorf("pollPing returned %v, want last error %v", err, want)
+	}
+	if calls < 2 {
+		t.Errorf("expected at least 2 attempts before deadline, got %d", calls)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("pollPing returned before deadline: %v elapsed", elapsed)
+	}
+}
 
 func TestFirmwareNeedsReflash(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## What

Replace the single `Ping()` after reflash with a 10 s polling retry, so a successful first-boot Pico flash no longer leaves a misleading `POST: Continuing without Pico. Phone will not function.` line in the journal.

## Why

Observed on the working `192.168.2.28` carrier swap (PR #335 merge plus a fresh `make image-v2-flash`). The factory-fresh-flash flow added in #334 worked end-to-end, but the journal said:

```
reflash: flash script succeeded reason=post-fail
TX cmd=PING
reflash: PING failed after flash error="serial: timeout waiting for response to PING"
POST: Continuing without Pico. Phone will not function.
```

`flash-pico.sh` already sleeps twice for 2 s during its own flow, and `reflashPico` adds another 2 s before opening the serial port. That's usually enough, but a virgin Pico cold-booting freshly written firmware sometimes isn't ready in time for a single `Ping()` whose internal timeout is 2 s. The next systemd cycle catches up and POST passes, so it's self-healing, but the message is a lie during the gap.

Polling with 500 ms backoff up to 10 s gives ~4 attempts. A healthy Pico is caught immediately; a slow one within a couple seconds. Same code path runs for both reflash reasons (`post-fail` and `version-mismatch`).

## Test plan

- [x] `go test ./...` in `pi/digitsd` (3 new `TestPollPing_*` cases: immediate success, success on retry, deadline expiry)
- [x] `golangci-lint run ./...` clean
- [ ] (manual, next factory-fresh flash) confirm journal shows `reflash: PING PASS` instead of `Phone will not function` after the first auto-flash
