### PR TITLE
feat(server): first-time-login theme picker at /welcome

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -162,6 +162,13 @@ func ensureUser(ctx context.Context, s *stores, spec seededUser, minimal bool) (
 	if err := s.auth.SetTheme(ctx, u.ID, spec.Theme); err != nil {
 		return nil, nil, fmt.Errorf("set theme: %w", err)
 	}
+	// Seeded users have a deterministic theme already, so flip the flag so
+	// they don't bounce through /welcome on every dev-up. To exercise the
+	// picker locally, run:
+	//   psql $DATABASE_URL -c "UPDATE users SET theme_chosen = FALSE WHERE email = 'dev@digits.local'"
+	if err := s.auth.MarkThemeChosen(ctx, u.ID); err != nil {
+		return nil, nil, fmt.Errorf("mark theme chosen: %w", err)
+	}
 	hh, err := ensureHousehold(ctx, s.house, u.ID, spec.HouseholdName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("ensure household: %w", err)

--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -152,5 +152,5 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, loginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, LoginRedirectFor(user), http.StatusSeeOther)
 }

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -129,7 +129,7 @@ func (h *Handlers) HandleMagicLinkVerify(w http.ResponseWriter, r *http.Request)
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, loginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, LoginRedirectFor(user), http.StatusSeeOther)
 }
 
 // HandleDevSession creates an authenticated session in one round-trip for e2e testing.
@@ -183,14 +183,15 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, loginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, LoginRedirectFor(user), http.StatusSeeOther)
 }
 
-// loginRedirectFor returns the URL to redirect a newly-authenticated user to.
+// LoginRedirectFor returns the URL to redirect a newly-authenticated user to.
 // For dial-up theme users, /connecting renders a modem-dialing intro whose
 // Connect button provides the user gesture needed for post-auth audio.
