### PR TITLE
refactor(pi): drop wifi.Configurator interface and SystemConfigurator wrapper

### DIFF
--- a/pi/digits-setup/cmd/digits-setup/main.go
+++ b/pi/digits-setup/cmd/digits-setup/main.go
@@ -16,10 +16,9 @@ func main() {
 	}
 
 	scanner := &wifi.SystemScanner{}
-	configurator := &wifi.SystemConfigurator{}
 	ap := wifi.SystemAPController{}
 
-	mux := portal.NewHandler(scanner, configurator, ap)
+	mux := portal.NewHandler(scanner, wifi.Configure, ap)
 
 	log.Printf("digits-setup listening on %s", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {

--- a/pi/digits-setup/internal/portal/handler.go
+++ b/pi/digits-setup/internal/portal/handler.go
@@ -22,8 +22,9 @@ var staticFiles embed.FS
 // losing AP association.
 const apTeardownDelay = 2 * time.Second
 
-// NewHandler returns the HTTP mux for the captive portal.
-func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.APController) http.Handler {
+// NewHandler returns the HTTP mux for the captive portal. The configure
+// argument is invoked for each POST /api/configure with the request body.
+func NewHandler(scanner wifi.Scanner, configure func(wifi.ConfigRequest) error, ap wifi.APController) http.Handler {
 	mux := http.NewServeMux()
 
 	// teardownScheduled gates the deferred AP teardown so a duplicate or
@@ -71,7 +72,7 @@ func NewHandler(scanner wifi.Scanner, configurator wifi.Configurator, ap wifi.AP
 			return
 		}
 
-		if err := configurator.Configure(req); err != nil {
+		if err := configure(req); err != nil {
 			log.Printf("configure error: %v", err)
 			status := http.StatusInternalServerError
 			if errors.Is(err, wifi.ErrInvalidRequest) {

--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -24,11 +24,6 @@ type ConfigRequest struct {
 	Hidden   bool   `json:"hidden"`
 }
 
-// Configurator writes Wi-Fi config.
-type Configurator interface {
-	Configure(req ConfigRequest) error
-}
-
 // FileSystem abstracts file operations for testing.
 type FileSystem interface {
 	MkdirAll(path string, perm os.FileMode) error
@@ -115,10 +110,9 @@ func (SystemAPController) Down() error {
 	return nil
 }
 
-// SystemConfigurator is the production configurator.
-type SystemConfigurator struct{}
-
-func (c *SystemConfigurator) Configure(req ConfigRequest) error {
+// Configure writes Wi-Fi config using production filesystem and mount
+// implementations. Tests should call ConfigureWithDeps directly with mocks.
+func Configure(req ConfigRequest) error {
 	return ConfigureWithDeps(req, OSFileSystem{}, SystemMounter{})
 }
 


### PR DESCRIPTION
## Motivation

The `wifi` package exported a one-method `Configurator` interface with exactly one production implementation, `SystemConfigurator`, whose `Configure` method did nothing but call `ConfigureWithDeps(req, OSFileSystem{}, SystemMounter{})`. No tests mocked that interface; the tests that exist call `ConfigureWithDeps` directly with mock `FileSystem` and `Mounter` (those two interfaces are real test seams and stay).

So the interface plus empty struct were ceremonial only: an unused indirection layer covering a one-line wrap.

## Change

- Delete `wifi.Configurator` interface and `wifi.SystemConfigurator` struct.
- Add a top-level `wifi.Configure(req)` function that does the same hardcoded-deps wrap.
- Change `portal.NewHandler` to take a `func(wifi.ConfigRequest) error` so the call site is a plain function invocation.
- `cmd/digits-setup/main.go` now passes `wifi.Configure` directly.

No behavior change. The real test seams (`FileSystem`, `Mounter`, `Scanner`, `APController`) are untouched.

## Test plan

- [x] `go build ./...` (digits-setup)
- [x] `go test ./...` (digits-setup; wifi tests use `ConfigureWithDeps` with mocks and continue to pass)
- [x] `go vet ./...`