### PR TITLE
fix(ci): serialize release workflows so back-to-back merges don't drop a tag

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -16,6 +16,13 @@ on:
       - "firmware/.releaserc-full.cjs"
       - "firmware/.releaserc-tagonly.cjs"
 
+# See server-release.yml for why this exists. Serializes release runs
+# so back-to-back merges don't race semantic-release into silently
+# skipping a tag.
+concurrency:
+  group: fw-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -15,6 +15,13 @@ on:
       - ".github/workflows/pi-release.yml"
       - "pi/.releaserc.cjs"
 
+# See server-release.yml for why this exists. Serializes release runs
+# so back-to-back merges don't race semantic-release into silently
+# skipping a tag.
+concurrency:
+  group: pi-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -14,6 +14,17 @@ on:
       - "server/**"
       - ".github/workflows/server-release.yml"
 
+# Serialize release runs so two PRs merging back-to-back don't race
+# semantic-release. Without this, the second run's checkout is "behind"
+# the now-advanced remote main and semantic-release bails with
+# "The local branch main is behind the remote one, therefore a new
+# version won't be published" -- silently skipping the tag for that
+# PR's commits. cancel-in-progress=false queues the second run instead
+# of cancelling, so each merge eventually gets analyzed.
+concurrency:
+  group: server-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

After PR #347 merged, production signald stayed on v1.44.1 (#348's tag) because semantic-release skipped #347's release run with:

> The local branch main is behind the remote one, therefore a new version won't be published.

Cause: PRs #347 and #346 merged within seconds of each other. The release workflow for #347 checked out main at one moment, semantic-release ran moments later, and by then #346 had advanced remote main. The local checkout was "behind" and semantic-release exited 0 without publishing. Net result: #347's `TypeRepair` handler never tagged, never built, never deployed. Caught manually triggering `server-release` after the fact.

## Fix

Add a `concurrency` group to each release workflow with `cancel-in-progress: false` so back-to-back merges queue serially. The second run still happens, just after the first finishes, against an up-to-date checkout.

Applied to all three of:
- `.github/workflows/server-release.yml`
- `.github/workflows/pi-release.yml`
- `.github/workflows/fw-release.yml`

(All three use the same `semantic-release` shape and would race the same way.)

## Test plan

- [x] YAML still parses (`gh workflow view` post-merge will confirm)
- [ ] Next time two PRs touching the same scope merge near each other, both get their tags. Hard to force-test without merging back-to-back PRs; this is a "watch the next race window" verification.

## Note

The semantic-release check that surfaced this is itself sensible (don't publish from stale state); the fix is on the workflow side rather than configuring semantic-release to push through anyway.