### PR TITLE
refactor(digitsd): expose ServiceCodeHandler callbacks as fields

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1865,7 +1865,7 @@ func main() {
 			slog.Warn("confirm: another confirmation already pending, ignoring", "prompt", promptName)
 		}
 	}
-	svcCodes.SetVolumeCallback(func(level int) {
+	svcCodes.OnVolume = func(level int) {
 		if err := phone.SetVolume(level); err != nil {
 			slog.Warn("volume set failed", "error", err)
 		}
@@ -1873,16 +1873,16 @@ func main() {
 		time.Sleep(250 * time.Millisecond)
 		doubleBeep()
 		mixer.PlayLoop("tone_dial")
-	})
-	svcCodes.SetShutdownCallback(func() {
+	}
+	svcCodes.OnShutdown = func() {
 		slog.Info("service code: executing shutdown")
 		_ = exec.Command("sudo", "shutdown", "-h", "now").Run()
-	})
-	svcCodes.SetRebootCallback(func() {
+	}
+	svcCodes.OnReboot = func() {
 		slog.Info("service code: executing reboot")
 		_ = exec.Command("sudo", "reboot").Run()
-	})
-	svcCodes.SetSetupCallback(func() {
+	}
+	svcCodes.OnSetup = func() {
 		slog.Info("service code: *#SETUP# (*#73887#) -> awaiting confirmation")
 		confirm("confirm_wifi_setup", func() {
 			slog.Info("service code setup confirmed: removing wifi-configured flag, rebooting")
@@ -1907,9 +1907,9 @@ func main() {
 			time.Sleep(200 * time.Millisecond)
 			_ = exec.Command("sudo", "reboot").Run()
 		})
-	})
+	}
 
-	svcCodes.SetAudioTestCallback(func() {
+	svcCodes.OnAudioTest = func() {
 		slog.Info("service code: *#TEST# -> audio test (record 5s, playback)")
 		mixer.StopAll()
 
@@ -1983,7 +1983,7 @@ func main() {
 
 		// Resume dial tone
 		mixer.PlayLoop("tone_dial")
-	})
+	}
 
 	// Detect SWD flash capability. Start with file existence checks; if the
 	// required binaries are present, probe the SWD bus in the background to
@@ -2012,7 +2012,7 @@ func main() {
 		}()
 	}
 
-	svcCodes.SetRepairCallback(func() {
+	svcCodes.OnRepair = func() {
 		slog.Info("service code: *#0* -> awaiting confirmation")
 		confirm("confirm_re_pair", func() {
 			slog.Info("service code repair confirmed: clearing device token, rebooting into pairing mode")
@@ -2033,20 +2033,20 @@ func main() {
 			}
 			_ = exec.Command("sudo", "reboot").Run()
 		})
-	})
+	}
 
-	svcCodes.SetUpdateCallback(func() {
+	svcCodes.OnUpdate = func() {
 		slog.Info("service code: *#UPDATE# (*#873283#) -- checking for updates")
 		go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion, "", "", flashCapable.Load(), nil, requeryFirmware)
-	})
+	}
 
-	svcCodes.SetFactoryResetCallback(func() {
+	svcCodes.OnFactoryReset = func() {
 		slog.Info("service code: *#00000# -> awaiting confirmation")
 		confirm("confirm_factory_reset", func() {
 			slog.Info("service code factory reset confirmed")
 			triggerFactoryReset(sig, deviceID)
 		})
-	})
+	}
 
 	// 6b. Create easter egg detector
 	easterEggs := phone.NewEasterEggDetector([]phone.EasterEgg{

--- a/pi/digitsd/internal/phone/servicecodes.go
+++ b/pi/digitsd/internal/phone/servicecodes.go
@@ -23,7 +23,9 @@ const (
 )
 
 // ServiceCodeHandler processes hidden service codes entered via the keypad.
-// Codes are detected from a rolling key buffer.
+// Codes are detected from a rolling key buffer. Callers assign the OnXxx
+// callbacks directly after construction; nil entries make the matching code
+// a no-op (the code is still consumed and the buffer cleared).
 //
 // Fixed codes:
 //
@@ -31,71 +33,35 @@ const (
 //	*##*     → reboot
 //	*#8378#  → *#TEST# — audio test (records clip, plays back)
 //	*#73887# → *#SETUP# — Wi-Fi re-provisioning (removes /data/wifi-configured, reboots)
+//	*#0*     → force re-pair
+//	*#00000# → factory reset
+//	*#873283# → *#UPDATE# — check for updates
 //
 // Volume codes: *#*N where N=0-9
 type ServiceCodeHandler struct {
-	buffer      string
-	onVolume    func(level int)
-	onAudioTest func()
-	onShutdown  func()
-	onReboot    func()
-	onSetup        func()
-	onRepair       func()
-	onFactoryReset func()
-	onUpdate       func()
+	OnVolume       func(level int)
+	OnAudioTest    func()
+	OnShutdown     func()
+	OnReboot       func()
+	OnSetup        func()
+	OnRepair       func()
+	OnFactoryReset func()
+	OnUpdate       func()
+
+	buffer string
 }
 
 // bufferMaxLen is the maximum number of keys kept in the rolling buffer.
 // Must be >= the longest service code (currently *#873283# = 9 chars).
 const bufferMaxLen = 9
 
-// NewServiceCodeHandler creates a new handler with no callbacks set.
-func NewServiceCodeHandler() *ServiceCodeHandler {
-	return &ServiceCodeHandler{}
-}
-
-// SetVolumeCallback sets the function called when a volume code (*#*N) is entered.
-func (h *ServiceCodeHandler) SetVolumeCallback(fn func(level int)) {
-	h.onVolume = fn
-}
-
-// SetAudioTestCallback sets the function called for *#8378# (*#TEST#).
-func (h *ServiceCodeHandler) SetAudioTestCallback(fn func()) {
-	h.onAudioTest = fn
-}
-
-// SetShutdownCallback sets the function called for *#*# (shutdown).
-func (h *ServiceCodeHandler) SetShutdownCallback(fn func()) {
-	h.onShutdown = fn
-}
-
-// SetRebootCallback sets the function called for *##* (reboot).
-func (h *ServiceCodeHandler) SetRebootCallback(fn func()) {
-	h.onReboot = fn
-}
-
 // WifiConfiguredFlag is the sentinel file that indicates Wi-Fi has been
 // provisioned. Its absence triggers AP mode on next boot.
 const WifiConfiguredFlag = "/data/wifi-configured"
 
-// SetSetupCallback sets the function called for *#73887# (*#SETUP#).
-func (h *ServiceCodeHandler) SetSetupCallback(fn func()) {
-	h.onSetup = fn
-}
-
-// SetRepairCallback sets the function called for *#0* (force re-pairing).
-func (h *ServiceCodeHandler) SetRepairCallback(fn func()) {
-	h.onRepair = fn
-}
-
-// SetFactoryResetCallback sets the function called for *#00000# (factory reset).
-func (h *ServiceCodeHandler) SetFactoryResetCallback(fn func()) {
-	h.onFactoryReset = fn
-}
-
-// SetUpdateCallback sets the function called for *#873283# (*#UPDATE#).
-func (h *ServiceCodeHandler) SetUpdateCallback(fn func()) {
-	h.onUpdate = fn
+// NewServiceCodeHandler creates a new handler with no callbacks set.
+func NewServiceCodeHandler() *ServiceCodeHandler {
+	return &ServiceCodeHandler{}
 }
 
 // AddKey processes a keypress. Returns the kind of code that was triggered
@@ -129,8 +95,8 @@ func (h *ServiceCodeHandler) check() ServiceCodeResult {
 		last9 := h.buffer[len(h.buffer)-9:]
 		if last9 == "*#873283#" {
 			slog.Info("service code: *#873283# (*#UPDATE#) -> check for updates")
-			if h.onUpdate != nil {
-				go h.onUpdate()
+			if h.OnUpdate != nil {
+				go h.OnUpdate()
 			}
 			h.buffer = ""
 			return ServiceCodeTerminal
@@ -144,16 +110,16 @@ func (h *ServiceCodeHandler) check() ServiceCodeResult {
 		switch last8 {
 		case "*#00000#":
 			slog.Info("service code: *#00000# -> factory reset")
-			if h.onFactoryReset != nil {
-				go h.onFactoryReset()
+			if h.OnFactoryReset != nil {
+				go h.OnFactoryReset()
 			}
 			h.buffer = ""
 			return ServiceCodeTerminal
 		}
 		if last8 == "*#73887#" {
 			slog.Info("service code: *#73887# (*#SETUP#) -> Wi-Fi re-provisioning")
-			if h.onSetup != nil {
-				go h.onSetup()
+			if h.OnSetup != nil {
+				go h.OnSetup()
 			} else {
 				slog.Info("service code: *#73887# triggered but no setup callback registered -- ignoring")
 			}
@@ -169,8 +135,8 @@ func (h *ServiceCodeHandler) check() ServiceCodeResult {
 		last7 := h.buffer[len(h.buffer)-7:]
 		if last7 == "*#8378#" {
 			slog.Info("service code: *#8378# (*#TEST#) -> audio test")
-			if h.onAudioTest != nil {
-				go h.onAudioTest()
+			if h.OnAudioTest != nil {
+				go h.OnAudioTest()
 			}
 			h.buffer = ""
 			return ServiceCodeNonTerminal
@@ -187,22 +153,22 @@ func (h *ServiceCodeHandler) check() ServiceCodeResult {
 	switch last4 {
 	case "*#0*":
 		slog.Info("service code: *#0* -> force re-pair")
-		if h.onRepair != nil {
-			go h.onRepair()
+		if h.OnRepair != nil {
+			go h.OnRepair()
 		}
 		h.buffer = ""
 		return ServiceCodeTerminal
 	case "*#*#":
 		slog.Info("service code: *#*# -> shutdown")
-		if h.onShutdown != nil {
-			go h.onShutdown()
+		if h.OnShutdown != nil {
+			go h.OnShutdown()
 		}
 		h.buffer = ""
 		return ServiceCodeTerminal
 	case "*##*":
 		slog.Info("service code: *##* -> reboot")
-		if h.onReboot != nil {
-			go h.onReboot()
+		if h.OnReboot != nil {
+			go h.OnReboot()
 		}
 		h.buffer = ""
 		return ServiceCodeTerminal
@@ -213,9 +179,9 @@ func (h *ServiceCodeHandler) check() ServiceCodeResult {
 		ch := last4[3]
 		if ch >= '0' && ch <= '9' {
 			level := int(ch - '0')
-			if h.onVolume != nil {
+			if h.OnVolume != nil {
 				slog.Info("service code: volume", "level", level)
-				h.onVolume(level)
+				h.OnVolume(level)
 			}
 			h.buffer = ""
 			return ServiceCodeNonTerminal

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -31,7 +31,7 @@ func TestServiceCodeReboot(t *testing.T) {
 func TestServiceCodeVolume(t *testing.T) {
 	var gotLevel int
 	h := NewServiceCodeHandler()
-	h.SetVolumeCallback(func(level int) { gotLevel = level })
+	h.OnVolume = func(level int) { gotLevel = level }
 
 	for _, k := range "*#*" {
 		h.AddKey(string(k))
@@ -46,7 +46,7 @@ func TestServiceCodeVolume(t *testing.T) {
 
 func TestServiceCodeAudioTest(t *testing.T) {
 	h := NewServiceCodeHandler()
-	h.SetAudioTestCallback(func() {})
+	h.OnAudioTest = func() {}
 
 	code := "*#8378#"
 	var triggered bool
@@ -70,7 +70,7 @@ func TestServiceCodeAudioTest(t *testing.T) {
 func TestServiceCodeVolume8Works(t *testing.T) {
 	var gotLevel int
 	h := NewServiceCodeHandler()
-	h.SetVolumeCallback(func(level int) { gotLevel = level })
+	h.OnVolume = func(level int) { gotLevel = level }
 
 	for _, k := range "*#*" {
 		h.AddKey(string(k))
@@ -131,7 +131,7 @@ func TestServiceCodeReset(t *testing.T) {
 func TestServiceCodeSetup(t *testing.T) {
 	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetSetupCallback(func() { called <- struct{}{} })
+	h.OnSetup = func() { called <- struct{}{} }
 
 	code := "*#73887#"
 	var triggered bool
@@ -161,7 +161,7 @@ func TestServiceCodeSetup(t *testing.T) {
 // don't fire.
 func TestServiceCodeSetupNotTriggeredByPrefix(t *testing.T) {
 	h := NewServiceCodeHandler()
-	h.SetSetupCallback(func() { t.Error("setup should not trigger on partial sequence") })
+	h.OnSetup = func() { t.Error("setup should not trigger on partial sequence") }
 
 	// Type all but the last character
 	for _, k := range "*#73887" {
@@ -175,7 +175,7 @@ func TestServiceCodeSetupNotTriggeredByPrefix(t *testing.T) {
 // when preceded by other keypresses (rolling buffer behavior).
 func TestServiceCodeSetupAfterOtherKeys(t *testing.T) {
 	h := NewServiceCodeHandler()
-	h.SetSetupCallback(func() {}) // register to prevent defaultSetupAction (which reboots)
+	h.OnSetup = func() {} // register to prevent defaultSetupAction (which reboots)
 
 	// Type some digits first
 	for _, k := range "555" {
@@ -199,19 +199,19 @@ func TestServiceCodeSetupAfterOtherKeys(t *testing.T) {
 // TestServiceCodeSetupRegistered verifies the setup callback is stored.
 func TestServiceCodeSetupRegistered(t *testing.T) {
 	h := NewServiceCodeHandler()
-	if h.onSetup != nil {
-		t.Error("onSetup should be nil before registration")
+	if h.OnSetup != nil {
+		t.Error("OnSetup should be nil before registration")
 	}
-	h.SetSetupCallback(func() {})
-	if h.onSetup == nil {
-		t.Error("onSetup should be non-nil after registration")
+	h.OnSetup = func() {}
+	if h.OnSetup == nil {
+		t.Error("OnSetup should be non-nil after registration")
 	}
 }
 
 func TestServiceCodeRepair(t *testing.T) {
 	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetRepairCallback(func() { called <- struct{}{} })
+	h.OnRepair = func() { called <- struct{}{} }
 
 	code := "*#0*"
 	var triggered bool
@@ -237,7 +237,7 @@ func TestServiceCodeRepair(t *testing.T) {
 func TestServiceCodeFactoryReset(t *testing.T) {
 	called := make(chan struct{}, 1)
 	h := NewServiceCodeHandler()
-	h.SetFactoryResetCallback(func() { called <- struct{}{} })
+	h.OnFactoryReset = func() { called <- struct{}{} }
 
 	code := "*#00000#"
 	var triggered bool
@@ -262,8 +262,8 @@ func TestServiceCodeFactoryReset(t *testing.T) {
 
 func TestServiceCodeRepairDoesNotTriggerShutdown(t *testing.T) {
 	h := NewServiceCodeHandler()
-	h.SetShutdownCallback(func() { t.Error("shutdown should not trigger on *#0*") })
-	h.SetRepairCallback(func() {})
+	h.OnShutdown = func() { t.Error("shutdown should not trigger on *#0*") }
+	h.OnRepair = func() {}
 
 	for _, k := range "*#0*" {
 		h.AddKey(string(k))
@@ -310,7 +310,7 @@ func TestServiceCodeInCode(t *testing.T) {
 func TestFactoryResetVsRickRollEasterEgg(t *testing.T) {
 	resetFired := make(chan struct{}, 1)
 	svc := NewServiceCodeHandler()
-	svc.SetFactoryResetCallback(func() { resetFired <- struct{}{} })
+	svc.OnFactoryReset = func() { resetFired <- struct{}{} }
 
 	rickRoll := make(chan string, 1)
 	eggs := NewEasterEggDetector([]EasterEgg{


### PR DESCRIPTION
Eight `SetXxxCallback(fn)` methods each did `h.onXxx = fn` and nothing else, with one-line docstrings restating the same fact. The setters added no behavior worth preserving (no validation, no notify, no locking).

Promote the callbacks to exported fields on the struct (`OnVolume`, `OnAudioTest`, `OnShutdown`, `OnReboot`, `OnSetup`, `OnRepair`, `OnFactoryReset`, `OnUpdate`) and let callers assign them directly. The wire-up block in digitsd `main.go` now reads as a sequence of field assignments instead of setter calls; adding a future code is one struct field and one assignment instead of field + setter + docstring + call.

Net change: -67 lines, no behavior change. Tests updated to assign the new fields directly.

## Test plan
- [x] `go build ./...` (digitsd)
- [x] `go test ./...` (digitsd, all packages green)
