### PR TITLE
chore(server): drop test-only Hub() accessor on web.Handler

### DIFF
--- a/server/internal/web/dashboard_sse_integration_test.go
+++ b/server/internal/web/dashboard_sse_integration_test.go
@@ -84,7 +84,7 @@ func TestDashboardStream_HubRegisterTriggersFrame(t *testing.T) {
 	_, _ = setupLineWithConn(t, h, database, hh, number, "Kitchen")
 	// setupLineWithConn already registers a conn. Unregister so the test
 	// drives a fresh Register below and observes the resulting Notify.
-	h.Hub().Unregister(number, h.Hub().Get(number))
+	h.hub.Unregister(number, h.hub.Get(number))
 
 	req, _ := http.NewRequest("GET", dashStreamURL(srv), nil)
 	req.AddCookie(cookie)
@@ -107,8 +107,8 @@ func TestDashboardStream_HubRegisterTriggersFrame(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 1)}
-	h.Hub().Register(number, conn)
-	t.Cleanup(func() { h.Hub().Unregister(number, conn) })
+	h.hub.Register(number, conn)
+	t.Cleanup(func() { h.hub.Unregister(number, conn) })
 
 	ev, _, err := readSSEFrame(t, ctx, sr)
 	if err != nil {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -381,11 +381,6 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	}, nil
 }
 
-// Hub returns the signaling hub (used in tests).
-func (h *Handler) Hub() *signaling.Hub {
-	return h.hub
-}
-
 func (h *Handler) Router() http.Handler {
 	mux := http.NewServeMux()
 

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -381,7 +381,7 @@ func TestPhoneRestartOnline(t *testing.T) {
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	form := url.Values{"mode": {"service"}}
 	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
@@ -460,7 +460,7 @@ func TestPhoneRestartInvalidMode(t *testing.T) {
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	form := url.Values{"mode": {"explode"}}
 	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
@@ -498,7 +498,7 @@ func TestPhoneOnlineStatus(t *testing.T) {
 	}
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	req = httptest.NewRequest("GET", "/phones/3140001/online", nil)
 	req.Header.Set("Accept", "application/json")
@@ -784,7 +784,7 @@ func TestPhoneSilentModePushesToConnectedDevice(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
@@ -813,7 +813,7 @@ func TestPhoneSilentModeNoOpSkipsPush(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	// Line defaults to silent_mode=false on insert. Saving false again must be a no-op.
 	if w := postSilentMode(t, h, cookie, "off", false); w.Code != http.StatusSeeOther {
@@ -855,7 +855,7 @@ func TestPhoneVoiceStylePushesToConnectedDevice(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	if w := postVoiceStyle(t, h, cookie, "modern", false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
@@ -884,7 +884,7 @@ func TestPhoneVoiceStyleNoOpSkipsPush(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register("3140001", conn)
+	h.hub.Register("3140001", conn)
 
 	// Line defaults to copper on insert — saving copper again must be a no-op.
 	if w := postVoiceStyle(t, h, cookie, "copper", false); w.Code != http.StatusSeeOther {
@@ -1490,8 +1490,8 @@ func seedPairedHandsetForTest(t *testing.T, h *Handler, database *db.Database, h
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register(number, conn)
-	h.Hub().UpdateDeviceInfo(number, "", "", fwVersion, "", false)
+	h.hub.Register(number, conn)
+	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "", false)
 }
 
 // fakeReleasesForTest builds a fake GitHubReleases populated with the given

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -220,7 +220,7 @@ func setupLineWithConn(t *testing.T, h *Handler, database *db.Database, hh *hous
 		t.Fatalf("add line %s: %v", number, err)
 	}
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.Hub().Register(number, conn)
+	h.hub.Register(number, conn)
 	t.Cleanup(func() {
 		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
 	})


### PR DESCRIPTION
`Handler.Hub()` was annotated `// (used in tests)` and existed only so tests could reach the unexported `hub` field. But every test in the `web` package is in that same package and can read `h.hub` directly. Switch the 13 test call sites over and delete the method so the production type stops advertising a hook that only tests consume.