### PR TITLE
feat(server): AM theme software update controls and voice-style fix

### DIFF
--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -155,6 +155,14 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to create user", http.StatusInternalServerError)
 			return
 		}
+		// Skip /welcome for fresh dev-session users so e2e tests don't have to
+		// click through the theme picker on every run. The picker can still be
+		// exercised locally by flipping theme_chosen back to false in SQL.
+		if err := h.store.MarkThemeChosen(r.Context(), user.ID); err != nil {
+			slog.Error("dev-session: mark theme chosen", "err", err, "user_id", user.ID)
+		} else {
+			user.ThemeChosen = true
+		}
 	} else if err != nil {
 		slog.Error("dev-session: lookup user", "err", err)
 		http.Error(w, "failed to look up user", http.StatusInternalServerError)

--- a/server/internal/updates/fixture.go
+++ b/server/internal/updates/fixture.go
@@ -1,10 +1,10 @@
 package updates
 
 // FakeReleaseIndex returns a GitHubReleases instance pre-populated with a
-// static release index for e2e testing. The firmware component has three
-// releases: 1.2.0, 1.3.0 (groomed), and 1.4.0 (groomed, latest). The pi
-// component is empty. Callers that seed a device at fw 1.2.0 will see the
-// update chip with notes for 1.3.0 and 1.4.0.
+// static release index for e2e testing. Firmware has three releases (1.2.0,
+// 1.3.0 groomed, 1.4.0 groomed/latest) and pi has three releases (0.5.0,
+// 0.6.0 groomed, 0.7.0 groomed/latest). Callers that seed a device at fw
+// 1.2.0 or pi 0.5.0 will see the update chip with notes for the newer ones.
 func FakeReleaseIndex() *GitHubReleases {
 	idx := &ReleaseIndex{
 		Firmware: ComponentIndex{
@@ -28,8 +28,24 @@ func FakeReleaseIndex() *GitHubReleases {
 			},
 		},
 		Pi: ComponentIndex{
-			Latest:   "",
-			Releases: make(map[string]*Release),
+			Latest: "0.7.0",
+			Releases: map[string]*Release{
+				"0.5.0": {
+					Version: "0.5.0",
+					Date:    "2025-09-01",
+					Notes:   "",
+				},
+				"0.6.0": {
+					Version: "0.6.0",
+					Date:    "2026-01-10",
+					Notes:   "Faster boot. New OTA progress reporting.",
+				},
+				"0.7.0": {
+					Version: "0.7.0",
+					Date:    "2026-04-01",
+					Notes:   "V2 mixer state shipped via OTA.\nHP DAC volume baseline raised.",
+				},
+			},
 		},
 	}
 	return NewGitHubReleasesWithIndex(idx)

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -252,14 +252,15 @@ func (h *Handler) handleTestStartConference(w http.ResponseWriter, r *http.Reque
 }
 
 // handleDevSeedFirmware registers a fake hub entry for a line number with the
-// given firmware version. It is only reachable when DevMode is true and lets
-// the Playwright e2e suite exercise the firmware update chip without a real
-// device connection.
+// given firmware (and optional pi) version. It is only reachable when DevMode
+// is true and lets the Playwright e2e suite (and interactive dev sessions)
+// exercise the update chip without a real device connection.
 //
-// POST /dev/seed-firmware?number=<line-number>&fw=<semver>
+// POST /dev/seed-firmware?number=<line-number>&fw=<semver>[&pi=<semver>]
 func (h *Handler) handleDevSeedFirmware(w http.ResponseWriter, r *http.Request) {
 	number := r.URL.Query().Get("number")
 	fw := r.URL.Query().Get("fw")
+	pi := r.URL.Query().Get("pi")
 	if number == "" || fw == "" {
 		http.Error(w, "number and fw query params are required", http.StatusBadRequest)
 		return
@@ -272,7 +273,7 @@ func (h *Handler) handleDevSeedFirmware(w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 	h.hub.Register(number, conn)
-	h.hub.UpdateDeviceInfo(number, "", "", fw, "")
+	h.hub.UpdateDeviceInfo(number, pi, "", fw, "")
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = fmt.Fprintf(w, `{"ok":true,"number":%q,"fw":%q}`, number, fw)
+	_, _ = fmt.Fprintf(w, `{"ok":true,"number":%q,"fw":%q,"pi":%q}`, number, fw, pi)
 }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -161,6 +161,24 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-key--wide { min-width: 100px; }
 .am-key--tall { min-height: 68px; padding-top: 12px; padding-bottom: 10px; }
 
+/* Amber-glow accent: chicklet drawn in case beige but ringed in lamp light, used
+   when the key is the call-to-action (e.g. an available software install). */
+.am-key--accent {
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.75),
+    inset 0 -1px 0 rgba(100,85,45,0.4),
+    0 2px 0 var(--btn-press),
+    0 3px 4px rgba(40,30,15,0.3),
+    0 0 0 1px rgba(255,165,32,0.55),
+    0 0 8px rgba(255,165,32,0.3);
+}
+.am-key--accent .am-key__symbol { color: #6a3a08; }
+.am-key:disabled, .am-key.is-disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
+.am-key:disabled:active, .am-key.is-disabled:active { transform: none; }
+
+/* AM only loads its own stylesheet, so it needs its own .hidden rule. */
+.hidden { display: none !important; }
+
 /* Status lamp: small round LED with glow ring */
 .am-lamp {
   width: 11px; height: 11px; border-radius: 50%; display: inline-block;
@@ -1047,10 +1065,11 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-settings__kv-led { font-size: 13px; letter-spacing: 0.06em; word-break: break-all; }
 .am-settings__kv-lamp { flex: 0 0 auto; }
 
-/* Theme picker cartridge: swatch strip + name + description + LED lamp */
+/* Theme picker cartridge. Bare variant (voice-style picker, no swatch) gets
+   a 2-col grid so its lamp pins right instead of floating mid-card. */
 .am-cartridge {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 14px;
   padding: 12px 16px;
@@ -1062,6 +1081,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
   transition: transform 80ms, box-shadow 80ms;
   position: relative;
 }
+.am-cartridge:has(.am-cartridge__swatch) { grid-template-columns: auto 1fr auto auto; }
 .am-cartridge:hover { transform: translateY(-1px); }
 .am-cartridge input[type="radio"] { position: absolute; opacity: 0; pointer-events: none; }
 .am-cartridge__swatch {
@@ -1151,7 +1171,7 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
   .am-settings__layout { grid-template-columns: 1fr; }
   .am-settings__nav { position: static; flex-direction: row; flex-wrap: wrap; gap: 6px; }
   .am-settings__nav-label { flex-basis: 100%; padding: 0 0 4px; }
-  .am-cartridge { grid-template-columns: auto 1fr auto; }
+  .am-cartridge:has(.am-cartridge__swatch) { grid-template-columns: auto 1fr auto; }
   .am-cartridge__tag { grid-column: 2 / 3; grid-row: 2; justify-self: start; }
   .am-settings__kv-row { grid-template-columns: 1fr; gap: 4px; }
 }
@@ -1218,6 +1238,101 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-handset__update-body ul, .am-handset__update-body ol { margin: 0 0 4px; padding-left: 20px; }
 .am-handset__update-body code { font-family: var(--font-mono); font-size: 11px; }
 .am-handset__update-empty { margin: 0; font-style: italic; color: var(--ink-muted); font-size: 12px; }
+
+/* Software update plate: per-component installed/latest wells + INSTALL key. */
+.am-update__offline { margin: 0; line-height: 1.5; }
+.am-update__components { display: flex; flex-direction: column; gap: 14px; }
+.am-update__component { display: flex; flex-direction: column; gap: 8px; padding: 10px 0; border-top: 1px dashed rgba(100,80,40,0.25); }
+.am-update__component:first-child { padding-top: 0; border-top: 0; }
+.am-update__row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.am-update__meta { display: flex; flex-direction: column; gap: 6px; flex: 1 1 auto; min-width: 240px; }
+.am-update__label { margin: 0; }
+.am-update__versions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.am-update__version { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.am-update__version-cap {
+  font-family: var(--font-body); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-muted);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.am-update__version-cap--latest { color: var(--ink-soft); }
+.am-update__cap-lamp { width: 7px; height: 7px; }
+.am-update__version-well { padding: 5px 10px; display: inline-flex; align-items: center; min-height: 0; }
+.am-update__version-well--latest { box-shadow: inset 0 2px 4px rgba(0,0,0,0.7), inset 0 0 0 1px rgba(255,165,32,0.3), inset 0 -1px 0 rgba(255,255,255,0.05), 0 1px 0 rgba(255,255,255,0.4); }
+.am-update__version-led { font-size: 13px; letter-spacing: 0.08em; }
+.am-update__arrow { color: var(--ink-muted); font-size: 11px; line-height: 1; align-self: center; }
+.am-update__status { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; }
+.am-update__status-cap { font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+.am-update__actions { display: flex; align-items: center; gap: 10px; flex: 0 0 auto; }
+.am-update__install { min-width: 96px; }
+
+.am-update__choose, .am-update__notes { margin: 0; }
+.am-update__choose-tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px;
+  font-family: var(--font-body); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-soft);
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  border: 1px solid var(--btn-press); border-radius: 4px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.55), 0 1px 2px rgba(40,30,15,0.18);
+  cursor: pointer; user-select: none; list-style: none;
+}
+.am-update__choose-tab::-webkit-details-marker { display: none; }
+.am-update__choose-tab::before { content: '\25B8'; font-size: 9px; color: var(--ink-muted); transition: transform 120ms; }
+details[open] > .am-update__choose-tab::before { transform: rotate(90deg); }
+.am-update__choose-tab:hover { color: var(--ink); }
+
+.am-update__release-list { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; max-height: 240px; overflow-y: auto; padding: 2px; }
+.am-update__release {
+  display: grid; grid-template-columns: auto auto auto auto 1fr; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: rgba(255,255,255,0.35);
+  border: 1px solid rgba(100,80,40,0.25);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 80ms, box-shadow 80ms;
+}
+.am-update__release:hover { border-color: rgba(100,80,40,0.45); }
+.am-update__release input[type="radio"] { position: absolute; opacity: 0; pointer-events: none; }
+.am-update__release-dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #40100a 0%, #1a0804 70%);
+  border: 1px solid #0a0504;
+  box-shadow: inset 0 1px 1px rgba(255,255,255,0.08);
+  flex: 0 0 auto;
+}
+.am-update__release input[type="radio"]:checked ~ .am-update__release-dot {
+  background: radial-gradient(circle at 30% 30%, #ffd080 0%, var(--led-amber) 60%, #9a5808 100%);
+  box-shadow: 0 0 6px rgba(255,165,32,0.6), 0 0 10px rgba(255,165,32,0.25);
+}
+.am-update__release:has(input[type="radio"]:checked) {
+  border-color: rgba(255,165,32,0.55);
+  box-shadow: 0 0 0 1px rgba(255,165,32,0.18);
+}
+.am-update__release:focus-within { outline: 2px solid rgba(255,165,32,0.55); outline-offset: 2px; }
+.am-update__release-ver { font-family: var(--font-mono); font-size: 12px; font-weight: 600; color: var(--ink); letter-spacing: 0.04em; }
+.am-update__release-tag {
+  font-family: var(--font-body); font-size: 8px; font-weight: 600; letter-spacing: 0.22em;
+  text-transform: uppercase; padding: 2px 6px; border-radius: 3px;
+  background: var(--case-shade); color: #f4ebcb;
+}
+.am-update__release-tag--installed { background: rgba(43,125,52,0.85); color: #eafff0; }
+.am-update__release-date { font-family: var(--font-mono); font-size: 10.5px; color: var(--ink-muted); justify-self: end; }
+
+.am-update__progress { margin-top: 4px; }
+.am-update__progress-well { display: flex; align-items: center; gap: 10px; padding: 8px 12px; }
+.am-update__progress-lamp { flex: 0 0 auto; }
+.am-update__progress-led { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.am-update__notes { margin-top: 4px; }
+.am-update__notes-list { margin-top: 10px; }
+
+@media (max-width: 780px) {
+  .am-update__row { flex-direction: column; align-items: stretch; }
+  .am-update__actions { justify-content: flex-end; }
+  .am-update__release { grid-template-columns: auto 1fr auto; }
+  .am-update__release-date { grid-column: 2 / -1; justify-self: start; font-size: 10px; }
+  .am-update__release-tag { justify-self: end; }
+}
 
 /* Actions plate: brass Save/Delete keys aligned left, with hint text. */
 .am-handset__actions { display: flex; flex-direction: column; gap: 10px; }
@@ -1919,6 +2034,16 @@ body.am .deck-kick-confirm .deck-confirm__go {
 .am-phones__row-name a:hover { color: var(--chip-blue); }
 .am-phones__empty { padding: 14px 18px; }
 .am-phones__row-num-caption { font-family: var(--font-mono); font-size: 11px; color: var(--ink-muted); letter-spacing: 0.04em; }
+.am-phones__update-flag {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-left: 8px; padding: 1px 7px 2px;
+  border-radius: 3px;
+  background: rgba(255,165,32,0.08);
+  border: 1px solid rgba(255,165,32,0.32);
+  vertical-align: 1px;
+}
+.am-phones__update-flag .am-lamp { width: 7px; height: 7px; }
+.am-phones__update-cap { font-size: 9px; letter-spacing: 0.18em; }
 .am-phones__row--edit { display: flex; align-items: center; gap: 10px; }
 .am-phones__edit-form { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
 .am-phones__edit-input { flex: 1; min-width: 0; padding: 6px 10px; font: 13px/1 var(--font-body); color: var(--ink); background: rgba(0,0,0,0.12); border: 1px solid rgba(100,80,40,0.35); border-radius: 4px; }

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -815,7 +815,7 @@
         headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
         body: body.toString()
       })
-      .then(function(r) { return r.json(); })
+      .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function(data) {
         if (data.error) { amShowResult(prefix, 'failed', 'Failed: ' + data.error); return; }
         if (text) text.textContent = 'Triggered, awaiting handset';
@@ -831,7 +831,7 @@
         attempts++;
         if (attempts > 120) { clearInterval(pollers[prefix]); amShowResult(prefix, 'failed', 'Timed out, please retry'); return; }
         fetch('/phones/' + phoneNumber + '/update-status')
-        .then(function(r) { return r.json(); })
+        .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
         .then(function(data) {
           if (!data.status) return;
           var text = document.getElementById(prefix + '-progress-text');

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -768,25 +768,7 @@
       {{template "am-silent-mode-section" .}}
     </section>
 
-    {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
-    <section class="am-plate am-handset__plate am-handset__plate--wide">
-      <span class="am-plate__label">Update notes</span>
-      <div class="am-handset__updates">
-        {{range .PiUpdateNotes}}
-        <article class="am-handset__update-note">
-          <span class="am-handset__update-ver">pi {{.Version}}</span>
-          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
-        </article>
-        {{end}}
-        {{range .FirmwareUpdateNotes}}
-        <article class="am-handset__update-note">
-          <span class="am-handset__update-ver">fw {{.Version}}</span>
-          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
-        </article>
-        {{end}}
-      </div>
-    </section>
-    {{end}}
+    {{template "am-software-update-section" .}}
 
     <section class="am-plate am-handset__plate am-handset__plate--wide am-handset__plate--danger am-handset__actions">
       <span class="am-plate__label">Actions</span>
@@ -805,6 +787,87 @@
     </section>
 
   </div>
+
+  <script>
+  (function() {
+    var phoneNumber = {{.Line.Number}};
+    var pollers = {pi: null, fw: null};
+
+    window.amTriggerComponentUpdate = function(prefix, paramName) {
+      var btn = document.getElementById(prefix + '-install-btn');
+      var radio = document.querySelector('input[name="' + paramName + '"]:checked');
+      var body = new URLSearchParams();
+      if (radio) body.append(paramName, radio.value);
+      amStartUpdate(prefix, btn, body);
+    };
+
+    function amStartUpdate(prefix, btn, body) {
+      var progress = document.getElementById(prefix + '-update-progress');
+      var lamp = document.getElementById(prefix + '-progress-lamp');
+      var text = document.getElementById(prefix + '-progress-text');
+      if (btn) btn.disabled = true;
+      if (progress) progress.classList.remove('hidden');
+      if (lamp) { lamp.classList.remove('am-lamp--on-green', 'am-lamp--on-red'); lamp.classList.add('am-lamp--on-amber'); }
+      if (text) { text.classList.remove('am-led--green', 'am-led--red', 'am-led--dim'); text.textContent = 'Sending update command'; }
+
+      fetch('/phones/' + phoneNumber + '/update', {
+        method: 'POST',
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: body.toString()
+      })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.error) { amShowResult(prefix, 'failed', 'Failed: ' + data.error); return; }
+        if (text) text.textContent = 'Triggered, awaiting handset';
+        amStartPolling(prefix);
+      })
+      .catch(function(err) { amShowResult(prefix, 'failed', 'Network error: ' + err.message); });
+    }
+
+    function amStartPolling(prefix) {
+      if (pollers[prefix]) clearInterval(pollers[prefix]);
+      var attempts = 0;
+      pollers[prefix] = setInterval(function() {
+        attempts++;
+        if (attempts > 120) { clearInterval(pollers[prefix]); amShowResult(prefix, 'failed', 'Timed out, please retry'); return; }
+        fetch('/phones/' + phoneNumber + '/update-status')
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+          if (!data.status) return;
+          var text = document.getElementById(prefix + '-progress-text');
+          switch (data.status) {
+            case 'downloading': if (text) text.textContent = ('Downloading ' + (data.detail || '')).trim(); break;
+            case 'applying':    if (text) text.textContent = ('Applying ' + (data.detail || '')).trim(); break;
+            case 'rebooting':   if (text) text.textContent = 'Rebooting handset'; break;
+            case 'success':     clearInterval(pollers[prefix]); amShowResult(prefix, 'success', data.detail || 'Update installed'); setTimeout(function(){ location.reload(); }, 2000); break;
+            case 'up_to_date':  clearInterval(pollers[prefix]); amShowResult(prefix, 'success', data.detail || 'Already up to date'); break;
+            case 'failed':      clearInterval(pollers[prefix]); amShowResult(prefix, 'failed', data.detail || 'Update failed'); break;
+          }
+        }).catch(function(){});
+      }, 1000);
+    }
+
+    function amShowResult(prefix, kind, message) {
+      var lamp = document.getElementById(prefix + '-progress-lamp');
+      var text = document.getElementById(prefix + '-progress-text');
+      var btn = document.getElementById(prefix + '-install-btn');
+      if (lamp) {
+        lamp.classList.remove('am-lamp--on-amber', 'am-lamp--on-green', 'am-lamp--on-red');
+        lamp.classList.add(kind === 'success' ? 'am-lamp--on-green' : 'am-lamp--on-red');
+      }
+      if (text) {
+        text.classList.remove('am-led--green', 'am-led--red');
+        text.classList.add(kind === 'success' ? 'am-led--green' : 'am-led--red');
+        text.textContent = message;
+      }
+      if (kind !== 'success' && btn) btn.disabled = false;
+    }
+
+    window.addEventListener('pagehide', function() {
+      Object.keys(pollers).forEach(function(p) { if (pollers[p]) clearInterval(pollers[p]); });
+    });
+  })();
+  </script>
 
   {{template "page-footer" .}}
 
@@ -831,4 +894,167 @@
   <span class="am-led am-led--dim am-handset__status-cap">OFFLINE</span>
 </span>
 {{end}}
+{{end}}
+
+{{define "am-software-update-section"}}
+<section class="am-plate am-handset__plate am-handset__plate--wide am-update">
+  <span class="am-plate__label">Software update</span>
+
+  {{if not .Online}}
+    <p class="am-hint am-update__offline">Handset is offline. Updates resume when it reconnects.</p>
+    {{if .LastSeenAt}}<p class="am-hint am-update__offline">Last seen {{.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}.</p>{{end}}
+  {{else if not .DeviceInfo}}
+    <p class="am-hint am-update__offline">Waiting for handset to report version info.</p>
+    <form method="POST" action="/phones/{{.Line.Number}}/update" style="margin: 8px 0 0;">
+      <button type="submit" class="am-key">
+        <span class="am-key__symbol">&#x21BB;</span>
+        <span class="am-key__label">Check for updates</span>
+      </button>
+    </form>
+  {{else}}
+    <div class="am-update__components">
+
+      <div class="am-update__component">
+        <div class="am-update__row">
+          <div class="am-update__meta">
+            <span class="am-label am-update__label">Pi software</span>
+            <div class="am-update__versions">
+              <div class="am-update__version">
+                <span class="am-update__version-cap">Installed</span>
+                <span class="am-well am-update__version-well"><span class="am-led am-update__version-led">{{if .DeviceInfo.PiVersion}}{{.DeviceInfo.PiVersion}}{{else}}---{{end}}</span></span>
+              </div>
+              {{if and .LatestPiVersion .DeviceInfo.PiVersion (ne .DeviceInfo.PiVersion .LatestPiVersion)}}
+                <span class="am-update__arrow" aria-hidden="true">&#x25B6;</span>
+                <div class="am-update__version">
+                  <span class="am-update__version-cap am-update__version-cap--latest"><span class="am-lamp am-lamp--on-amber am-update__cap-lamp" aria-hidden="true"></span>Latest</span>
+                  <span class="am-well am-update__version-well am-update__version-well--latest"><span class="am-led am-update__version-led">{{.LatestPiVersion}}</span></span>
+                </div>
+              {{else if .LatestPiVersion}}
+                <span class="am-update__status" aria-label="Up to date">
+                  <span class="am-lamp am-lamp--on-green am-update__cap-lamp" aria-hidden="true"></span>
+                  <span class="am-led am-led--green am-update__status-cap">Up to date</span>
+                </span>
+              {{end}}
+            </div>
+          </div>
+          <div class="am-update__actions">
+            {{if .PiReleases}}
+              {{$canInstall := and .LatestPiVersion (or (not .DeviceInfo.PiVersion) (ne .DeviceInfo.PiVersion .LatestPiVersion))}}
+              <button type="button" id="pi-install-btn" class="am-key {{if $canInstall}}am-key--accent{{end}} am-update__install" onclick="amTriggerComponentUpdate('pi', 'target_pi_version')">
+                <span class="am-key__symbol">&#x25B6;</span>
+                <span class="am-key__label">Install</span>
+              </button>
+            {{end}}
+          </div>
+        </div>
+
+        {{if gt (len .PiReleases) 1}}
+        <details class="am-update__choose">
+          <summary class="am-update__choose-tab">Choose version</summary>
+          <div class="am-update__release-list">
+            {{range .PiReleases}}
+            <label class="am-update__release {{if eq .Version $.LatestPiVersion}}am-update__release--latest{{end}}">
+              <input type="radio" name="target_pi_version" value="{{.Version}}" {{if eq .Version $.LatestPiVersion}}checked{{end}}>
+              <span class="am-update__release-dot" aria-hidden="true"></span>
+              <span class="am-update__release-ver">{{.Version}}</span>
+              {{if eq .Version $.LatestPiVersion}}<span class="am-update__release-tag">Latest</span>{{end}}
+              {{if and $.DeviceInfo.PiVersion (eq .Version $.DeviceInfo.PiVersion)}}<span class="am-update__release-tag am-update__release-tag--installed">Installed</span>{{end}}
+              {{if .Date}}<span class="am-update__release-date">{{.Date}}</span>{{end}}
+            </label>
+            {{end}}
+          </div>
+        </details>
+        {{end}}
+
+        <div id="pi-update-progress" class="am-update__progress hidden">
+          <div class="am-well am-update__progress-well">
+            <span id="pi-progress-lamp" class="am-lamp am-lamp--on-amber am-update__progress-lamp" aria-hidden="true"></span>
+            <span id="pi-progress-text" class="am-led am-update__progress-led">Sending update command</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="am-update__component">
+        <div class="am-update__row">
+          <div class="am-update__meta">
+            <span class="am-label am-update__label">Firmware</span>
+            <div class="am-update__versions">
+              <div class="am-update__version">
+                <span class="am-update__version-cap">Installed</span>
+                <span class="am-well am-update__version-well"><span class="am-led am-update__version-led">{{if .DeviceInfo.FirmwareVersion}}{{.DeviceInfo.FirmwareVersion}}{{else}}---{{end}}</span></span>
+              </div>
+              {{if and .LatestFirmwareVersion .DeviceInfo.FirmwareVersion (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion)}}
+                <span class="am-update__arrow" aria-hidden="true">&#x25B6;</span>
+                <div class="am-update__version">
+                  <span class="am-update__version-cap am-update__version-cap--latest"><span class="am-lamp am-lamp--on-amber am-update__cap-lamp" aria-hidden="true"></span>Latest</span>
+                  <span class="am-well am-update__version-well am-update__version-well--latest"><span class="am-led am-update__version-led">{{.LatestFirmwareVersion}}</span></span>
+                </div>
+              {{else if .LatestFirmwareVersion}}
+                <span class="am-update__status" aria-label="Up to date">
+                  <span class="am-lamp am-lamp--on-green am-update__cap-lamp" aria-hidden="true"></span>
+                  <span class="am-led am-led--green am-update__status-cap">Up to date</span>
+                </span>
+              {{end}}
+            </div>
+          </div>
+          <div class="am-update__actions">
+            {{if .FWReleases}}
+              {{$canInstall := and .LatestFirmwareVersion (or (not .DeviceInfo.FirmwareVersion) (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion))}}
+              <button type="button" id="fw-install-btn" class="am-key {{if $canInstall}}am-key--accent{{end}} am-update__install" onclick="amTriggerComponentUpdate('fw', 'target_fw_version')">
+                <span class="am-key__symbol">&#x25B6;</span>
+                <span class="am-key__label">Install</span>
+              </button>
+            {{end}}
+          </div>
+        </div>
+
+        {{if gt (len .FWReleases) 1}}
+        <details class="am-update__choose">
+          <summary class="am-update__choose-tab">Choose version</summary>
+          <div class="am-update__release-list">
+            {{range .FWReleases}}
+            <label class="am-update__release {{if eq .Version $.LatestFirmwareVersion}}am-update__release--latest{{end}}">
+              <input type="radio" name="target_fw_version" value="{{.Version}}" {{if eq .Version $.LatestFirmwareVersion}}checked{{end}}>
+              <span class="am-update__release-dot" aria-hidden="true"></span>
+              <span class="am-update__release-ver">{{.Version}}</span>
+              {{if eq .Version $.LatestFirmwareVersion}}<span class="am-update__release-tag">Latest</span>{{end}}
+              {{if and $.DeviceInfo.FirmwareVersion (eq .Version $.DeviceInfo.FirmwareVersion)}}<span class="am-update__release-tag am-update__release-tag--installed">Installed</span>{{end}}
+              {{if .Date}}<span class="am-update__release-date">{{.Date}}</span>{{end}}
+            </label>
+            {{end}}
+          </div>
+        </details>
+        {{end}}
+
+        <div id="fw-update-progress" class="am-update__progress hidden">
+          <div class="am-well am-update__progress-well">
+            <span id="fw-progress-lamp" class="am-lamp am-lamp--on-amber am-update__progress-lamp" aria-hidden="true"></span>
+            <span id="fw-progress-text" class="am-led am-update__progress-led">Sending update command</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    {{if or .PiUpdateNotes .FirmwareUpdateNotes}}
+    <details class="am-update__notes">
+      <summary class="am-update__choose-tab">Release notes</summary>
+      <div class="am-handset__updates am-update__notes-list">
+        {{range .PiUpdateNotes}}
+        <article class="am-handset__update-note">
+          <span class="am-handset__update-ver">pi {{.Version}}</span>
+          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
+        </article>
+        {{end}}
+        {{range .FirmwareUpdateNotes}}
+        <article class="am-handset__update-note">
+          <span class="am-handset__update-ver">fw {{.Version}}</span>
+          {{if .Notes}}<div class="am-handset__update-body">{{renderNotes .Notes}}</div>{{else}}<p class="am-handset__update-empty">Notes not available yet.</p>{{end}}
+        </article>
+        {{end}}
+      </div>
+    </details>
+    {{end}}
+  {{end}}
+</section>
 {{end}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -421,6 +421,12 @@
         {{else}}OFFLINE
         {{end}}
         {{if $l.Line.Settings.SilentMode}} &middot; SILENT{{end}}
+        {{if or $l.PiUpdateNotes $l.FirmwareUpdateNotes}}
+        <span class="am-phones__update-flag" title="Software update available">
+          <span class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+          <span class="am-led am-phones__update-cap">UPDATE</span>
+        </span>
+        {{end}}
       </div>
     </div>
     <div class="am-roster__actions">


### PR DESCRIPTION
## Summary

Three answering-machine theme polish items, all staying inside the AM idiom (plate, well, lamp, chicklet, LED).

* **`/phones/{n}` Software update plate.** AM previously only showed update notes with no way to actually install them. Replaced the read-only Update notes plate with a real Software update plate: per component (Pi, Firmware) it shows installed/latest LED wells, a green Up to date or amber Latest indicator, an amber-accent INSTALL chicklet, an optional Choose version disclosure with radio cards, and an LED progress well that flips amber to green or red as the device reports back. Wired with a small fetch + 1s status poll; pollers clear on terminal status, install-button reuse, and `pagehide`.

* **`/phones` update-available indicator.** AM was missing the equivalent of the intercom theme's `update available` chip on the lines list. Added an inline amber-lamp + LED `UPDATE` token to the meta line whenever the row has `PiUpdateNotes` or `FirmwareUpdateNotes`, sharing the same separator pattern as `ONLINE / FW x.y.z / SILENT`.

* **Voice-style dot placement fix.** `.am-cartridge` defaulted to a 4-col grid (`auto 1fr auto auto`) built for the swatched theme picker. The voice-style picker has only body + lamp, so the lamp landed in column 2 next to the text instead of pinned right (see the screenshot the user posted of `Copper wire` / `Modern HD`). Scoped the 4-col template behind `.am-cartridge:has(.am-cartridge__swatch)`; bare cartridges now use `1fr auto`. No markup change.

Dev/test only: `/dev/seed-firmware` accepts an optional `&pi=<semver>` and `FakeReleaseIndex()` grows three Pi releases so dev sessions can exercise both columns of the new plate.

## Screenshots

### Update-available indicator on `/phones` (AM)
![/phones list with UPDATE flag](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-update-phones-list.png)

### Software update plate on `/phones/{n}` (AM)
![Phone detail Software update plate](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-update-detail-default.png)

### Version picker + release notes expanded
![Phone detail expanded](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-update-detail-expanded.png)

### Voice-style dot placement fix
![Voice style cards with dots pinned right](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-update-voice-style-fix.png)

## Test plan

- [x] `make build` (server)
- [x] `make test` (server)
- [x] `golangci-lint run ./...` (server)
- [x] Visual: `/phones` (AM) shows `UPDATE` token on rows with stale fw or pi
- [x] Visual: `/phones/{n}` (AM) Software update plate renders for online + DeviceInfo
- [x] Visual: Up to date state shows green lamp and removes amber accent from INSTALL
- [x] Visual: Choose version disclosure expands and shows tape-card radio list with `LATEST` and `INSTALLED` tags
- [x] Visual: Release notes disclosure expands and renders per-version notes
- [x] Visual: Voice-style cards have dots pinned to the right edge of each card
- [ ] Live install against a real handset (cannot exercise from this environment; backend handler is unchanged from intercom path)