### PR TITLE
feat(server): show LAN IP for each phone on /phones (owner-only)

### DIFF
--- a/server/internal/httputil/clientip.go
+++ b/server/internal/httputil/clientip.go
@@ -1,6 +1,6 @@
 // Package httputil provides small request-scoped helpers shared across
-// signald handlers. Today it carries client-IP resolution and a
-// private-address predicate.
+// signald handlers, such as client-IP resolution and a private-address
+// predicate.
 package httputil
 
 import (

--- a/server/internal/httputil/clientip.go
+++ b/server/internal/httputil/clientip.go
@@ -1,0 +1,74 @@
+// Package httputil provides small request-scoped helpers shared across
+// signald handlers. Today it carries client-IP resolution and a
+// private-address predicate.
+package httputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ClientIP returns the resolved client IP for an inbound HTTP request.
+//
+// Preference order:
+//  1. The first entry of X-Forwarded-For, trimmed.
+//  2. Host portion of r.RemoteAddr (port stripped).
+//  3. r.RemoteAddr verbatim if SplitHostPort cannot parse it.
+//
+// Assumption: a single trusted reverse proxy (nginx-proxy-manager) is the
+// only writer of X-Forwarded-For. Behind that assumption the leftmost
+// XFF entry is the original client. If the deployment grows additional
+// proxies, this function must be revisited.
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.SplitN(xff, ",", 2)
+		return strings.TrimSpace(parts[0])
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// privateNets is built once at init from the canonical CIDRs we treat
+// as "LAN-only" for display purposes: RFC1918 plus loopback (v4 and v6),
+// link-local (v4 and v6), and IPv6 ULA. Non-private ranges (public,
+// CGNAT 100.64/10) are explicitly NOT included.
+var privateNets []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"::1/128",
+		"fe80::/10",
+		"fc00::/7",
+	} {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic("httputil: bad private CIDR " + cidr + ": " + err.Error())
+		}
+		privateNets = append(privateNets, n)
+	}
+}
+
+// IsPrivateAddr reports whether ip parses as an IP address inside one of
+// the private ranges enumerated above. Empty or unparseable input returns
+// false.
+func IsPrivateAddr(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range privateNets {
+		if n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/httputil/clientip_test.go
+++ b/server/internal/httputil/clientip_test.go
@@ -18,7 +18,6 @@ func TestClientIP(t *testing.T) {
 		{name: "no_xff_uses_remoteaddr", remoteAddr: "192.168.1.42:34567", xff: "", want: "192.168.1.42"},
 		{name: "no_xff_ipv6_brackets", remoteAddr: "[fe80::1]:34567", xff: "", want: "fe80::1"},
 		{name: "no_xff_no_port_returns_raw", remoteAddr: "192.168.1.42", xff: "", want: "192.168.1.42"},
-		{name: "empty_xff_falls_through", remoteAddr: "192.168.1.42:34567", xff: "", want: "192.168.1.42"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/httputil/clientip_test.go
+++ b/server/internal/httputil/clientip_test.go
@@ -1,0 +1,74 @@
+package httputil
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{name: "xff_single", remoteAddr: "172.18.0.1:34567", xff: "192.168.1.42", want: "192.168.1.42"},
+		{name: "xff_with_spaces", remoteAddr: "172.18.0.1:34567", xff: "  192.168.1.42  ", want: "192.168.1.42"},
+		{name: "xff_multiple_takes_first", remoteAddr: "172.18.0.1:34567", xff: "192.168.1.42, 10.0.0.1, 8.8.8.8", want: "192.168.1.42"},
+		{name: "no_xff_uses_remoteaddr", remoteAddr: "192.168.1.42:34567", xff: "", want: "192.168.1.42"},
+		{name: "no_xff_ipv6_brackets", remoteAddr: "[fe80::1]:34567", xff: "", want: "fe80::1"},
+		{name: "no_xff_no_port_returns_raw", remoteAddr: "192.168.1.42", xff: "", want: "192.168.1.42"},
+		{name: "empty_xff_falls_through", remoteAddr: "192.168.1.42:34567", xff: "", want: "192.168.1.42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{
+				RemoteAddr: tc.remoteAddr,
+				Header:     make(http.Header),
+			}
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if got := ClientIP(r); got != tc.want {
+				t.Errorf("ClientIP: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPrivateAddr(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{ip: "10.0.0.1", want: true},
+		{ip: "10.255.255.255", want: true},
+		{ip: "172.16.0.1", want: true},
+		{ip: "172.31.255.254", want: true},
+		{ip: "172.32.0.1", want: false},
+		{ip: "192.168.0.1", want: true},
+		{ip: "192.168.255.255", want: true},
+		{ip: "127.0.0.1", want: true},
+		{ip: "127.255.255.255", want: true},
+		{ip: "169.254.1.1", want: true},
+		{ip: "::1", want: true},
+		{ip: "fe80::1", want: true},
+		{ip: "fc00::1", want: true},
+		{ip: "fd00::beef", want: true},
+		{ip: "8.8.8.8", want: false},
+		{ip: "1.1.1.1", want: false},
+		{ip: "100.64.0.1", want: false},
+		{ip: "100.127.255.254", want: false},
+		{ip: "2001:4860:4860::8888", want: false},
+		{ip: "", want: false},
+		{ip: "not-an-ip", want: false},
+		{ip: "192.168.1.999", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ip, func(t *testing.T) {
+			if got := IsPrivateAddr(tc.ip); got != tc.want {
+				t.Errorf("IsPrivateAddr(%q) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/ratelimit/ratelimit.go
+++ b/server/internal/ratelimit/ratelimit.go
@@ -2,11 +2,11 @@
 package ratelimit
 
 import (
-	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
+
+	"github.com/justinlindh/digits/server/internal/httputil"
 )
 
 type bucket struct {
@@ -75,24 +75,11 @@ func (l *Limiter) Cleanup() {
 // Middleware returns an http.Handler that rejects requests over the rate limit with 429.
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := clientIP(r)
+		ip := httputil.ClientIP(r)
 		if !l.Allow(ip) {
 			http.Error(w, "Too many requests. Please try again later.", http.StatusTooManyRequests)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-// clientIP extracts the client IP, preferring X-Forwarded-For (first entry).
-func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.SplitN(xff, ",", 2)
-		return strings.TrimSpace(parts[0])
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -23,6 +23,11 @@ type Conn struct {
 	Send       chan []byte
 	LastSeen   time.Time
 
+	// RemoteAddr is the resolved LAN address of the connected device, or
+	// "" when the resolved client address is not in a private range. Set
+	// once at WS upgrade time by handleWS and not mutated thereafter.
+	RemoteAddr string
+
 	// Device info (reported on connect via device_info message)
 	PiVersion       string
 	PiCommit        string
@@ -170,6 +175,14 @@ type DeviceInfoSnapshot struct {
 	PiCommit        string
 	FirmwareVersion string
 	FirmwareCommit  string
+
+	// RemoteAddr is the resolved LAN address of the connected device.
+	// Owner-scope HTML only: rendered on /phones and /phones/{number} for
+	// the device owner, never serialized to JSON, SSE, or any other
+	// external surface. The json:"-" tag enforces that for this type;
+	// downstream code that copies the field into another type must apply
+	// the same care.
+	RemoteAddr string `json:"-"`
 }
 
 // DeviceInfo returns version info for a connected phone. Returns nil if offline.
@@ -185,6 +198,7 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 		PiCommit:        conn.PiCommit,
 		FirmwareVersion: conn.FirmwareVersion,
 		FirmwareCommit:  conn.FirmwareCommit,
+		RemoteAddr:      conn.RemoteAddr,
 	}
 }
 

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -24,8 +24,8 @@ type Conn struct {
 	LastSeen   time.Time
 
 	// RemoteAddr is the resolved LAN address of the connected device, or
-	// "" when the resolved client address is not in a private range. Set
-	// once at WS upgrade time by handleWS and not mutated thereafter.
+	// "" when the resolved client address is not in a private range. The
+	// WS handler assigns it when the Conn is created; see handler_ws.go.
 	RemoteAddr string
 
 	// Device info (reported on connect via device_info message)

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -85,7 +85,7 @@ func TestDeviceInfoIncludesRemoteAddr(t *testing.T) {
 	}
 }
 
-func TestDeviceInfoRemoteAddrEmptyWhenOffline(t *testing.T) {
+func TestDeviceInfoNilWhenOffline(t *testing.T) {
 	hub := NewHub()
 	if got := hub.DeviceInfo("3140002"); got != nil {
 		t.Errorf("DeviceInfo for unregistered number = %+v, want nil", got)

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -1,6 +1,10 @@
 package signaling
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
 
 func TestUnregisterOnlyRemovesMatchingConnection(t *testing.T) {
 	hub := NewHub()
@@ -56,5 +60,69 @@ func TestRegisterHandlesAlreadyClosedSendChannel(t *testing.T) {
 
 	if got := hub.Get(number); got != newConn {
 		t.Fatalf("expected new connection to be registered")
+	}
+}
+
+func TestDeviceInfoIncludesRemoteAddr(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{
+		Send:            make(chan []byte, 1),
+		PiVersion:       "1.2.3",
+		FirmwareVersion: "0.4.0",
+		RemoteAddr:      "192.168.1.42",
+	}
+	hub.Register("3140001", conn)
+
+	info := hub.DeviceInfo("3140001")
+	if info == nil {
+		t.Fatal("DeviceInfo returned nil for registered conn")
+	}
+	if info.RemoteAddr != "192.168.1.42" {
+		t.Errorf("DeviceInfo.RemoteAddr = %q, want %q", info.RemoteAddr, "192.168.1.42")
+	}
+	if info.PiVersion != "1.2.3" {
+		t.Errorf("DeviceInfo.PiVersion = %q, want %q", info.PiVersion, "1.2.3")
+	}
+}
+
+func TestDeviceInfoRemoteAddrEmptyWhenOffline(t *testing.T) {
+	hub := NewHub()
+	if got := hub.DeviceInfo("3140002"); got != nil {
+		t.Errorf("DeviceInfo for unregistered number = %+v, want nil", got)
+	}
+}
+
+func TestRegisterOverwritesRemoteAddrOnReconnect(t *testing.T) {
+	hub := NewHub()
+	first := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.42"}
+	hub.Register("3140003", first)
+
+	second := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.99"}
+	hub.Register("3140003", second)
+
+	info := hub.DeviceInfo("3140003")
+	if info == nil {
+		t.Fatal("expected DeviceInfo after reconnect")
+	}
+	if info.RemoteAddr != "192.168.1.99" {
+		t.Errorf("RemoteAddr after reconnect = %q, want %q", info.RemoteAddr, "192.168.1.99")
+	}
+}
+
+func TestDeviceInfoSnapshotJSONOmitsRemoteAddr(t *testing.T) {
+	snap := DeviceInfoSnapshot{
+		PiVersion:       "1.2.3",
+		FirmwareVersion: "0.4.0",
+		RemoteAddr:      "192.168.1.42",
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(data, []byte("192.168.1.42")) {
+		t.Errorf("RemoteAddr value leaked into JSON: %s", data)
+	}
+	if bytes.Contains(data, []byte("RemoteAddr")) {
+		t.Errorf("RemoteAddr field name appeared in JSON: %s", data)
 	}
 }

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2227,3 +2227,64 @@ func TestHandleCalls_AM_PaginationControls(t *testing.T) {
 		}
 	}
 }
+
+func TestPhonesPage_RendersLANIPWhenSet(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	_, conn := setupLineWithConn(t, h, database, hh, "3140042", "Kitchen")
+	conn.RemoteAddr = "192.168.1.42"
+
+	req := httptest.NewRequest(http.MethodGet, "/phones", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "192.168.1.42") {
+		t.Errorf("phones page missing LAN IP %q in body", "192.168.1.42")
+	}
+}
+
+func TestPhonesPage_OmitsLANIPWhenEmpty(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	_, conn := setupLineWithConn(t, h, database, hh, "3140043", "Hallway")
+	conn.RemoteAddr = ""
+
+	req := httptest.NewRequest(http.MethodGet, "/phones", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, `class="lines__ip`) {
+		t.Errorf("phones page rendered LAN IP markup despite empty RemoteAddr")
+	}
+}
+
+func TestPhonesPage_OmitsLANIPWhenOffline(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	// Add a line WITHOUT registering a Conn: phone is offline.
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140044", "Garage", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/phones", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if strings.Contains(body, `class="lines__ip`) {
+		t.Errorf("phones page rendered LAN IP markup for offline phone")
+	}
+}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2362,3 +2362,22 @@ func TestHandleWS_RemoteAddrFallsBackToRemoteAddr(t *testing.T) {
 		t.Errorf("RemoteAddr = %q, want %q", got, "127.0.0.1")
 	}
 }
+
+func TestDashboard_DoesNotRenderLANIP(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+	_, conn := setupLineWithConn(t, h, database, hh, "3140055", "Living Room")
+	conn.RemoteAddr = "192.168.77.77"
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "192.168.77.77") {
+		t.Errorf("dashboard rendered LAN IP %q in body; this surface must not surface device IPs", "192.168.77.77")
+	}
+}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/db"
@@ -428,12 +429,12 @@ func TestNotFound(t *testing.T) {
 }
 
 // setupPairedDevice creates a paired device via the pairing flow and returns
-// the hardware ID and plaintext device token.
-func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairing.Store, householdStore *household.Store, authStore *auth.Store) (hardwareID, token string) {
+// the hardware ID, phone number, and plaintext device token.
+func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairing.Store, householdStore *household.Store, authStore *auth.Store) (hardwareID, number, token string) {
 	t.Helper()
 
 	hardwareID = fmt.Sprintf("test-hw-%d", time.Now().UnixNano())
-	number := fmt.Sprintf("99%05d", time.Now().UnixNano()%100000)
+	number = fmt.Sprintf("99%05d", time.Now().UnixNano()%100000)
 
 	// Create a household for the line
 	user, err := authStore.GetUserByEmail(context.Background(), "test@example.com")
@@ -468,7 +469,7 @@ func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairin
 		_, _ = database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
 	})
 
-	return hardwareID, token
+	return hardwareID, number, token
 }
 
 func TestPhoneRestartOnline(t *testing.T) {
@@ -1023,7 +1024,7 @@ func TestWSRegister_PairedDevice_MissingToken(t *testing.T) {
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
-	hwID, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+	hwID, _, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
 	ws := dialWS(t, srv)
 	sendMsg(t, ws, signaling.Message{
@@ -1046,7 +1047,7 @@ func TestWSRegister_PairedDevice_WrongToken(t *testing.T) {
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
-	hwID, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+	hwID, _, _ := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
 	ws := dialWS(t, srv)
 	sendMsg(t, ws, signaling.Message{
@@ -1070,7 +1071,7 @@ func TestWSRegister_PairedDevice_CorrectToken(t *testing.T) {
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
-	hwID, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+	hwID, _, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
 	ws := dialWS(t, srv)
 	sendMsg(t, ws, signaling.Message{
@@ -2286,5 +2287,78 @@ func TestPhonesPage_OmitsLANIPWhenOffline(t *testing.T) {
 	body := w.Body.String()
 	if strings.Contains(body, `class="lines__ip`) {
 		t.Errorf("phones page rendered LAN IP markup for offline phone")
+	}
+}
+
+// runWSConnectAndCaptureAddr dials srv's /ws with the given header set,
+// sends a register message for the paired device, waits for hub registration,
+// and returns the RemoteAddr the hub stored for that connection.
+func runWSConnectAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signaling.Hub, hardwareID, number, token, xff string) string {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	headers := http.Header{}
+	if xff != "" {
+		headers.Set("X-Forwarded-For", xff)
+	}
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.WriteJSON(signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      number,
+		HardwareID:  hardwareID,
+		DeviceToken: token,
+	}); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	waitForRegister(t, hub, number)
+	c := hub.Get(number)
+	if c == nil {
+		t.Fatal("hub.Get returned nil after register")
+	}
+	return c.RemoteAddr
+}
+
+func TestHandleWS_RemoteAddrFromXFFWhenPrivate(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "192.168.1.7")
+	if got != "192.168.1.7" {
+		t.Errorf("RemoteAddr = %q, want %q", got, "192.168.1.7")
+	}
+}
+
+func TestHandleWS_RemoteAddrEmptyWhenPublicXFF(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "8.8.8.8")
+	if got != "" {
+		t.Errorf("RemoteAddr = %q, want empty for public XFF", got)
+	}
+}
+
+func TestHandleWS_RemoteAddrFallsBackToRemoteAddr(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	// httptest.Server listens on 127.0.0.1, which is in IsPrivateAddr's
+	// loopback range; with no XFF the resolved RemoteAddr should be
+	// "127.0.0.1".
+	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "")
+	if got != "127.0.0.1" {
+		t.Errorf("RemoteAddr = %q, want %q", got, "127.0.0.1")
 	}
 }

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2314,11 +2314,11 @@ func runWSConnectAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signali
 		t.Fatalf("write register: %v", err)
 	}
 	waitForRegister(t, hub, number)
-	c := hub.Get(number)
-	if c == nil {
-		t.Fatal("hub.Get returned nil after register")
+	info := hub.DeviceInfo(number)
+	if info == nil {
+		t.Fatal("hub.DeviceInfo returned nil after register")
 	}
-	return c.RemoteAddr
+	return info.RemoteAddr
 }
 
 func TestHandleWS_RemoteAddrFromXFFWhenPrivate(t *testing.T) {

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/justinlindh/digits/server/internal/httputil"
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
@@ -87,9 +88,14 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		wsWriteTimeout = 10 * time.Second
 	)
 
+	remoteAddr := httputil.ClientIP(r)
+	if !httputil.IsPrivateAddr(remoteAddr) {
+		remoteAddr = ""
+	}
 	conn := &signaling.Conn{
 		WS:         ws,
 		HardwareID: msg.HardwareID,
+		RemoteAddr: remoteAddr,
 		Send:       make(chan []byte, 32),
 		LastSeen:   time.Now(),
 	}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -160,6 +160,14 @@
                 {{end}}
               </div>
             </div>
+            {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
+            <div>
+              <div class="field__label" style="margin-bottom: 4px;">LAN IP</div>
+              <div class="hstack hstack--wrap" style="gap: 8px;">
+                <span class="num" style="font-size: 13.5px; color: var(--ink);">{{.DeviceInfo.RemoteAddr}}</span>
+              </div>
+            </div>
+            {{end}}
             {{if $.LastSeenAt}}
             <div>
               <div class="field__label" style="margin-bottom: 4px;">Last check-in</div>

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -756,6 +756,12 @@
             <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.FirmwareVersion}}{{if .DeviceInfo.FirmwareCommit}} &middot; {{.DeviceInfo.FirmwareCommit}}{{end}}</span></dd>
           </div>
           {{end}}
+          {{if and .Online .DeviceInfo.RemoteAddr}}
+          <div class="am-settings__kv-row">
+            <dt class="am-settings__kv-key am-label">LAN IP</dt>
+            <dd class="am-settings__kv-val am-well"><span class="am-led am-settings__kv-led">{{.DeviceInfo.RemoteAddr}}</span></dd>
+          </div>
+          {{end}}
         {{end}}
         {{if .LastSeenAt}}
         <div class="am-settings__kv-row">

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -357,10 +357,7 @@
       <a class="lines__row" href="/phones/{{.Line.Number}}">
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
         <span class="lines__name">{{.Line.Name}}{{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}</span>
-        <span class="lines__num">{{fmtPhone .Line.Number}}</span>
-        {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
-          <span class="lines__ip num muted">{{.DeviceInfo.RemoteAddr}}</span>
-        {{end}}
+        <span class="lines__num">{{fmtPhone .Line.Number}}{{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}<span class="lines__ip num muted" style="display: block; font-size: 11px;">{{.DeviceInfo.RemoteAddr}}</span>{{end}}</span>
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
       </a>
       {{if or .FirmwareUpdateNotes .PiUpdateNotes}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -422,7 +422,7 @@
       <div class="am-phones__row-num-caption">{{fmtPhone $l.Line.Number}}</div>
       <div class="am-roster__meta">
         {{if $l.OnCall}}IN SESSION
-        {{else if $l.Online}}ONLINE{{if and $l.DeviceInfo $l.DeviceInfo.FirmwareVersion}} &middot; FW {{$l.DeviceInfo.FirmwareVersion}}{{end}}
+        {{else if $l.Online}}ONLINE{{if and $l.DeviceInfo $l.DeviceInfo.FirmwareVersion}} &middot; FW {{$l.DeviceInfo.FirmwareVersion}}{{end}}{{if and $l.DeviceInfo $l.DeviceInfo.RemoteAddr}} &middot; {{$l.DeviceInfo.RemoteAddr}}{{end}}
         {{else}}OFFLINE
         {{end}}
         {{if $l.Line.Settings.SilentMode}} &middot; SILENT{{end}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -266,7 +266,12 @@
       <tbody>
         {{range .Lines}}
         <tr>
-          <td class="num"><a href="/phones/{{.Line.Number}}">{{fmtPhone .Line.Number}}</a></td>
+          <td class="num">
+            <a href="/phones/{{.Line.Number}}">{{fmtPhone .Line.Number}}</a>
+            {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
+              <span class="num muted" style="display: block; font-size: 11px; margin-top: 2px;">{{.DeviceInfo.RemoteAddr}}</span>
+            {{end}}
+          </td>
           <td>
             <a href="/phones/{{.Line.Number}}">{{.Line.Name}}</a>
             {{if .Line.Settings.SilentMode}}
@@ -353,6 +358,9 @@
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
         <span class="lines__name">{{.Line.Name}}{{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}</span>
         <span class="lines__num">{{fmtPhone .Line.Number}}</span>
+        {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
+          <span class="lines__ip num muted">{{.DeviceInfo.RemoteAddr}}</span>
+        {{end}}
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
       </a>
       {{if or .FirmwareUpdateNotes .PiUpdateNotes}}


### PR DESCRIPTION
## Summary

Surfaces each paired phone's LAN IP on `/phones` and `/phones/{number}`, owner-scope only, present-tense only. Closes #381.

- New `server/internal/httputil` package with `ClientIP` (XFF first, RemoteAddr fallback, host-only) and `IsPrivateAddr` (RFC1918 + loopback + link-local + ULA). The rate limiter now consumes both helpers instead of carrying its own copy.
- `signaling.Conn.RemoteAddr` is set at WS upgrade time, suppressed to `""` for any non-private address (the LAN-only filter), and surfaced through the existing `Hub.DeviceInfo` snapshot. The snapshot's new field carries `json:"-"` and a doc comment marking it owner-scope HTML only; the `TestDeviceInfoSnapshotJSONOmitsRemoteAddr` test pins that contract.
- All three themes (intercom, dialup, answering-machine) render the IP on both the list and detail pages, gated by `online && DeviceInfo.RemoteAddr != ""`. Layout fix on the mobile card: the IP nests inside `lines__num` so the four-column grid stays four-children.
- Integration tests cover `/phones` rendering (set / empty / offline), `handleWS` capture (private XFF, public XFF, loopback fallback), and a defense-in-depth pin that the dashboard does not render the IP.

## Threat model note

The "linked households don't see this" part of the original issue framing is operational ("not a surface they need"), not privacy. Linked households already learn each other's LAN and public addresses via WebRTC ICE candidate exchange during a call. The `json:"-"` tag and the dashboard pin are defense in depth against accidental future serialization, not a meaningful new privacy boundary. Surfacing peer IPs in call logs / link-health is a separate idea worth its own issue if interesting.

## Test plan

- [x] Unit: `httputil.{ClientIP,IsPrivateAddr}`, `signaling.Hub.DeviceInfo` round-trip, JSON-omit pin.
- [x] Integration: `/phones` rendering (3 cases), `handleWS` capture (3 cases), dashboard pin.
- [x] `make test` and `golangci-lint run ./...` clean.
- [x] `make test-integration` (full suite, ephemeral DB, serial) green.
- [ ] Per-theme `agent-browser` screenshots against prod. **To be added after a worktree deploy.**

## Screenshots

To be added after deploying the branch to the GPU box.
