### PR TITLE
fix(server): thread ctx through admin and updates HTTP clients

### DIFF
--- a/server/internal/admin/stats.go
+++ b/server/internal/admin/stats.go
@@ -32,7 +32,7 @@ func NewStatsClient(url, secret string) *StatsClient {
 }
 
 func (c *StatsClient) Fetch(ctx context.Context) (*Stats, error) {
-	req, err := http.NewRequest("GET", c.url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", c.url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -202,7 +202,7 @@ func (g *GitHubReleases) fetch(ctx context.Context) (*ReleaseIndex, error) {
 // fetchSHA256 downloads a .sha256 asset and returns the trimmed content.
 // Returns "" on any error.
 func (g *GitHubReleases) fetchSHA256(ctx context.Context, url string) string {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
`StatsClient.Fetch` and `GitHubReleases.fetchSHA256` accepted a `context.Context` but called `http.NewRequest`, which silently dropped it. Caller cancellation and deadlines had no effect on the in-flight HTTP request.

Switching both to `http.NewRequestWithContext` makes the ctx parameter actually do what its presence in the signature implies.