### PR TITLE
fix(ci): release groomer Goose lookup must use release view, not list

### DIFF
--- a/.github/workflows/release-groom.yml
+++ b/.github/workflows/release-groom.yml
@@ -90,10 +90,21 @@ jobs:
           if [ -z "$current_date" ] || [ "$current_date" = "null" ]; then
             current_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           fi
-          # Most recent prior release whose body contains the literal "Silly Goose Award".
-          # Past tense matters: only releases strictly before this one count.
-          last_goose_date=$(gh release list --limit 200 --json tagName,publishedAt,body \
-            --jq "[.[] | select(.publishedAt < \"$current_date\") | select(.body | contains(\"Silly Goose Award\"))] | sort_by(.publishedAt) | last | .publishedAt // \"\"")
+          # gh release list --json does not expose body, so do a two-step lookup:
+          # get the 50 most-recent prior tags, then view each in order until we find
+          # one whose body contains the literal phrase "Silly Goose Award".
+          mapfile -t prior_entries < <(gh release list --limit 200 --json tagName,publishedAt \
+            --jq "[.[] | select(.publishedAt < \"$current_date\")] | sort_by(.publishedAt) | reverse | .[0:50] | .[] | \"\(.tagName)|\(.publishedAt)\"")
+          last_goose_date=""
+          for entry in "${prior_entries[@]}"; do
+            prior_tag="${entry%%|*}"
+            prior_date="${entry##*|}"
+            body=$(gh release view "$prior_tag" --json body -q .body 2>/dev/null || true)
+            if printf '%s' "$body" | grep -q "Silly Goose Award"; then
+              last_goose_date="$prior_date"
+              break
+            fi
+          done
           if [ -n "$last_goose_date" ]; then
             current_epoch=$(date -d "$current_date" +%s)
             last_epoch=$(date -d "$last_goose_date" +%s)


### PR DESCRIPTION
## What

Fixes the `Compute Silly Goose gap` step in `release-groom.yml`. The original implementation tried `gh release list --json tagName,publishedAt,body`, but `body` is not a valid field for `release list` (only `release view` exposes it). Every grooming run since the Goose mechanic landed has failed in this step with `Unknown JSON field: "body"` before even reaching the Claude call, so no release has actually been re-groomed with the new prompt.

The fix is a two-step lookup: get the 50 most-recent prior tags via `release list` (which does support `tagName` + `publishedAt`), then walk them in publish-date descending order calling `release view --json body` until one contains the literal phrase "Silly Goose Award". First match wins; the loop short-circuits.

## Why

In the steady state a recently-awarded Goose is found in the first one or two `view` calls, so this is cheap. The 50-tag cap bounds the worst case (no Goose anywhere in recent history) so we don't accidentally pull every release in the project.

## Test plan

Verified the new lookup logic locally with the same `gh` commands the workflow runs:

```
$ # current_date = fw/v1.8.0 publish time
$ mapfile -t prior_entries < <(gh release list --limit 200 --json tagName,publishedAt --jq '...')
$ for entry in "${prior_entries[@]}"; do
    body=$(gh release view "${entry%%|*}" --json body -q .body)
    grep -q "Silly Goose Award" <<<"$body" && echo "match: ${entry%%|*}" && break
  done
```

No matches today (no release has the phrase yet, since every prior groomer attempt failed in this step). After this lands, the first re-fired release will get "inaugural" context, and subsequent ones will chain forward correctly.