### PR TITLE
test(server): cover cache-bust contract for /static/ assets

### DIFF
--- a/server/internal/web/static_server_test.go
+++ b/server/internal/web/static_server_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/justinlindh/digits/server/internal/version"
 )
 
 // Production path: /static/* must be served from the embedded FS so the
@@ -85,4 +87,89 @@ func TestStaticFileServer_DevDefaultDirResolves(t *testing.T) {
 	// We don't assert on response content here because CWD may not host
 	// the default directory; the presence of a non-nil handler is enough
 	// to confirm the fallback branch doesn't blow up at construction.
+}
+
+// A request carrying a query string (the {{static}} helper's commit-suffixed
+// shape) must come back with the long-lived immutable header so Cloudflare
+// caches each release's asset URLs aggressively. Regressing this
+// re-creates the AM-theme staleness bug that motivated the cache-bust
+// scheme: see PR #370.
+func TestStaticFileServer_VersionedAssetSetsImmutableCacheControl(t *testing.T) {
+	h := staticFileServer(false, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/static/dialup.css?v=abc123", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET versioned asset: got %d, want 200", rec.Code)
+	}
+	got := rec.Header().Get("Cache-Control")
+	want := "public, max-age=31536000, immutable"
+	if got != want {
+		t.Errorf("Cache-Control on versioned asset: got %q, want %q", got, want)
+	}
+}
+
+// A request without a query string is the unversioned fallback (dev mode,
+// templates that intentionally point at stable assets). It must NOT carry
+// the immutable header; if it did, a stale CSS URL would never refresh
+// even after the bug's fix shipped.
+func TestStaticFileServer_BareAssetHasNoImmutableCacheControl(t *testing.T) {
+	h := staticFileServer(false, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/static/dialup.css", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET bare asset: got %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Errorf("Cache-Control on bare asset: got %q, want empty", got)
+	}
+}
+
+// The {{static}} template helper must produce commit-suffixed URLs when a
+// build commit is wired in via -ldflags. Without this, the cache-bust
+// scheme silently no-ops in production and the AM-theme staleness bug
+// returns on the next CSS-class rename.
+func TestStaticTemplateHelper_AppendsCommitSuffix(t *testing.T) {
+	prev := version.Commit
+	t.Cleanup(func() { version.Commit = prev })
+	version.Commit = "abc123"
+
+	staticFn, ok := TemplateFuncs()["static"].(func(string) string)
+	if !ok {
+		t.Fatal("TemplateFuncs()[\"static\"] is not func(string) string")
+	}
+
+	got := staticFn("answering-machine.css")
+	want := "/static/answering-machine.css?v=abc123"
+	if got != want {
+		t.Errorf("static helper: got %q, want %q", got, want)
+	}
+}
+
+// In dev (and any build that did not wire -ldflags) version.Commit defaults
+// to "unknown"; an empty string is also valid in test contexts. Either
+// shape must collapse to a bare /static/ URL so the dev disk-serve path
+// continues to revalidate per request rather than locking in stale bytes.
+func TestStaticTemplateHelper_BareURLWhenCommitMissing(t *testing.T) {
+	prev := version.Commit
+	t.Cleanup(func() { version.Commit = prev })
+
+	staticFn, ok := TemplateFuncs()["static"].(func(string) string)
+	if !ok {
+		t.Fatal("TemplateFuncs()[\"static\"] is not func(string) string")
+	}
+
+	for _, sentinel := range []string{"", "unknown"} {
+		version.Commit = sentinel
+		got := staticFn("answering-machine.css")
+		want := "/static/answering-machine.css"
+		if got != want {
+			t.Errorf("static helper with Commit=%q: got %q, want %q", sentinel, got, want)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Holistic-review finding across the AM theme cluster merged in the last 24h: PRs #368 and #369 introduced new HTML class names that referenced new shapes in `answering-machine.css`. Cloudflare's 4h edge cache kept serving the pre-merge CSS against the unchanged `/static/` URLs, so the mobile MENU drawer (#369) and the AM Software update plate (#368) visually broke for any user that hit a cached edge.

PR #370 fixed it by suffixing static-asset URLs with the build commit and setting a 1-year immutable `Cache-Control` on responses that carry a query string, so each release writes URLs no edge has cached. That fix landed without regression tests; only manual verification was checked off in the #370 test plan.

## What this PR adds

Four pure-test additions to `server/internal/web/static_server_test.go`. No production code changes.

The contract has two halves that a future PR can trivially break:

1. The `{{static}}` template helper appends `?v=COMMIT` when a build commit is wired in via `-ldflags`, and falls back to a bare `/static/` path when `version.Commit` is empty or the literal string `unknown`. If the helper silently no-ops in production, every release's CSS still rides the prior URL and the AM-theme staleness symptom comes right back on the next class rename.
2. `staticFileServer` sets `Cache-Control: public, max-age=31536000, immutable` iff the request URL has a query string. If that gate gets dropped or inverted, bare `/static/` URLs (the dev path and the stable image/audio refs that #370 intentionally left unversioned) lock in stale bytes for a year.

Tests added:

- `TestStaticFileServer_VersionedAssetSetsImmutableCacheControl`: a `?v=...` request comes back with the immutable header.
- `TestStaticFileServer_BareAssetHasNoImmutableCacheControl`: a bare request comes back with no `Cache-Control` header.
- `TestStaticTemplateHelper_AppendsCommitSuffix`: with `version.Commit` set to `abc123`, the helper returns `/static/foo.css?v=abc123`.
- `TestStaticTemplateHelper_BareURLWhenCommitMissing`: with `version.Commit` empty or `unknown`, the helper returns a bare `/static/foo.css`.

The `dialup.css` smoke fixture already shipped via the embed FS makes the cache-control assertions trivially deterministic; no test fixtures or new files needed.

## Motivated by (last 24h merges)

- #368 feat(server): AM theme software update controls and voice-style fix
- #369 fix(server): collapse AM mobile chrome behind a single MENU drawer
- #370 fix(server): cache-bust static assets via commit-suffixed query params

## Test plan

- [x] `go build ./...` clean in `server/`
- [x] `go test ./internal/web/ -run 'TestStatic' -count=1` clean (8 tests pass, including the 4 new ones)
- [x] `go vet ./internal/web/...` clean
- [x] `golangci-lint run ./internal/web/...` clean