### PR TITLE
fix(server): generate invite codes as uppercase only

### DIFF
--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const inviteCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+const inviteCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const inviteCodeLength = 8
 
 // HouseholdLink represents a link (invitation or active connection) between two households.

--- a/server/internal/household/link_unit_test.go
+++ b/server/internal/household/link_unit_test.go
@@ -1,0 +1,20 @@
+package household
+
+import "testing"
+
+func TestGenerateInviteCode_UppercaseAlphanumericOnly(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		code, err := generateInviteCode()
+		if err != nil {
+			t.Fatalf("generateInviteCode: %v", err)
+		}
+		if len(code) != inviteCodeLength {
+			t.Errorf("expected length %d, got %d (%q)", inviteCodeLength, len(code), code)
+		}
+		for _, r := range code {
+			if (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+				t.Fatalf("code %q contains non-uppercase-alphanumeric rune %q (iter %d)", code, r, i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Mixed-case invite codes were unacceptable. The accept handler at `server/internal/web/handler_links.go:124` uppercases user input before lookup:

```go
code := strings.TrimSpace(strings.ToUpper(r.FormValue("code")))
```

But the generator's alphabet (`server/internal/household/link.go:12`) included lowercase letters. A code like `C7Fne5hv` became `C7FNE5HV` after normalization, then missed the case-sensitive Postgres `WHERE invite_code = \$1` lookup and surfaced as "invite code not found or already used".

Caught while testing the invite flow on real devices.

Fix: narrow the alphabet to `A-Z0-9`. New codes always match after `ToUpper`, and users can type freely in any case.

## Test plan

- [x] `TestGenerateInviteCode_UppercaseAlphanumericOnly` (200 iterations) fails on the old alphabet, passes on the new one
- [x] `go test ./...` clean
- [x] `golangci-lint run ./...` clean
- [ ] Generate a fresh invite in prod after deploy and accept it from a second device

## Notes

The three currently-pending mixed-case invites in prod will be invalidated by this change (all but one happens to be all-uppercase by coincidence). They were test invites; users should generate fresh ones.