### PR TITLE
fix(digitsd,image): *#SETUP# actually clears wifi-configured flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,8 @@ docs: update wiring notes
 
 **Git.** Remote: `github` (`git@github.com:justinlindh/digits.git`). PRs required to merge into main; no direct pushes. PR template at `.github/pull_request_template.md`.
 
+**`gh` PR/issue bodies.** With a single-quoted heredoc (`<<'EOF'`), the shell does no interpretation, so write backticks and quotes literally. Escaping them as `\`` or `\"` ships the backslashes to GitHub verbatim and breaks the rendered formatting (symptom: published body shows `\`foo\`` everywhere instead of `foo` in inline code).
+
 **Style.** Go uses standard project layout, raw SQL with `database/sql` (no ORM), errors returned not panicked. Server web UI uses htmx + Tailwind, templates in `internal/web/templates/`. Firmware uses C with Pico SDK conventions.
 
 ## Definition of done for substantial work

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1749,15 +1749,21 @@ func main() {
 	})
 	svcCodes.SetSetupCallback(func() {
 		slog.Info("service code: *#SETUP# (*#73887#) -> removing wifi-configured flag, rebooting")
-		err := os.Remove(phone.WifiConfiguredFlag)
-		switch {
-		case err == nil:
+		// /data/wifi-configured is owned by root (digits-setup writes it as
+		// root); /data itself is mode 755 root:root. digitsd runs as the
+		// 'digits' user, which lacks write access to /data and so cannot
+		// unlink the flag directly. The digits-updater sudoers entry grants
+		// NOPASSWD on rm -f for this exact path.
+		out, err := exec.Command("sudo", "/usr/bin/rm", "-f", phone.WifiConfiguredFlag).CombinedOutput()
+		if err != nil {
+			slog.Warn("service code setup: remove wifi flag failed", "path", phone.WifiConfiguredFlag, "error", err, "output", strings.TrimSpace(string(out)))
+		} else {
 			slog.Info("service code setup: removed wifi flag -- Pi will boot into AP mode", "path", phone.WifiConfiguredFlag)
-		case os.IsNotExist(err):
-			slog.Info("service code setup: wifi flag already absent -- Pi will boot into AP mode", "path", phone.WifiConfiguredFlag)
-		default:
-			slog.Warn("service code setup: remove wifi flag failed", "path", phone.WifiConfiguredFlag, "error", err)
 		}
+		// The Pi takes ~30s to come back; without an audible cue the silence
+		// reads as a freeze and tempts a hard power-cut mid-boot.
+		doubleBeep()
+		time.Sleep(1500 * time.Millisecond)
 		_ = exec.Command("sudo", "reboot").Run()
 	})
 

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -4,6 +4,7 @@
 #   - run openocd for SWD firmware flashing
 #   - stop/start digitsd service
 #   - reboot the device (remote restart, factory reset, or service code)
+#   - clear /data/wifi-configured flag for *#SETUP# Wi-Fi re-provisioning
 digits ALL=(root) NOPASSWD: /usr/bin/mount -o remount\,rw /, /usr/bin/mount -o remount\,ro /
 digits ALL=(root) NOPASSWD: /usr/bin/mkdir -p *
 digits ALL=(root) NOPASSWD: /usr/bin/cp /tmp/asset-* *
@@ -11,6 +12,7 @@ digits ALL=(root) NOPASSWD: /usr/bin/cp /data/digits/staging/digitsd-aarch64 /us
 digits ALL=(root) NOPASSWD: /usr/bin/chmod *
 digits ALL=(root) NOPASSWD: /usr/bin/mv /usr/local/bin/digitsd.tmp /usr/local/bin/digitsd
 digits ALL=(root) NOPASSWD: /usr/bin/rm -f /usr/local/bin/digitsd.tmp
+digits ALL=(root) NOPASSWD: /usr/bin/rm -f /data/wifi-configured
 digits ALL=(root) NOPASSWD: /usr/bin/openocd
 digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service
 digits ALL=(root) NOPASSWD: /usr/sbin/reboot


### PR DESCRIPTION
## Summary

`*#SETUP#` was supposed to put the Pi back into AP mode for Wi-Fi re-provisioning. In practice it just rebooted into station mode. Reported live tonight from V2 Black 2 ("froze and didn't come back until hard power reset").

## Root cause

The SETUP service-code callback called `os.Remove("/data/wifi-configured")` directly. digitsd runs as the `digits` user, but:
- `/data` is `755 root:root` (default `mkfs.ext4` from `partition-setup.sh:182`; `init-data.sh` never chowns the partition root)
- `/data/wifi-configured` is `600 root:root` (created by `digits-setup` running as root, `pi/digits-setup/internal/wifi/configure.go:215`)

Unlink needs write+exec on the parent directory; `digits` has only `r-x` on `/data`. So `os.Remove` returns EACCES, gets logged at WARN, and is swallowed. `sudo reboot` then runs, the Pi comes back, `digits-ap-check init` sees the flag still present, and `do_station_up` rejoins Wi-Fi. The AP path is never entered. Bug has existed since the original `*#SETUP#` commit (March 28); the existing unit test only verifies callback dispatch with an in-memory func.

The "freeze" was the ~30s of dead silence between the keypress and digitsd coming back: the line goes silent, no dial tone, looks indistinguishable from a hung Pi.

Verified empirically on the device:
```
$ sudo -u digits rm /data/wifi-configured
rm: cannot remove '/data/wifi-configured': Permission denied
```

## Fix

1. Route the rm through `sudo /usr/bin/rm -f` and add a narrow new NOPASSWD entry to `/etc/sudoers.d/digits-updater` for that exact path. Same shape as the existing `rm /usr/local/bin/digitsd.tmp` grant.
2. Play `doubleBeep()` + 1.5s pause before `sudo reboot` so the user hears "got it" before the line goes silent.
3. Note the `gh` heredoc-escaping gotcha in `CLAUDE.md` (caught while reviewing the original published body of this PR).

## Verification

End-to-end on V2 Black 2:

```
04:28:07.886  service code: *#SETUP# (*#73887#) -> removing wifi-configured flag, rebooting
04:28:07      sudo[8939]: digits : COMMAND=/usr/bin/rm -f /data/wifi-configured
04:28:07      sudo[8939]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=999)
04:28:07      sudo[8939]: pam_unix(sudo:session): session closed for user root
04:28:07.927  service code setup: removed wifi flag -- Pi will boot into AP mode
[connection closed: device rebooting]
```

Pi rebooted into AP mode, `Digits-XXXX` broadcast, re-provisioning via captive portal completed.

## Test plan

- [x] `go test ./...` in `pi/digitsd` passes
- [x] `golangci-lint run ./...` clean
- [x] `visudo -cf` validates the updated sudoers file
- [x] Live verified on V2 Black 2: flag removed via sudo, AP came up, captive portal worked