### PR TITLE
feat(hardware): add 2-color keypad badges for Bambu X1C

### DIFF
--- a/hardware/badges/README.md
+++ b/hardware/badges/README.md
@@ -1,0 +1,47 @@
+# Keypad badges
+
+Small adhesive-mounted badges carrying the Digits keypad mark, sized for FDM printing on a Bambu X1C with the AMS for two-color filament swap.
+
+## Files
+
+- `tile-30mm.svg`: 30 mm rounded square. Most compact, prints fastest.
+- `pill-25x40mm.svg`: 25 mm wide, 40 mm tall vertical pill. Has the most quiet space around the mark.
+- `round-32mm.svg`: 32 mm circle. Most "logo medallion."
+- `preview.html`: open in a browser to compare all three shapes across the palette options below.
+
+Each SVG declares two filled groups: `#badge-bg` (the silhouette) and `#badge-fg` (the 12 keypad buttons). The colors written into the file are visual cues only. The actual print color is whatever filament you load.
+
+## Printing on Bambu X1C
+
+1. Bambu Studio: **File > Import > Import SVG**, select one of the three shape files.
+2. When asked for height, set **base = 1.6 mm** (the silhouette) and **emboss = 0.4 mm** (the keypad buttons). Total badge thickness 2.0 mm.
+3. The slicer will detect the two color regions in the SVG. Assign filament A to the silhouette, filament B to the buttons.
+4. Print orientation: flat on the build plate, badge face up. No supports.
+5. Recommended layer height: 0.16 mm (gives the keypad buttons 2-3 layers of color B; tactile but not catchy).
+
+For a thinner badge (e.g. mounting on a phone where 2 mm is too thick), reduce the base to 1.0 mm. The 0.4 mm emboss stays the same.
+
+## Adhesive
+
+3M VHB tape (the thin variant, around 0.4 mm) on the smooth bottom face works well on the painted metal of vintage phone housings. Cyanoacrylate also works but is permanent. Avoid hot glue: the PLA softens around it.
+
+## Palettes
+
+The SVG defaults ship a different palette per shape so you can see the range without opening the slicer. Swap in any of these by editing the two `fill="..."` attributes in the SVG, or just load whichever filaments you have and ignore the file colors.
+
+| Name        | Background | Foreground | Vibe                                   |
+|-------------|------------|------------|----------------------------------------|
+| Parchment   | `#fff7e6`  | `#c1410c`  | Matches the digits.family favicon.     |
+| Walnut      | `#1a140e`  | `#ede3d1`  | Matches the webapp intercom dark theme.|
+| Bone        | `#f5f1ea`  | `#2a1f18`  | Matches the webapp intercom light theme.|
+| Sage        | `#626f47`  | `#fff7e6`  | Calm, woodsy.                          |
+| Brass       | `#1a140e`  | `#dda867`  | Luxe vintage.                          |
+| Coral       | `#ff7a59`  | `#fff7e6`  | Warm pop.                              |
+| Charcoal    | `#222222`  | `#e0b964`  | Industrial signage.                    |
+| Plum        | `#5a3a4f`  | `#f4e4b8`  | Unexpected.                            |
+| Cobalt      | `#1c3a6e`  | `#f7eed8`  | Oceanic.                               |
+| Terracotta  | `#b85a3c`  | `#e8d4a4`  | Mediterranean tile.                    |
+
+## Geometry
+
+All three shapes use the same keypad geometry: 12 rounded squares in a 3x4 grid, each button 4 mm with 1 mm gaps, total mark footprint 14 mm wide x 19 mm tall. The mark is centered on each silhouette. If you want to scale, scale the whole SVG uniformly. The keypad never falls outside the silhouette.

--- a/hardware/badges/pill-25x40mm.svg
+++ b/hardware/badges/pill-25x40mm.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="25mm" height="40mm" viewBox="0 0 25 40">
+  <g id="badge-bg" fill="#1a140e">
+    <rect width="25" height="40" rx="12.5"/>
+  </g>
+  <g id="badge-fg" fill="#ede3d1">
+    <rect x="5.5"  y="10.5" width="4" height="4" rx="1"/>
+    <rect x="10.5" y="10.5" width="4" height="4" rx="1"/>
+    <rect x="15.5" y="10.5" width="4" height="4" rx="1"/>
+    <rect x="5.5"  y="15.5" width="4" height="4" rx="1"/>
+    <rect x="10.5" y="15.5" width="4" height="4" rx="1"/>
+    <rect x="15.5" y="15.5" width="4" height="4" rx="1"/>
+    <rect x="5.5"  y="20.5" width="4" height="4" rx="1"/>
+    <rect x="10.5" y="20.5" width="4" height="4" rx="1"/>
+    <rect x="15.5" y="20.5" width="4" height="4" rx="1"/>
+    <rect x="5.5"  y="25.5" width="4" height="4" rx="1"/>
+    <rect x="10.5" y="25.5" width="4" height="4" rx="1"/>
+    <rect x="15.5" y="25.5" width="4" height="4" rx="1"/>
+  </g>
+</svg>

