### PR TITLE
fix(server): propagate crypto/rand error from pairing token generation

### DIFF
--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -118,7 +118,10 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, hou
 		return "", "", fmt.Errorf("create line: %w", err)
 	}
 
-	token := randomHex(32)
+	token, err := randomHex(32)
+	if err != nil {
+		return "", "", fmt.Errorf("generate device token: %w", err)
+	}
 	tokenHash := device.HashToken(token)
 
 	// Update device: set line_id, device_token (hashed), mark as paired, clear pairing code
@@ -196,10 +199,12 @@ func (s *Store) RegenerateCode(ctx context.Context, hardwareID string) (string, 
 	return code, nil
 }
 
-func randomHex(n int) string {
+func randomHex(n int) (string, error) {
 	b := make([]byte, n)
-	rand.Read(b)
-	return hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // randomCode generates a cryptographically random numeric code of the given length.


### PR DESCRIPTION
`randomHex` in `pairing.go` discarded `crypto/rand.Read`'s error and returned the (possibly partially-zero) buffer anyway. Every other `rand.Read` call site in the repo (`auth.randomToken`, `admin.AuthStore`, `household.LinkStore`, `config.deviceid`) checks the error and bubbles it up.

Change `randomHex` to return `(string, error)` and propagate from `ClaimDevice` as `generate device token: %w`. A zero-byte rand source is exceedingly rare in practice, but a silent short or all-zero token is the wrong failure mode for a long-lived auth credential.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (unrelated autodeploy file-perms test was failing pre-change)
- [x] `go build -tags=integration ./internal/pairing/`
