### PR TITLE
refactor(pi): unexport wifi package internals

### DIFF
--- a/pi/digits-setup/internal/wifi/configure.go
+++ b/pi/digits-setup/internal/wifi/configure.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-// ErrInvalidRequest is returned by ConfigureWithDeps for user-facing validation
+// ErrInvalidRequest is returned by Configure for user-facing validation
 // failures (missing SSID, etc.) so handlers can return 400 vs. 500.
 var ErrInvalidRequest = errors.New("invalid configure request")
 
@@ -24,43 +24,43 @@ type ConfigRequest struct {
 	Hidden   bool   `json:"hidden"`
 }
 
-// FileSystem abstracts file operations for testing.
-type FileSystem interface {
+// fileSystem abstracts file operations for testing.
+type fileSystem interface {
 	MkdirAll(path string, perm os.FileMode) error
 	WriteFile(name string, data []byte, perm os.FileMode) error
 	Remove(name string) error
 	Rename(oldpath, newpath string) error
 }
 
-// OSFileSystem is the real filesystem.
-type OSFileSystem struct{}
+// osFileSystem is the real filesystem.
+type osFileSystem struct{}
 
-func (OSFileSystem) MkdirAll(path string, perm os.FileMode) error {
+func (osFileSystem) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 
-func (OSFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error {
+func (osFileSystem) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return os.WriteFile(name, data, perm)
 }
 
-func (OSFileSystem) Remove(name string) error {
+func (osFileSystem) Remove(name string) error {
 	return os.Remove(name)
 }
 
-func (OSFileSystem) Rename(oldpath, newpath string) error {
+func (osFileSystem) Rename(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)
 }
 
-// Mounter abstracts remounting the root filesystem.
-type Mounter interface {
+// mounter abstracts remounting the root filesystem.
+type mounter interface {
 	RemountRW() error
 	RemountRO() error
 }
 
-// SystemMounter calls `mount -o remount,{rw,ro} /`.
-type SystemMounter struct{}
+// systemMounter calls `mount -o remount,{rw,ro} /`.
+type systemMounter struct{}
 
-func (SystemMounter) RemountRW() error {
+func (systemMounter) RemountRW() error {
 	out, err := exec.Command("mount", "-o", "remount,rw", "/").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("remount rw: %w: %s", err, out)
@@ -68,7 +68,7 @@ func (SystemMounter) RemountRW() error {
 	return nil
 }
 
-func (SystemMounter) RemountRO() error {
+func (systemMounter) RemountRO() error {
 	out, err := exec.Command("mount", "-o", "remount,ro", "/").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("remount ro: %w: %s", err, out)
@@ -111,9 +111,9 @@ func (SystemAPController) Down() error {
 }
 
 // Configure writes Wi-Fi config using production filesystem and mount
-// implementations. Tests should call ConfigureWithDeps directly with mocks.
+// implementations. Tests call configureWithDeps directly with mocks.
 func Configure(req ConfigRequest) error {
-	return ConfigureWithDeps(req, OSFileSystem{}, SystemMounter{})
+	return configureWithDeps(req, osFileSystem{}, systemMounter{})
 }
 
 const (
@@ -132,12 +132,12 @@ func uuidForSSID(ssid string) string {
 	return s[0:8] + "-" + s[8:12] + "-" + s[12:16] + "-" + s[16:20] + "-" + s[20:32]
 }
 
-// ConfigureWithDeps performs configuration with injectable dependencies.
+// configureWithDeps performs configuration with injectable dependencies.
 //
 // The flag at wifiConfiguredFlag is written last so a partial failure during
 // the operational write does not promote the device to station mode on next
 // boot with a half-written config.
-func ConfigureWithDeps(req ConfigRequest, fs FileSystem, mounter Mounter) error {
+func configureWithDeps(req ConfigRequest, fs fileSystem, m mounter) error {
 	if req.SSID == "" {
 		return fmt.Errorf("%w: ssid is required", ErrInvalidRequest)
 	}
@@ -180,11 +180,11 @@ method=auto
 		return fmt.Errorf("backup write: %w", err)
 	}
 
-	if err := mounter.RemountRW(); err != nil {
+	if err := m.RemountRW(); err != nil {
 		return fmt.Errorf("remount rw: %w", err)
 	}
 	defer func() {
-		if err := mounter.RemountRO(); err != nil {
+		if err := m.RemountRO(); err != nil {
 			log.Printf("configure: remount ro failed: %v", err)
 		}
 	}()
@@ -214,7 +214,7 @@ method=auto
 }
 
 // writeAtomic writes data to path via a sibling temp file and atomic rename.
-func writeAtomic(fs FileSystem, path string, data []byte, perm os.FileMode) error {
+func writeAtomic(fs fileSystem, path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
 	if err := fs.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)

--- a/pi/digits-setup/internal/wifi/configure_test.go
+++ b/pi/digits-setup/internal/wifi/configure_test.go
@@ -78,7 +78,7 @@ func TestConfigureSuccess(t *testing.T) {
 	mounter := &mockMounter{}
 
 	req := ConfigRequest{SSID: "MyNetwork", Password: "secret123"}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+	if err := configureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -125,7 +125,7 @@ func TestConfigureMissingSSID(t *testing.T) {
 	fs := newMockFS()
 	mounter := &mockMounter{}
 
-	err := ConfigureWithDeps(ConfigRequest{Password: "secret"}, fs, mounter)
+	err := configureWithDeps(ConfigRequest{Password: "secret"}, fs, mounter)
 	if err == nil {
 		t.Fatal("expected error for missing SSID")
 	}
@@ -145,7 +145,7 @@ func TestConfigureHiddenNetwork(t *testing.T) {
 	mounter := &mockMounter{}
 
 	req := ConfigRequest{SSID: "SecretNet", Password: "pass123", Hidden: true}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+	if err := configureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestConfigureVisibleNetworkNoScanSSID(t *testing.T) {
 	mounter := &mockMounter{}
 
 	req := ConfigRequest{SSID: "VisibleNet", Password: "pass123"}
-	if err := ConfigureWithDeps(req, fs, mounter); err != nil {
+	if err := configureWithDeps(req, fs, mounter); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -186,7 +186,7 @@ func TestConfigureFilenameCollisionPrevention(t *testing.T) {
 	req1 := ConfigRequest{SSID: "Network 1", Password: "pass1"}
 	req2 := ConfigRequest{SSID: "Network-1", Password: "pass2"}
 
-	if err := ConfigureWithDeps(req1, fs, &mockMounter{}); err != nil {
+	if err := configureWithDeps(req1, fs, &mockMounter{}); err != nil {
 		t.Fatalf("first configure failed: %v", err)
 	}
 	path1 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network 1")[:6]+".nmconnection")
@@ -194,7 +194,7 @@ func TestConfigureFilenameCollisionPrevention(t *testing.T) {
 		t.Fatalf("first network file not written to %s", path1)
 	}
 
-	if err := ConfigureWithDeps(req2, fs, &mockMounter{}); err != nil {
+	if err := configureWithDeps(req2, fs, &mockMounter{}); err != nil {
 		t.Fatalf("second configure failed: %v", err)
 	}
 	path2 := filepath.Join("/data/wifi", "digits-wifi-Network-1-"+uuidForSSID("Network-1")[:6]+".nmconnection")
@@ -215,7 +215,7 @@ func TestConfigureRemountRWFailureAbortsWithoutFlag(t *testing.T) {
 	mounter := &mockMounter{failRW: true}
 
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	err := ConfigureWithDeps(req, fs, mounter)
+	err := configureWithDeps(req, fs, mounter)
 	if err == nil {
 		t.Fatal("expected error from failing remount rw")
 	}
@@ -235,7 +235,7 @@ func TestConfigureRemountRWFailureAbortsWithoutFlag(t *testing.T) {
 // failOpWriteFS fails WriteFile once, for the operational path only. Used to
 // verify that a failed operational write leaves the backup present and does
 // NOT set the wifi-configured flag (the "half-written config never promotes
-// to station" invariant from ConfigureWithDeps' doc comment).
+// to station" invariant from configureWithDeps' doc comment).
 type failOpWriteFS struct {
 	*mockFS
 }
@@ -248,7 +248,7 @@ func (f *failOpWriteFS) WriteFile(name string, data []byte, perm os.FileMode) er
 }
 
 func TestConfigureMissingSSIDIsInvalidRequest(t *testing.T) {
-	err := ConfigureWithDeps(ConfigRequest{Password: "pw"}, newMockFS(), &mockMounter{})
+	err := configureWithDeps(ConfigRequest{Password: "pw"}, newMockFS(), &mockMounter{})
 	if !errors.Is(err, ErrInvalidRequest) {
 		t.Fatalf("err = %v, want ErrInvalidRequest", err)
 	}
@@ -260,7 +260,7 @@ func TestConfigureOperationalWriteFailureKeepsBackupOmitsFlag(t *testing.T) {
 	mounter := &mockMounter{}
 
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	err := ConfigureWithDeps(req, fs, mounter)
+	err := configureWithDeps(req, fs, mounter)
 	if err == nil {
 		t.Fatal("expected error from failing operational write")
 	}
@@ -284,7 +284,7 @@ func TestConfigureLegacyCleanupBothDirs(t *testing.T) {
 	fs.files["/etc/NetworkManager/system-connections/digits-wifi.nmconnection"] = mockFile{data: []byte("old"), perm: 0600}
 
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	if err := ConfigureWithDeps(req, fs, &mockMounter{}); err != nil {
+	if err := configureWithDeps(req, fs, &mockMounter{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, ok := fs.files["/data/wifi/digits-wifi.nmconnection"]; ok {
@@ -298,7 +298,7 @@ func TestConfigureLegacyCleanupBothDirs(t *testing.T) {
 func TestConfigureLegacyCleanupMissingIsOK(t *testing.T) {
 	fs := newMockFS()
 	req := ConfigRequest{SSID: "Net", Password: "pw"}
-	if err := ConfigureWithDeps(req, fs, &mockMounter{}); err != nil {
+	if err := configureWithDeps(req, fs, &mockMounter{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

The `wifi` package's only external entry point is `Configure(req)`. The `FileSystem` and `Mounter` interfaces, their `OSFileSystem` and `SystemMounter` implementations, and `ConfigureWithDeps` exist purely as a test seam and mock-injection path. None of them are referenced outside `package wifi`.

This change lowercases all five (`fileSystem`, `mounter`, `osFileSystem`, `systemMounter`, `configureWithDeps`) so the public API matches what external callers actually use. Tests live in `package wifi`, so they keep direct access.

`SystemAPController` and `APController` are intentionally kept exported: they are wired through `cmd/digits-setup/main.go` into `portal.NewHandler`.

## Test plan

- [x] `go build ./...` clean in `pi/digits-setup/`
- [x] `go test ./...` passes in `pi/digits-setup/`
- [x] `go vet ./...` clean
