### PR TITLE
feat(pi): add numpad panic button for recovery mode

### DIFF
--- a/pi/digits-panic-check/go.mod
+++ b/pi/digits-panic-check/go.mod
@@ -1,0 +1,5 @@
+module github.com/justinlindh/digits/pi/digits-panic-check
+
+go 1.26
+
+require golang.org/x/sys v0.41.0

--- a/pi/digits-panic-check/go.sum
+++ b/pi/digits-panic-check/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/pi/digits-panic-check/main.go
+++ b/pi/digits-panic-check/main.go
@@ -178,16 +178,20 @@ func parseStarHeld(lines []string) (bool, error) {
 // parseScanLine checks whether the given column reads 0 (pressed) in a
 // SCAN line like "SCAN R3/GP25=LOW: C0=0 C1=1 C2=1".
 func parseScanLine(line string, col int) (bool, error) {
+	colData := line
+	if i := strings.Index(line, ": "); i >= 0 {
+		colData = line[i+2:]
+	}
 	target := fmt.Sprintf("C%d=", col)
-	idx := strings.Index(line, target)
+	idx := strings.Index(colData, target)
 	if idx < 0 {
 		return false, fmt.Errorf("column C%d not found in %q", col, line)
 	}
 	valPos := idx + len(target)
-	if valPos >= len(line) {
+	if valPos >= len(colData) {
 		return false, fmt.Errorf("no value after C%d= in %q", col, line)
 	}
-	return line[valPos] == '0', nil
+	return colData[valPos] == '0', nil
 }
 
 func main() {

--- a/pi/digits-panic-check/main.go
+++ b/pi/digits-panic-check/main.go
@@ -1,0 +1,205 @@
+// digits-panic-check reads the keypad matrix from the Pico over UART and
+// enters recovery mode if the * key is held during early boot.
+//
+// Exit codes:
+//   0: no key held, or Pico not responding (normal boot continues)
+//   1: * key detected, recovery flag written, reboot initiated
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	defaultSerialDev  = "/dev/serial0"
+	defaultBaud       = 115200
+	recoveryFlagPath  = "/data/digits/recovery-mode"
+	keydumpTimeout    = 2 * time.Second
+	starKeyRow        = 3
+	starKeyCol        = 0
+	keydumpTotalLines = 6 // 1 ROWS + 1 COLS + 4 SCAN
+)
+
+// serialOpener abstracts serial port construction for testing.
+type serialOpener func(device string, baud int) (io.ReadWriteCloser, error)
+
+// rebootFunc abstracts the reboot call for testing.
+type rebootFunc func() error
+
+// config holds runtime settings, injectable for testing.
+type config struct {
+	serialDev        string
+	baud             int
+	recoveryFlagPath string
+	openSerial       serialOpener
+	reboot           rebootFunc
+}
+
+func defaultConfig() config {
+	return config{
+		serialDev:        defaultSerialDev,
+		baud:             defaultBaud,
+		recoveryFlagPath: recoveryFlagPath,
+		openSerial:       openSerial,
+		reboot: func() error {
+			return exec.Command("systemctl", "reboot").Run()
+		},
+	}
+}
+
+// run executes the panic check. Returns true if recovery was triggered.
+func run(cfg config) (bool, error) {
+	port, err := cfg.openSerial(cfg.serialDev, cfg.baud)
+	if err != nil {
+		// Serial port not available: don't block boot.
+		log.Printf("cannot open serial port: %v (continuing normal boot)", err)
+		return false, nil
+	}
+	defer port.Close()
+
+	// Send KEYDUMP command.
+	if _, err := port.Write([]byte("KEYDUMP\n")); err != nil {
+		log.Printf("cannot write KEYDUMP: %v (continuing normal boot)", err)
+		return false, nil
+	}
+
+	// Read response lines with a timeout.
+	lines, err := readLines(port, keydumpTotalLines, keydumpTimeout)
+	if err != nil {
+		log.Printf("KEYDUMP read failed: %v (continuing normal boot)", err)
+		return false, nil
+	}
+
+	// Parse scan lines and check if * is held.
+	held, err := parseStarHeld(lines)
+	if err != nil {
+		log.Printf("KEYDUMP parse failed: %v (continuing normal boot)", err)
+		return false, nil
+	}
+
+	if !held {
+		log.Println("no panic key held, continuing normal boot")
+		return false, nil
+	}
+
+	log.Println("* key held: entering recovery mode")
+
+	// Write recovery flag.
+	flagDir := filepath.Dir(cfg.recoveryFlagPath)
+	if err := os.MkdirAll(flagDir, 0755); err != nil {
+		return false, fmt.Errorf("mkdir %s: %w", flagDir, err)
+	}
+	if err := os.WriteFile(cfg.recoveryFlagPath, []byte("panic-button\n"), 0644); err != nil {
+		return false, fmt.Errorf("write recovery flag: %w", err)
+	}
+
+	// Close serial port before reboot so digitsd does not get EBUSY.
+	port.Close()
+
+	if err := cfg.reboot(); err != nil {
+		return true, fmt.Errorf("reboot: %w", err)
+	}
+	return true, nil
+}
+
+// readLines reads up to count newline-delimited lines from r within the
+// given timeout. Returns whatever lines were collected if the timeout fires
+// before all lines arrive.
+func readLines(r io.Reader, count int, timeout time.Duration) ([]string, error) {
+	type result struct {
+		line string
+		err  error
+	}
+
+	ch := make(chan result, count)
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			ch <- result{line: scanner.Text()}
+		}
+		if err := scanner.Err(); err != nil {
+			ch <- result{err: err}
+		}
+		close(ch)
+	}()
+
+	var lines []string
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for len(lines) < count {
+		select {
+		case res, ok := <-ch:
+			if !ok {
+				return lines, fmt.Errorf("serial closed after %d lines (expected %d)", len(lines), count)
+			}
+			if res.err != nil {
+				return lines, res.err
+			}
+			lines = append(lines, res.line)
+		case <-timer.C:
+			return lines, fmt.Errorf("timeout after %d lines (expected %d)", len(lines), count)
+		}
+	}
+	return lines, nil
+}
+
+// parseStarHeld checks the KEYDUMP output for the * key (row 3, col 0).
+// A column value of 0 means the key is pressed.
+//
+// Expected format (6 lines):
+//
+//	ROWS: R0/GP27=1 R1/GP26=1 ...
+//	COLS: C0/GP24=1 C1/GP23=1 ...
+//	SCAN R0/GP27=LOW: C0=1 C1=1 C2=1
+//	SCAN R1/GP26=LOW: C0=1 C1=1 C2=1
+//	SCAN R2/GP21=LOW: C0=1 C1=1 C2=1
+//	SCAN R3/GP25=LOW: C0=0 C1=1 C2=1   <-- C0=0 means * is pressed
+func parseStarHeld(lines []string) (bool, error) {
+	// Find the SCAN line for row 3.
+	scanPrefix := fmt.Sprintf("SCAN R%d/", starKeyRow)
+	for _, line := range lines {
+		if !strings.HasPrefix(line, scanPrefix) {
+			continue
+		}
+		return parseScanLine(line, starKeyCol)
+	}
+	return false, fmt.Errorf("no SCAN line found for row %d", starKeyRow)
+}
+
+// parseScanLine checks whether the given column reads 0 (pressed) in a
+// SCAN line like "SCAN R3/GP25=LOW: C0=0 C1=1 C2=1".
+func parseScanLine(line string, col int) (bool, error) {
+	target := fmt.Sprintf("C%d=", col)
+	idx := strings.Index(line, target)
+	if idx < 0 {
+		return false, fmt.Errorf("column C%d not found in %q", col, line)
+	}
+	valPos := idx + len(target)
+	if valPos >= len(line) {
+		return false, fmt.Errorf("no value after C%d= in %q", col, line)
+	}
+	return line[valPos] == '0', nil
+}
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("digits-panic-check: ")
+
+	cfg := defaultConfig()
+	triggered, err := run(cfg)
+	if err != nil {
+		log.Fatalf("fatal: %v", err)
+	}
+	if triggered {
+		os.Exit(1)
+	}
+}

