### PR TITLE
refactor(server): hoist withTx into dbutil and reuse in household.Store

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -24,29 +24,6 @@ const (
 	roleAdded = "added"
 )
 
-// withTx runs fn inside a database transaction. Commits on success,
-// rolls back on error or panic.
-func withTx(ctx context.Context, d *sql.DB, fn func(*sql.Tx) error) error {
-	tx, err := d.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-	if err := fn(tx); err != nil {
-		return err
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-	committed = true
-	return nil
-}
-
 type Call struct {
 	ID                      int64
 	Caller                  string
@@ -440,7 +417,7 @@ func (t *Tracker) CreateConferencePersistent(ctx context.Context, host string, o
 		return nil, err
 	}
 
-	txErr := withTx(ctx, t.db.DB, func(tx *sql.Tx) error {
+	txErr := dbutil.WithTx(ctx, t.db.DB, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
 			conf.ID, conf.Host, conf.OriginatingCallID,
@@ -510,7 +487,7 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 	h := t.health
 	t.mu.Unlock()
 
-	if err := withTx(ctx, t.db.DB, func(tx *sql.Tx) error {
+	if err := dbutil.WithTx(ctx, t.db.DB, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE conferences SET state = 'ended', ended_at = NOW(), end_reason = $1 WHERE id = $2`,
 			reason, confID,
@@ -607,7 +584,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 	var continuationCallID int64
 	// DB failure past this point does not roll back the in-memory state
 	// (symmetric with EndConferencePersistent).
-	if txErr := withTx(ctx, t.db.DB, func(tx *sql.Tx) error {
+	if txErr := dbutil.WithTx(ctx, t.db.DB, func(tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx,
 			`UPDATE conference_members SET left_at = NOW(), left_reason = $1
 			 WHERE conference_id = $2 AND phone = $3`,

--- a/server/internal/dbutil/dbutil.go
+++ b/server/internal/dbutil/dbutil.go
@@ -1,7 +1,10 @@
-// Package dbutil provides shared helpers for database query construction.
+// Package dbutil provides shared helpers for database query construction
+// and transaction lifecycle management.
 package dbutil
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 )
@@ -17,4 +20,28 @@ func Placeholders(n int) string {
 		parts[i] = fmt.Sprintf("$%d", i+1)
 	}
 	return strings.Join(parts, ", ")
+}
+
+// WithTx runs fn inside a database transaction. Commits on success; rolls
+// back on error or panic. The committed flag guards against calling Rollback
+// after a successful Commit (which lib/pq surfaces as ErrTxDone).
+func WithTx(ctx context.Context, db *sql.DB, fn func(*sql.Tx) error) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if err := fn(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	committed = true
+	return nil
 }

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
 // Household represents a family/household group.
@@ -37,31 +39,23 @@ func NewStore(db *sql.DB) *Store {
 
 // Create inserts a new household and adds ownerUserID as an admin member in a single transaction.
 func (s *Store) Create(ctx context.Context, name, ownerUserID string) (*Household, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
 	h := &Household{}
-	err = tx.QueryRowContext(ctx,
-		`INSERT INTO households (name) VALUES ($1) RETURNING id, name, timezone, created_at`,
-		name,
-	).Scan(&h.ID, &h.Name, &h.Timezone, &h.CreatedAt)
-	if err != nil {
-		return nil, fmt.Errorf("insert household: %w", err)
-	}
-
-	_, err = tx.ExecContext(ctx,
-		`INSERT INTO household_members (user_id, household_id, role) VALUES ($1, $2, 'admin')`,
-		ownerUserID, h.ID,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("insert owner member: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit tx: %w", err)
+	if err := dbutil.WithTx(ctx, s.db, func(tx *sql.Tx) error {
+		if err := tx.QueryRowContext(ctx,
+			`INSERT INTO households (name) VALUES ($1) RETURNING id, name, timezone, created_at`,
+			name,
+		).Scan(&h.ID, &h.Name, &h.Timezone, &h.CreatedAt); err != nil {
+			return fmt.Errorf("insert household: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO household_members (user_id, household_id, role) VALUES ($1, $2, 'admin')`,
+			ownerUserID, h.ID,
+		); err != nil {
+			return fmt.Errorf("insert owner member: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return h, nil
 }


### PR DESCRIPTION
## Motivation

The `calls` package owned a private `withTx` helper that wrapped `BeginTx` + deferred `Rollback` + `Commit` (with a `committed` flag for panic safety). The `household` package open-coded the same pattern in `Store.Create` with inline begin/defer-rollback/commit ceremony. That was the only place the canonical transaction lifecycle was at risk of drifting between packages.

## Change

- Promote the helper to `dbutil.WithTx` so there is one canonical implementation.
- Drop the private copy from `calls/tracker.go` and retarget its three callers (`CreateConferencePersistent`, `EndConferencePersistent`, `DropMemberPersistent`).
- Rewrite `household.Store.Create` to use it, deleting the inline begin/defer/commit lines.
- After this change the only `db.BeginTx` call site in the tree is inside `dbutil.WithTx` itself.

The committed-flag rollback guard is preserved: it suppresses the post-`Commit` `Rollback` that `lib/pq` surfaces as `ErrTxDone`. Behavior is unchanged.

## Why this scope

`dbutil` already houses the other shared SQL helper (`Placeholders`), so it is the obvious home. I considered also hoisting the `defer rows.Close` boilerplate that several stores repeat, but that pattern is shorter, well-understood, and not duplicated across packages, so it is out of scope here.

## Test plan

- [x] `go build ./...` (server)
- [x] `go test ./internal/calls/... ./internal/dbutil/... ./internal/household/...`
- [x] `go vet ./...`