### PR TITLE
fix(digitsd): populate loss/jitter from InboundRTPStreamStats

### DIFF
--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -146,7 +146,7 @@ func (r *Reporter) sample() (Sample, bool) {
 		}
 	}
 
-	// Drop if neither RR nor ICE pair produced anything useful.
+	// Drop if neither InboundRTP nor ICE pair produced anything useful.
 	if out.LossPct == nil && out.JitterMs == nil && out.RttMs == nil &&
 		out.BytesIn == nil && out.BytesOut == nil && out.ConnType == "" {
 		return Sample{}, false

--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -40,6 +40,10 @@ type Reporter struct {
 	getter   StatsGetter
 	send     func(Sample) error
 	interval time.Duration
+
+	prevPacketsReceived uint32
+	prevPacketsLost     int32
+	havePrev            bool
 }
 
 const defaultInterval = 2 * time.Second
@@ -89,14 +93,29 @@ func (r *Reporter) sample() (Sample, bool) {
 	report := r.getter.GetStats()
 	out := Sample{TS: time.Now()}
 
-	// RemoteInboundRTP: the remote's latest Receiver Report ABOUT our
-	// outbound stream. Gives loss and jitter as reported by the peer.
+	// InboundRTPStreamStats: pion's local view of the inbound stream. Includes
+	// jitter directly (in seconds; convert to ms) and lifetime PacketsReceived /
+	// PacketsLost counters that we delta against the previous sample to get a
+	// per-window loss percentage.
+	//
+	// pion v4.2.11 does NOT emit RemoteInboundRTPStreamStats in this codec
+	// configuration, so we cannot use the remote's RR. Confirmed empirically.
 	for _, st := range report {
-		if rr, ok := st.(pionwebrtc.RemoteInboundRTPStreamStats); ok {
-			loss := float32(rr.FractionLost * 100.0)
-			out.LossPct = &loss
-			jitter := float32(rr.Jitter * 1000.0)
+		if in, ok := st.(pionwebrtc.InboundRTPStreamStats); ok {
+			jitter := float32(in.Jitter * 1000.0)
 			out.JitterMs = &jitter
+			if r.havePrev {
+				recvDelta := int64(in.PacketsReceived) - int64(r.prevPacketsReceived)
+				lostDelta := int64(in.PacketsLost) - int64(r.prevPacketsLost)
+				total := recvDelta + lostDelta
+				if total > 0 && lostDelta >= 0 {
+					loss := float32(lostDelta) * 100.0 / float32(total)
+					out.LossPct = &loss
+				}
+			}
+			r.prevPacketsReceived = in.PacketsReceived
+			r.prevPacketsLost = in.PacketsLost
+			r.havePrev = true
 			break // typical voice call: one audio track
 		}
 	}

--- a/pi/digitsd/internal/webrtc/linkhealth.go
+++ b/pi/digitsd/internal/webrtc/linkhealth.go
@@ -34,8 +34,9 @@ type StatsGetter interface {
 }
 
 // Reporter samples WebRTC stats on a ticker and invokes send on each
-// non-empty sample. Zero-valued samples (no RR received yet AND no ICE
-// pair) are skipped entirely to avoid wire noise.
+// non-empty sample. Zero-valued samples (no InboundRTP data yet AND no ICE
+// pair) are skipped entirely to avoid wire noise. Fields owned by Run()
+// goroutine after start; sample() is not safe for concurrent use.
 type Reporter struct {
 	getter   StatsGetter
 	send     func(Sample) error
@@ -87,7 +88,7 @@ func (r *Reporter) Run(ctx context.Context) {
 }
 
 // sample walks a GetStats() report and extracts a Sample. Returns ok=false
-// if the report has no useful data to report (no RR yet AND no nominated
+// if the report has no useful data to report (no InboundRTP data yet AND no nominated
 // ICE pair).
 func (r *Reporter) sample() (Sample, bool) {
 	report := r.getter.GetStats()
@@ -108,7 +109,7 @@ func (r *Reporter) sample() (Sample, bool) {
 				recvDelta := int64(in.PacketsReceived) - int64(r.prevPacketsReceived)
 				lostDelta := int64(in.PacketsLost) - int64(r.prevPacketsLost)
 				total := recvDelta + lostDelta
-				if total > 0 && lostDelta >= 0 {
+				if total > 0 && lostDelta >= 0 && recvDelta >= 0 {
 					loss := float32(lostDelta) * 100.0 / float32(total)
 					out.LossPct = &loss
 				}

--- a/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_bench_test.go
@@ -8,7 +8,6 @@ import (
 
 func BenchmarkReporterSample(b *testing.B) {
 	report := buildFakeReport(b, fakeInput{
-		FractionLost:  0.012,
 		JitterSec:     0.0154,
 		RttSec:        0.072,
 		LocalCandType: pionwebrtc.ICECandidateTypeSrflx,

--- a/pi/digitsd/internal/webrtc/linkhealth_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_test.go
@@ -211,3 +211,76 @@ func TestSample_PopulatesLossFromInboundRTPDelta(t *testing.T) {
 		t.Errorf("LossPct=%v want ~4.76", got)
 	}
 }
+
+func TestSample_LossNilOnCounterReset(t *testing.T) {
+	g := &fakeStatsGetter{}
+	r := NewReporter(g, nil, time.Second)
+
+	// Baseline: 100 received, 5 lost.
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{PacketsReceived: 100, PacketsLost: 5},
+	}
+	if _, ok := r.sample(); !ok {
+		t.Fatal("baseline sample dropped")
+	}
+
+	// Counter reset: PacketsLost decreases (track replacement).
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{PacketsReceived: 110, PacketsLost: 2},
+	}
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("post-reset sample dropped")
+	}
+	if s.LossPct != nil {
+		t.Errorf("LossPct should be nil on counter reset, got %v", *s.LossPct)
+	}
+}
+
+func TestSample_LossNilOnZeroTrafficWindow(t *testing.T) {
+	g := &fakeStatsGetter{}
+	r := NewReporter(g, nil, time.Second)
+
+	// Two identical samples: no traffic moved.
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{PacketsReceived: 50, PacketsLost: 0},
+	}
+	if _, ok := r.sample(); !ok {
+		t.Fatal("baseline sample dropped")
+	}
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("zero-traffic sample dropped")
+	}
+	if s.LossPct != nil {
+		t.Errorf("LossPct should be nil on zero-traffic window, got %v", *s.LossPct)
+	}
+}
+
+func TestSample_LossOneHundredOnAllLossWindow(t *testing.T) {
+	g := &fakeStatsGetter{}
+	r := NewReporter(g, nil, time.Second)
+
+	// Baseline.
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{PacketsReceived: 100, PacketsLost: 0},
+	}
+	if _, ok := r.sample(); !ok {
+		t.Fatal("baseline sample dropped")
+	}
+
+	// All-loss window: PacketsReceived flat, PacketsLost gained 10.
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{PacketsReceived: 100, PacketsLost: 10},
+	}
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("all-loss sample dropped")
+	}
+	if s.LossPct == nil {
+		t.Fatal("LossPct nil")
+	}
+	if got := *s.LossPct; got < 99.9 || got > 100.1 {
+		t.Errorf("LossPct=%v want 100.0", got)
+	}
+}

--- a/pi/digitsd/internal/webrtc/linkhealth_test.go
+++ b/pi/digitsd/internal/webrtc/linkhealth_test.go
@@ -16,22 +16,23 @@ type fakeStatsGetter struct {
 func (f *fakeStatsGetter) GetStats() pionwebrtc.StatsReport { return f.report }
 
 func TestReporterSampleNominalPath(t *testing.T) {
-	report := buildFakeReport(t, fakeInput{
-		FractionLost:  0.012, // 1.2%
+	in := fakeInput{
 		JitterSec:     0.0154,
 		RttSec:        0.072,
 		LocalCandType: pionwebrtc.ICECandidateTypeSrflx,
 		BytesSent:     5000,
 		BytesReceived: 4800,
-	})
-	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
+	}
+	r := NewReporter(&fakeStatsGetter{report: buildFakeReport(t, in)}, nil, 0)
 
 	s, ok := r.sample()
 	if !ok {
 		t.Fatal("expected sample, got drop")
 	}
-	if s.LossPct == nil || *s.LossPct < 1.15 || *s.LossPct > 1.25 {
-		t.Fatalf("loss_pct: got %v want ≈1.2", s.LossPct)
+	// First sample has no prior baseline, so LossPct stays nil even though
+	// jitter is populated immediately from InboundRTPStreamStats.
+	if s.LossPct != nil {
+		t.Fatalf("loss_pct: got %v want nil on first sample", *s.LossPct)
 	}
 	if s.JitterMs == nil || *s.JitterMs < 15.0 || *s.JitterMs > 16.0 {
 		t.Fatalf("jitter_ms: got %v want ≈15.4", s.JitterMs)
@@ -57,21 +58,21 @@ func TestReporterSampleSkipsEmptyReport(t *testing.T) {
 	}
 }
 
-func TestReporterSampleOnlyRemoteInbound(t *testing.T) {
-	// Only RR data (loss + jitter), no ICE pair. Should still emit a sample.
+func TestReporterSampleOnlyInboundRTP(t *testing.T) {
+	// Only InboundRTP data (jitter), no ICE pair. Should still emit a sample
+	// because JitterMs is populated.
 	report := pionwebrtc.StatsReport{
-		"remote-inbound-0": pionwebrtc.RemoteInboundRTPStreamStats{
-			FractionLost: 0.05,
-			Jitter:       0.010,
+		"inbound-0": pionwebrtc.InboundRTPStreamStats{
+			Jitter: 0.010,
 		},
 	}
 	r := NewReporter(&fakeStatsGetter{report: report}, nil, 0)
 	s, ok := r.sample()
 	if !ok {
-		t.Fatal("expected sample from RR-only report")
+		t.Fatal("expected sample from InboundRTP-only report")
 	}
-	if s.LossPct == nil {
-		t.Fatalf("LossPct nil")
+	if s.JitterMs == nil {
+		t.Fatalf("JitterMs nil")
 	}
 	if s.RttMs != nil {
 		t.Fatalf("RttMs should be nil without ICE pair")
@@ -128,7 +129,6 @@ func TestReporterRunCancelsCleanly(t *testing.T) {
 // --- Test helpers ---
 
 type fakeInput struct {
-	FractionLost  float64
 	JitterSec     float64
 	RttSec        float64
 	LocalCandType pionwebrtc.ICECandidateType
@@ -139,9 +139,8 @@ type fakeInput struct {
 func buildFakeReport(tb testing.TB, in fakeInput) pionwebrtc.StatsReport {
 	tb.Helper()
 	report := pionwebrtc.StatsReport{}
-	report["remote-inbound-0"] = pionwebrtc.RemoteInboundRTPStreamStats{
-		FractionLost: in.FractionLost,
-		Jitter:       in.JitterSec,
+	report["inbound-0"] = pionwebrtc.InboundRTPStreamStats{
+		Jitter: in.JitterSec,
 	}
 	report["candidate-local-0"] = pionwebrtc.ICECandidateStats{
 		ID:            "candidate-local-0",
@@ -156,4 +155,59 @@ func buildFakeReport(tb testing.TB, in fakeInput) pionwebrtc.StatsReport {
 		LocalCandidateID:     "candidate-local-0",
 	}
 	return report
+}
+
+func TestSample_PopulatesJitterFromInboundRTP(t *testing.T) {
+	g := &fakeStatsGetter{
+		report: pionwebrtc.StatsReport{
+			"id1": pionwebrtc.InboundRTPStreamStats{
+				Jitter: 0.012, // 12 ms in seconds
+			},
+		},
+	}
+	r := NewReporter(g, nil, time.Second)
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("expected sample, got drop")
+	}
+	if s.JitterMs == nil {
+		t.Fatal("JitterMs nil")
+	}
+	if got := *s.JitterMs; got < 11.9 || got > 12.1 {
+		t.Errorf("JitterMs=%v want ~12.0", got)
+	}
+}
+
+func TestSample_PopulatesLossFromInboundRTPDelta(t *testing.T) {
+	g := &fakeStatsGetter{}
+	r := NewReporter(g, nil, time.Second)
+
+	// First sample establishes baseline: 100 received, 0 lost.
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{
+			PacketsReceived: 100,
+			PacketsLost:     0,
+		},
+	}
+	if _, ok := r.sample(); !ok {
+		t.Fatal("first sample dropped unexpectedly")
+	}
+
+	// Second sample: 200 received, 5 lost since baseline (5 / (100+5) ~= 4.76%).
+	g.report = pionwebrtc.StatsReport{
+		"id1": pionwebrtc.InboundRTPStreamStats{
+			PacketsReceived: 200,
+			PacketsLost:     5,
+		},
+	}
+	s, ok := r.sample()
+	if !ok {
+		t.Fatal("second sample dropped")
+	}
+	if s.LossPct == nil {
+		t.Fatal("LossPct nil on second sample")
+	}
+	if got := *s.LossPct; got < 4.5 || got > 5.0 {
+		t.Errorf("LossPct=%v want ~4.76", got)
+	}
 }


### PR DESCRIPTION
## Why

`/calls`, `/call/live/{id}`, and `/conference/live/{uuid}` have shown `-` for **loss** and **jitter** on every call since the link-health observation deck shipped (#227 / #237 / #260 / #261). RTT, route, and bytes have always populated correctly.

Root cause is on the phone side: digitsd's link-health reporter type-asserted against `pionwebrtc.RemoteInboundRTPStreamStats` (the remote's RR view of our outbound). Pion v4.x does not emit that type in our codec configuration, so the assertion failed every tick and `LossPct` / `JitterMs` were always nil. The wire payload, server store, and templates were all correct.

## What

Switch the type assertion to `InboundRTPStreamStats` (pion's local view of the inbound stream). Jitter comes from the field directly (seconds to ms). For loss the inbound type carries lifetime `PacketsReceived` / `PacketsLost` counters, so the Reporter now keeps the previous-cycle counters and reports loss as `lostDelta * 100 / (recvDelta + lostDelta)` over the last sample window.

Followup commit on this branch tightens the loss guard with `recvDelta >= 0` (closes a corner where `PacketsReceived` decreases on track replacement), documents the single-goroutine ownership invariant on `Reporter`, refreshes the doc comments that still referred to the old RR path, and adds three guard-branch tests (counter reset, zero-traffic window, all-loss window).

This means the displayed loss/jitter is now **what each phone is hearing**, not what the remote claims about us. That is the metric users actually care about for "how good is my call quality" and matches the existing copy on the deck (`Bars show packet loss and jitter reported by each endpoint`).

## Verification

- digitsd unit tests pass (11 reporter cases covering nominal, RR-only, ICE-only, counter reset, zero-traffic, all-loss windows).
- golangci-lint clean.
- Deployed to two production phones, placed call 119 between lines 245-1234 and 245-7890. Prod DB:
  ```
  call_id | endpoint | n  | loss_n | jit_n | jit_min   | jit_max
  --------+----------+----+--------+-------+-----------+----------
      119 | 2451234  |  5 |      5 |     5 |  7.067957 | 16.259243
      119 | 2457890  |  5 |      5 |     5 | 4.220025  | 14.963619
  ```
  vs prior call 118 on the unfixed binary, same lines: `5 / 0 / 0`.
- `/call/live/119` renders both endpoints' bars with values:

  ![call 119 detail with populated loss and jitter](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-loss-jitter-call119.png)

## Test plan

- [ ] CI green (digitsd unit, server unit, server integration).
- [ ] After merge + deploy, place a call, confirm `/calls` row links into a detail view with non-dash loss / jitter for both endpoints.
- [ ] 3-way conference observation deck matrix populates per-edge loss / jitter (covered by deployment, no separate code path).