### PR TITLE
refactor(server): extract deviceColumns and linkColumns constants

### DIFF
--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -16,6 +16,12 @@ import (
 // ErrNotFound is returned when a device cannot be found.
 var ErrNotFound = errors.New("device not found")
 
+// deviceColumns is the SELECT/RETURNING list for queries that scan into a
+// Device. Field order must stay aligned with the destination order in every
+// .Scan call below.
+const deviceColumns = `id, line_id, hardware_id, device_id, device_token,
+	pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at`
+
 // Device represents a physical handset paired to a line.
 type Device struct {
 	ID                   int64
@@ -46,8 +52,7 @@ func (s *Store) Create(ctx context.Context, lineID int64, hardwareID string) (*D
 	err := s.db.QueryRowContext(ctx, `
 		INSERT INTO devices (line_id, hardware_id)
 		VALUES ($1, $2)
-		RETURNING id, line_id, hardware_id, device_id, device_token,
-		          pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
+		RETURNING `+deviceColumns+`
 	`, lineID, hardwareID).Scan(
 		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
 		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
@@ -62,8 +67,7 @@ func (s *Store) Create(ctx context.Context, lineID int64, hardwareID string) (*D
 func (s *Store) GetByID(ctx context.Context, id int64) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
+		SELECT `+deviceColumns+`
 		FROM devices
 		WHERE id = $1
 	`, id).Scan(
@@ -83,8 +87,7 @@ func (s *Store) GetByID(ctx context.Context, id int64) (*Device, error) {
 func (s *Store) GetByHardwareID(ctx context.Context, hwID string) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
+		SELECT `+deviceColumns+`
 		FROM devices
 		WHERE hardware_id = $1
 	`, hwID).Scan(
@@ -103,8 +106,7 @@ func (s *Store) GetByHardwareID(ctx context.Context, hwID string) (*Device, erro
 // ListByLine returns all devices associated with a given line.
 func (s *Store) ListByLine(ctx context.Context, lineID int64) ([]Device, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
+		SELECT `+deviceColumns+`
 		FROM devices
 		WHERE line_id = $1
 		ORDER BY created_at
@@ -220,8 +222,7 @@ func (s *Store) TouchLastSeen(ctx context.Context, hardwareID string) error {
 func (s *Store) GetByPairingCode(ctx context.Context, code string) (*Device, error) {
 	d := &Device{}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, line_id, hardware_id, device_id, device_token,
-		       pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
+		SELECT `+deviceColumns+`
 		FROM devices
 		WHERE pairing_code = $1
 		  AND pairing_code_expires_at > NOW()

--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -12,6 +12,12 @@ import (
 const inviteCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const inviteCodeLength = 8
 
+// linkColumns is the SELECT/RETURNING list for queries that scan into a
+// HouseholdLink. Field order must stay aligned with the destination order in
+// every .Scan call (and inside scanLinks) below.
+const linkColumns = `id, household_a_id, household_b_id, status, invite_code, invited_by,
+	accepted_by, created_at, accepted_at, revoked_at, revoked_by`
+
 // HouseholdLink represents a link (invitation or active connection) between two households.
 type HouseholdLink struct {
 	ID           string
@@ -63,8 +69,7 @@ func (s *LinkStore) CreateInvite(ctx context.Context, fromHouseholdID, invitedBy
 	err = s.db.QueryRowContext(ctx, `
 		INSERT INTO household_links (household_a_id, invited_by, invite_code, status)
 		VALUES ($1, $2, $3, 'pending')
-		RETURNING id, household_a_id, household_b_id, status, invite_code, invited_by,
-		          accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		RETURNING `+linkColumns+`
 	`, fromHouseholdID, invitedByUserID, code).Scan(
 		&link.ID, &link.HouseholdAID, &link.HouseholdBID, &link.Status, &link.InviteCode,
 		&link.InvitedBy, &link.AcceptedBy, &link.CreatedAt, &link.AcceptedAt,
@@ -82,8 +87,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 	// Fetch the pending invite
 	link := &HouseholdLink{}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, household_a_id, household_b_id, status, invite_code, invited_by,
-		       accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		SELECT `+linkColumns+`
 		FROM household_links
 		WHERE invite_code = $1 AND status = 'pending'
 	`, code).Scan(
@@ -128,8 +132,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 		    accepted_by = $3,
 		    accepted_at = $4
 		WHERE id = $5
-		RETURNING id, household_a_id, household_b_id, status, invite_code, invited_by,
-		          accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		RETURNING `+linkColumns+`
 	`, aID, bID, acceptingUserID, now, link.ID).Scan(
 		&link.ID, &link.HouseholdAID, &link.HouseholdBID, &link.Status, &link.InviteCode,
 		&link.InvitedBy, &link.AcceptedBy, &link.CreatedAt, &link.AcceptedAt,
@@ -144,8 +147,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 // GetLinkedHouseholds returns all active links where householdID is either a or b.
 func (s *LinkStore) GetLinkedHouseholds(ctx context.Context, householdID string) ([]HouseholdLink, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, household_a_id, household_b_id, status, invite_code, invited_by,
-		       accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		SELECT `+linkColumns+`
 		FROM household_links
 		WHERE status = 'active'
 		  AND (household_a_id = $1 OR household_b_id = $1)
@@ -198,8 +200,7 @@ func (s *LinkStore) RevokeLink(ctx context.Context, linkID, revokedByUserID stri
 func (s *LinkStore) GetByID(ctx context.Context, id string) (*HouseholdLink, error) {
 	link := &HouseholdLink{}
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, household_a_id, household_b_id, status, invite_code, invited_by,
-		       accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		SELECT `+linkColumns+`
 		FROM household_links WHERE id = $1
 	`, id).Scan(
 		&link.ID, &link.HouseholdAID, &link.HouseholdBID, &link.Status, &link.InviteCode,
@@ -218,8 +219,7 @@ func (s *LinkStore) GetByID(ctx context.Context, id string) (*HouseholdLink, err
 // GetPendingForHousehold returns all pending invites where householdID is the inviting household.
 func (s *LinkStore) GetPendingForHousehold(ctx context.Context, householdID string) ([]HouseholdLink, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, household_a_id, household_b_id, status, invite_code, invited_by,
-		       accepted_by, created_at, accepted_at, revoked_at, revoked_by
+		SELECT `+linkColumns+`
 		FROM household_links
 		WHERE status = 'pending' AND household_a_id = $1
 	`, householdID)


### PR DESCRIPTION
## Summary

#354 (`callColumns` + `scanCallRows` in `calls/tracker.go`) and #355 (`lineColumns` + `scanLineRow` in `line/store.go`) set a clear convention this week: store files put their SELECT/RETURNING column list in a single named constant and use it from every query that scans into the same struct.

The same shape (one column list duplicated across many queries) lived unconsolidated in two adjacent stores. This PR finishes the sweep:

- `server/internal/device/store.go`: 5 sites (`Create` RETURNING, `GetByID`, `GetByHardwareID`, `ListByLine`, `GetByPairingCode`) now share `deviceColumns`.
- `server/internal/household/link.go`: 6 sites (`CreateInvite` RETURNING, `AcceptInvite` SELECT and UPDATE...RETURNING, `GetLinkedHouseholds`, `GetByID`, `GetPendingForHousehold`) now share `linkColumns`. `scanLinks` already factored the multi-row scan; this finishes the job for the SELECT list.

No new scan helpers and no signature changes: this is a pure column-list dedupe so adding or renaming a column means editing one constant rather than four (devices) or six (household_links) hand-aligned blocks.

## Motivated by (last 24h)

- #354 refactor(server): share Call row scan between Recent and RecentForPhones
- #355 refactor(server): share Line row scan across List variants

## Test plan

- [x] `go build ./...` in `server/` (clean)
- [x] `go test ./internal/device/... ./internal/household/...` (clean for unit-tier; integration tier needs Postgres)
- [x] `go vet ./internal/device/... ./internal/household/...` (clean)
- [x] `gofmt -l` on both files (clean)
- [ ] CI integration tests against Postgres confirm the SELECT/RETURNING strings still produce equivalent rows. The concatenated SQL is byte-equivalent up to whitespace, which Postgres ignores.