### PR TITLE
fix(digitsd): survive signald connect failure so wifi-fallback can run

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2168,12 +2168,18 @@ func main() {
 		requestICEServers(sig)
 	}
 
-	// Refresh ICE credentials periodically (TURN creds are time-limited)
+	// Refresh ICE credentials periodically (TURN creds are time-limited).
+	// Read cb.sig under cb.mu so we use the current client after reconnects.
 	go func() {
 		ticker := time.NewTicker(30 * time.Minute)
 		defer ticker.Stop()
 		for range ticker.C {
-			requestICEServers(sig)
+			cb.mu.Lock()
+			s := cb.sig
+			cb.mu.Unlock()
+			if s != nil {
+				requestICEServers(s)
+			}
 		}
 	}()
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2121,9 +2121,30 @@ func main() {
 	}
 	defer sockSrv.Close()
 
-	// 10. Connect signaling client
-	if err := sig.Connect(); err != nil {
-		log.Fatalf("signald connect: %v", err)
+	// 10. WiFi auto-fallback supervisor. Must start before the signaling
+	// connect attempt: if the network is wedged (wrong WiFi password, DNS
+	// failure), the supervisor is the only path back to AP/setup mode.
+	wifiSupervisor := wififallback.NewSupervisor(
+		cfg.WiFiFallback,
+		wififallback.NewNMCLIChecker(),
+		wififallback.NewScriptAPController(),
+		ctrl.IsCallActive,
+		slog.Default().With("subsystem", "wifi-fallback"),
+	)
+	wifiCtx, wifiCancel := context.WithCancel(context.Background())
+	defer wifiCancel()
+	go wifiSupervisor.Run(wifiCtx)
+
+	// Clear boot counter: digitsd reached its main daemon phase with the
+	// wifi-fallback supervisor running. Even if the network is down, the
+	// supervisor will eventually bring the device into AP mode, so the
+	// device is not wedged. The initramfs boot-check increments this
+	// counter on every boot; clearing it here prevents threshold-based
+	// recovery from triggering on a device that is functioning normally.
+	if err := bootcount.Clear(bootcount.DefaultPath); err != nil {
+		slog.Warn("failed to clear boot counter", "err", err)
+	} else {
+		slog.Info("boot counter: cleared (healthy boot)")
 	}
 
 	// 11. Ready
@@ -2139,15 +2160,13 @@ func main() {
 		slog.Debug("watchdog: not available", "err", err)
 	}
 
-	// Clear boot counter (we're healthy)
-	if err := bootcount.Clear(bootcount.DefaultPath); err != nil {
-		slog.Warn("failed to clear boot counter", "err", err)
+	// 12. Connect signaling client (non-fatal: the main loop reconnects)
+	if err := sig.Connect(); err != nil {
+		slog.Warn("signald connect failed, will retry", "error", err)
 	} else {
-		slog.Info("boot counter: cleared (healthy boot)")
+		sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+		requestICEServers(sig)
 	}
-
-	sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
-	requestICEServers(sig)
 
 	// Refresh ICE credentials periodically (TURN creds are time-limited)
 	go func() {
@@ -2157,21 +2176,6 @@ func main() {
 			requestICEServers(sig)
 		}
 	}()
-
-	// WiFi auto-fallback supervisor. Watches NM connectivity and flips the
-	// device into setup-AP mode if the configured network is unreachable for
-	// longer than the grace window. Held during active calls. Disabled when
-	// cfg.WiFiFallback.Enabled is false.
-	wifiSupervisor := wififallback.NewSupervisor(
-		cfg.WiFiFallback,
-		wififallback.NewNMCLIChecker(),
-		wififallback.NewScriptAPController(),
-		ctrl.IsCallActive,
-		slog.Default().With("subsystem", "wifi-fallback"),
-	)
-	wifiCtx, wifiCancel := context.WithCancel(context.Background())
-	defer wifiCancel()
-	go wifiSupervisor.Run(wifiCtx)
 
 	// Pairing code refresh: reconnect before the code expires so the
 	// server issues a fresh one. Timer starts when we receive a code.

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -49,7 +49,8 @@ func (c *Client) SetInsecureSkipTLS(skip bool) {
 }
 
 // Connect dials the WebSocket URL, sends a register message, and starts
-// the readPump goroutine.
+// the readPump goroutine. On failure, the done channel is closed so that
+// callers selecting on Done() can detect the failure and retry.
 func (c *Client) Connect() error {
 	dialer := websocket.DefaultDialer
 	if c.insecureSkipTLS {
@@ -59,29 +60,35 @@ func (c *Client) Connect() error {
 	}
 	conn, _, err := dialer.Dial(c.url, http.Header{})
 	if err != nil {
+		close(c.done)
 		return fmt.Errorf("signal: dial %s: %w", c.url, err)
 	}
 	c.conn = conn
+
+	ok := false
+	defer func() {
+		if !ok {
+			_ = conn.Close()
+			close(c.done)
+		}
+	}()
 
 	// Send registration
 	reg := &Message{Type: TypeRegister, Number: c.number, HardwareID: c.hardwareID, DeviceToken: c.deviceToken}
 	data, err := reg.Marshal()
 	if err != nil {
-		_ = conn.Close()
 		return fmt.Errorf("signal: marshal register: %w", err)
 	}
 	c.mu.Lock()
 	err = conn.WriteMessage(websocket.TextMessage, data)
 	c.mu.Unlock()
 	if err != nil {
-		_ = conn.Close()
 		return fmt.Errorf("signal: send register: %w", err)
 	}
 
 	// Reset read deadline on each server ping so Cloudflare/proxy
 	// idle timeouts don't kill the connection.
 	if err := c.conn.SetReadDeadline(time.Now().Add(pingTimeout)); err != nil {
-		_ = conn.Close()
 		return fmt.Errorf("signal: set read deadline: %w", err)
 	}
 	c.conn.SetPingHandler(func(appData string) error {
@@ -92,6 +99,7 @@ func (c *Client) Connect() error {
 	})
 
 	go c.readPump()
+	ok = true
 	return nil
 }
 

--- a/pi/digitsd/internal/signal/client_test.go
+++ b/pi/digitsd/internal/signal/client_test.go
@@ -112,6 +112,20 @@ func TestClient_ReceiveMessages(t *testing.T) {
 	}
 }
 
+// TestClient_ConnectFailureClosesDone verifies that a failed Connect() closes
+// the Done() channel so callers can detect the failure and retry.
+func TestClient_ConnectFailureClosesDone(t *testing.T) {
+	c := NewClient("ws://127.0.0.1:1/ws", "+15550001111", "test-hw-id", "")
+	if err := c.Connect(); err == nil {
+		t.Fatal("expected Connect to fail on unreachable host")
+	}
+	select {
+	case <-c.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() channel not closed after Connect failure")
+	}
+}
+
 // TestClient_SendMessage verifies that Send() delivers a message to the server.
 func TestClient_SendMessage(t *testing.T) {
 	received := make(chan *Message, 1)

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-ap-check
@@ -94,11 +94,12 @@ reset_wifi_config() {
 do_station_up() {
     log "Wi-Fi configured -- starting normal boot"
 
-    # Clear boot counter -- we reached userspace successfully. digitsd
-    # will clear it again later, but doing it here covers the window
-    # between boot and digitsd startup.
-    BOOT_COUNTER="/data/digits/boot-counter"
-    echo "0" > "$BOOT_COUNTER" 2>/dev/null || true
+    # Boot counter is NOT cleared here. The initramfs boot-check
+    # increments it on every boot; only digitsd clears it once it
+    # reaches a healthy main loop with the wifi-fallback supervisor
+    # running. Clearing it here defeats the boot-counter recovery
+    # path: a device with a wrong WiFi password would reset the
+    # counter every boot and never reach the threshold.
 
     # Stop AP services
     systemctl stop digits-ap.service digits-dnsmasq-ap.service digits-setup.service 2>/dev/null || true


### PR DESCRIPTION
## Summary

When a wrong WiFi password is entered during setup, NM fails and digitsd's
signaling dial fails with a DNS error. `log.Fatalf` on that failure killed
digitsd before the wifi-fallback supervisor could start, permanently wedging
the device with no path back to AP/setup mode.

- **Signal client**: `Connect()` now closes the `done` channel on failure so
  the main loop's reconnect case fires immediately.
- **digitsd main**: initial `sig.Connect()` failure is non-fatal. The existing
  reconnect loop (exponential backoff, max 60s) handles retry.
- **Boot ordering**: wifi-fallback supervisor and boot-counter clear are moved
  before `sig.Connect()` so they always execute regardless of network state.
- **digits-ap-check**: `do_station_up` no longer clears the boot counter. That
  early clear defeated the initramfs boot-counter recovery path (counter was
  reset to 0 on every boot before digitsd could fail, so the threshold of 3
  was never reached).

Root-caused from SD card journal analysis of a device stuck in this state:
NM logged `no secrets: No agents were available for this request`, digitsd
crash-looped at restart counter 61, boot counter stuck at 0.

## Test plan

- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] All existing signal client tests pass
- [x] New `TestClient_ConnectFailureClosesDone` verifies done channel closes
- [x] All wififallback supervisor tests pass
- [x] Full `go test ./...` passes (all packages)