### PR TITLE
fix(digitsd): keep easter eggs from eating service-code digits

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2076,8 +2076,12 @@ func main() {
 						})
 					}
 				}
-				// Check easter eggs, then service codes
-				if !easterEggs.AddKey(key) {
+				// Mid-service-code: route the key only to svcCodes so easter
+				// eggs (e.g., "0000" Rick Roll) cannot eat digits belonging
+				// to a code like "*#00000#" (factory reset). Otherwise: try
+				// easter eggs first, then fall through to service codes.
+				inCode := svcCodes.InCode()
+				if inCode || !easterEggs.AddKey(key) {
 					switch svcCodes.AddKey(key) {
 					case phone.ServiceCodeTerminal:
 						ctrl.Reset()

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -113,6 +113,14 @@ func (h *ServiceCodeHandler) Reset() {
 	h.buffer = ""
 }
 
+// InCode reports whether the user is mid-entry of a service code. All service
+// codes begin with '*', so a buffer starting with '*' means a code is in
+// progress. Callers use this to suppress competing key consumers (e.g., the
+// easter-egg detector) that would otherwise eat keys belonging to the code.
+func (h *ServiceCodeHandler) InCode() bool {
+	return len(h.buffer) > 0 && h.buffer[0] == '*'
+}
+
 func (h *ServiceCodeHandler) check() ServiceCodeResult {
 	// --- 9-character codes ---
 	if len(h.buffer) >= 9 {

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -269,3 +269,64 @@ func TestServiceCodeRepairDoesNotTriggerShutdown(t *testing.T) {
 		h.AddKey(string(k))
 	}
 }
+
+func TestServiceCodeInCode(t *testing.T) {
+	h := NewServiceCodeHandler()
+	if h.InCode() {
+		t.Error("empty buffer should not be InCode")
+	}
+	h.AddKey("0")
+	if h.InCode() {
+		t.Error("buffer starting with digit should not be InCode")
+	}
+	h.Reset()
+	h.AddKey("*")
+	if !h.InCode() {
+		t.Error("buffer starting with '*' should be InCode")
+	}
+	for _, k := range "#000" {
+		h.AddKey(string(k))
+	}
+	if !h.InCode() {
+		t.Error("mid-code buffer (*#000) should be InCode")
+	}
+}
+
+// TestFactoryResetVsRickRollEasterEgg exercises the dispatcher pattern from
+// cmd/digitsd/main.go that gates easter eggs on InCode(). It guards against
+// the regression where the "0000" easter egg ate the 4th zero of *#00000#
+// before the service code handler could see the full sequence.
+func TestFactoryResetVsRickRollEasterEgg(t *testing.T) {
+	resetFired := make(chan struct{}, 1)
+	svc := NewServiceCodeHandler()
+	svc.SetFactoryResetCallback(func() { resetFired <- struct{}{} })
+
+	rickRoll := make(chan string, 1)
+	eggs := NewEasterEggDetector([]EasterEgg{
+		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
+	}, func(clip string) { rickRoll <- clip })
+	eggs.MinGap = 0
+
+	for _, k := range "*#00000#" {
+		key := string(k)
+		// Mirrors main.go dispatch: suppress easter eggs while mid-code.
+		if !svc.InCode() {
+			if eggs.AddKey(key) {
+				continue
+			}
+		}
+		svc.AddKey(key)
+	}
+
+	select {
+	case <-resetFired:
+	case <-time.After(time.Second):
+		t.Fatal("factory reset never fired for *#00000#")
+	}
+	select {
+	case clip := <-rickRoll:
+		t.Errorf("Rick Roll should not fire during *#00000#, got clip %q", clip)
+	case <-time.After(50 * time.Millisecond):
+		// expected: no easter egg
+	}
+}


### PR DESCRIPTION
## Summary

- \`*#00000#\` triggered the Rick Roll easter egg instead of factory reset because the easter-egg trigger \`0000\` is a substring of the code.
- The dispatch loop fed each key to the easter-egg detector first and short-circuited the service-code handler on a match, so the 4th zero of \`*#00000#\` fired Rick Roll and the service-code buffer never saw the full sequence.
- Add \`ServiceCodeHandler.InCode()\` (true when the buffer starts with \`*\`) and gate the easter-egg check on \`!InCode()\` in the digitsd dispatch loop. All service codes begin with \`*\`, so once the user types it they're committed to a code path until completion or hang-up.

## Trace before fix

Keys: \`*\`, \`#\`, 0, 0, 0, 0, 0, \`#\`

| Key | easter buf | svc buf | Result |
|---|---|---|---|
| \`*\` | \`*\` | \`*\` | no match |
| \`#\` | \`*#\` | \`*#\` | no match |
| \`0\` | \`*#0\` | \`*#0\` | no match |
| \`0\` | \`*#00\` | \`*#00\` | no match |
| \`0\` | \`*#000\` | \`*#000\` | no match |
| \`0\` | matches \`0000\` → fires Rick Roll, buffer cleared | \`*#000\` (svc skipped) | Rick Roll plays |
| \`0\` | \`0\` | \`*#0000\` | no match |
| \`#\` | \`0#\` | \`*#0000#\` (7 chars) | factory reset never fires |

## Test plan

- [x] \`go test ./internal/phone/\` passes (new \`TestServiceCodeInCode\` and \`TestFactoryResetVsRickRollEasterEgg\` regression test that mirrors the dispatch logic)
- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` clean from \`pi/digitsd\`
- [ ] Hardware verification on a phone: dial \`*#00000#\` → factory reset triggers, Rick Roll does not play
- [ ] Hardware verification: dial \`0000\` from idle → Rick Roll still plays