### PR TITLE
chore(digitsd): drop unused Config.NeedsPairing and Config.IsConfigured

### DIFF
--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -280,18 +280,6 @@ func (c *Config) SetDeviceToken(token string) error {
 	return c.Save()
 }
 
-// NeedsPairing returns true when a pairing code is present but no device
-// token has been issued yet.
-func (c *Config) NeedsPairing() bool {
-	return c.PairingCode != "" && c.DeviceToken == ""
-}
-
-// IsConfigured returns true when the minimum required fields (server URL and
-// either a device token or a pairing code) are present.
-func (c *Config) IsConfigured() bool {
-	return c.ServerURL != "" && (c.DeviceToken != "" || c.PairingCode != "")
-}
-
 // Path returns the file path this config was loaded from.
 func (c *Config) Path() string {
 	return c.path

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -53,48 +53,6 @@ func TestLoadValid(t *testing.T) {
 	}
 }
 
-func TestLoadPartialConfig(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	data := `{"server_url": "wss://digits.family/ws", "pairing_code": "B3Z1", "phone_number": "3140002"}`
-	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	c, err := Load(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !c.NeedsPairing() {
-		t.Error("NeedsPairing should be true when pairing_code is set and device_token is empty")
-	}
-	if !c.IsConfigured() {
-		t.Error("IsConfigured should be true when server_url and pairing_code are set")
-	}
-}
-
-func TestLoadTokenPresent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	data := `{"server_url": "wss://digits.family/ws", "device_token": "tok-xyz"}`
-	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	c, err := Load(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if c.NeedsPairing() {
-		t.Error("NeedsPairing should be false when device_token is present")
-	}
-	if !c.IsConfigured() {
-		t.Error("IsConfigured should be true when server_url and device_token are set")
-	}
-}
-
 func TestLoadBadJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")


### PR DESCRIPTION
## Summary

Both predicates are exported on `*Config` but reachable only from their own unit tests; `deadcode` confirms no production main calls either. The matching `TestLoadPartialConfig` and `TestLoadTokenPresent` cases existed to exercise the predicates, so removing them follows directly. Coverage of `Load()` with mixed `pairing_code` / `device_token` shapes is still provided by `TestLoadValid` (all four fields set) and the existing `wifi_fallback` Load tests.

Drops 54 lines of public API surface that nothing in `cmd/digitsd` consults; the actual pairing-state decisions are made on the bare fields (`PairingCode`, `DeviceToken`) at the call sites where they're checked.

## Test plan

- `go build ./...` clean in `pi/digitsd/`
- `go test ./...` clean in `pi/digitsd/`
- `golangci-lint run ./...` clean