### PR TITLE
fix(server): cache-bust static assets via commit-suffixed query params

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -115,7 +115,7 @@ func run(ctx context.Context) error {
 		slog.Info("Google OAuth enabled")
 	}
 
-	loginTmpl, err := template.ParseFS(web.TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
+	loginTmpl, err := template.New("").Funcs(web.TemplateFuncs()).ParseFS(web.TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
 	if err != nil {
 		return fmt.Errorf("parse login template: %w", err)
 	}

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -42,7 +42,7 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 	emailSender := email.NewNoopSender()
 
 	// Parse login template from the embedded FS
-	loginTmpl, err := template.New("").ParseFS(TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
+	loginTmpl, err := template.New("").Funcs(TemplateFuncs()).ParseFS(TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
 	if err != nil {
 		t.Fatalf("parse login template: %v", err)
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -39,6 +39,115 @@ func TemplateFS() embed.FS {
 	return templateFS
 }
 
+// TemplateFuncs returns the html/template FuncMap that page templates expect.
+// Exposed so test helpers that parse templates directly (without going through
+// NewHandler) get the same {{static}}, {{fmtPhone}}, etc. helpers as prod.
+func TemplateFuncs() template.FuncMap {
+	return baseTemplateFuncs()
+}
+
+func baseTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"fmtPhone": line.FormatNumber,
+		"fmtDuration": func(seconds int) string {
+			if seconds < 60 {
+				return fmt.Sprintf("%ds", seconds)
+			}
+			return fmt.Sprintf("%d:%02d", seconds/60, seconds%60)
+		},
+		"derefFloat32": func(p *float32) float32 {
+			if p == nil {
+				return 0
+			}
+			return *p
+		},
+		"derefInt64": func(p *int64) int64 {
+			if p == nil {
+				return 0
+			}
+			return *p
+		},
+		"iter": func(n int) []int {
+			out := make([]int, n)
+			for i := range out {
+				out[i] = i
+			}
+			return out
+		},
+		"inc": func(n int) int { return n + 1 },
+		"mod": func(a, b int) int {
+			if b == 0 {
+				return 0
+			}
+			return a % b
+		},
+		"humanBytes": func(n int64) string {
+			switch {
+			case n > 1024*1024:
+				return fmt.Sprintf("%.1fM", float64(n)/(1024*1024))
+			case n > 1024:
+				return fmt.Sprintf("%.1fK", float64(n)/1024)
+			default:
+				return fmt.Sprintf("%dB", n)
+			}
+		},
+		"pctToSegments": func(pct float32) segDesc {
+			lit := int(pct / 10.0)
+			if pct > 0 && lit == 0 {
+				lit = 1
+			}
+			if lit > 10 {
+				lit = 10
+			}
+			sev := ""
+			switch {
+			case pct >= 2.0:
+				sev = "bad"
+			case pct >= 0.5:
+				sev = "warn"
+			}
+			return segDesc{Lit: lit, Severity: sev}
+		},
+		"msToSegments": func(ms float32) segDesc {
+			lit := int(ms / 6.0)
+			if ms > 0 && lit == 0 {
+				lit = 1
+			}
+			if lit > 10 {
+				lit = 10
+			}
+			sev := ""
+			switch {
+			case ms >= 40.0:
+				sev = "bad"
+			case ms >= 20.0:
+				sev = "warn"
+			}
+			return segDesc{Lit: lit, Severity: sev}
+		},
+		"renderNotes": renderNotes,
+		// staticURL returns a cache-bust-suffixed /static/ URL. Cloudflare and
+		// other CDNs key on the full URL including query, so each release's
+		// commit-suffixed URL bypasses the prior release's cached entry. In
+		// dev (commit unset) we fall back to the bare path so the disk-served
+		// edits still revalidate per request.
+		"static": func(path string) string {
+			if version.Commit == "" || version.Commit == "unknown" {
+				return "/static/" + path
+			}
+			return "/static/" + path + "?v=" + version.Commit
+		},
+		"edgeFor": func(edges []ConferenceLinkHealthEdge, from, peer string) *ConferenceLinkHealthEdge {
+			for i := range edges {
+				if edges[i].From == from && edges[i].Peer == peer {
+					return &edges[i]
+				}
+			}
+			return nil
+		},
+	}
+}
+
 // devStaticDirDefault is the disk path (relative to the process CWD) used
 // for /static/ when DevMode is on and no explicit override is supplied.
 // It matches the Makefile's dev-up target, which runs signald with CWD
@@ -51,23 +160,36 @@ const devStaticDirDefault = "internal/web/static"
 // production mode it serves the embedded FS, keeping the binary
 // self-contained. Both code paths route /static/dialup.css to the same
 // file content for a given checkout.
+//
+// Requests carrying a query string (e.g. /static/foo.css?v=<commit>) are
+// served with a 1-year immutable cache header; templates use the {{static}}
+// helper to produce those versioned URLs so a new release writes a new URL
+// that bypasses any CDN cache of the prior one.
 func staticFileServer(devMode bool, diskDir string) http.Handler {
+	var base http.Handler
 	if devMode {
 		if diskDir == "" {
 			diskDir = devStaticDirDefault
 		}
-		return http.StripPrefix("/static/", http.FileServer(http.Dir(diskDir)))
+		base = http.StripPrefix("/static/", http.FileServer(http.Dir(diskDir)))
+	} else {
+		// fs.Sub strips the "static" prefix from the embedded FS so request
+		// paths align with the disk-mode handler's StripPrefix treatment.
+		sub, err := fs.Sub(staticFS, "static")
+		if err != nil {
+			// embed declares the "static" directory above; sub-rooting to it
+			// cannot fail at runtime. A panic here would indicate a programmer
+			// error in the embed declaration.
+			panic(fmt.Errorf("fs.Sub(staticFS, \"static\"): %w", err))
+		}
+		base = http.StripPrefix("/static/", http.FileServer(http.FS(sub)))
 	}
-	// fs.Sub strips the "static" prefix from the embedded FS so request
-	// paths align with the disk-mode handler's StripPrefix treatment.
-	sub, err := fs.Sub(staticFS, "static")
-	if err != nil {
-		// embed declares the "static" directory above; sub-rooting to it
-		// cannot fail at runtime. A panic here would indicate a programmer
-		// error in the embed declaration.
-		panic(fmt.Errorf("fs.Sub(staticFS, \"static\"): %w", err))
-	}
-	return http.StripPrefix("/static/", http.FileServer(http.FS(sub)))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		}
+		base.ServeHTTP(w, r)
+	})
 }
 
 type Handler struct {
@@ -168,94 +290,7 @@ type Deps struct {
 }
 
 func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
-	funcMap := template.FuncMap{
-		"fmtPhone": line.FormatNumber,
-		"fmtDuration": func(seconds int) string {
-			if seconds < 60 {
-				return fmt.Sprintf("%ds", seconds)
-			}
-			return fmt.Sprintf("%d:%02d", seconds/60, seconds%60)
-		},
-		"derefFloat32": func(p *float32) float32 {
-			if p == nil {
-				return 0
-			}
-			return *p
-		},
-		"derefInt64": func(p *int64) int64 {
-			if p == nil {
-				return 0
-			}
-			return *p
-		},
-		"iter": func(n int) []int {
-			out := make([]int, n)
-			for i := range out {
-				out[i] = i
-			}
-			return out
-		},
-		"inc": func(n int) int { return n + 1 },
-		"mod": func(a, b int) int {
-			if b == 0 {
-				return 0
-			}
-			return a % b
-		},
-		"humanBytes": func(n int64) string {
-			switch {
-			case n > 1024*1024:
-				return fmt.Sprintf("%.1fM", float64(n)/(1024*1024))
-			case n > 1024:
-				return fmt.Sprintf("%.1fK", float64(n)/1024)
-			default:
-				return fmt.Sprintf("%dB", n)
-			}
-		},
-		"pctToSegments": func(pct float32) segDesc {
-			lit := int(pct / 10.0)
-			if pct > 0 && lit == 0 {
-				lit = 1
-			}
-			if lit > 10 {
-				lit = 10
-			}
-			sev := ""
-			switch {
-			case pct >= 2.0:
-				sev = "bad"
-			case pct >= 0.5:
-				sev = "warn"
-			}
-			return segDesc{Lit: lit, Severity: sev}
-		},
-		"msToSegments": func(ms float32) segDesc {
-			lit := int(ms / 6.0)
-			if ms > 0 && lit == 0 {
-				lit = 1
-			}
-			if lit > 10 {
-				lit = 10
-			}
-			sev := ""
-			switch {
-			case ms >= 40.0:
-				sev = "bad"
-			case ms >= 20.0:
-				sev = "warn"
-			}
-			return segDesc{Lit: lit, Severity: sev}
-		},
-		"renderNotes": renderNotes,
-		"edgeFor": func(edges []ConferenceLinkHealthEdge, from, peer string) *ConferenceLinkHealthEdge {
-			for i := range edges {
-				if edges[i].From == from && edges[i].Peer == peer {
-					return &edges[i]
-				}
-			}
-			return nil
-		},
-	}
+	funcMap := baseTemplateFuncs()
 	// parsePage closes over the layout + shared-partials file list so each
 	// page only names itself. Adding a new layout or partial touches one line.
 	parsePage := func(page string) (*template.Template, error) {

--- a/server/internal/web/templates/connecting.html
+++ b/server/internal/web/templates/connecting.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Connecting - Digits</title>
-<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-<link rel="stylesheet" href="/static/dialup.css">
-<link rel="stylesheet" href="/static/connecting.css">
+<link rel="icon" type="image/svg+xml" href="{{static "favicon.svg"}}">
+<link rel="stylesheet" href="{{static "dialup.css"}}">
+<link rel="stylesheet" href="{{static "connecting.css"}}">
 </head>
 <body class="dialup{{if and .User (ne .User.CRTMode "off")}} crt-page{{end}}"
       data-household="{{.HouseholdName}}"
@@ -95,6 +95,6 @@
 </div>
 
 <audio id="dialup-audio" preload="auto" src="/static/audio/dialup.m4a"></audio>
-<script src="/static/connecting.js"></script>
+<script src="{{static "connecting.js"}}"></script>
 </body>
 </html>

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -4,12 +4,12 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{block "title" .}}Digits{{end}} · Digits</title>
-<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-<link rel="preload" href="/static/fonts/inter-tight-500.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="/static/fonts/jetbrains-mono-400.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/answering-machine.css">
-<script src="/static/htmx.min.js"></script>
-<script src="/static/sse.min.js"></script>
+<link rel="icon" type="image/svg+xml" href="{{static "favicon.svg"}}">
+<link rel="preload" href="{{static "fonts/inter-tight-500.woff2"}}" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{{static "fonts/jetbrains-mono-400.woff2"}}" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="{{static "answering-machine.css"}}">
+<script src="{{static "htmx.min.js"}}"></script>
+<script src="{{static "sse.min.js"}}"></script>
 </head>
 <body class="am">
 

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -4,10 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{block "title" .}}Digits{{end}} | Digits</title>
-<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-<link rel="stylesheet" href="/static/dialup.css">
-<script src="/static/htmx.min.js"></script>
-<script src="/static/sse.min.js"></script>
+<link rel="icon" type="image/svg+xml" href="{{static "favicon.svg"}}">
+<link rel="stylesheet" href="{{static "dialup.css"}}">
+<script src="{{static "htmx.min.js"}}"></script>
+<script src="{{static "sse.min.js"}}"></script>
 </head>
 <body class="dialup{{if and .User (eq .User.CRTMode "all")}} crt-all{{end}}">
 

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -4,12 +4,12 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{block "title" .}}Digits{{end}} | Digits</title>
-<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-<link rel="preload" href="/static/fonts/fraunces-variable.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="/static/fonts/inter-tight-500.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/static/digits.css">
-<script src="/static/htmx.min.js"></script>
-<script src="/static/sse.min.js"></script>
+<link rel="icon" type="image/svg+xml" href="{{static "favicon.svg"}}">
+<link rel="preload" href="{{static "fonts/fraunces-variable.woff2"}}" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="{{static "fonts/inter-tight-500.woff2"}}" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="{{static "digits.css"}}">
+<script src="{{static "htmx.min.js"}}"></script>
+<script src="{{static "sse.min.js"}}"></script>
 </head>
 <body>
 

