### PR TITLE
feat(pi): raise V2 baseline volume via HP DAC mixer

### DIFF
--- a/.claude/skills/deploy-phone/SKILL.md
+++ b/.claude/skills/deploy-phone/SKILL.md
@@ -23,6 +23,20 @@ Diagnostic tools: `alsatest`, `latbench`, `latclient`, `memprofile`, `pipetest`,
 - `digits-recovery` and `digits-setup` are simple cross-compiles, no Docker needed.
 - `digits-setup` output binary is named `digits-setup-arm64`, not `digits-setup`.
 
+## Deployable Config Files
+
+`/data` is its own writable partition (`/dev/mmcblk0p4`, mounted `rw,noatime`), so anything that lives under `/data/...` does **not** need the rootfs remount cycle: scp, `sudo cp`, done.
+
+| File | Source path in repo | Install destination | Apply step |
+|------|---------------------|---------------------|------------|
+| ALSA mixer state | `pi/digits_mixer_v{1,2}.state` (pick by PCB version of the target phone) | `/data/digits_mixer.state` | `sudo alsactl restore <card> -f /data/digits_mixer.state` |
+
+`<card>` is `digitscodec` for V2 (TLV320AIC3104 onboard) and `Zero` for V1 (Codec Zero HAT). Confirm before applying with `amixer -c digitscodec info` (V2) or `amixer -c Zero info` (V1). Image build (`tools/build-image.sh`) picks the right `_v1`/`_v2` source by PCB mode and copies it on first flash; for an in-place update you have to pick the matching source file yourself.
+
+`alsactl restore` may print `alsa-lib main.c:...(snd_use_case_mgr_open) error: failed to import hw:N use case configuration -2` -- harmless. The numid-keyed control values still apply.
+
+After the restore, **verify control values with `amixer cget name='<control>'`, not `sget`.** TLV320AIC3104 has no UCM mapping, so simple-control lookups (`sget`) fail with "Unable to find simple control" even when the underlying kcontrol exists and is correct.
+
 ## Device Info
 
 Phone IPs, SSH credentials, and device details are in `CLAUDE.local.md`. Read it before deploying.
@@ -60,6 +74,14 @@ The `mount` output must show `ro` -- if it shows `rw`, remount immediately:
 ```bash
 sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,ro /'
 ```
+
+If `remount,ro` returns `mount: /: mount point is busy.` even though `lsof` shows no writeable handles, flush systemd-journald first and retry:
+
+```bash
+sshpass -p <password> ssh <user>@<ip> 'sudo journalctl --flush --sync && sync && sudo mount -o remount,ro /'
+```
+
+journald keeps `/var/log/journal/.../*.journal` open `O_RDWR` and intermittently has dirty in-memory state that the kernel counts as a write reference. `--flush --sync` collapses it back to a clean state and the remount succeeds.
 
 ## Multi-Phone Deploy
 

--- a/pi/digits_mixer_v2.state
+++ b/pi/digits_mixer_v2.state
@@ -234,8 +234,8 @@ state.digitscodec {
 	control.17 {
 		iface MIXER
 		name 'HP DAC Playback Volume'
-		value.0 80
-		value.1 80
+		value.0 100
+		value.1 100
 		comment {
 			access 'read write'
 			type INTEGER
@@ -243,8 +243,8 @@ state.digitscodec {
 			range '0 - 118'
 			dbmin -9999999
 			dbmax 0
-			dbvalue.0 -1900
-			dbvalue.1 -1900
+			dbvalue.0 -900
+			dbvalue.1 -900
 		}
 	}
 	control.18 {

--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -61,15 +61,7 @@ func detectCodec() *codecConfig {
 				MixerName:      "PCM",
 				ALSAMin:        40,
 				ALSAMax:        115,
-				// V2 codec is noticeably quieter than V1 at the same level
-				// step. The TLV320AIC3104 PCM mixer drives the headphone amp
-				// through several attenuated stages (HP DAC at -19 dB, HP at
-				// +5 dB) so PCM needs to sit near the top of its range to
-				// reach a comfortable handset earpiece level. Level 8 maps
-				// to roughly -8 dB at PCM, which puts the earpiece at a
-				// telephone-normal SPL on first boot. Users can drop it
-				// later via *#*N service codes.
-				DefaultLevel: 8,
+				DefaultLevel:   5,
 			}
 			return
 		}


### PR DESCRIPTION
## What

Raise the V2 codec earpiece baseline by ~+10 dB by removing unnecessary attenuation in the HP DAC mixer stage, and reset the V2 first-boot volume default from 8 back to 5 to match V1's UX.

## Why

V2 (TLV320AIC3104) was noticeably quieter than V1 (Codec Zero HAT) at the same volume level step. The handset path stacks three attenuators on top of each other:

- PCM Playback Volume: -43..-6 dB, swept by user-facing level 0-9
- HP DAC Playback Volume: was at value 80 = **-19 dB**
- HP Playback Volume (output amp): +5 dB out of a +9 dB max

At default level 5, total chain loss was about -37 dB. The HP DAC stage was the dominant source and the -19 dB value had no engineering reason behind it; the chip allows up to 0 dB.

Raising `HP DAC Playback Volume` to value 100 (-9 dB) in `pi/digits_mixer_v2.state` recovers about +10 dB of clean digital headroom. The analog stage and PCM mapping are unchanged, so peak distortion behavior at top-of-scale level 9 is unchanged. Clarity is preserved because voice (and dialtone) sit well below 0 dBFS digitally, so removing this attenuation does not push anything into clipping.

With the boost in place, level 5 produces telephone-normal SPL on first boot, so `DefaultLevel` for the V2 config in `pi/digitsd/internal/audio/alsa.go` is reset from 8 back to 5.

## Test plan

- [x] digitsd unit tests pass: `go test ./internal/audio/... ./internal/phone/...`
- [x] `golangci-lint run ./...` clean from `pi/digitsd/`
- [x] Built and deployed digitsd 1.16.0-17-ge6e94bc5-dirty + new mixer state to Black V2 (line 19, hw `7164e808-929f-409d-92fa-11b31502986c`)
- [x] Live A/B with phone off-hook on dialtone: alternated `HP DAC Playback Volume` between 80 (before) and 100 (after); louder state clearly preferred, no clarity loss
- [x] Verified post-deploy state: `HP DAC Playback Volume = 100`, `PCM Playback Volume = 106` (level 8 from persisted file), `HP Playback Volume = 5`, digitsd active, rootfs back to `ro`
- [x] V1 codec path untouched (V1 detection branch in `detectCodec()` is unchanged); image build picks `_v1` vs `_v2` mixer state by `PCB_MODE` so V1 phones are not affected

The skill update under `.claude/skills/deploy-phone/SKILL.md` documents what was missing during this deploy: config-file deploys under `/data` skip the rootfs remount cycle, the `alsactl restore` apply step for mixer state, the `journalctl --flush --sync` recovery when `remount,ro` returns `mount: / busy`, and that TLV320AIC3104 controls must be read with `amixer cget`, not `sget` (no UCM mapping).