### PR TITLE
chore(server): drop dead FlashCapable plumbing post-#340

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -228,7 +228,7 @@ After SDP/ICE exchange, audio flows peer-to-peer via WebRTC DTLS-SRTP.
 | Type              | Direction      | Key Fields                            | Purpose                              |
 |-------------------|----------------|---------------------------------------|--------------------------------------|
 | `register`        | Phone -> Server | `number`                             | Register phone number on connect     |
-| `device_info`     | Phone -> Server | version fields, `flash_capable`      | Report device version info           |
+| `device_info`     | Phone -> Server | version fields                       | Report device version info           |
 | `call`            | Phone -> Server | `to`                                 | Initiate call to another number      |
 | `ring`            | Server -> Phone | `from`                               | Notify callee of incoming call       |
 | `sdp`             | Bidirectional  | `to`, `from`, `sdp`                  | Relay SDP offer/answer               |

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -28,7 +28,6 @@ type Conn struct {
 	PiCommit        string
 	FirmwareVersion string
 	FirmwareCommit  string
-	FlashCapable    bool
 }
 
 // dashNotifier is the subset of *dashboard/events.Broadcaster the Hub uses
@@ -171,7 +170,6 @@ type DeviceInfoSnapshot struct {
 	PiCommit        string
 	FirmwareVersion string
 	FirmwareCommit  string
-	FlashCapable    bool
 }
 
 // DeviceInfo returns version info for a connected phone. Returns nil if offline.
@@ -187,7 +185,6 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 		PiCommit:        conn.PiCommit,
 		FirmwareVersion: conn.FirmwareVersion,
 		FirmwareCommit:  conn.FirmwareCommit,
-		FlashCapable:    conn.FlashCapable,
 	}
 }
 
@@ -217,7 +214,7 @@ func (h *Hub) ClearUpdateStatus(number string) {
 }
 
 // UpdateDeviceInfo sets version info for a connected phone under the write lock.
-func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string, flashCapable bool) bool {
+func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	conn, ok := h.conns[number]
@@ -228,7 +225,6 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string, 
 	conn.PiCommit = piCommit
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
-	conn.FlashCapable = flashCapable
 	return true
 }
 

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -135,9 +135,6 @@ type Message struct {
 	UpdateStatus string `json:"update_status,omitempty"` // downloading, applying, rebooting, success, failed
 	UpdateDetail string `json:"update_detail,omitempty"` // human-readable detail
 
-	// Flash capability (device_info messages)
-	FlashCapable bool `json:"flash_capable,omitempty"`
-
 	// Restart fields (restart messages)
 	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -83,7 +83,7 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeRequestICE:
 		r.handleRequestICE(ctx, from, msg)
 	case TypeDeviceInfo:
-		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.FlashCapable) {
+		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit) {
 			slog.Info("device_info", "number", from,
 				"pi_version", msg.PiVersion,
 				"fw_version", msg.FirmwareVersion)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1590,7 +1590,7 @@ func seedPairedHandsetForTest(t *testing.T, h *Handler, database *db.Database, h
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	h.hub.Register(number, conn)
-	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "", false)
+	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "")
 }
 
 // fakeReleasesForTest builds a fake GitHubReleases populated with the given

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -272,7 +272,7 @@ func (h *Handler) handleDevSeedFirmware(w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 	h.hub.Register(number, conn)
-	h.hub.UpdateDeviceInfo(number, "", "", fw, "", false)
+	h.hub.UpdateDeviceInfo(number, "", "", fw, "")
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprintf(w, `{"ok":true,"number":%q,"fw":%q}`, number, fw)
 }


### PR DESCRIPTION
## Summary

Holistic-review finding from the 2026-04-28 across-PR pass.

PR #340 (`chore(server): drop SWD chip from phone detail`) removed both UI consumers of `DeviceInfo.FlashCapable`: the SWD chip on the phone-detail page and the `{{if .DeviceInfo.FlashCapable}}` gate around the "Update firmware" disclosure. The PR description was explicit: "All shipped devices are flash-capable, so the SWD indicator chip is now noise."

The field was nonetheless left plumbed through:
- `server/internal/signaling/protocol.go` (Message struct)
- `server/internal/signaling/hub.go` (Conn struct, DeviceInfoSnapshot, UpdateDeviceInfo signature)
- `server/internal/signaling/relay.go` (dispatch)
- `server/README.md` message-types table

After #340 there is no server-side consumer that reads the value.

## What this PR does

Drops `FlashCapable` from server-side code and docs. The two test/handler call sites for `UpdateDeviceInfo` are updated to drop the trailing `false` argument.

digitsd keeps emitting the `flash_capable` JSON field; the server's JSON decoder silently ignores unknown fields on unmarshal, so:
- Old digitsd to new server: server ignores `flash_capable` (fine).
- New digitsd to old server: digitsd still sends it (fine).
- A subsequent digitsd-side cleanup can drop the wire field once cross-version concerns clear.

## Motivated by (last 24h merges)

- #340 chore(server): drop SWD chip from phone detail (the explicit "noise" call)

## Test plan

- [x] `go build ./...` clean (server module, Go 1.26.1 via auto-toolchain)
- [x] `go test ./internal/signaling/ ./internal/web/` pass
- [x] `go vet ./...` clean
- [ ] CI-side `golangci-lint` (host binary is built against Go 1.25 and refuses 1.26.1 modules)