--- a/pi/digits-panic-check/main_test.go
+++ b/pi/digits-panic-check/main_test.go
@@ -16,15 +16,11 @@ type mockSerial struct {
 	rx       *bytes.Buffer // data the "Pico" sends back
 	tx       bytes.Buffer  // data written by the binary
 	closed   bool
-	readErr  error       // injected read error
-	writeErr error       // injected write error
-	readDelay time.Duration // artificial delay per read
+	readErr  error // injected read error
+	writeErr error // injected write error
 }
 
 func (m *mockSerial) Read(p []byte) (int, error) {
-	if m.readDelay > 0 {
-		time.Sleep(m.readDelay)
-	}
 	if m.readErr != nil {
 		return 0, m.readErr
 	}

--- a/pi/digits-panic-check/main_test.go
+++ b/pi/digits-panic-check/main_test.go
@@ -1,0 +1,486 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockSerial implements io.ReadWriteCloser with canned responses.
+type mockSerial struct {
+	rx       *bytes.Buffer // data the "Pico" sends back
+	tx       bytes.Buffer  // data written by the binary
+	closed   bool
+	readErr  error       // injected read error
+	writeErr error       // injected write error
+	readDelay time.Duration // artificial delay per read
+}
+
+func (m *mockSerial) Read(p []byte) (int, error) {
+	if m.readDelay > 0 {
+		time.Sleep(m.readDelay)
+	}
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	return m.rx.Read(p)
+}
+
+func (m *mockSerial) Write(p []byte) (int, error) {
+	if m.writeErr != nil {
+		return 0, m.writeErr
+	}
+	return m.tx.Write(p)
+}
+
+func (m *mockSerial) Close() error {
+	m.closed = true
+	return nil
+}
+
+// keydumpResponse builds a standard KEYDUMP response with the given column
+// values for each row. Each row is a slice of 3 column values (0 or 1).
+func keydumpResponse(rows [4][3]int) string {
+	var b strings.Builder
+	b.WriteString("ROWS: R0/GP27=1 R1/GP26=1 R2/GP21=1 R3/GP25=1\n")
+	b.WriteString("COLS: C0/GP24=1 C1/GP23=1 C2/GP22=1\n")
+	gpPins := [4]int{27, 26, 21, 25}
+	for r := 0; r < 4; r++ {
+		b.WriteString("SCAN R")
+		b.WriteByte('0' + byte(r))
+		b.WriteString("/GP")
+		b.WriteString(itoa(gpPins[r]))
+		b.WriteString("=LOW:")
+		for c := 0; c < 3; c++ {
+			b.WriteString(" C")
+			b.WriteByte('0' + byte(c))
+			b.WriteByte('=')
+			b.WriteByte('0' + byte(rows[r][c]))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func itoa(n int) string {
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	return string(rune('0'+n/10)) + string(rune('0'+n%10))
+}
+
+func TestParseStarHeld_Pressed(t *testing.T) {
+	// * is at row 3, col 0. C0=0 means pressed.
+	lines := strings.Split(strings.TrimSuffix(keydumpResponse([4][3]int{
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+		{0, 1, 1}, // * pressed
+	}), "\n"), "\n")
+
+	held, err := parseStarHeld(lines)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !held {
+		t.Fatal("expected * to be held")
+	}
+}
+
+func TestParseStarHeld_NotPressed(t *testing.T) {
+	lines := strings.Split(strings.TrimSuffix(keydumpResponse([4][3]int{
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1}, // nothing pressed
+	}), "\n"), "\n")
+
+	held, err := parseStarHeld(lines)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if held {
+		t.Fatal("expected * to NOT be held")
+	}
+}
+
+func TestParseStarHeld_OtherKeyPressed(t *testing.T) {
+	// Row 3, col 1 is '0' key. Should not trigger.
+	lines := strings.Split(strings.TrimSuffix(keydumpResponse([4][3]int{
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 0, 1}, // 0 key pressed, not *
+	}), "\n"), "\n")
+
+	held, err := parseStarHeld(lines)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if held {
+		t.Fatal("expected * to NOT be held when 0 key is pressed")
+	}
+}
+
+func TestParseStarHeld_NoScanLines(t *testing.T) {
+	lines := []string{
+		"ROWS: R0/GP27=1",
+		"COLS: C0/GP24=1",
+	}
+	_, err := parseStarHeld(lines)
+	if err == nil {
+		t.Fatal("expected error for missing scan lines")
+	}
+}
+
+func TestParseStarHeld_MalformedScanLine(t *testing.T) {
+	lines := []string{
+		"ROWS: R0/GP27=1",
+		"COLS: C0/GP24=1",
+		"SCAN R0/GP27=LOW: garbage",
+		"SCAN R1/GP26=LOW: garbage",
+		"SCAN R2/GP21=LOW: garbage",
+		"SCAN R3/GP25=LOW: garbage",
+	}
+	_, err := parseStarHeld(lines)
+	if err == nil {
+		t.Fatal("expected error for malformed scan line")
+	}
+}
+
+func TestParseScanLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		col     int
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "col0 pressed",
+			line: "SCAN R3/GP25=LOW: C0=0 C1=1 C2=1",
+			col:  0,
+			want: true,
+		},
+		{
+			name: "col0 not pressed",
+			line: "SCAN R3/GP25=LOW: C0=1 C1=1 C2=1",
+			col:  0,
+			want: false,
+		},
+		{
+			name: "col1 pressed",
+			line: "SCAN R3/GP25=LOW: C0=1 C1=0 C2=1",
+			col:  1,
+			want: true,
+		},
+		{
+			name: "v1 four columns",
+			line: "SCAN R3/GP5=LOW: C0=0 C1=1 C2=1 C3=1",
+			col:  0,
+			want: true,
+		},
+		{
+			name:    "missing column",
+			line:    "SCAN R3/GP25=LOW: C1=1 C2=1",
+			col:     0,
+			wantErr: true,
+		},
+		{
+			name:    "truncated value",
+			line:    "SCAN R3/GP25=LOW: C0=",
+			col:     0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseScanLine(tt.line, tt.col)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRun_StarHeld(t *testing.T) {
+	tmpDir := t.TempDir()
+	flagPath := filepath.Join(tmpDir, "recovery-mode")
+
+	response := keydumpResponse([4][3]int{
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+		{0, 1, 1},
+	})
+
+	mock := &mockSerial{rx: bytes.NewBufferString(response)}
+	rebooted := false
+
+	cfg := config{
+		serialDev:        "/dev/serial0",
+		baud:             115200,
+		recoveryFlagPath: flagPath,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			rebooted = true
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !triggered {
+		t.Fatal("expected recovery to be triggered")
+	}
+	if !rebooted {
+		t.Fatal("expected reboot to be called")
+	}
+	if !mock.closed {
+		t.Fatal("expected serial port to be closed")
+	}
+
+	data, err := os.ReadFile(flagPath)
+	if err != nil {
+		t.Fatalf("recovery flag not written: %v", err)
+	}
+	if !strings.Contains(string(data), "panic-button") {
+		t.Fatalf("unexpected flag content: %q", string(data))
+	}
+}
+
+func TestRun_NoKeyHeld(t *testing.T) {
+	response := keydumpResponse([4][3]int{
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+		{1, 1, 1},
+	})
+
+	mock := &mockSerial{rx: bytes.NewBufferString(response)}
+
+	cfg := config{
+		serialDev:        "/dev/serial0",
+		baud:             115200,
+		recoveryFlagPath: "/nonexistent/recovery-mode",
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger")
+	}
+}
+
+func TestRun_SerialOpenFails(t *testing.T) {
+	cfg := config{
+		serialDev: "/dev/serial0",
+		baud:      115200,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return nil, errors.New("device not found")
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger on serial failure")
+	}
+}
+
+func TestRun_PicoNotResponding(t *testing.T) {
+	// Mock that never sends any data (simulates unresponsive Pico).
+	mock := &mockSerial{rx: bytes.NewBuffer(nil)}
+
+	cfg := config{
+		serialDev: "/dev/serial0",
+		baud:      115200,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger on timeout")
+	}
+}
+
+func TestRun_WriteFails(t *testing.T) {
+	mock := &mockSerial{
+		rx:       bytes.NewBuffer(nil),
+		writeErr: errors.New("write error"),
+	}
+
+	cfg := config{
+		serialDev: "/dev/serial0",
+		baud:      115200,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger on write failure")
+	}
+}
+
+func TestRun_MalformedResponse(t *testing.T) {
+	mock := &mockSerial{
+		rx: bytes.NewBufferString("garbage line 1\ngarbage line 2\ngarbage 3\ngarbage 4\ngarbage 5\ngarbage 6\n"),
+	}
+
+	cfg := config{
+		serialDev: "/dev/serial0",
+		baud:      115200,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger on malformed response")
+	}
+}
+
+func TestRun_PartialResponse(t *testing.T) {
+	// Only 3 lines instead of 6.
+	mock := &mockSerial{
+		rx: bytes.NewBufferString("ROWS: R0/GP27=1\nCOLS: C0/GP24=1\nSCAN R0/GP27=LOW: C0=1\n"),
+	}
+
+	cfg := config{
+		serialDev: "/dev/serial0",
+		baud:      115200,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			t.Fatal("reboot should not be called")
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if triggered {
+		t.Fatal("expected no recovery trigger on partial response")
+	}
+}
+
+func TestRun_V1FourColumns(t *testing.T) {
+	// V1 board has 4 columns. * is still row 3, col 0.
+	tmpDir := t.TempDir()
+	flagPath := filepath.Join(tmpDir, "recovery-mode")
+
+	var b strings.Builder
+	b.WriteString("ROWS: R0/GP2=1 R1/GP3=1 R2/GP4=1 R3/GP5=1\n")
+	b.WriteString("COLS: C0/GP6=1 C1/GP7=1 C2/GP8=1 C3/GP9=1\n")
+	b.WriteString("SCAN R0/GP2=LOW: C0=1 C1=1 C2=1 C3=1\n")
+	b.WriteString("SCAN R1/GP3=LOW: C0=1 C1=1 C2=1 C3=1\n")
+	b.WriteString("SCAN R2/GP4=LOW: C0=1 C1=1 C2=1 C3=1\n")
+	b.WriteString("SCAN R3/GP5=LOW: C0=0 C1=1 C2=1 C3=1\n")
+
+	mock := &mockSerial{rx: bytes.NewBufferString(b.String())}
+	rebooted := false
+
+	cfg := config{
+		serialDev:        "/dev/serial0",
+		baud:             115200,
+		recoveryFlagPath: flagPath,
+		openSerial: func(string, int) (io.ReadWriteCloser, error) {
+			return mock, nil
+		},
+		reboot: func() error {
+			rebooted = true
+			return nil
+		},
+	}
+
+	triggered, err := run(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !triggered {
+		t.Fatal("expected recovery to be triggered for V1 board")
+	}
+	if !rebooted {
+		t.Fatal("expected reboot")
+	}
+}
+
+func TestReadLines_Timeout(t *testing.T) {
+	// Reader that blocks forever.
+	r, _ := io.Pipe()
+	defer r.Close()
+
+	lines, err := readLines(r, 6, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if len(lines) != 0 {
+		t.Fatalf("expected 0 lines, got %d", len(lines))
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Fatalf("expected timeout in error, got: %v", err)
+	}
+}

--- a/pi/digits-panic-check/serial_linux.go
+++ b/pi/digits-panic-check/serial_linux.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// serialPort wraps an os.File with proper termios configuration.
+type serialPort struct {
+	file *os.File
+}
+
+func (s *serialPort) Read(p []byte) (int, error)  { return s.file.Read(p) }
+func (s *serialPort) Write(p []byte) (int, error) { return s.file.Write(p) }
+func (s *serialPort) Close() error                { return s.file.Close() }
+
+// openSerial opens the given device at the specified baud rate with 8N1,
+// raw mode, and a 200ms read timeout (VTIME=2).
+func openSerial(device string, baud int) (io.ReadWriteCloser, error) {
+	f, err := os.OpenFile(device, os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", device, err)
+	}
+
+	fd := int(f.Fd())
+	t, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("tcgets: %w", err)
+	}
+
+	speed, ok := baudToSpeed(baud)
+	if !ok {
+		f.Close()
+		return nil, fmt.Errorf("unsupported baud rate: %d", baud)
+	}
+
+	// Raw mode: no echo, no canonical processing, no signals.
+	t.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP |
+		unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	t.Oflag &^= unix.OPOST
+	t.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	t.Cflag &^= unix.CSIZE | unix.PARENB
+	t.Cflag |= unix.CS8 | unix.CLOCAL | unix.CREAD
+
+	t.Ispeed = speed
+	t.Ospeed = speed
+
+	// VMIN=0, VTIME=2: read returns after 200ms with whatever is available.
+	t.Cc[unix.VMIN] = 0
+	t.Cc[unix.VTIME] = 2
+
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, t); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("tcsets: %w", err)
+	}
+
+	return &serialPort{file: f}, nil
+}
+
+func baudToSpeed(baud int) (uint32, bool) {
+	switch baud {
+	case 9600:
+		return unix.B9600, true
+	case 19200:
+		return unix.B19200, true
+	case 38400:
+		return unix.B38400, true
+	case 57600:
+		return unix.B57600, true
+	case 115200:
+		return unix.B115200, true
+	default:
+		return 0, false
+	}
+}

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -119,6 +119,11 @@ cd /digits/pi/digits-recovery
 mkdir -p bin
 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/digits-recovery .
 
+# Cross-compile digits-panic-check (pure Go + golang.org/x/sys, no CGO).
+info "Cross-compiling digits-panic-check for aarch64..."
+cd /digits/pi/digits-panic-check
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /digits/tools/build/digits-panic-check .
+
 info "Binaries ready in tools/build/"
 
 # An image without firmware is a regression we don't ship: prefer the

--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-ap-check.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-ap-check.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/digits/digits
 # Run after filesystem and first-boot are done, before networking
 DefaultDependencies=no
 Wants=digits-first-boot.service
-After=local-fs.target digits-first-boot.service
+After=local-fs.target digits-first-boot.service digits-panic-check.service
 Before=network-pre.target
 
 [Service]

--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-panic-check.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-panic-check.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Digits Numpad Panic Button Check
+Documentation=https://github.com/justinlindh/digits
+# Run after filesystem is ready but before AP check and networking.
+# If the user is holding * on the keypad, write the recovery flag and reboot.
+DefaultDependencies=no
+Wants=local-fs.target
+After=local-fs.target digits-first-boot.service
+Before=digits-ap-check.service network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/digits-panic-check
+
+[Install]
+WantedBy=sysinit.target

--- a/pi/image/rootfs-overlay/etc/systemd/system/digits-panic-check.service
+++ b/pi/image/rootfs-overlay/etc/systemd/system/digits-panic-check.service
@@ -10,6 +10,7 @@ Before=digits-ap-check.service network-pre.target
 
 [Service]
 Type=oneshot
+SuccessExitStatus=1
 ExecStart=/usr/local/bin/digits-panic-check
 
 [Install]

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -391,6 +391,7 @@ INPUT_IMG="${1:-}"
 
 # Verify pre-built binaries exist
 [[ -f "${BUILD_DIR}/digitsd" ]] || die "Missing ${BUILD_DIR}/digitsd -- run cross-compilation first (see README)"
+[[ -f "${BUILD_DIR}/digits-panic-check" ]] || die "Missing ${BUILD_DIR}/digits-panic-check -- run cross-compilation first"
 [[ -f "${REPO_DIR}/pi/digits-recovery/bin/digits-recovery" ]] || die "Missing pi/digits-recovery/bin/digits-recovery -- run pi/digits-recovery build first"
 
 # Verify overlay directory exists
@@ -615,6 +616,7 @@ hostside_add_to_groups "$ROOTFS_MNT" "digits" audio i2c
 info "Copying Digits binaries..."
 
 install -m 755 "${BUILD_DIR}/digitsd" "${ROOTFS_MNT}/usr/local/bin/digitsd"
+install -m 755 "${BUILD_DIR}/digits-panic-check" "${ROOTFS_MNT}/usr/local/bin/digits-panic-check"
 
 
 # ── step 13: copy rootfs overlay (host-side) ────────────────────────────────
@@ -1131,6 +1133,7 @@ hostside_mask_service "$ROOTFS_MNT" "logrotate.timer"
 
 # Enable Digits services
 hostside_enable_service "$ROOTFS_MNT" "digits-first-boot.service"
+hostside_enable_service "$ROOTFS_MNT" "digits-panic-check.service"
 hostside_enable_service "$ROOTFS_MNT" "digits-ap-check.service"
 hostside_enable_service "$ROOTFS_MNT" "digits-mixer.service"
 hostside_enable_service "$ROOTFS_MNT" "digitsd.service"


### PR DESCRIPTION
## Summary

- Adds `digits-panic-check`, a small Go binary that runs early in the boot sequence and checks whether the user is holding the `*` key on the phone's keypad. If held, it writes `/data/digits/recovery-mode` and reboots into recovery/AP mode.
- This is a third layer of recovery defense. Layer 1: boot counter detects crash loops. Layer 2: wifi-fallback supervisor detects stuck connections. Layer 3 (this PR): manual escape hatch for cases where neither automated path fires, such as a wrong WiFi password causing digitsd to crash-loop before the supervisor can react.
- On normal boot (no key held), the check adds ~200ms latency. On any failure (Pico unresponsive, serial errors, malformed KEYDUMP), the binary exits cleanly and boot continues.

## What changed

| File | Purpose |
|------|---------|
| `pi/digits-panic-check/main.go` | Binary: opens `/dev/serial0`, sends `KEYDUMP`, parses matrix, checks `*` key |
| `pi/digits-panic-check/serial_linux.go` | Linux termios serial port opener (raw mode, 115200 8N1) |
| `pi/digits-panic-check/main_test.go` | Unit tests for parser and full run flow (mock serial) |
| `pi/image/rootfs-overlay/.../digits-panic-check.service` | Systemd oneshot unit, runs after `local-fs.target`, before `digits-ap-check` |
| `pi/image/rootfs-overlay/.../digits-ap-check.service` | Added `After=digits-panic-check.service` |
| `pi/image/entrypoint.sh` | Cross-compiles `digits-panic-check` for aarch64 during image build |
| `tools/build-image.sh` | Installs binary to rootfs, enables service, sanity-checks binary exists |

## How it works

1. `digits-panic-check.service` runs as a oneshot early in boot
2. Binary opens `/dev/serial0` at 115200 baud, sends `KEYDUMP\n`
3. Pico responds with 6 lines: `ROWS:`, `COLS:`, and 4 `SCAN` lines (one per keypad row)
4. Binary parses `SCAN R3/...` line for `C0=0` (column 0 reading low = `*` key pressed)
5. If pressed: writes `/data/digits/recovery-mode`, closes serial, calls `systemctl reboot`
6. On next boot, initramfs `boot-check.sh` sees the flag and enters recovery (AP mode)
7. If not pressed: exits 0 immediately, boot continues

## Test plan

- [x] Unit tests pass: parser tests for pressed/not-pressed/malformed/V1-4-col/V2-3-col, full run tests for all failure modes (serial open fails, Pico timeout, write error, partial response)
- [ ] Image build with `make image-v2-dev` succeeds
- [ ] On a real device: normal boot with no key held shows <1s added latency
- [ ] On a real device: hold `*` during power-on, device enters recovery AP mode