### PR TITLE
fix(digitsd): tighten service-code prefix to "*#" so lone '*' doesn't gate eggs

### DIFF
--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -113,12 +113,14 @@ func (h *ServiceCodeHandler) Reset() {
 	h.buffer = ""
 }
 
-// InCode reports whether the user is mid-entry of a service code. All service
-// codes begin with '*', so a buffer starting with '*' means a code is in
-// progress. Callers use this to suppress competing key consumers (e.g., the
-// easter-egg detector) that would otherwise eat keys belonging to the code.
+// InCode reports whether the user is mid-entry of a service code. Every
+// service code begins with the two-character prefix "*#", so requiring both
+// chars (rather than just '*') keeps the suppression window tight: a lone
+// '*' followed by digits stays in normal-dial mode, where easter eggs like
+// "0000" still fire as expected. Callers use this to suppress competing key
+// consumers that would otherwise eat keys belonging to the code.
 func (h *ServiceCodeHandler) InCode() bool {
-	return len(h.buffer) > 0 && h.buffer[0] == '*'
+	return len(h.buffer) >= 2 && h.buffer[0] == '*' && h.buffer[1] == '#'
 }
 
 func (h *ServiceCodeHandler) check() ServiceCodeResult {

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -281,10 +281,21 @@ func TestServiceCodeInCode(t *testing.T) {
 	}
 	h.Reset()
 	h.AddKey("*")
-	if !h.InCode() {
-		t.Error("buffer starting with '*' should be InCode")
+	if h.InCode() {
+		t.Error("lone '*' should not be InCode (a code requires the '*#' prefix)")
 	}
-	for _, k := range "#000" {
+	h.AddKey("0")
+	if h.InCode() {
+		t.Error("'*' followed by digit should not be InCode (not a code prefix)")
+	}
+	h.Reset()
+	for _, k := range "*#" {
+		h.AddKey(string(k))
+	}
+	if !h.InCode() {
+		t.Error("'*#' prefix should be InCode")
+	}
+	for _, k := range "000" {
 		h.AddKey(string(k))
 	}
 	if !h.InCode() {
@@ -328,5 +339,36 @@ func TestFactoryResetVsRickRollEasterEgg(t *testing.T) {
 		t.Errorf("Rick Roll should not fire during *#00000#, got clip %q", clip)
 	case <-time.After(50 * time.Millisecond):
 		// expected: no easter egg
+	}
+}
+
+// TestEasterEggFiresAfterLoneStar guards the suppression-window scope: a
+// stray '*' followed by digits is normal-dial input, not a service code, and
+// must not block easter eggs (which require the full '*#' prefix to suppress).
+func TestEasterEggFiresAfterLoneStar(t *testing.T) {
+	svc := NewServiceCodeHandler()
+	rickRoll := make(chan string, 1)
+	eggs := NewEasterEggDetector([]EasterEgg{
+		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
+	}, func(clip string) { rickRoll <- clip })
+	eggs.MinGap = 0
+
+	for _, k := range "*0000" {
+		key := string(k)
+		if !svc.InCode() {
+			if eggs.AddKey(key) {
+				continue
+			}
+		}
+		svc.AddKey(key)
+	}
+
+	select {
+	case clip := <-rickRoll:
+		if clip != "rickroll" {
+			t.Errorf("expected rickroll, got %q", clip)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Rick Roll should fire for *0000 (lone '*' is not a service code)")
 	}
 }


### PR DESCRIPTION
Follow-up to #342, addressing the [false-suppression note](https://github.com/justinlindh/digits/pull/342#issuecomment-4331822561) from the review on that PR.

## Summary

- After #342, \`InCode()\` returned true the moment the buffer started with \`*\`, suppressing the easter-egg detector for everything that followed. A lone \`*\` from idle plus four zeros (\`*0000\`) is normal-dial input, not a service code, and used to fire Rick Roll. With \#342 it stopped firing.
- Every real service code begins with the two-character prefix \`*#\`. Tightening \`InCode()\` to require both characters keeps the original bug fix (\`*#00000#\` → factory reset, no Rick Roll) while restoring pre-#342 behavior for lone-\`*\` sequences.
- Added \`TestEasterEggFiresAfterLoneStar\` as a regression for that case; tightened \`TestServiceCodeInCode\` to cover the new boundary.

## Test plan

- [x] \`go test ./internal/phone/\` passes (full suite, plus new lone-\`*\` regression)
- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` clean from \`pi/digitsd\`
- [ ] Hardware verification on a phone: dial \`*#00000#\` → factory reset still triggers, no Rick Roll
- [ ] Hardware verification: dial \`*0000\` → Rick Roll plays
- [ ] Hardware verification: dial \`0000\` from idle → Rick Roll plays