### PR TITLE
fix(digitsd): send TypeRepair from triggerFactoryReset so server unpairs

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1295,8 +1295,7 @@ func triggerFactoryReset(sig *sigclient.Client, deviceID string) {
 	// wipes /data (and with it the local DeviceToken), so the device comes
 	// back unpaired. Without this, the server still has paired_at set and
 	// rejects the post-reset register-without-token as "device_token
-	// required", looping every 3 seconds. Same trap as the *#0* repair
-	// callback, fixed there in PRs #346/#347. Brief sleep so the message
+	// required", looping every 3 seconds. Brief sleep so the message
 	// lands (writes are async on the WS Send channel).
 	if sig != nil && deviceID != "" {
 		sendSignal(sig, &sigclient.Message{Type: sigclient.TypeRepair, HardwareID: deviceID})

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1277,7 +1277,7 @@ func readPCBRev() string {
 // statusFunc is a callback to report update progress back to the server.
 type statusFunc func(status, detail string)
 
-func triggerFactoryReset() {
+func triggerFactoryReset(sig *sigclient.Client, deviceID string) {
 	if err := bootcount.SetThreshold(bootcount.DefaultPath, 3); err != nil {
 		slog.Error("factory reset: failed to set boot counter", "err", err)
 		return
@@ -1289,6 +1289,18 @@ func triggerFactoryReset() {
 	// recovery menu still appears, just with a misleading header.
 	if err := os.WriteFile(bootcount.AutoFactoryResetFlag, []byte("1\n"), 0644); err != nil {
 		slog.Warn("factory reset: write auto-reset flag failed", "path", bootcount.AutoFactoryResetFlag, "err", err)
+	}
+	// Tell the server to invalidate its copy of paired_at + device_token
+	// over the still-authenticated WS, BEFORE we reboot. Factory reset
+	// wipes /data (and with it the local DeviceToken), so the device comes
+	// back unpaired. Without this, the server still has paired_at set and
+	// rejects the post-reset register-without-token as "device_token
+	// required", looping every 3 seconds. Same trap as the *#0* repair
+	// callback, fixed there in PRs #346/#347. Brief sleep so the message
+	// lands (writes are async on the WS Send channel).
+	if sig != nil && deviceID != "" {
+		sendSignal(sig, &sigclient.Message{Type: sigclient.TypeRepair, HardwareID: deviceID})
+		time.Sleep(500 * time.Millisecond)
 	}
 	slog.Info("factory reset: boot counter set to 3, auto-reset flag written, rebooting")
 	_ = exec.Command("sudo", "reboot").Run()
@@ -2009,7 +2021,7 @@ func main() {
 		slog.Info("service code: *#00000# -> awaiting confirmation")
 		confirm("confirm_factory_reset", func() {
 			slog.Info("service code factory reset confirmed")
-			triggerFactoryReset()
+			triggerFactoryReset(sig, deviceID)
 		})
 	})
 
@@ -2550,7 +2562,7 @@ func main() {
 
 			case sigclient.TypeFactoryReset:
 				slog.Info("factory reset: triggered by server")
-				go triggerFactoryReset()
+				go triggerFactoryReset(sig, deviceID)
 
 			case sigclient.TypeContacts, sigclient.TypeContactsUpdated:
 				entries := make([]contacts.Entry, 0, len(msg.Contacts))


### PR DESCRIPTION
## Summary

Cross-PR drift caught by the holistic-coherence pass over the last 24h of merges (#342, #343, #344, #345, #346, #347, #340, #341, #348).

PR #346's commit body claimed:

> triggerFactoryReset also writes a TypeRepair message over the authenticated WS before reboot so the server invalidates its copy of paired_at and device_token. Server-side handler is in PR #347.

The PR #347 server-side handler shipped (`handler_ws.go` intercepts `TypeRepair` and calls `device.Store.Unpair`), but the matching `digitsd` send never landed. `triggerFactoryReset` only sets the boot counter and writes the auto-factory-reset flag. Result: both factory-reset paths drop the device's local `DeviceToken` (the wipe nukes `/data`) without telling the server, leaving `paired_at` populated. The post-reset register-without-token then trips the exact `"device_token required"` rejection that #347 fixed for the `*#0*` repair flow:

- `*#00000#` keypad confirm callback at `pi/digitsd/cmd/digitsd/main.go:2012`
- Server-triggered `TypeFactoryReset` case at `pi/digitsd/cmd/digitsd/main.go:2553`

## Fix

Wire the `TypeRepair` send + 500ms drain into `triggerFactoryReset` itself (now takes `sig` and `deviceID` args) so both call sites are covered with one change. Mirrors the pattern used in the `*#0*` callback at `pi/digitsd/cmd/digitsd/main.go:1990`. The send is gated on non-nil `sig` and non-empty `deviceID`; if the WS happens to be down the function still proceeds with the local boot-counter + flag write and reboots.

## Motivated by (last 24h)

- #342 fix(digitsd): keep easter eggs from eating service-code digits
- #343 fix(digitsd): tighten service-code prefix to "*#" so lone '*' doesn't gate eggs
- #345 fix(digitsd,image): *#SETUP# actually clears wifi-configured flag
- #346 feat(digitsd,firmware,image): keypad confirmation for sensitive service codes
- #347 feat(server): handle phone-initiated repair to invalidate stale pairing

## Test plan

- [x] `go build ./...` from `pi/digitsd/`
- [x] `go test ./...` from `pi/digitsd/` (all packages green)
- [x] `go vet ./...` from `pi/digitsd/`
- [ ] On-device verification: dial `*#00000#`, confirm with `*`, observe server log for "repair: device unpaired by client request" before the device reboots; after factory reset completes, the device re-onboards via AP and pairs with a fresh code instead of looping on `device_token required`.
- [ ] CI: `golangci-lint` (local v2.5 was built with go 1.25 and refuses to load the module's go 1.26 directive, so relying on CI for the lint pass).