--- a/hardware/badges/preview.html
+++ b/hardware/badges/preview.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Digits keypad badges: shape and palette preview</title>
+<style>
+  body { font-family: Georgia, serif; background: #f4f1ec; color: #1a1a1a; margin: 32px; }
+  h1 { font-weight: 400; letter-spacing: 1px; }
+  h2 { font-weight: 600; font-size: 14px; letter-spacing: 2px; text-transform: uppercase; color: #6b6358; margin-top: 40px; }
+  .grid { display: grid; gap: 16px; margin-top: 16px; }
+  .grid--shapes { grid-template-columns: repeat(3, max-content); align-items: end; }
+  .grid--palettes { grid-template-columns: repeat(auto-fill, 200px); }
+  .card { background: #fff; padding: 16px; border: 1px solid #d8d2c8; }
+  .card .frame { display: flex; align-items: center; justify-content: center; min-height: 120px; }
+  .card .label { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #6b6358; margin: 0 0 8px; }
+  .card .hex { font-family: ui-monospace, monospace; font-size: 10px; color: #6b6358; margin-top: 8px; display: flex; gap: 8px; justify-content: center; }
+  .card .swatch { display: inline-block; width: 10px; height: 10px; border: 1px solid #d8d2c8; vertical-align: middle; margin-right: 4px; }
+</style>
+</head>
+<body>
+
+<h1>Digits keypad badges</h1>
+
+<h2>Shapes (default palette per shape)</h2>
+<div class="grid grid--shapes">
+  <div class="card">
+    <p class="label">Tile 30 mm / Parchment</p>
+    <div class="frame"><object data="tile-30mm.svg" width="120"></object></div>
+  </div>
+  <div class="card">
+    <p class="label">Pill 25x40 mm / Walnut</p>
+    <div class="frame"><object data="pill-25x40mm.svg" width="100"></object></div>
+  </div>
+  <div class="card">
+    <p class="label">Round 32 mm / Sage</p>
+    <div class="frame"><object data="round-32mm.svg" width="128"></object></div>
+  </div>
+</div>
+
+<h2>Palette explorer (tile)</h2>
+<div class="grid grid--palettes" id="palette-grid"></div>
+
+<h2>Palette explorer (pill)</h2>
+<div class="grid grid--palettes" id="pill-grid"></div>
+
+<h2>Palette explorer (round)</h2>
+<div class="grid grid--palettes" id="round-grid"></div>
+
+<script>
+const palettes = [
+  { name: "Parchment",  bg: "#fff7e6", fg: "#c1410c" },
+  { name: "Walnut",     bg: "#1a140e", fg: "#ede3d1" },
+  { name: "Bone",       bg: "#f5f1ea", fg: "#2a1f18" },
+  { name: "Sage",       bg: "#626f47", fg: "#fff7e6" },
+  { name: "Brass",      bg: "#1a140e", fg: "#dda867" },
+  { name: "Coral",      bg: "#ff7a59", fg: "#fff7e6" },
+  { name: "Charcoal",   bg: "#222222", fg: "#e0b964" },
+  { name: "Plum",       bg: "#5a3a4f", fg: "#f4e4b8" },
+  { name: "Cobalt",     bg: "#1c3a6e", fg: "#f7eed8" },
+  { name: "Terracotta", bg: "#b85a3c", fg: "#e8d4a4" },
+];
+
+const keypadButtons = (xs, ys, w, h, rx) => xs.flatMap(x => ys.map(y =>
+  `<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${rx}"/>`
+)).join("");
+
+const shapes = {
+  tile: {
+    width: 120, viewBox: "0 0 30 30",
+    bg: '<rect width="30" height="30" rx="4"/>',
+    fg: keypadButtons([8, 13, 18], [5.5, 10.5, 15.5, 20.5], 4, 4, 1),
+  },
+  pill: {
+    width: 100, viewBox: "0 0 25 40",
+    bg: '<rect width="25" height="40" rx="12.5"/>',
+    fg: keypadButtons([5.5, 10.5, 15.5], [10.5, 15.5, 20.5, 25.5], 4, 4, 1),
+  },
+  round: {
+    width: 128, viewBox: "0 0 32 32",
+    bg: '<circle cx="16" cy="16" r="16"/>',
+    fg: keypadButtons([9, 14, 19], [6.5, 11.5, 16.5, 21.5], 4, 4, 1),
+  },
+};
+
+function renderCards(containerId, shapeKey) {
+  const shape = shapes[shapeKey];
+  const html = palettes.map(p => `
+    <div class="card">
+      <p class="label">${p.name}</p>
+      <div class="frame">
+        <svg width="${shape.width}" viewBox="${shape.viewBox}" xmlns="http://www.w3.org/2000/svg">
+          <g fill="${p.bg}">${shape.bg}</g>
+          <g fill="${p.fg}">${shape.fg}</g>
+        </svg>
+      </div>
+      <div class="hex">
+        <span><span class="swatch" style="background:${p.bg}"></span>${p.bg}</span>
+        <span><span class="swatch" style="background:${p.fg}"></span>${p.fg}</span>
+      </div>
+    </div>
+  `).join("");
+  document.getElementById(containerId).innerHTML = html;
+}
+
+renderCards("palette-grid", "tile");
+renderCards("pill-grid", "pill");
+renderCards("round-grid", "round");
+</script>
+
+</body>
+</html>

--- a/hardware/badges/round-32mm.svg
+++ b/hardware/badges/round-32mm.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32mm" height="32mm" viewBox="0 0 32 32">
+  <g id="badge-bg" fill="#626f47">
+    <circle cx="16" cy="16" r="16"/>
+  </g>
+  <g id="badge-fg" fill="#fff7e6">
+    <rect x="9"  y="6.5"  width="4" height="4" rx="1"/>
+    <rect x="14" y="6.5"  width="4" height="4" rx="1"/>
+    <rect x="19" y="6.5"  width="4" height="4" rx="1"/>
+    <rect x="9"  y="11.5" width="4" height="4" rx="1"/>
+    <rect x="14" y="11.5" width="4" height="4" rx="1"/>
+    <rect x="19" y="11.5" width="4" height="4" rx="1"/>
+    <rect x="9"  y="16.5" width="4" height="4" rx="1"/>
+    <rect x="14" y="16.5" width="4" height="4" rx="1"/>
+    <rect x="19" y="16.5" width="4" height="4" rx="1"/>
+    <rect x="9"  y="21.5" width="4" height="4" rx="1"/>
+    <rect x="14" y="21.5" width="4" height="4" rx="1"/>
+    <rect x="19" y="21.5" width="4" height="4" rx="1"/>
+  </g>
+</svg>

--- a/hardware/badges/tile-30mm.svg
+++ b/hardware/badges/tile-30mm.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="30mm" height="30mm" viewBox="0 0 30 30">
+  <g id="badge-bg" fill="#fff7e6">
+    <rect width="30" height="30" rx="4"/>
+  </g>
+  <g id="badge-fg" fill="#c1410c">
+    <rect x="8"  y="5.5"  width="4" height="4" rx="1"/>
+    <rect x="13" y="5.5"  width="4" height="4" rx="1"/>
+    <rect x="18" y="5.5"  width="4" height="4" rx="1"/>
+    <rect x="8"  y="10.5" width="4" height="4" rx="1"/>
+    <rect x="13" y="10.5" width="4" height="4" rx="1"/>
+    <rect x="18" y="10.5" width="4" height="4" rx="1"/>
+    <rect x="8"  y="15.5" width="4" height="4" rx="1"/>
+    <rect x="13" y="15.5" width="4" height="4" rx="1"/>
+    <rect x="18" y="15.5" width="4" height="4" rx="1"/>
+    <rect x="8"  y="20.5" width="4" height="4" rx="1"/>
+    <rect x="13" y="20.5" width="4" height="4" rx="1"/>
+    <rect x="18" y="20.5" width="4" height="4" rx="1"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Three printable shapes carrying the Digits keypad mark, sized for adhesive mount on the phone housings:

- `tile-30mm.svg`: 30 mm rounded square. Most compact.
- `pill-25x40mm.svg`: 25x40 mm vertical pill. Quietest framing.
- `round-32mm.svg`: 32 mm round medallion. Most "logo."

Each SVG carries two filled groups (`#badge-bg` silhouette + `#badge-fg` 12 buttons) so Bambu Studio can split by color and assign filaments per region.

## Palettes

Ten palettes documented in `README.md`. Defaults per shape are Parchment (matches the digits.family favicon), Walnut (matches webapp dark mode), and Sage (woodsy). Edit the two `fill="..."` attributes or just load whatever filaments you have.

## Preview

`preview.html` renders every shape across every palette:

![preview](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-359-badges-preview.png)

## Geometry

12 buttons, 4x4 mm with 1 mm gaps, total mark footprint 14 mm wide x 19 mm tall. Mark always centered on the silhouette.

## Test plan

- [x] All three SVGs validate (open cleanly in a browser).
- [x] preview.html renders all 30 shape x palette combinations on a fresh visit.
- [ ] Reviewer to print a single tile in Parchment palette and confirm 0.4 mm emboss is tactile but not catchy.