### PR TITLE
refactor(server): drop unused offset arg from dbutil.Placeholders

### DIFF
--- a/server/internal/calls/history.go
+++ b/server/internal/calls/history.go
@@ -111,7 +111,7 @@ func (t *Tracker) RecentHistoryForPhones(ctx context.Context, phones []string, c
 // that were merged into a conference.
 func (t *Tracker) recentCallsForHistory(ctx context.Context, phones []string, cursor *HistoryCursor, limit int) ([]Call, error) {
 	n := len(phones)
-	ph := dbutil.Placeholders(n, 0)
+	ph := dbutil.Placeholders(n)
 
 	args := make([]interface{}, 0, n+3)
 	for _, p := range phones {

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -709,7 +709,7 @@ func (t *Tracker) RecentForPhones(ctx context.Context, phoneNumbers []string, li
 
 	// Build IN clause — reuse same $1..$N placeholders for both caller and callee
 	n := len(phoneNumbers)
-	ph := dbutil.Placeholders(n, 0)
+	ph := dbutil.Placeholders(n)
 	query := fmt.Sprintf(
 		`SELECT `+callColumns+
 			` FROM calls WHERE caller IN (%s) OR callee IN (%s) ORDER BY started_at DESC LIMIT $%d`,

--- a/server/internal/dbutil/dbutil.go
+++ b/server/internal/dbutil/dbutil.go
@@ -8,14 +8,13 @@ import (
 
 // Placeholders returns a comma-separated string of PostgreSQL positional
 // placeholders ($1, $2, …, $n) for use in SQL IN clauses.
-// offset shifts the starting index (e.g. offset=2 gives $2,$3,…).
-func Placeholders(n, offset int) string {
+func Placeholders(n int) string {
 	if n <= 0 {
 		return ""
 	}
 	parts := make([]string, n)
 	for i := range parts {
-		parts[i] = fmt.Sprintf("$%d", offset+i+1)
+		parts[i] = fmt.Sprintf("$%d", i+1)
 	}
 	return strings.Join(parts, ", ")
 }


### PR DESCRIPTION
## Summary

`dbutil.Placeholders(n, offset)` returns a comma-separated `$1, $2, ..., $n` string for `IN` clauses. Both call sites (`calls.recentCallsForHistory`, `calls.Tracker.RecentForPhones`) pass `offset=0`, no tests cover any non-zero offset, and the function has no other callers.

The argument was speculative flexibility for `IN` clauses that come after other parameters in the same query, but every real query in the tree has only ever wanted `$1..$n`. Drop the parameter, simplify the body to `i+1`, and update both callers; the API now matches the only shape it has ever been used in.

## Test plan

- `go build ./...` clean in `server/`
- `go test ./...` clean for `internal/dbutil` and `internal/calls`
- `golangci-lint run ./...` clean