### PR TITLE
chore(server): drop SWD chip from phone detail

### DIFF
--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -139,9 +139,6 @@
                   {{if .DeviceInfo.FirmwareVersion}}{{.DeviceInfo.FirmwareVersion}}{{else}}<span class="muted italic">unknown</span>{{end}}
                 </span>
                 {{if .DeviceInfo.FirmwareCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.FirmwareCommit}}</span>{{end}}
-                {{if .DeviceInfo.FlashCapable}}
-                  <span class="chip"><span class="chip__dot"></span>SWD</span>
-                {{end}}
                 {{if and .LatestFirmwareVersion (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion)}}
                   {{if .FirmwareUpdateNotes}}
                   <details class="update-details" style="display: inline-block;">
@@ -210,7 +207,6 @@
           </details>
 
           <!-- Firmware update -->
-          {{if .DeviceInfo.FlashCapable}}
           <details class="disclosure">
             <summary>Update firmware</summary>
             <div class="panel__body">
@@ -246,9 +242,6 @@
               {{end}}
             </div>
           </details>
-          {{else}}
-          <p class="muted" style="font-size: 12.5px; margin: 0;">Firmware updates require SWD wiring: flash via USB.</p>
-          {{end}}
           {{end}}
 
           {{else}}
@@ -752,7 +745,7 @@
           {{if .DeviceInfo.FirmwareVersion}}
           <div class="am-settings__kv-row">
             <dt class="am-settings__kv-key am-label">Firmware</dt>
-            <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.FirmwareVersion}}{{if .DeviceInfo.FirmwareCommit}} &middot; {{.DeviceInfo.FirmwareCommit}}{{end}}{{if .DeviceInfo.FlashCapable}} &middot; SWD{{end}}</span></dd>
+            <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.FirmwareVersion}}{{if .DeviceInfo.FirmwareCommit}} &middot; {{.DeviceInfo.FirmwareCommit}}{{end}}</span></dd>
           </div>
           {{end}}
         {{end}}


### PR DESCRIPTION
## Summary
- All shipped devices are flash-capable, so the SWD indicator chip is now noise. Drop it from the firmware row on the phone detail page.
- Drop the now-dead `{{if .DeviceInfo.FlashCapable}}` branches around the firmware update disclosure and its "requires SWD wiring" fallback copy.
- Drop the matching ` · SWD` suffix from the firmware row on the answering-machine theme so all three themes (intercom, dialup, answering-machine) are clean.

## Test plan
- [x] `go build ./cmd/signald/` succeeds
- [x] `go vet ./internal/web/...` clean
- [x] `go test ./internal/web/...` passes
- [ ] Eyeball `/phones/<n>` under each theme (intercom, dialup, answering-machine) to confirm the firmware row no longer shows SWD and the firmware update disclosure still renders


---
_Generated by [Claude Code](https://claude.ai/code/session_01JUYmDPCtkzi2B6LB4ru2CX)_