### PR TITLE
feat(server): add keypad logo mark to intercom theme rail

### DIFF
--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -135,9 +135,15 @@ hr { border: 0; border-top: 1px solid var(--rule); margin: 0; }
 
 .rail__brand {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 10px;
   min-width: 0;
+}
+.rail__brand-icon {
+  width: 21px;
+  height: 28px;
+  flex-shrink: 0;
+  color: var(--ink);
 }
 .rail__mark {
   font-family: var(--font-display);

--- a/server/internal/web/static/favicon.svg
+++ b/server/internal/web/static/favicon.svg
@@ -1,3 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#c9d1d9" stroke-width="2">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <style>
+    rect { fill: #2a1f18; }
+    @media (prefers-color-scheme: dark) {
+      rect { fill: #ede3d1; }
+    }
+  </style>
+  <rect x="10" y="5"  width="8" height="8" rx="2"/>
+  <rect x="20" y="5"  width="8" height="8" rx="2"/>
+  <rect x="30" y="5"  width="8" height="8" rx="2"/>
+  <rect x="10" y="15" width="8" height="8" rx="2"/>
+  <rect x="20" y="15" width="8" height="8" rx="2"/>
+  <rect x="30" y="15" width="8" height="8" rx="2"/>
+  <rect x="10" y="25" width="8" height="8" rx="2"/>
+  <rect x="20" y="25" width="8" height="8" rx="2"/>
+  <rect x="30" y="25" width="8" height="8" rx="2"/>
+  <rect x="10" y="35" width="8" height="8" rx="2"/>
+  <rect x="20" y="35" width="8" height="8" rx="2"/>
+  <rect x="30" y="35" width="8" height="8" rx="2"/>
 </svg>

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -16,8 +16,7 @@
 
 {{/* keypad-icon emits the 3x4 DTMF keypad mark. Caller wraps with
      <svg viewBox="0 0 36 48" fill="currentColor"> so CSS controls size
-     and color. The 12 buttons are filled rounded squares; labels are
-     rendered as wordmark text alongside, not on the icon itself. */}}
+     and color. */}}
 {{define "keypad-icon"}}<rect x="4" y="5" width="8" height="8" rx="2"/><rect x="14" y="5" width="8" height="8" rx="2"/><rect x="24" y="5" width="8" height="8" rx="2"/><rect x="4" y="15" width="8" height="8" rx="2"/><rect x="14" y="15" width="8" height="8" rx="2"/><rect x="24" y="15" width="8" height="8" rx="2"/><rect x="4" y="25" width="8" height="8" rx="2"/><rect x="14" y="25" width="8" height="8" rx="2"/><rect x="24" y="25" width="8" height="8" rx="2"/><rect x="4" y="35" width="8" height="8" rx="2"/><rect x="14" y="35" width="8" height="8" rx="2"/><rect x="24" y="35" width="8" height="8" rx="2"/>{{end}}
 
 {{/* house-icon-dialup-spoke emits a chunky Win98 pixel-art house with

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -14,6 +14,12 @@
      via CSS. Use viewBox="0 0 80 80", fill="none", stroke="currentColor". */}}
 {{define "house-icon"}}<path d="M10 40 L40 16 L70 40 L70 66 Q70 68 68 68 L12 68 Q10 68 10 66 Z"/><rect x="33" y="50" width="14" height="18" rx="1"/><rect x="18" y="44" width="10" height="10"/><rect x="52" y="44" width="10" height="10"/><path d="M58 12 L58 30" stroke-linecap="round"/><circle cx="58" cy="10" r="2" fill="currentColor"/>{{end}}
 
+{{/* keypad-icon emits the 3x4 DTMF keypad mark. Caller wraps with
+     <svg viewBox="0 0 36 48" fill="currentColor"> so CSS controls size
+     and color. The 12 buttons are filled rounded squares; labels are
+     rendered as wordmark text alongside, not on the icon itself. */}}
+{{define "keypad-icon"}}<rect x="4" y="5" width="8" height="8" rx="2"/><rect x="14" y="5" width="8" height="8" rx="2"/><rect x="24" y="5" width="8" height="8" rx="2"/><rect x="4" y="15" width="8" height="8" rx="2"/><rect x="14" y="15" width="8" height="8" rx="2"/><rect x="24" y="15" width="8" height="8" rx="2"/><rect x="4" y="25" width="8" height="8" rx="2"/><rect x="14" y="25" width="8" height="8" rx="2"/><rect x="24" y="25" width="8" height="8" rx="2"/><rect x="4" y="35" width="8" height="8" rx="2"/><rect x="14" y="35" width="8" height="8" rx="2"/><rect x="24" y="35" width="8" height="8" rx="2"/>{{end}}
+
 {{/* house-icon-dialup-spoke emits a chunky Win98 pixel-art house with
      a roof-mounted antenna and two gold signal arcs overhead. Each
      family spoke on /links uses this in the dialup theme. Dark-blue

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -16,6 +16,7 @@
 {{if ne .Page "login"}}
 <header class="rail">
   <div class="rail__brand">
+    <svg class="rail__brand-icon" viewBox="0 0 36 48" fill="currentColor" aria-hidden="true">{{template "keypad-icon"}}</svg>
     <span class="rail__mark">Digits</span>
     {{if .HouseholdName}}<span class="rail__household">{{.HouseholdName}}</span>{{end}}
     {{if .HouseholdDND}}


### PR DESCRIPTION
## Summary

- Introduces a 3x4 DTMF keypad as the Digits brand mark, paired with the existing Fraunces "Digits" wordmark in the intercom theme rail.
- Replaces the previous generic phone-receiver favicon with the same keypad mark, theme-adaptive via `prefers-color-scheme`.
- Implementation is a single Go template partial (`{{define "keypad-icon"}}` in `_partials.html`), so the mark can be reused on other surfaces later without duplicating geometry.

## Scope

Intercom theme + favicon only. The dialup and answering-machine themes are intentionally untouched: each has theme-specific brand chrome (Win98 pixel-art title bar for dialup, "Digits 2500" plate with subtitle for AM) and dropping a Fraunces-typography lockup into either would clash with the deliberate retro aesthetic.

## Screenshots

Light mode rail:

![rail light](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-keypad-mark-light.png)

Dark mode rail:

![rail dark](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-keypad-mark-dark.png)

Full overview page (light):

![full page](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-keypad-mark-fullpage.png)

## Test plan

- [x] `make test` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] Light mode rail renders icon + Fraunces wordmark + household separator + "Lindh Family" all aligned (verified via `make dev-up` and agent-browser)
- [x] Dark mode rail (`appearance='night'`) inherits `--ink` correctly via `currentColor`
- [x] Favicon served at `/static/favicon.svg`
- [ ] Reviewer to spot-check that the icon does not visually regress with a long household name (overflow/wrap behavior)