### PR TITLE
feat(server): handle phone-initiated repair to invalidate stale pairing

### DIFF
--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -185,6 +185,24 @@ func (s *Store) CompletePairing(ctx context.Context, id int64) error {
 	return nil
 }
 
+// Unpair invalidates the device's paired_at and device_token so the next
+// register-without-token from this hardware ID will be issued a fresh
+// pairing code instead of being rejected. Used by the Phone -> Server
+// repair flow (the *#0* service code) so digitsd can tell the server
+// "I'm intentionally clearing my local token, please drop yours too."
+// No-op (returns nil) if the device row doesn't exist.
+func (s *Store) Unpair(ctx context.Context, hardwareID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE devices
+		SET paired_at = NULL, device_token = NULL
+		WHERE hardware_id = $1
+	`, hardwareID)
+	if err != nil {
+		return fmt.Errorf("unpair: %w", err)
+	}
+	return nil
+}
+
 // TouchLastSeen updates last_seen_at to NOW() for the device with the given hardware ID.
 func (s *Store) TouchLastSeen(ctx context.Context, hardwareID string) error {
 	_, err := s.db.ExecContext(ctx,

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -26,6 +26,7 @@ const (
 	TypeRestart       = "restart"        // Server → Phone: restart service or reboot
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
+	TypeRepair        = "repair"         // Phone → Server: invalidate pairing (used by *#0* before reboot)
 )
 
 // Conference message types (three-way calling)

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -157,6 +157,22 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("bad websocket message", "number", number, "err", err)
 			continue
 		}
+		// TypeRepair is intercepted here (not in relay) because we have the
+		// authenticated connection's HardwareID in scope and don't need to
+		// thread the device store into the Relay. The phone calls this from
+		// its *#0* callback before reboot to invalidate server-side pairing,
+		// so the next register-without-token is treated as a fresh pair-up
+		// rather than rejected as "device_token required".
+		if msg.Type == signaling.TypeRepair {
+			if h.deviceStore != nil && msg.HardwareID != "" {
+				if err := h.deviceStore.Unpair(r.Context(), msg.HardwareID); err != nil {
+					slog.Warn("repair: unpair failed", "hardware_id", msg.HardwareID, "err", err)
+				} else {
+					slog.Info("repair: device unpaired by client request", "hardware_id", msg.HardwareID, "number", number)
+				}
+			}
+			continue
+		}
 		h.relay.HandleMessage(r.Context(), number, msg)
 	}
 }


### PR DESCRIPTION
## Summary

Pre-existing bug in `*#0*` (force re-pair service code) on the phone. The phone clears its local `DeviceToken` and reboots, expecting to come back unpaired. The server still has `paired_at` and `device_token` populated for that hardware_id, so when the phone re-registers without a token, `handler_ws.go` rejects with `"device_token required"` (line 73-76) and the loop runs forever. User hears constant dial tone instead of welcome+code.

`*#0*` was added with the original service-code work but never exercised end-to-end. Caught while testing the new keypad-confirmation gating (the `*#SETUP#` follow-up PRs).

## Fix

New `TypeRepair` Phone→Server message. Phone sends it over the still-authenticated WS *before* clearing local state and rebooting. Server intercepts in `handler_ws.go` (where `msg.HardwareID` is already in scope from the WS register frame, so no need to thread the device store into `Relay`) and calls a new `device.Store.Unpair` which `UPDATE devices SET paired_at = NULL, device_token = NULL`. On next register-without-token the phone takes the `!paired` branch and is issued a fresh pairing code.

## Stacking

Companion phone-side changes (the `TypeRepair` sender + the `*#0*` confirmation gating that made this bug observable) live on a separate digitsd branch and will land after this merges.

## Test plan

- [x] `go test ./...` passes (no new tests; `Unpair` is a single SQL update, behavior verified live in the integration test below)
- [x] `golangci-lint run ./...` clean
- [x] Live verified on V2 Black 2: before fix, manual `UPDATE devices SET paired_at=NULL, device_token=NULL` was required to unbreak; after fix, phone sends `TypeRepair` on `*#0*` and server handles it autonomously