### PR TITLE
fix(server): collapse AM mobile chrome behind a single MENU drawer

### DIFF
--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -550,6 +550,10 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
   flex-wrap: wrap;
 }
 .am-shell__brand-slot { display: inline-flex; align-items: center; gap: 12px; padding-right: 8px; }
+/* Drawer wraps tabs + identity (household, DND, signout). On desktop it just
+   absorbs the remaining width; on mobile the whole thing collapses behind
+   the MENU toggle so the topbar stays brand+MENU. */
+.am-shell__drawer { display: flex; align-items: center; gap: 14px; flex: 1 1 auto; min-width: 0; }
 .am-shell__household { margin-left: auto; font-family: var(--font-body); font-size: 9px; letter-spacing: 0.22em; color: var(--ink-muted); font-weight: 600; text-transform: uppercase; }
 .am-shell__dnd { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; padding: 4px 8px; border-radius: 4px; }
 .am-shell__dnd:hover, .am-shell__dnd:focus-visible { background: rgba(255,61,46,0.08); outline: none; }
@@ -562,19 +566,28 @@ html, body { margin: 0; padding: 0; font-family: var(--font-body); color: var(--
 .am-shell__toggle { display: none; }
 
 @media (max-width: 720px) {
-  .am-shell__nav { padding: 18px 20px 14px; gap: 10px; }
+  .am-shell__nav { padding: 18px 20px 14px; gap: 10px; flex-wrap: wrap; }
+  .am-shell__brand-slot { flex: 1 1 auto; min-width: 0; padding-right: 0; }
   .am-shell__main { padding: 4px 20px 24px; }
   .am-shell__toggle {
-    display: inline-flex;
+    display: inline-flex; flex: 0 0 auto;
     padding: 8px 14px;
     font-family: var(--font-body); font-size: 10px; font-weight: 600; letter-spacing: 0.16em; text-transform: uppercase;
     color: var(--ink); background: var(--case);
     border: 1px solid var(--btn-press); border-radius: 4px;
     box-shadow: 0 1px 0 var(--btn-press), 0 2px 3px rgba(40,30,15,0.2);
   }
-  .am-tabs { flex-wrap: wrap; width: 100%; order: 99; }
-  .am-tabs:not(.is-open) { display: none; }
-  .am-shell__household { font-size: 8px; }
+  .am-shell__drawer:not(.is-open) { display: none; }
+  .am-shell__drawer.is-open {
+    flex-direction: column; align-items: stretch;
+    width: 100%; order: 99;
+    gap: 12px;
+    padding-top: 10px; margin-top: 4px;
+    border-top: 1px dashed rgba(100,80,40,0.25);
+  }
+  .am-shell__drawer.is-open .am-tabs { flex-wrap: wrap; }
+  .am-shell__drawer.is-open .am-shell__household { margin-left: 0; font-size: 9px; }
+  .am-shell__drawer.is-open .am-shell__signout-form { align-self: flex-start; }
 }
 
 /* =========================================================================

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -20,32 +20,34 @@
       <span class="am__brand">Digits 2500<small>Family Telephone System</small></span>
     </div>
 
-    <button class="am-shell__toggle" id="am-nav-toggle" type="button" aria-label="Toggle navigation" aria-controls="am-nav-tabs" aria-expanded="false">Menu</button>
+    <button class="am-shell__toggle" id="am-nav-toggle" type="button" aria-label="Toggle navigation" aria-controls="am-nav-drawer" aria-expanded="false">Menu</button>
 
-    <nav class="am-tabs" id="am-nav-tabs" aria-label="Sections">
-      <a class="am-tab {{if eq .Page "dashboard"}}is-active{{end}}" href="/">Overview</a>
-      <a class="am-tab {{if eq .Page "phones"}}is-active{{end}}" href="/phones">Lines</a>
-      <a class="am-tab {{if eq .Page "links"}}is-active{{end}}" href="/links">Families</a>
-      {{if .CallHistoryEnabled}}
-      <a class="am-tab {{if eq .Page "calls"}}is-active{{end}}" href="/calls">Calls</a>
+    <div class="am-shell__drawer" id="am-nav-drawer">
+      <nav class="am-tabs" aria-label="Sections">
+        <a class="am-tab {{if eq .Page "dashboard"}}is-active{{end}}" href="/">Overview</a>
+        <a class="am-tab {{if eq .Page "phones"}}is-active{{end}}" href="/phones">Lines</a>
+        <a class="am-tab {{if eq .Page "links"}}is-active{{end}}" href="/links">Families</a>
+        {{if .CallHistoryEnabled}}
+        <a class="am-tab {{if eq .Page "calls"}}is-active{{end}}" href="/calls">Calls</a>
+        {{end}}
+        <a class="am-tab {{if eq .Page "settings"}}is-active{{end}}" href="/settings">Settings</a>
+      </nav>
+
+      {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
+
+      {{if .HouseholdDND}}
+      <a href="/settings#do-not-disturb" class="am-shell__dnd" title="Household Do Not Disturb is on" aria-label="Do Not Disturb is on">
+        <span class="am-lamp am-lamp--on-red am-shell__dnd-lamp" aria-hidden="true"></span>
+        <span class="am-led am-led--red am-shell__dnd-cap">DND</span>
+      </a>
       {{end}}
-      <a class="am-tab {{if eq .Page "settings"}}is-active{{end}}" href="/settings">Settings</a>
-    </nav>
 
-    {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
-
-    {{if .HouseholdDND}}
-    <a href="/settings#do-not-disturb" class="am-shell__dnd" title="Household Do Not Disturb is on" aria-label="Do Not Disturb is on">
-      <span class="am-lamp am-lamp--on-red am-shell__dnd-lamp" aria-hidden="true"></span>
-      <span class="am-led am-led--red am-shell__dnd-cap">DND</span>
-    </a>
-    {{end}}
-
-    <form class="am-shell__signout-form" method="POST" action="/auth/logout">
-      <button class="am-key am-key--nav" type="submit">
-        <span class="am-key__label">Sign out</span>
-      </button>
-    </form>
+      <form class="am-shell__signout-form" method="POST" action="/auth/logout">
+        <button class="am-key am-key--nav" type="submit">
+          <span class="am-key__label">Sign out</span>
+        </button>
+      </form>
+    </div>
   </header>
 
   <main class="am-shell__main">
@@ -64,10 +66,10 @@
 <script>
 (function () {
   var toggle = document.getElementById('am-nav-toggle');
-  var tabs = document.getElementById('am-nav-tabs');
-  if (!toggle || !tabs) return;
+  var drawer = document.getElementById('am-nav-drawer');
+  if (!toggle || !drawer) return;
   toggle.addEventListener('click', function () {
-    var open = tabs.classList.toggle('is-open');
+    var open = drawer.classList.toggle('is-open');
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
   });
 })();


### PR DESCRIPTION
## Summary

The AM theme's mobile topbar was wrapping into two awkward rows: brand + MENU on the first, and the household label + Sign out chicklet stacked underneath in their own band. MENU floated alone next to the small two-line wordmark and read as a disconnected fourth element rather than part of a coherent control strip.

This wraps the tabs nav and the household / DND / Sign out cluster in a single `.am-shell__drawer` that the MENU button toggles. On desktop the drawer is just a flex container that absorbs the remaining width with the same internal alignment as before (no visual change). On mobile the entire drawer collapses behind MENU, so the topbar reads as brand left, MENU right, and tapping MENU drops a panel below containing the tabs, the household label, DND if active, and Sign out.

A11y: `aria-controls` and `aria-expanded` on the toggle are pointed at the new drawer id and verified to flip correctly on click.

## Screenshots

### Mobile, menu closed
![Mobile closed](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-menu-mobile-closed.png)

### Mobile, menu open
![Mobile open](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-menu-mobile-open.png)

### Desktop (unchanged)
![Desktop](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-am-menu-desktop.png)

## Test plan

- [x] `make build`
- [x] `make test`
- [x] `golangci-lint run ./...`
- [x] Mobile (390x844): topbar is brand + MENU only; MENU expands to a panel below with tabs + household + Sign out
- [x] Mobile: `aria-expanded` flips false to true on click; `aria-controls` matches the drawer id
- [x] Desktop (1440x900): chrome unchanged (tabs in middle, household + Sign out right-aligned)