--- a/server/internal/web/templates/welcome.html
+++ b/server/internal/web/templates/welcome.html
@@ -4,8 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Pick your vibe - Digits</title>
-<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
-<link rel="stylesheet" href="/static/welcome.css">
+<link rel="icon" type="image/svg+xml" href="{{static "favicon.svg"}}">
+<link rel="stylesheet" href="{{static "welcome.css"}}">
 </head>
 <body class="welcome-body">
 

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -144,7 +144,7 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	linkStore := household.NewLinkStore(database.DB)
 	googleAuth := auth.NewGoogleAuth("", "", "", "", authStore)
 	emailSender := email.NewNoopSender()
-	loginTmpl, err := template.New("").ParseFS(TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
+	loginTmpl, err := template.New("").Funcs(TemplateFuncs()).ParseFS(TemplateFS(), "templates/layout-v2.html", "templates/_partials.html", "templates/login.html")
 	if err != nil {
 		t.Fatalf("parse login template: %v", err)
 	}


### PR DESCRIPTION
## Summary

Cloudflare caches `/static/*.css` and the other static assets for 4 hours (`max-age=14400`). After PR #368 and #369 deployed, the new HTML referenced new class names (`am-shell__drawer`, `am-update__row`, etc.) but Cloudflare kept serving the pre-merge CSS to anyone who hit the edge cache, so:

- The AM mobile MENU button toggled `aria-expanded` and added `.is-open` to a div the cached CSS didn't know how to style: nothing happened visually.
- The Software update plate on phone-detail mobile collapsed without the column reorientation, so the INSTALL chicklet, "Up to date" lamp, and version well piled on top of each other.

Both issues were CSS staleness on a stable URL, not a code bug.

## Fix

- New `{{static "path"}}` template helper returns `/static/path?v=<commit-sha>`. Cloudflare keys cache entries on the full URL including query, so each release writes URLs the CDN has never seen, gets a clean cache miss, fetches fresh content. The prior URL's cache entry becomes a tombstone that ages out harmlessly.
- All `<link>` and `<script>` refs in the four layouts (`layout-v2`, `layout-dialup`, `layout-answering-machine`, `connecting`) plus `welcome.html` updated to use the helper. Body-section `<img>` and `<audio>` refs left bare (stable assets, not part of the breakage).
- `staticFileServer` now sets `Cache-Control: public, max-age=31536000, immutable` when the request carries a query string, so the fingerprinted URLs can cache aggressively at the edge while unversioned fallbacks (dev mode, where `version.Commit` is `unknown`) revalidate per request.
- `baseTemplateFuncs` extracted to a package-level helper exposed via `TemplateFuncs()` so the two test files and `cmd/signald/main.go` (which parse `layout-v2.html` outside `NewHandler`) share the same funcMap. Without that, the binary panicked on startup with `function "static" not defined`.

## What about the currently-cached entries?

The OLD `/static/answering-machine.css` URL is still cached at Cloudflare for the rest of its 4-hour TTL. After this PR deploys:
- New page loads will reference `/static/answering-machine.css?v=<NEW-SHA>`, a cache miss, fresh content. ✅
- Anyone holding stale HTML in an open tab will continue requesting the bare URL and getting the stale CSS until they refresh.

Optional one-time Cloudflare cache purge of `/static/*` would clear the tombstones immediately. Not strictly required.

## Test plan

- [x] `make build`
- [x] `make test`
- [x] `golangci-lint run ./...`
- [x] Dev server: rendered `<head>` for `/login`, `/welcome`, `/links` (AM theme) all show `?v=<commit>` on every CSS/JS/font/favicon ref
- [x] Versioned asset request returns `Cache-Control: public, max-age=31536000, immutable`
- [x] Bare asset request returns no `Cache-Control` (default short-lived)