### PR TITLE
feat(digitsd): add voicemail storage package and config schema

### DIFF
--- a/firmware/src/led.c
+++ b/firmware/src/led.c
@@ -5,6 +5,7 @@
 #include "pico/time.h"
 
 #define LED_BLINK_INTERVAL_US 500000
+#define LED_SLOW_BLINK_INTERVAL_US 2000000
 
 static led_mode_t s_mode = LED_MODE_OFF;
 static bool s_led_on = false;
@@ -35,12 +36,20 @@ void led_set_mode(led_mode_t mode) {
 }
 
 void led_update(void) {
-    if (s_mode != LED_MODE_BLINK) {
+    int64_t interval_us;
+    switch (s_mode) {
+    case LED_MODE_BLINK:
+        interval_us = LED_BLINK_INTERVAL_US;
+        break;
+    case LED_MODE_SLOW_BLINK:
+        interval_us = LED_SLOW_BLINK_INTERVAL_US;
+        break;
+    default:
         return;
     }
 
     absolute_time_t now = get_absolute_time();
-    if (absolute_time_diff_us(s_last_toggle, now) >= LED_BLINK_INTERVAL_US) {
+    if (absolute_time_diff_us(s_last_toggle, now) >= interval_us) {
         s_led_on = !s_led_on;
         gpio_put(board->led_pin, s_led_on ? 1 : 0);
         s_last_toggle = now;

--- a/firmware/src/led.h
+++ b/firmware/src/led.h
@@ -7,6 +7,10 @@ typedef enum {
     LED_MODE_OFF = 0,
     LED_MODE_ON,
     LED_MODE_BLINK,
+    // LED_MODE_SLOW_BLINK is a longer-period blink (~2s) used for advisory
+    // indications such as a waiting voicemail message. Visually distinct
+    // from LED_MODE_BLINK so a glance can tell ringing from message-waiting.
+    LED_MODE_SLOW_BLINK,
 } led_mode_t;
 
 void led_init(void);

--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -173,6 +173,8 @@ static void process_pi_command(const char *cmd) {
         led_set_mode(LED_MODE_OFF);
     } else if (strcmp(cmd, "LED:BLINK") == 0) {
         led_set_mode(LED_MODE_BLINK);
+    } else if (strcmp(cmd, "LED:SLOW_BLINK") == 0) {
+        led_set_mode(LED_MODE_SLOW_BLINK);
     } else if (strcmp(cmd, "TONE:DIAL") == 0) {
         tone_play(TONE_DIAL);
     } else if (strcmp(cmd, "TONE:RINGBACK") == 0) {

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -28,6 +28,32 @@ type WiFiFallback struct {
 	APNoClientTimeout time.Duration `json:"ap_no_client_timeout"`
 }
 
+// Voicemail configures the answering-machine feature. Storage is phone-local;
+// there is no server-side index. Retrieval is dial-in only, from the same
+// phone the message was left at.
+type Voicemail struct {
+	// Enabled gates the entire feature. When false the FSM behaves as if
+	// voicemail did not exist: no ring timeout, no retrieval code intercept,
+	// no LED message-waiting indicator.
+	Enabled bool `json:"enabled"`
+
+	// RingTimeout is how long an inbound ring may go unanswered before
+	// digitsd auto-answers and starts recording. Mirrors a 4-ring delay on
+	// classic answering machines (~20s on 5Hz cadence).
+	RingTimeout time.Duration `json:"ring_timeout"`
+
+	// MaxMessageDuration caps a single recording. Once hit, the recording is
+	// finalized and the call is hung up.
+	MaxMessageDuration time.Duration `json:"max_message_duration"`
+
+	// MaxStoredMessages caps the on-disk archive. Oldest messages are evicted
+	// FIFO once the cap is exceeded.
+	MaxStoredMessages int `json:"max_stored_messages"`
+
+	// RetrievalCode is the digit sequence dialed off-hook to enter playback.
+	RetrievalCode string `json:"retrieval_code"`
+}
+
 // Config holds digitsd runtime configuration loaded from a JSON file.
 // CLI flags always override values loaded from the file.
 type Config struct {
@@ -67,6 +93,9 @@ type Config struct {
 	// WiFiFallback configures the WiFi auto-fallback supervisor.
 	WiFiFallback WiFiFallback `json:"wifi_fallback"`
 
+	// Voicemail configures the answering-machine feature. Disabled by default.
+	Voicemail Voicemail `json:"voicemail"`
+
 	// path is the file the config was loaded from; used by Save.
 	path string
 }
@@ -85,10 +114,23 @@ func defaultWiFiFallback() WiFiFallback {
 	}
 }
 
+// defaultVoicemail returns the canonical default Voicemail config. Single
+// source of truth used by Default() and the Load path.
+func defaultVoicemail() Voicemail {
+	return Voicemail{
+		Enabled:            false,
+		RingTimeout:        20 * time.Second,
+		MaxMessageDuration: 90 * time.Second,
+		MaxStoredMessages:  50,
+		RetrievalCode:      "*98",
+	}
+}
+
 // Default returns a Config with sensible defaults.
 func Default() *Config {
 	return &Config{
 		WiFiFallback: defaultWiFiFallback(),
+		Voicemail:    defaultVoicemail(),
 	}
 }
 
@@ -98,7 +140,7 @@ func Default() *Config {
 // If the primary file is corrupt (e.g. null bytes from a power cut), Load
 // automatically falls back to the .bak file.
 func Load(path string) (*Config, error) {
-	c := &Config{path: path, WiFiFallback: defaultWiFiFallback()}
+	c := &Config{path: path, WiFiFallback: defaultWiFiFallback(), Voicemail: defaultVoicemail()}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -130,7 +172,7 @@ func Load(path string) (*Config, error) {
 // a zero-value config so the daemon can still boot (in pairing mode).
 func loadBackup(path string) (*Config, error) {
 	bakPath := path + ".bak"
-	c := &Config{path: path, WiFiFallback: defaultWiFiFallback()}
+	c := &Config{path: path, WiFiFallback: defaultWiFiFallback(), Voicemail: defaultVoicemail()}
 
 	data, err := os.ReadFile(bakPath)
 	if err != nil {

--- a/pi/digitsd/internal/voicemail/store.go
+++ b/pi/digitsd/internal/voicemail/store.go
@@ -1,0 +1,457 @@
+// Package voicemail provides a phone-local store for answering-machine
+// recordings. Each digitsd instance owns its messages on disk under a single
+// directory. There is no server-side index; messages are retrieved only at
+// the phone they were left at.
+//
+// On-disk layout under Dir:
+//
+//	<unix_ms>.frames    length-prefixed Opus payloads (uint32 LE length, then bytes)
+//	<unix_ms>.meta      JSON metadata (heard flag, duration estimate)
+//
+// Writes are crash-safe: recordings stream to <id>.frames.tmp and rename
+// atomically only on Finalize. A crash mid-recording leaves an orphan .tmp
+// that the next OpenStore sweep removes.
+package voicemail
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Frame size constant matches internal/codec/opus.go (20ms at 48kHz).
+const opusFrameMs = 20
+
+// Options controls store retention.
+type Options struct {
+	// MaxMessages caps the number of stored messages. When exceeded, the
+	// oldest are deleted (FIFO). Zero disables the cap.
+	MaxMessages int
+	// MaxMessageDuration caps a single recording. Zero disables the cap;
+	// the recorder will accept frames indefinitely until Finalize.
+	MaxMessageDuration time.Duration
+	// Now is injected for tests. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// Message is a finalized voicemail.
+type Message struct {
+	ID         int64         // unix milliseconds; also the on-disk filename stem
+	Heard      bool          // true once played to completion at least once
+	Duration   time.Duration // approximate, computed from frame count at finalize
+	Path       string        // absolute path to the .frames file
+	RecordedAt time.Time
+}
+
+type metaFile struct {
+	Heard      bool      `json:"heard"`
+	DurationMs int64     `json:"duration_ms"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
+// Store is the on-disk message archive. Methods are safe for concurrent use.
+type Store struct {
+	dir  string
+	opts Options
+
+	mu sync.Mutex
+}
+
+// Open opens or creates the store at dir. Orphan .tmp files from a prior
+// crash are removed.
+func Open(dir string, opts Options) (*Store, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("voicemail: mkdir %s: %w", dir, err)
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	s := &Store{dir: dir, opts: opts}
+	if err := s.cleanOrphans(); err != nil {
+		slog.Warn("voicemail: orphan cleanup failed", "error", err)
+	}
+	return s, nil
+}
+
+func (s *Store) cleanOrphans() error {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) == ".tmp" {
+			if err := os.Remove(filepath.Join(s.dir, name)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// List returns all finalized messages, oldest first.
+func (s *Store) List() ([]Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listLocked()
+}
+
+func (s *Store) listLocked() ([]Message, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []Message
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if filepath.Ext(name) != ".frames" {
+			continue
+		}
+		stem := name[:len(name)-len(".frames")]
+		id, err := parseID(stem)
+		if err != nil {
+			continue
+		}
+		framesPath := filepath.Join(s.dir, name)
+		meta, err := s.readMeta(id)
+		if err != nil {
+			slog.Warn("voicemail: meta read failed", "id", id, "error", err)
+			meta = metaFile{}
+		}
+		recordedAt := meta.RecordedAt
+		if recordedAt.IsZero() {
+			recordedAt = time.UnixMilli(id)
+		}
+		msgs = append(msgs, Message{
+			ID:         id,
+			Heard:      meta.Heard,
+			Duration:   time.Duration(meta.DurationMs) * time.Millisecond,
+			Path:       framesPath,
+			RecordedAt: recordedAt,
+		})
+	}
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].ID < msgs[j].ID })
+	return msgs, nil
+}
+
+// UnheardCount returns the number of messages whose Heard flag is false.
+func (s *Store) UnheardCount() (int, error) {
+	msgs, err := s.List()
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, m := range msgs {
+		if !m.Heard {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// MarkHeard sets the Heard flag for the given message ID.
+func (s *Store) MarkHeard(id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	meta, err := s.readMeta(id)
+	if err != nil {
+		return err
+	}
+	if meta.Heard {
+		return nil
+	}
+	meta.Heard = true
+	return s.writeMeta(id, meta)
+}
+
+// Delete removes a message and its metadata.
+func (s *Store) Delete(id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	framesPath := filepath.Join(s.dir, fmt.Sprintf("%d.frames", id))
+	metaPath := filepath.Join(s.dir, fmt.Sprintf("%d.meta", id))
+	if err := os.Remove(framesPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Remove(metaPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// BeginRecording opens a fresh Recorder. AppendFrame queues raw Opus payloads
+// (one per 20ms RTP frame). Finalize promotes the temp file to a real message.
+// Discard removes the temp file without finalizing.
+func (s *Store) BeginRecording() (*Recorder, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := s.opts.Now().UnixMilli()
+	framesPath := filepath.Join(s.dir, fmt.Sprintf("%d.frames", id))
+	tmpPath := framesPath + ".tmp"
+
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("voicemail: open tmp: %w", err)
+	}
+	return &Recorder{
+		store:    s,
+		id:       id,
+		tmpPath:  tmpPath,
+		finalPath: framesPath,
+		file:     f,
+		maxFrames: framesForDuration(s.opts.MaxMessageDuration),
+	}, nil
+}
+
+// Recorder writes Opus frames for a single message.
+type Recorder struct {
+	store     *Store
+	id        int64
+	tmpPath   string
+	finalPath string
+
+	mu        sync.Mutex
+	file      *os.File
+	frames    int
+	maxFrames int // 0 means no cap
+	closed    bool
+}
+
+// AppendFrame writes one Opus payload. Returns true if the message has hit its
+// configured duration cap and should be finalized; false otherwise.
+func (r *Recorder) AppendFrame(payload []byte) (atCap bool, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false, errors.New("voicemail: recorder closed")
+	}
+	if len(payload) > 0xffff {
+		return false, fmt.Errorf("voicemail: opus payload too large (%d)", len(payload))
+	}
+	var hdr [4]byte
+	binary.LittleEndian.PutUint32(hdr[:], uint32(len(payload)))
+	if _, err := r.file.Write(hdr[:]); err != nil {
+		return false, err
+	}
+	if _, err := r.file.Write(payload); err != nil {
+		return false, err
+	}
+	r.frames++
+	if r.maxFrames > 0 && r.frames >= r.maxFrames {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Frames returns the number of frames written so far. For tests and cap checks.
+func (r *Recorder) Frames() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.frames
+}
+
+// Finalize closes the temp file, fsyncs, renames to the canonical path,
+// writes the metadata file, and applies retention. If no frames were written,
+// the temp file is discarded instead and (0, nil) returned.
+func (r *Recorder) Finalize() (Message, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return Message{}, errors.New("voicemail: recorder already closed")
+	}
+	r.closed = true
+
+	if r.frames == 0 {
+		_ = r.file.Close()
+		_ = os.Remove(r.tmpPath)
+		return Message{}, nil
+	}
+
+	if err := r.file.Sync(); err != nil {
+		_ = r.file.Close()
+		_ = os.Remove(r.tmpPath)
+		return Message{}, fmt.Errorf("voicemail: fsync: %w", err)
+	}
+	if err := r.file.Close(); err != nil {
+		_ = os.Remove(r.tmpPath)
+		return Message{}, fmt.Errorf("voicemail: close: %w", err)
+	}
+	if err := os.Rename(r.tmpPath, r.finalPath); err != nil {
+		_ = os.Remove(r.tmpPath)
+		return Message{}, fmt.Errorf("voicemail: rename: %w", err)
+	}
+
+	duration := time.Duration(r.frames) * opusFrameMs * time.Millisecond
+	recordedAt := r.store.opts.Now()
+	meta := metaFile{
+		Heard:      false,
+		DurationMs: duration.Milliseconds(),
+		RecordedAt: recordedAt,
+	}
+	r.store.mu.Lock()
+	defer r.store.mu.Unlock()
+	if err := r.store.writeMeta(r.id, meta); err != nil {
+		return Message{}, fmt.Errorf("voicemail: write meta: %w", err)
+	}
+
+	if err := r.store.evictLocked(); err != nil {
+		slog.Warn("voicemail: eviction failed", "error", err)
+	}
+
+	return Message{
+		ID:         r.id,
+		Heard:      false,
+		Duration:   duration,
+		Path:       r.finalPath,
+		RecordedAt: recordedAt,
+	}, nil
+}
+
+// Discard closes the temp file and removes it without finalizing. Safe to
+// call after Finalize (no-op).
+func (r *Recorder) Discard() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+	r.closed = true
+	_ = r.file.Close()
+	_ = os.Remove(r.tmpPath)
+}
+
+// Player iterates Opus frames for a finalized message. Frame returns
+// io.EOF when the message ends.
+type Player struct {
+	file *os.File
+}
+
+// Open returns a Player for the given message ID.
+func (s *Store) Open(id int64) (*Player, error) {
+	path := filepath.Join(s.dir, fmt.Sprintf("%d.frames", id))
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return &Player{file: f}, nil
+}
+
+// NextFrame returns the next Opus payload, or io.EOF when exhausted.
+func (p *Player) NextFrame() ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(p.file, hdr[:]); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, io.EOF
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			// Truncated header: treat as end of stream rather than an error,
+			// since a crash mid-write could leave a partial trailer.
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+	n := binary.LittleEndian.Uint32(hdr[:])
+	if n == 0 {
+		return []byte{}, nil
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(p.file, buf); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+	return buf, nil
+}
+
+// Close releases the underlying file handle.
+func (p *Player) Close() error {
+	return p.file.Close()
+}
+
+// --- internal helpers ---
+
+func (s *Store) metaPath(id int64) string {
+	return filepath.Join(s.dir, fmt.Sprintf("%d.meta", id))
+}
+
+func (s *Store) readMeta(id int64) (metaFile, error) {
+	var m metaFile
+	data, err := os.ReadFile(s.metaPath(id))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m, nil
+		}
+		return m, err
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return metaFile{}, err
+	}
+	return m, nil
+}
+
+func (s *Store) writeMeta(id int64, m metaFile) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	tmp := s.metaPath(id) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.metaPath(id))
+}
+
+// evictLocked enforces MaxMessages by deleting oldest first. Caller holds s.mu.
+func (s *Store) evictLocked() error {
+	if s.opts.MaxMessages <= 0 {
+		return nil
+	}
+	msgs, err := s.listLocked()
+	if err != nil {
+		return err
+	}
+	excess := len(msgs) - s.opts.MaxMessages
+	if excess <= 0 {
+		return nil
+	}
+	for i := 0; i < excess; i++ {
+		framesPath := filepath.Join(s.dir, fmt.Sprintf("%d.frames", msgs[i].ID))
+		metaPath := s.metaPath(msgs[i].ID)
+		if err := os.Remove(framesPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.Remove(metaPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseID(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// framesForDuration returns the cap in 20ms frames, or 0 to disable.
+func framesForDuration(d time.Duration) int {
+	if d <= 0 {
+		return 0
+	}
+	return int(d / (opusFrameMs * time.Millisecond))
+}

--- a/pi/digitsd/internal/voicemail/store_test.go
+++ b/pi/digitsd/internal/voicemail/store_test.go
@@ -1,0 +1,265 @@
+package voicemail
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T, opts Options) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := Open(dir, opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return s
+}
+
+func writeMessage(t *testing.T, s *Store, payloads ...[]byte) Message {
+	t.Helper()
+	r, err := s.BeginRecording()
+	if err != nil {
+		t.Fatalf("BeginRecording: %v", err)
+	}
+	for _, p := range payloads {
+		if _, err := r.AppendFrame(p); err != nil {
+			t.Fatalf("AppendFrame: %v", err)
+		}
+	}
+	m, err := r.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	return m
+}
+
+func TestRecordAndPlayRoundTrip(t *testing.T) {
+	s := newTestStore(t, Options{})
+	want := [][]byte{
+		[]byte{0x01, 0x02, 0x03},
+		[]byte{0x04, 0x05},
+		[]byte{0x06},
+	}
+	m := writeMessage(t, s, want...)
+	if m.ID == 0 {
+		t.Fatal("Finalize returned zero ID")
+	}
+	if m.Duration != 3*20*time.Millisecond {
+		t.Errorf("duration = %v, want 60ms", m.Duration)
+	}
+
+	p, err := s.Open(m.ID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer p.Close() //nolint:errcheck
+
+	for i, expected := range want {
+		got, err := p.NextFrame()
+		if err != nil {
+			t.Fatalf("NextFrame[%d]: %v", i, err)
+		}
+		if string(got) != string(expected) {
+			t.Errorf("frame %d = %x, want %x", i, got, expected)
+		}
+	}
+	if _, err := p.NextFrame(); !errors.Is(err, io.EOF) {
+		t.Errorf("expected EOF after last frame, got %v", err)
+	}
+}
+
+func TestEmptyRecordingDiscarded(t *testing.T) {
+	s := newTestStore(t, Options{})
+	r, err := s.BeginRecording()
+	if err != nil {
+		t.Fatalf("BeginRecording: %v", err)
+	}
+	m, err := r.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if m.ID != 0 {
+		t.Errorf("empty Finalize returned ID %d, want 0", m.ID)
+	}
+	msgs, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("List: %d messages after empty Finalize, want 0", len(msgs))
+	}
+}
+
+func TestDiscardRemovesTempFile(t *testing.T) {
+	s := newTestStore(t, Options{})
+	r, err := s.BeginRecording()
+	if err != nil {
+		t.Fatalf("BeginRecording: %v", err)
+	}
+	if _, err := r.AppendFrame([]byte{0xff}); err != nil {
+		t.Fatal(err)
+	}
+	r.Discard()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("dir has %d entries after Discard, want 0", len(entries))
+	}
+}
+
+func TestUnheardCountAndMarkHeard(t *testing.T) {
+	s := newTestStore(t, Options{Now: counterClock()})
+	a := writeMessage(t, s, []byte{1})
+	_ = writeMessage(t, s, []byte{2})
+
+	got, err := s.UnheardCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 2 {
+		t.Errorf("UnheardCount = %d, want 2", got)
+	}
+
+	if err := s.MarkHeard(a.ID); err != nil {
+		t.Fatalf("MarkHeard: %v", err)
+	}
+	got, err = s.UnheardCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("UnheardCount after MarkHeard = %d, want 1", got)
+	}
+
+	// Idempotent
+	if err := s.MarkHeard(a.ID); err != nil {
+		t.Fatalf("MarkHeard idempotent: %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := newTestStore(t, Options{Now: counterClock()})
+	m := writeMessage(t, s, []byte{0xaa})
+	if err := s.Delete(m.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	msgs, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("List after Delete: %d, want 0", len(msgs))
+	}
+	// Deleting a missing ID is not an error.
+	if err := s.Delete(m.ID); err != nil {
+		t.Errorf("Delete of missing ID returned %v, want nil", err)
+	}
+}
+
+func TestFIFOEviction(t *testing.T) {
+	s := newTestStore(t, Options{MaxMessages: 2, Now: counterClock()})
+	a := writeMessage(t, s, []byte{1})
+	b := writeMessage(t, s, []byte{2})
+	c := writeMessage(t, s, []byte{3})
+
+	msgs, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("List: %d messages, want 2", len(msgs))
+	}
+	if msgs[0].ID != b.ID || msgs[1].ID != c.ID {
+		t.Errorf("after eviction: ids = [%d %d], want [%d %d]", msgs[0].ID, msgs[1].ID, b.ID, c.ID)
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, fileFor(a.ID))); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("oldest frames file still present after eviction: %v", err)
+	}
+}
+
+func TestMaxMessageDurationCap(t *testing.T) {
+	s := newTestStore(t, Options{MaxMessageDuration: 60 * time.Millisecond})
+	r, err := s.BeginRecording()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 3 frames * 20ms = 60ms => atCap on the third.
+	for i := 0; i < 2; i++ {
+		atCap, err := r.AppendFrame([]byte{byte(i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if atCap {
+			t.Errorf("frame %d reported atCap early", i)
+		}
+	}
+	atCap, err := r.AppendFrame([]byte{0xff})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !atCap {
+		t.Errorf("expected atCap=true on 3rd frame")
+	}
+	if _, err := r.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOpenSweepRemovesOrphanTmp(t *testing.T) {
+	dir := t.TempDir()
+	orphan := filepath.Join(dir, "12345.frames.tmp")
+	if err := os.WriteFile(orphan, []byte("partial"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(dir, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(orphan); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("orphan tmp survived Open: %v", err)
+	}
+}
+
+func TestPlayerHandlesTruncatedTrailer(t *testing.T) {
+	s := newTestStore(t, Options{})
+	m := writeMessage(t, s, []byte{0xaa, 0xbb})
+
+	// Truncate the frames file to simulate a partial trailing record.
+	f, err := os.OpenFile(m.Path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(2); err != nil { // leave only first two bytes of header
+		t.Fatal(err)
+	}
+	f.Close() //nolint:errcheck
+
+	p, err := s.Open(m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close() //nolint:errcheck
+	if _, err := p.NextFrame(); !errors.Is(err, io.EOF) {
+		t.Errorf("truncated read should yield EOF, got %v", err)
+	}
+}
+
+// counterClock returns a Now that advances 1ms per call so successive
+// recordings get distinct IDs without sleeping.
+func counterClock() func() time.Time {
+	var n int64
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return func() time.Time {
+		n++
+		return base.Add(time.Duration(n) * time.Millisecond)
+	}
+}
+
+func fileFor(id int64) string { return fmt.Sprintf("%d.frames", id) }


### PR DESCRIPTION
Phone-local message store with crash-safe atomic finalize, FIFO retention,
and per-message length cap. Disabled by default via the new Voicemail config
struct; nothing reads the new fields yet.

Storage layout under the configured directory:
  <unix_ms>.frames    length-prefixed Opus payloads
  <unix_ms>.meta      JSON metadata (heard flag, duration)

Recordings stream to a .tmp file and rename atomically only on Finalize, so
a crash mid-recording leaves an orphan that the next Open() sweeps away.