-// All other themes go straight to the dashboard.
-func loginRedirectFor(u *User) string {
+// All other themes go straight to the dashboard. Exported so the welcome
+// handler and onboarding handler can use the same theme-aware landing rule.
+func LoginRedirectFor(u *User) string {
 	if u != nil && u.Theme == ThemeDialup {
 		return "/connecting"
 	}

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -125,6 +125,26 @@ func (s *Store) MarkThemeChosen(ctx context.Context, userID string) error {
 	return err
 }
 
+// SetThemeAndMarkChosen flips both theme and theme_chosen in one UPDATE and
+// returns the refreshed user. Used by the welcome handler so a partial write
+// can't leave a user with their picked theme but theme_chosen=false (which
+// would loop them back to /welcome until the next submit).
+func (s *Store) SetThemeAndMarkChosen(ctx context.Context, userID string, theme Theme) (*User, error) {
+	if !theme.Valid() {
+		return nil, fmt.Errorf("invalid theme: %q", theme)
+	}
+	u := &User{}
+	err := s.db.QueryRowContext(ctx,
+		`UPDATE users SET theme = $1, theme_chosen = TRUE WHERE id = $2
+		 RETURNING id, email, name, google_id, theme, theme_chosen, crt_mode, appearance, created_at, last_login_at`,
+		theme, userID,
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.ThemeChosen, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
+	if err != nil {
+		return nil, fmt.Errorf("set theme and mark chosen: %w", err)
+	}
+	return u, nil
+}
+
 // SetCRTMode updates the user's selected CRT bezel mode.
 func (s *Store) SetCRTMode(ctx context.Context, userID string, mode CRTMode) error {
 	if !mode.Valid() {

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -25,6 +25,7 @@ type User struct {
 	Name        string
 	GoogleID    *string
 	Theme       Theme
+	ThemeChosen bool
 	CRTMode     CRTMode
 	Appearance  Appearance
 	CreatedAt   time.Time
@@ -55,21 +56,21 @@ func (s *Store) CreateUser(ctx context.Context, email, name string, googleID *st
 	u := &User{}
 	err := s.db.QueryRowContext(ctx,
 		`INSERT INTO users (email, name, google_id) VALUES ($1, $2, $3)
-		 RETURNING id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at`,
+		 RETURNING id, email, name, google_id, theme, theme_chosen, crt_mode, appearance, created_at, last_login_at`,
 		email, name, googleID,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.ThemeChosen, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt)
 	if err != nil {
 		return nil, fmt.Errorf("create user: %w", err)
 	}
 	return u, nil
 }
 
-const userSelectBase = `SELECT id, email, name, google_id, theme, crt_mode, appearance, created_at, last_login_at FROM users WHERE `
+const userSelectBase = `SELECT id, email, name, google_id, theme, theme_chosen, crt_mode, appearance, created_at, last_login_at FROM users WHERE `
 
 func (s *Store) queryUser(ctx context.Context, whereClause string, arg any) (*User, error) {
 	u := &User{}
 	err := s.db.QueryRowContext(ctx, userSelectBase+whereClause, arg).Scan(
-		&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt,
+		&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.ThemeChosen, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrUserNotFound
@@ -113,6 +114,14 @@ func (s *Store) SetTheme(ctx context.Context, userID string, theme Theme) error 
 		return fmt.Errorf("invalid theme: %q", theme)
 	}
 	_, err := s.db.ExecContext(ctx, `UPDATE users SET theme = $1 WHERE id = $2`, theme, userID)
+	return err
+}
+
+// MarkThemeChosen marks the welcome theme picker as completed. One-shot:
+// once true, the welcome gate releases and later /settings/theme changes
+// don't toggle it back.
+func (s *Store) MarkThemeChosen(ctx context.Context, userID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET theme_chosen = TRUE WHERE id = $1`, userID)
 	return err
 }
 

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -361,6 +361,21 @@ END $$;`,
 		`ALTER TABLE users ADD COLUMN IF NOT EXISTS appearance TEXT NOT NULL DEFAULT 'day'`,
 		// v24: household-level do-not-disturb master switch.
 		`ALTER TABLE households ADD COLUMN IF NOT EXISTS do_not_disturb BOOLEAN NOT NULL DEFAULT FALSE`,
+		// v25: per-user "has picked a theme" flag for the first-time-login
+		// theme picker. Pre-existing users are backfilled to TRUE so the
+		// welcome wizard only fires for new accounts; the schema_version
+		// guard (mirroring v22) ensures the backfill runs exactly once even
+		// if a QA workflow has since flipped some rows back to FALSE.
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 25) THEN
+
+        ALTER TABLE users ADD COLUMN IF NOT EXISTS theme_chosen BOOLEAN NOT NULL DEFAULT FALSE;
+        UPDATE users SET theme_chosen = TRUE;
+
+        INSERT INTO schema_version (version) VALUES (25);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -89,6 +89,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 			t.Fatalf("create/get user A: %v", err)
 		}
 	}
+	markUserOnboarded(t, authStore, userA.ID)
 	userB, err := authStore.CreateUser(context.Background(), "e2e-calls-b@example.com", "Calls User B", nil)
 	if err != nil {
 		userB, err = authStore.GetUserByEmail(context.Background(), "e2e-calls-b@example.com")
@@ -96,6 +97,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 			t.Fatalf("create/get user B: %v", err)
 		}
 	}
+	markUserOnboarded(t, authStore, userB.ID)
 
 	hhA, err := householdStore.Create(context.Background(), "Calls Family A", userA.ID)
 	if err != nil {
@@ -229,6 +231,7 @@ func TestCallsPageRenders3WayConference(t *testing.T) {
 			t.Fatalf("create/get user: %v", err)
 		}
 	}
+	markUserOnboarded(t, authStore, user.ID)
 
 	hh, err := householdStore.Create(context.Background(), "Conf Family", user.ID)
 	if err != nil {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -497,10 +497,9 @@ func (h *Handler) Router() http.Handler {
 	// Order matters: welcome runs first so the household onboarding screens
 	// render in the user's chosen theme, not the intercom default.
 	protectedHandler := h.authStore.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Welcome gate. Skip for the welcome route itself (so the picker can
-		// render and submit), /auth/* (logout etc. must always work), and
-		// /api/* + /ws (JSON/SSE/WS clients can't follow HTML page redirects;
-		// they get their natural 4xx from the route handler instead).
+		// Welcome gate. Exempts /welcome itself plus the universal set
+		// (/auth/*, /api/*, /ws) so JSON/SSE/WS clients get their natural
+		// 4xx instead of an HTML redirect.
 		if !isGateExempt(r.URL.Path, "/welcome") {
 			user := auth.UserFromContext(r.Context())
 			if user != nil && !user.ThemeChosen {
@@ -508,11 +507,10 @@ func (h *Handler) Router() http.Handler {
 				return
 			}
 		}
-		// Onboarding gate. Same exemption set as welcome, plus /onboard
-		// itself and /welcome (welcome runs before household exists).
-		if h.householdStore != nil &&
-			!isGateExempt(r.URL.Path, "/welcome") &&
-			r.URL.Path != "/onboard" {
+		// Onboarding gate. Adds /onboard (its redirect target) and
+		// /welcome (the picker runs before a household exists) to the
+		// universal exempt set.
+		if h.householdStore != nil && !isGateExempt(r.URL.Path, "/welcome", "/onboard") {
 			user := auth.UserFromContext(r.Context())
 			if user != nil && h.householdStore.NeedsOnboarding(r.Context(), user.ID) {
 				http.Redirect(w, r, "/onboard", http.StatusSeeOther)
@@ -528,15 +526,17 @@ func (h *Handler) Router() http.Handler {
 }
 
 // isGateExempt reports whether a request path should bypass the welcome and
-// onboarding redirect gates. API, WebSocket, and auth paths are exempt
+// onboarding redirect gates. /auth/*, /api/*, and /ws[/*] are always exempt
 // because their consumers can't (or shouldn't) follow an HTML page redirect:
 // SSE/fetch clients would parse the HTML as JSON, WS upgrades would fail,
-// and the auth flow itself must reach /auth/login regardless of state. The
-// caller's own redirect target (e.g. "/welcome") is exempt for the same
-// reason a redirect to itself would loop.
-func isGateExempt(path, selfTarget string) bool {
-	if path == selfTarget {
-		return true
+// and the auth flow itself must reach /auth/login regardless of state. Each
+// gate also passes its own redirect target (and any other gate's target it
+// needs to defer to) as `extra` so a redirect-to-self can't loop.
+func isGateExempt(path string, extra ...string) bool {
+	for _, p := range extra {
+		if path == p {
+			return true
+		}
 	}
 	if strings.HasPrefix(path, "/auth/") {
 		return true

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -88,6 +88,7 @@ type Handler struct {
 	tmplPhoneDetail    *template.Template
 	tmplLinks          *template.Template
 	tmplConnecting     *template.Template
+	tmplWelcome        *template.Template
 	tmplCallLivePanel          *template.Template
 	tmplCallLiveDetail         *template.Template
 	tmplConferenceLivePanel    *template.Template
@@ -308,6 +309,10 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	tmplWelcome, err := parsePage("welcome.html")
+	if err != nil {
+		return nil, err
+	}
 	tmplCallLivePanel, err := template.New("call-live-panel").Funcs(funcMap).ParseFS(templateFS, "templates/_call-live-panel.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse call-live-panel: %w", err)
@@ -361,6 +366,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplPhoneDetail:    tmplPhoneDetail,
 		tmplLinks:          tmplLinks,
 		tmplConnecting:     tmplConnecting,
+		tmplWelcome:        tmplWelcome,
 		tmplCallLivePanel:          tmplCallLivePanel,
 		tmplCallLiveDetail:         tmplCallLiveDetail,
 		tmplConferenceLivePanel:    tmplConferenceLivePanel,
@@ -433,6 +439,8 @@ func (h *Handler) Router() http.Handler {
 	protected := http.NewServeMux()
 	protected.HandleFunc("GET /", h.handleDashboard)
 	protected.HandleFunc("GET /connecting", h.handleConnecting)
+	protected.HandleFunc("GET /welcome", h.handleWelcomeGet)
+	protected.HandleFunc("POST /welcome", h.handleWelcomePost)
 	protected.HandleFunc("GET /onboard", h.handleOnboardGet)
 	protected.HandleFunc("POST /onboard", h.handleOnboardPost)
 	protected.HandleFunc("GET /phones", h.handlePhonesGet)
@@ -478,30 +486,68 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /api/call/{id}/disconnect", h.handleCallDisconnect)
 	protected.HandleFunc("GET /api/lines/number-available", h.handleAPINumberAvailable)
 
-	// Onboarding gate: redirect users without a household to /onboard
-	// Only active when householdStore is set (nil means feature disabled)
-	protectedHandler := h.authStore.RequireAuth(protected)
-	if h.householdStore != nil {
-		protectedHandler = h.authStore.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Don't gate the onboard routes themselves
-			if r.URL.Path == "/onboard" || strings.HasPrefix(r.URL.Path, "/auth/") {
-				protected.ServeHTTP(w, r)
+	// Two gates compose in front of protected routes, both behind RequireAuth:
+	//
+	//   1. Welcome gate: until theme_chosen=true, send the user to /welcome
+	//      so they pick a theme. Always active (the column has a backfill so
+	//      pre-existing users skip it).
+	//   2. Onboarding gate: until the user has a household, send them to
+	//      /onboard. Only active when householdStore is wired.
+	//
+	// Order matters: welcome runs first so the household onboarding screens
+	// render in the user's chosen theme, not the intercom default.
+	protectedHandler := h.authStore.RequireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Welcome gate. Skip for the welcome route itself (so the picker can
+		// render and submit), /auth/* (logout etc. must always work), and
+		// /api/* + /ws (JSON/SSE/WS clients can't follow HTML page redirects;
+		// they get their natural 4xx from the route handler instead).
+		if !isGateExempt(r.URL.Path, "/welcome") {
+			user := auth.UserFromContext(r.Context())
+			if user != nil && !user.ThemeChosen {
+				http.Redirect(w, r, "/welcome", http.StatusSeeOther)
 				return
 			}
+		}
+		// Onboarding gate. Same exemption set as welcome, plus /onboard
+		// itself and /welcome (welcome runs before household exists).
+		if h.householdStore != nil &&
+			!isGateExempt(r.URL.Path, "/welcome") &&
+			r.URL.Path != "/onboard" {
 			user := auth.UserFromContext(r.Context())
-			if user != nil {
-				if h.householdStore.NeedsOnboarding(r.Context(), user.ID) {
-					http.Redirect(w, r, "/onboard", http.StatusSeeOther)
-					return
-				}
+			if user != nil && h.householdStore.NeedsOnboarding(r.Context(), user.ID) {
+				http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+				return
 			}
-			protected.ServeHTTP(w, r)
-		}))
-	}
+		}
+		protected.ServeHTTP(w, r)
+	}))
 	mux.Handle("/", protectedHandler)
 
 	// Wrap with root-domain redirect before security headers.
 	return rootDomainRedirect(h.cfg.BaseURL, securityHeadersMiddleware(mux))
+}
+
+// isGateExempt reports whether a request path should bypass the welcome and
+// onboarding redirect gates. API, WebSocket, and auth paths are exempt
+// because their consumers can't (or shouldn't) follow an HTML page redirect:
+// SSE/fetch clients would parse the HTML as JSON, WS upgrades would fail,
+// and the auth flow itself must reach /auth/login regardless of state. The
+// caller's own redirect target (e.g. "/welcome") is exempt for the same
+// reason a redirect to itself would loop.
+func isGateExempt(path, selfTarget string) bool {
+	if path == selfTarget {
+		return true
+	}
+	if strings.HasPrefix(path, "/auth/") {
+		return true
+	}
+	if strings.HasPrefix(path, "/api/") {
+		return true
+	}
+	if path == "/ws" || strings.HasPrefix(path, "/ws/") {
+		return true
+	}
+	return false
 }
 
 func securityHeadersMiddleware(next http.Handler) http.Handler {

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -49,6 +49,9 @@ func (h *Handler) handleOnboardPost(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to create household", http.StatusInternalServerError)
 		return
 	}
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	// Route through LoginRedirectFor so a fresh dialup user lands on the
+	// modem connect screen on first session, matching the post-pick behavior
+	// from /welcome and the post-login behavior on subsequent visits.
+	http.Redirect(w, r, auth.LoginRedirectFor(user), http.StatusSeeOther)
 }
 

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -443,6 +443,7 @@ func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairin
 			t.Fatalf("create user: %v", err)
 		}
 	}
+	markUserOnboarded(t, authStore, user.ID)
 	hh, err := householdStore.Create(context.Background(), "Test Household", user.ID)
 	if err != nil {
 		t.Fatalf("create household: %v", err)
@@ -1200,6 +1201,7 @@ func seedLinkedFamily(t *testing.T, h *Handler, database *db.Database, authStore
 	if err != nil {
 		t.Fatalf("create other user: %v", err)
 	}
+	markUserOnboarded(t, authStore, otherUser.ID)
 	otherHH, err := h.householdStore.Create(context.Background(), otherName, otherUser.ID)
 	if err != nil {
 		t.Fatalf("create other household: %v", err)

--- a/server/internal/web/handler_welcome.go
+++ b/server/internal/web/handler_welcome.go
@@ -1,0 +1,67 @@
+package web
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/version"
+)
+
+// welcomeData carries data for the /welcome template. Welcome is pre-theme
+// (the user has not picked one yet) and renders its own neutral chrome, so
+// it does not embed chromeData. Theme IDs are passed in from Go rather than
+// hardcoded in the template so a future theme rename can't silently drift
+// from auth.Theme*.
+type welcomeData struct {
+	Version       string
+	User          *auth.User
+	ThemeIntercom auth.Theme
+	ThemeDialup   auth.Theme
+	ThemeAM       auth.Theme
+}
+
+func (h *Handler) handleWelcomeGet(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	renderWith(w, h.tmplWelcome, "welcome.html", welcomeData{
+		Version:       version.Version,
+		User:          user,
+		ThemeIntercom: auth.ThemeIntercom,
+		ThemeDialup:   auth.ThemeDialup,
+		ThemeAM:       auth.ThemeAnsweringMachine,
+	})
+}
+
+func (h *Handler) handleWelcomePost(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	theme := auth.Theme(r.FormValue("theme"))
+	if !theme.Valid() {
+		http.Redirect(w, r, "/welcome", http.StatusSeeOther)
+		return
+	}
+	if err := h.authStore.SetTheme(r.Context(), user.ID, theme); err != nil {
+		slog.Error("welcome: set theme failed", "err", err, "theme", theme, "user_id", user.ID)
+		http.Error(w, "failed to save theme", http.StatusInternalServerError)
+		return
+	}
+	if err := h.authStore.MarkThemeChosen(r.Context(), user.ID); err != nil {
+		slog.Error("welcome: mark theme chosen failed", "err", err, "user_id", user.ID)
+		http.Error(w, "failed to save theme", http.StatusInternalServerError)
+		return
+	}
+	// Mutate the request-scoped User snapshot so LoginRedirectFor sees the
+	// theme we just persisted; UserFromContext otherwise still holds the
+	// pre-pick value and would mis-route dialup picks to / instead of
+	// /connecting. Cheaper than a re-fetch for a once-per-account flow.
+	user.Theme = theme
+	user.ThemeChosen = true
+	http.Redirect(w, r, auth.LoginRedirectFor(user), http.StatusSeeOther)
+}

--- a/server/internal/web/handler_welcome.go
+++ b/server/internal/web/handler_welcome.go
@@ -47,21 +47,11 @@ func (h *Handler) handleWelcomePost(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/welcome", http.StatusSeeOther)
 		return
 	}
-	if err := h.authStore.SetTheme(r.Context(), user.ID, theme); err != nil {
-		slog.Error("welcome: set theme failed", "err", err, "theme", theme, "user_id", user.ID)
+	updated, err := h.authStore.SetThemeAndMarkChosen(r.Context(), user.ID, theme)
+	if err != nil {
+		slog.Error("welcome: set theme and mark chosen failed", "err", err, "theme", theme, "user_id", user.ID)
 		http.Error(w, "failed to save theme", http.StatusInternalServerError)
 		return
 	}
-	if err := h.authStore.MarkThemeChosen(r.Context(), user.ID); err != nil {
-		slog.Error("welcome: mark theme chosen failed", "err", err, "user_id", user.ID)
-		http.Error(w, "failed to save theme", http.StatusInternalServerError)
-		return
-	}
-	// Mutate the request-scoped User snapshot so LoginRedirectFor sees the
-	// theme we just persisted; UserFromContext otherwise still holds the
-	// pre-pick value and would mis-route dialup picks to / instead of
-	// /connecting. Cheaper than a re-fetch for a once-per-account flow.
-	user.Theme = theme
-	user.ThemeChosen = true
-	http.Redirect(w, r, auth.LoginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, auth.LoginRedirectFor(updated), http.StatusSeeOther)
 }

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -116,19 +116,24 @@ func newLHEnv(t *testing.T) lhSetup {
 		_, _ = db.Exec("DELETE FROM users WHERE email IN ($1,$2,$3)", emailA, emailB, emailC)
 	})
 
-	// Create users.
+	// Create users. markUserOnboarded flips the welcome-gate flag so the
+	// users behave like already-onboarded users on protected routes; the
+	// welcome flow itself is exercised separately.
 	userA, err := env.authStore.CreateUser(context.Background(), emailA, "LH User A", nil)
 	if err != nil {
 		t.Fatalf("create user A: %v", err)
 	}
+	markUserOnboarded(t, env.authStore, userA.ID)
 	userB, err := env.authStore.CreateUser(context.Background(), emailB, "LH User B", nil)
 	if err != nil {
 		t.Fatalf("create user B: %v", err)
 	}
+	markUserOnboarded(t, env.authStore, userB.ID)
 	userC, err := env.authStore.CreateUser(context.Background(), emailC, "LH User C", nil)
 	if err != nil {
 		t.Fatalf("create user C: %v", err)
 	}
+	markUserOnboarded(t, env.authStore, userC.ID)
 
 	// Create households.
 	hhA, err := env.householdStore.Create(context.Background(), hhNameA, userA.ID)

--- a/server/internal/web/static/welcome.css
+++ b/server/internal/web/static/welcome.css
@@ -1,0 +1,500 @@
+/* Welcome (first-time theme picker)
+ *
+ * Standalone page. The user has not chosen a theme yet, so this CSS does not
+ * inherit the layout-v2 / dialup / answering-machine variables. It brings
+ * its own neutral chrome and renders three in-card mini-previews of the
+ * actual themes so the choice is visual.
+ */
+
+:root {
+  --welcome-bg-1: #1a1714;
+  --welcome-bg-2: #2a221b;
+  --welcome-fg: #f3eadb;
+  --welcome-mute: #b6a991;
+  --welcome-card-shadow: 0 18px 40px -16px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.35);
+  --welcome-card-shadow-hover: 0 28px 60px -18px rgba(0, 0, 0, 0.65), 0 4px 10px rgba(0, 0, 0, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+.welcome-body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--welcome-fg);
+  background:
+    radial-gradient(circle at 20% 0%, rgba(220, 170, 90, 0.16), transparent 40%),
+    radial-gradient(circle at 80% 100%, rgba(110, 90, 200, 0.18), transparent 45%),
+    linear-gradient(160deg, var(--welcome-bg-1), var(--welcome-bg-2));
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+.welcome {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 56px 28px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+  min-height: 100vh;
+}
+
+/* Header */
+.welcome__head {
+  text-align: center;
+  max-width: 640px;
+}
+
+.welcome__eyebrow {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--welcome-mute);
+}
+
+.welcome__title {
+  margin: 0 0 12px;
+  font-size: clamp(34px, 5vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.welcome__sub {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--welcome-mute);
+}
+
+/* Cards row */
+.welcome__cards {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  width: 100%;
+}
+
+@media (max-width: 880px) {
+  .welcome__cards {
+    grid-template-columns: 1fr;
+    max-width: 420px;
+    margin: 0 auto;
+  }
+}
+
+.welcome__cardform {
+  margin: 0;
+  display: flex;
+}
+
+.welcome-card {
+  appearance: none;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 14px;
+  padding: 26px 22px 22px;
+  border-radius: 18px;
+  width: 100%;
+  min-height: 360px;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+  box-shadow: var(--welcome-card-shadow);
+}
+
+.welcome-card:hover,
+.welcome-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: var(--welcome-card-shadow-hover);
+  outline: none;
+}
+
+.welcome-card:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 4px;
+}
+
+.welcome-card__chip {
+  align-self: flex-start;
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.18);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.welcome-card__name {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-top: auto;
+}
+
+.welcome-card__tag {
+  font-size: 13.5px;
+  line-height: 1.4;
+  opacity: 0.78;
+}
+
+.welcome-card__cta {
+  margin-top: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0.95;
+}
+
+/* ============================================================
+   Intercom card (modern home intercom: cream + brass)
+   ============================================================ */
+.welcome-card--intercom {
+  background: linear-gradient(180deg, #f4ead7 0%, #ebdfc6 100%);
+  color: #2a221b;
+  border: 1px solid rgba(120, 90, 40, 0.22);
+}
+
+.welcome-card__chip--intercom {
+  background: rgba(120, 90, 40, 0.16);
+  color: #5a4421;
+}
+
+.welcome-card__name--intercom {
+  color: #2a221b;
+}
+
+.welcome-card__cta--intercom {
+  color: #8a6418;
+}
+
+.ic-preview {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #faf3e3;
+  border-radius: 12px;
+  border: 1px solid rgba(120, 90, 40, 0.14);
+  padding: 22px;
+  min-height: 140px;
+}
+
+.ic-preview__plate {
+  position: relative;
+  width: 110px;
+  height: 130px;
+  background: linear-gradient(180deg, #d8c089 0%, #b8965a 100%);
+  border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5),
+              inset 0 -2px 0 rgba(0, 0, 0, 0.18),
+              0 4px 8px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 12px;
+}
+
+.ic-preview__grille {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+  width: 70px;
+}
+
+.ic-preview__grille span {
+  width: 100%;
+  height: 6px;
+  background: #3a2c14;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.ic-preview__btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #f0d99a, #a37b2e 70%);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.55),
+              inset 0 -2px 2px rgba(0, 0, 0, 0.3),
+              0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+/* ============================================================
+   Dialup card (Win95 + AOL: bevels + Times)
+   ============================================================ */
+.welcome-card--dialup {
+  background: #c0c0c0;
+  color: #000080;
+  font-family: "Times New Roman", Times, Georgia, serif;
+  border: 2px solid;
+  border-color: #ffffff #404040 #404040 #ffffff;
+  border-radius: 0;
+  box-shadow: 0 0 0 2px #808080,
+              var(--welcome-card-shadow);
+}
+
+.welcome-card--dialup:hover,
+.welcome-card--dialup:focus-visible {
+  box-shadow: 0 0 0 2px #808080,
+              var(--welcome-card-shadow-hover);
+}
+
+.welcome-card__chip--dialup {
+  background: #000080;
+  color: #ffffff;
+  border-radius: 0;
+  letter-spacing: 0.22em;
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+  font-size: 10px;
+}
+
+.welcome-card__name--dialup {
+  color: #000080;
+  font-weight: 700;
+  font-family: "Times New Roman", Times, serif;
+  letter-spacing: 0;
+}
+
+.welcome-card__cta--dialup {
+  color: #800000;
+  font-family: "Times New Roman", Times, serif;
+}
+
+.du-preview {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #c0c0c0;
+  border: 2px solid;
+  border-color: #404040 #ffffff #ffffff #404040;
+  min-height: 140px;
+  font-family: "Tahoma", "MS Sans Serif", sans-serif;
+}
+
+.du-preview__bar {
+  background: linear-gradient(90deg, #000080 0%, #1084d0 100%);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.du-preview__bar-icon {
+  width: 12px;
+  height: 12px;
+  background: #ffff00;
+  border: 1px solid #000;
+}
+
+.du-preview__bar-title {
+  flex: 1;
+}
+
+.du-preview__bar-btns {
+  display: flex;
+  gap: 2px;
+}
+
+.du-preview__bar-btns b {
+  display: inline-block;
+  width: 14px;
+  height: 12px;
+  text-align: center;
+  font-weight: 400;
+  font-size: 10px;
+  line-height: 12px;
+  background: #c0c0c0;
+  color: #000;
+  border: 1px solid;
+  border-color: #ffffff #404040 #404040 #ffffff;
+}
+
+.du-preview__body {
+  flex: 1;
+  padding: 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+  font-size: 12px;
+}
+
+.du-preview__leds {
+  display: flex;
+  gap: 5px;
+}
+
+.du-preview__leds i {
+  width: 10px;
+  height: 5px;
+  border-radius: 1px;
+  background: #2a0000;
+  box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.6);
+}
+
+.du-preview__leds i:nth-child(1) { background: #ff3030; box-shadow: 0 0 6px #ff5050; }
+.du-preview__leds i:nth-child(2) { background: #2ad84a; box-shadow: 0 0 5px #5fff7a; }
+.du-preview__leds i:nth-child(4) { background: #ffb84a; box-shadow: 0 0 5px #ffd070; }
+
+.du-preview__line {
+  font-family: "Courier New", Courier, monospace;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.du-preview__line--small {
+  font-size: 10.5px;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+/* ============================================================
+   Answering machine card (beige plastic + LED counter)
+   ============================================================ */
+.welcome-card--am {
+  background: linear-gradient(180deg, #d8c8a4 0%, #c2b08a 100%);
+  color: #3a2e1a;
+  border: 1px solid rgba(58, 46, 26, 0.3);
+  border-radius: 14px;
+  position: relative;
+}
+
+.welcome-card__chip--am {
+  background: rgba(58, 46, 26, 0.18);
+  color: #3a2e1a;
+}
+
+.welcome-card__name--am {
+  color: #3a2e1a;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 19px;
+}
+
+.welcome-card__cta--am {
+  color: #7a3a18;
+  font-family: "Courier New", Courier, monospace;
+  text-transform: uppercase;
+}
+
+.am-preview {
+  flex: 1;
+  position: relative;
+  background: linear-gradient(180deg, #c4b288 0%, #a89878 100%);
+  border-radius: 8px;
+  padding: 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 140px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35),
+              inset 0 -2px 0 rgba(0, 0, 0, 0.18);
+}
+
+.am-preview__screw {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #6a5a3a, #2e2616 70%);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+.am-preview__screw--tl { top: 8px;    left: 8px; }
+.am-preview__screw--tr { top: 8px;    right: 8px; }
+.am-preview__screw--bl { bottom: 8px; left: 8px; }
+.am-preview__screw--br { bottom: 8px; right: 8px; }
+
+.am-preview__display {
+  align-self: center;
+  background: #1a1408;
+  color: #ff4f22;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-family: "Courier New", Courier, monospace;
+  font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  box-shadow: inset 0 0 6px rgba(255, 79, 34, 0.4),
+              inset 0 0 0 1px rgba(0, 0, 0, 0.6);
+}
+
+.am-preview__count {
+  font-size: 28px;
+  letter-spacing: 0.06em;
+  text-shadow: 0 0 6px rgba(255, 79, 34, 0.65);
+}
+
+.am-preview__label {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  opacity: 0.85;
+}
+
+.am-preview__keys {
+  display: flex;
+  gap: 8px;
+  align-self: center;
+}
+
+.am-preview__key {
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  background: linear-gradient(180deg, #6a5a3a, #4a3e26);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+              inset 0 -2px 0 rgba(0, 0, 0, 0.35),
+              0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.am-preview__key--rec {
+  background: linear-gradient(180deg, #c44a28, #821c08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3),
+              inset 0 -2px 0 rgba(0, 0, 0, 0.4),
+              0 0 8px rgba(255, 60, 30, 0.45);
+}
+
+/* Footer */
+.welcome__foot {
+  margin-top: auto;
+  font-size: 12px;
+  color: var(--welcome-mute);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.welcome__foot-sep {
+  opacity: 0.5;
+}
+
+.welcome__version {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  opacity: 0.7;
+}

--- a/server/internal/web/templates/welcome.html
+++ b/server/internal/web/templates/welcome.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pick your vibe - Digits</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+<link rel="stylesheet" href="/static/welcome.css">
+</head>
+<body class="welcome-body">
+
+<main class="welcome">
+  <header class="welcome__head">
+    <p class="welcome__eyebrow">One last thing</p>
+    <h1 class="welcome__title">Pick your vibe.</h1>
+    <p class="welcome__sub">Three ways to wear your phone network. You can change it anytime in Settings.</p>
+  </header>
+
+  <div class="welcome__cards" role="radiogroup" aria-label="Theme">
+
+    <form action="/welcome" method="POST" class="welcome__cardform">
+      <input type="hidden" name="theme" value="{{.ThemeIntercom}}">
+      <button type="submit" class="welcome-card welcome-card--intercom" aria-label="Pick the Home Intercom theme">
+        <span class="welcome-card__chip">DEFAULT</span>
+        <span class="ic-preview" aria-hidden="true">
+          <span class="ic-preview__plate">
+            <span class="ic-preview__grille">
+              <span></span><span></span><span></span><span></span>
+              <span></span><span></span><span></span><span></span>
+              <span></span><span></span><span></span><span></span>
+            </span>
+            <span class="ic-preview__btn"></span>
+          </span>
+        </span>
+        <span class="welcome-card__name welcome-card__name--intercom">Home Intercom</span>
+        <span class="welcome-card__tag">Quiet, modern. Like a doorbell.</span>
+        <span class="welcome-card__cta welcome-card__cta--intercom">Use this theme &rarr;</span>
+      </button>
+    </form>
+
+    <form action="/welcome" method="POST" class="welcome__cardform">
+      <input type="hidden" name="theme" value="{{.ThemeDialup}}">
+      <button type="submit" class="welcome-card welcome-card--dialup" aria-label="Pick the Retro 1997 dial-up theme">
+        <span class="welcome-card__chip welcome-card__chip--dialup">RETRO 1997</span>
+        <span class="du-preview" aria-hidden="true">
+          <span class="du-preview__bar">
+            <span class="du-preview__bar-icon"></span>
+            <span class="du-preview__bar-title">Dial-Up</span>
+            <span class="du-preview__bar-btns"><b>_</b><b>&#9634;</b><b>&#10005;</b></span>
+          </span>
+          <span class="du-preview__body">
+            <span class="du-preview__leds">
+              <i></i><i></i><i></i><i></i><i></i><i></i>
+            </span>
+            <span class="du-preview__line">CONNECTING&hellip;</span>
+            <span class="du-preview__line du-preview__line--small">v.90 &middot; 56 000 bps</span>
+          </span>
+        </span>
+        <span class="welcome-card__name welcome-card__name--dialup">Retro 1997</span>
+        <span class="welcome-card__tag">You&rsquo;ve got phones. Modem and all.</span>
+        <span class="welcome-card__cta welcome-card__cta--dialup">Connect &rarr;</span>
+      </button>
+    </form>
+
+    <form action="/welcome" method="POST" class="welcome__cardform">
+      <input type="hidden" name="theme" value="{{.ThemeAM}}">
+      <button type="submit" class="welcome-card welcome-card--am" aria-label="Pick the Answering Machine theme">
+        <span class="welcome-card__chip welcome-card__chip--am">MID-90s</span>
+        <span class="am-preview" aria-hidden="true">
+          <span class="am-preview__screw am-preview__screw--tl"></span>
+          <span class="am-preview__screw am-preview__screw--tr"></span>
+          <span class="am-preview__screw am-preview__screw--bl"></span>
+          <span class="am-preview__screw am-preview__screw--br"></span>
+          <span class="am-preview__display">
+            <span class="am-preview__count">01</span>
+            <span class="am-preview__label">NEW</span>
+          </span>
+          <span class="am-preview__keys">
+            <span class="am-preview__key am-preview__key--rec"></span>
+            <span class="am-preview__key"></span>
+            <span class="am-preview__key"></span>
+          </span>
+        </span>
+        <span class="welcome-card__name welcome-card__name--am">Answering Machine</span>
+        <span class="welcome-card__tag">Beige plastic. Tape sold separately.</span>
+        <span class="welcome-card__cta welcome-card__cta--am">Press play &rarr;</span>
+      </button>
+    </form>
+
+  </div>
+
+  <footer class="welcome__foot">
+    <span>Signed in as <b>{{if .User}}{{.User.Email}}{{end}}</b></span>
+    <span class="welcome__foot-sep">&middot;</span>
+    <span class="welcome__version">{{.Version}}</span>
+  </footer>
+</main>
+
+</body>
+</html>

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -168,6 +168,16 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	}, authStore
 }
 
+// markUserOnboarded flips the welcome-gate flag on a freshly-created test
+// user so requests to protected routes don't get bounced to /welcome. Real
+// users hit this state by submitting the picker; tests skip the picker.
+func markUserOnboarded(t *testing.T, store *auth.Store, userID string) {
+	t.Helper()
+	if err := store.MarkThemeChosen(context.Background(), userID); err != nil {
+		t.Fatalf("mark theme chosen for %s: %v", userID, err)
+	}
+}
+
 // addSessionCookie creates test@example.com on demand, opens a session, and
 // returns a cookie suitable for attaching to authenticated requests.
 func addSessionCookie(t *testing.T, store *auth.Store) *http.Cookie {
@@ -179,6 +189,7 @@ func addSessionCookie(t *testing.T, store *auth.Store) *http.Cookie {
 			t.Fatalf("create test user: %v", err)
 		}
 	}
+	markUserOnboarded(t, store, user.ID)
 	token, _, err := store.CreateSession(context.Background(), user.ID, auth.SessionTTL)
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -238,6 +249,7 @@ func seedE2EHousehold(t *testing.T, database *db.Database, authStore *auth.Store
 			t.Fatalf("create test user: %v", err)
 		}
 	}
+	markUserOnboarded(t, authStore, user.ID)
 	store := household.NewStore(database.DB)
 	hh, err := store.Create(context.Background(), "E2E Test Household", user.ID)
 	if err != nil {
@@ -312,6 +324,7 @@ func seedUnrelatedUser(t *testing.T, env callsTestEnv, label string) *auth.User 
 	if err != nil {
 		t.Fatalf("seedUnrelatedUser %s: CreateUser: %v", label, err)
 	}
+	markUserOnboarded(t, env.authStore, u.ID)
 	hh, err := env.householdStore.Create(context.Background(), hhName, u.ID)
 	if err != nil {
 		t.Fatalf("seedUnrelatedUser %s: Create household: %v", label, err)


### PR DESCRIPTION
## Summary

- New `/welcome` one-question wizard. After auth, users with `theme_chosen = false` are routed here to pick a theme; the choice persists and flips the flag.
- Three cards rendered in their own theme aesthetics so the choice is visual: **Home Intercom** (default, brass + cream), **Retro 1997** (Win95 + AOL bevels, dialup), **Answering Machine** (beige plastic + LED counter).
- Submit reuses the existing `auth.LoginRedirectFor` rule, so dialup picks land on the modem connect screen `/connecting` and other themes go to `/`. The same exported function now also routes the post-onboard redirect, so a fresh dialup user sees the modem screen on first session, not just on subsequent logins.
- Migration v25 adds `theme_chosen BOOLEAN`. Existing rows are backfilled to TRUE inside a `schema_version`-keyed DO block (mirroring v22) so only fresh signups see the picker.
- Welcome and onboarding gates are unified, both now skipping `/api/*` and `/ws*` so SSE/JSON/WS clients don't get HTML page redirects.

## How it lands

After auth, `theme_chosen = false` means you see this:

![welcome picker](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-362-welcome-picker.png)

Picking each card lands you in:

| Pick | Lands on |
|---|---|
| Home Intercom | `/` (intercom dashboard) |
| Retro 1997 | `/connecting` (modem dial-in screen) |
| Answering Machine | `/` (AM dashboard) |

**Home Intercom**
![intercom landing](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-362-landing-intercom.png)

**Retro 1997 (dialup) lands on the modem connect screen**
![dialup landing](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-362-landing-dialup.png)

**Answering Machine**
![am landing](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-362-landing-answering-machine.png)

## Test plan

- [x] `make test` (unit, server module) green
- [x] `make test-integration` green (test fixtures updated to flip `theme_chosen` post-`CreateUser` via a new `markUserOnboarded` helper)
- [x] `golangci-lint run ./...` clean
- [x] Local smoke test on dev server through agent-browser: each of the three cards routes to the correct landing screen
- [x] Subsequent navigation after picking does not bounce back to `/welcome`
- [x] Migration is idempotent on re-run (the `schema_version = 25` guard wraps both ALTER and UPDATE)
- [x] No em dashes in any added file (a few pre-existing ones in `handler.go` comment headers are out of scope and untouched)

## Notes for review

- `LoginRedirectFor` is now exported (was `loginRedirectFor`); call sites in `handlers.go`, `google.go`, `handler_onboard.go`, and `handler_welcome.go` all use the exported name.
- `handleWelcomePost` mutates the request-scoped `*auth.User` snapshot in memory (`user.Theme = theme; user.ThemeChosen = true`) instead of re-fetching from the DB. Saves a round trip and matches how `handleOnboardPost` already reuses the request-context user.
- Welcome page is standalone (not wrapped in `layout-v2`) because the user is pre-theme. CSS lives at `static/welcome.css`.
- To exercise the flow locally: `make dev-up`, then `docker exec digits-dev-user-db-1 psql -U digits -d digits -c \"UPDATE users SET theme_chosen = FALSE WHERE email = 'dev@digits.local'\"` and visit any protected route.