### PR TITLE
refactor(server): drop unused emailSender field on web Handler

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -144,7 +144,6 @@ func run(ctx context.Context) error {
 		HouseholdStore: householdStore,
 		PairingStore:   pairingStore,
 		LinkStore:      linkStore,
-		EmailSender:    emailSender,
 	}, web.HandlerConfig{
 		Addr:        cfg.Addr,
 		BaseURL:     cfg.BaseURL,

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/dashboard/events"
 	"github.com/justinlindh/digits/server/internal/device"
-	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/httputil"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -227,8 +226,6 @@ type Handler struct {
 	pairingStore *pairing.Store
 	// Household links
 	linkStore *household.LinkStore
-	// Email
-	emailSender email.Sender
 	// Rate limiters. All four are Handler fields so Router() has a single
 	// construction pattern; previously the magic-link verify and Google
 	// login limiters were instantiated inline inside Router(), which made
@@ -286,7 +283,6 @@ type Deps struct {
 	HouseholdStore *household.Store
 	PairingStore   *pairing.Store
 	LinkStore      *household.LinkStore
-	EmailSender    email.Sender
 }
 
 func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
@@ -414,7 +410,6 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		householdStore:     deps.HouseholdStore,
 		pairingStore:       deps.PairingStore,
 		linkStore:          deps.LinkStore,
-		emailSender:        deps.EmailSender,
 		authLimiter:        ratelimit.New(5, time.Minute),
 		magicVerifyLimiter: ratelimit.New(10, time.Minute),
 		googleLoginLimiter: ratelimit.New(10, time.Minute),

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -164,7 +164,6 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 		HouseholdStore: householdStore,
 		PairingStore:   pairingStore,
 		LinkStore:      linkStore,
-		EmailSender:    emailSender,
 	}, authStore
 }
 


### PR DESCRIPTION
The web `Handler` stored `deps.EmailSender` into an `emailSender` field that no handler method ever read. Magic-link mail is sent through `auth.Handlers`, which receives the sender directly in `signald/main.go`.

Removing the field, the matching `Deps` entry, and the now-unused `email` import leaves one less puzzle for anyone tracing where the sender ends up.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (only pre-existing autodeploy config-file-permissions test fails, unrelated)
