### PR TITLE
fix(server): self-report LAN IP from device, not WS upgrade

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"log/slog"
 	"math"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -2817,6 +2818,7 @@ func requestICEServers(sig *sigclient.Client) {
 }
 
 func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapable bool) {
+	localAddr := primaryLocalAddr()
 	if err := sig.Send(&sigclient.Message{
 		Type:            sigclient.TypeDeviceInfo,
 		PiVersion:       version.Version,
@@ -2824,11 +2826,31 @@ func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapa
 		FirmwareVersion: fwVersion,
 		FirmwareCommit:  fwCommit,
 		FlashCapable:    flashCapable,
+		LocalAddr:       localAddr,
 	}); err != nil {
 		slog.Warn("device_info: send failed", "error", err)
 	} else {
-		slog.Info("device_info sent", "pi_version", version.Version, "pi_commit", version.Commit, "fw_version", fwVersion, "fw_commit", fwCommit, "flash_capable", flashCapable)
+		slog.Info("device_info sent", "pi_version", version.Version, "pi_commit", version.Commit, "fw_version", fwVersion, "fw_commit", fwCommit, "flash_capable", flashCapable, "local_addr", localAddr)
 	}
+}
+
+// primaryLocalAddr returns the source IP that the OS would use to route to
+// the public internet, which is the address the device should self-report
+// to the signaling server. Uses a UDP "dial" to a sentinel: no packet is
+// actually sent because UDP is connectionless, but the kernel resolves the
+// route and assigns a local address. Returns "" when no default route
+// exists or the local address cannot be parsed.
+func primaryLocalAddr() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = conn.Close() }()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr == nil {
+		return ""
+	}
+	return addr.IP.String()
 }
 
 // writePCMWav writes mono 16-bit PCM samples to a WAV file. Used by the

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -153,6 +153,12 @@ type Message struct {
 	FirmwareVersion string `json:"firmware_version,omitempty"`
 	FirmwareCommit  string `json:"firmware_commit,omitempty"`
 
+	// LocalAddr is the device's primary LAN address as the device sees
+	// itself, reported in device_info so the server can display it on the
+	// owner's /phones page. The path through CF or NPM strips the source
+	// IP, so the device is the authoritative source.
+	LocalAddr string `json:"local_addr,omitempty"`
+
 	// Update trigger fields (update_trigger messages)
 	TargetPiVersion string `json:"target_pi_version,omitempty"`
 	TargetFWVersion string `json:"target_fw_version,omitempty"`

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/justinlindh/digits/server/internal/httputil"
 )
 
 // ErrNotConnected is returned by SendTo and SendToHardware when the target
@@ -23,9 +25,11 @@ type Conn struct {
 	Send       chan []byte
 	LastSeen   time.Time
 
-	// RemoteAddr is the resolved LAN address of the connected device, or
-	// "" when the resolved client address is not in a private range. The
-	// WS handler assigns it when the Conn is created; see handler_ws.go.
+	// RemoteAddr is the device's primary LAN address as it sees itself,
+	// reported by the device in the device_info message after register.
+	// Hub.UpdateDeviceInfo assigns it; non-private values are filtered to
+	// "" before storage. Empty until device_info arrives, or when the
+	// device reports a non-private address.
 	RemoteAddr string
 
 	// Device info (reported on connect via device_info message)
@@ -227,8 +231,15 @@ func (h *Hub) ClearUpdateStatus(number string) {
 	delete(h.updateStatus, number)
 }
 
-// UpdateDeviceInfo sets version info for a connected phone under the write lock.
-func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string) bool {
+// UpdateDeviceInfo sets version info and the device-reported LAN address for
+// a connected phone under the write lock. localAddr is filtered through
+// httputil.IsPrivateAddr; non-private values (or unparseable input) are
+// stored as "" so a compromised client cannot push a public IP into the
+// owner UI.
+func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit, localAddr string) bool {
+	if !httputil.IsPrivateAddr(localAddr) {
+		localAddr = ""
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	conn, ok := h.conns[number]
@@ -239,6 +250,7 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit string) 
 	conn.PiCommit = piCommit
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
+	conn.RemoteAddr = localAddr
 	return true
 }
 

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -127,6 +127,12 @@ type Message struct {
 	FirmwareVersion string `json:"firmware_version,omitempty"`
 	FirmwareCommit  string `json:"firmware_commit,omitempty"`
 
+	// LocalAddr is the device's primary LAN address as it sees itself,
+	// reported in device_info. The server filters non-private values
+	// before storing so a compromised client cannot push a public IP into
+	// the operator UI.
+	LocalAddr string `json:"local_addr,omitempty"`
+
 	// Update trigger fields (update_trigger messages)
 	TargetPiVersion string `json:"target_pi_version,omitempty"`
 	TargetFWVersion string `json:"target_fw_version,omitempty"`

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -83,10 +83,11 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeRequestICE:
 		r.handleRequestICE(ctx, from, msg)
 	case TypeDeviceInfo:
-		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit) {
+		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr) {
 			slog.Info("device_info", "number", from,
 				"pi_version", msg.PiVersion,
-				"fw_version", msg.FirmwareVersion)
+				"fw_version", msg.FirmwareVersion,
+				"local_addr", msg.LocalAddr)
 		}
 		// If device reconnects after a rebooting update, mark it as success
 		if status := r.Hub.GetUpdateStatus(from); status != nil && status.Status == "rebooting" {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1593,7 +1593,7 @@ func seedPairedHandsetForTest(t *testing.T, h *Handler, database *db.Database, h
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	h.hub.Register(number, conn)
-	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "")
+	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "", "")
 }
 
 // fakeReleasesForTest builds a fake GitHubReleases populated with the given
@@ -2290,17 +2290,15 @@ func TestPhonesPage_OmitsLANIPWhenOffline(t *testing.T) {
 	}
 }
 
-// runWSConnectAndCaptureAddr dials srv's /ws with the given header set,
-// sends a register message for the paired device, waits for hub registration,
-// and returns the RemoteAddr the hub stored for that connection.
-func runWSConnectAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signaling.Hub, hardwareID, number, token, xff string) string {
+// runDeviceInfoAndCaptureAddr dials srv's /ws, registers the paired device,
+// sends a device_info with the given local_addr, polls until the hub's
+// snapshot has settled to a non-zero or filtered value, then returns the
+// RemoteAddr the hub stored. localAddr "" sends an omitted local_addr so
+// older-firmware behavior (no field) can be tested.
+func runDeviceInfoAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signaling.Hub, hardwareID, number, token, localAddr string) string {
 	t.Helper()
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
-	headers := http.Header{}
-	if xff != "" {
-		headers.Set("X-Forwarded-For", xff)
-	}
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial ws: %v", err)
 	}
@@ -2314,52 +2312,64 @@ func runWSConnectAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signali
 		t.Fatalf("write register: %v", err)
 	}
 	waitForRegister(t, hub, number)
-	info := hub.DeviceInfo(number)
-	if info == nil {
-		t.Fatal("hub.DeviceInfo returned nil after register")
+
+	if err := conn.WriteJSON(signaling.Message{
+		Type:            signaling.TypeDeviceInfo,
+		PiVersion:       "1.0.0",
+		FirmwareVersion: "0.1.0",
+		LocalAddr:       localAddr,
+	}); err != nil {
+		t.Fatalf("write device_info: %v", err)
 	}
-	return info.RemoteAddr
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		info := hub.DeviceInfo(number)
+		if info != nil && info.PiVersion == "1.0.0" {
+			return info.RemoteAddr
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for device_info to land in the hub")
+	return ""
 }
 
-func TestHandleWS_RemoteAddrFromXFFWhenPrivate(t *testing.T) {
+func TestDeviceInfo_StoresPrivateLocalAddr(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
 	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
-	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "192.168.1.7")
+	got := runDeviceInfoAndCaptureAddr(t, srv, h.hub, hwID, number, token, "192.168.1.7")
 	if got != "192.168.1.7" {
 		t.Errorf("RemoteAddr = %q, want %q", got, "192.168.1.7")
 	}
 }
 
-func TestHandleWS_RemoteAddrEmptyWhenPublicXFF(t *testing.T) {
+func TestDeviceInfo_DropsPublicLocalAddr(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
 	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
-	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "8.8.8.8")
+	got := runDeviceInfoAndCaptureAddr(t, srv, h.hub, hwID, number, token, "8.8.8.8")
 	if got != "" {
-		t.Errorf("RemoteAddr = %q, want empty for public XFF", got)
+		t.Errorf("RemoteAddr = %q, want empty for public local_addr", got)
 	}
 }
 
-func TestHandleWS_RemoteAddrFallsBackToRemoteAddr(t *testing.T) {
+func TestDeviceInfo_EmptyWhenLocalAddrOmitted(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
 	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
-	// httptest.Server listens on 127.0.0.1, which is in IsPrivateAddr's
-	// loopback range; with no XFF the resolved RemoteAddr should be
-	// "127.0.0.1".
-	got := runWSConnectAndCaptureAddr(t, srv, h.hub, hwID, number, token, "")
-	if got != "127.0.0.1" {
-		t.Errorf("RemoteAddr = %q, want %q", got, "127.0.0.1")
+	got := runDeviceInfoAndCaptureAddr(t, srv, h.hub, hwID, number, token, "")
+	if got != "" {
+		t.Errorf("RemoteAddr = %q, want empty when local_addr is omitted", got)
 	}
 }
 

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/justinlindh/digits/server/internal/httputil"
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
@@ -88,14 +87,9 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		wsWriteTimeout = 10 * time.Second
 	)
 
-	remoteAddr := httputil.ClientIP(r)
-	if !httputil.IsPrivateAddr(remoteAddr) {
-		remoteAddr = ""
-	}
 	conn := &signaling.Conn{
 		WS:         ws,
 		HardwareID: msg.HardwareID,
-		RemoteAddr: remoteAddr,
 		Send:       make(chan []byte, 32),
 		LastSeen:   time.Now(),
 	}
@@ -279,7 +273,7 @@ func (h *Handler) handleDevSeedFirmware(w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 	h.hub.Register(number, conn)
-	h.hub.UpdateDeviceInfo(number, pi, "", fw, "")
+	h.hub.UpdateDeviceInfo(number, pi, "", fw, "", "")
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprintf(w, `{"ok":true,"number":%q,"fw":%q,"pi":%q}`, number, fw, pi)
 }


### PR DESCRIPTION
## Summary

Follow-up to #387: the LAN IP feature shipped, but on the prod box no phone showed an IP. The diagnostic logs (deployed temporarily on a debug branch) confirmed why.

Phones reach `app.digits.family` through Cloudflare. CF cannot see behind the home LAN NAT, so the XFF chain that arrives at signald looks like:

```
xff:              "68.224.37.131, 162.158.244.138"   user's WAN, CF edge
cf_connecting_ip: "68.224.37.131"                    same; CF authoritative
raw_remote_addr:  "192.168.1.75:39720"               LAN IP of cloudflared/NPM
```

The user's WAN address is correctly rejected by `IsPrivateAddr`, so every phone got `RemoteAddr=""`. The data the feature wants simply isn't on the wire by the time signald sees the request.

## Fix

Make the device the source of truth. `device_info` (sent immediately after register) now carries `local_addr`. digitsd reads its own routable source IP via `net.Dial("udp", "8.8.8.8:80")` (no packet sent; the kernel just resolves the route) and reports it. The server runs the value through `httputil.IsPrivateAddr` before storing so a compromised client cannot push a public IP into the operator UI.

`handler_ws.go` no longer captures from the request: that path was always going to be wrong under any non-trivial proxy chain.

## Verified on prod

After deploying this branch (server image `1.50.0-7-g44314b4a`, digitsd binary `1.19.1-1-g44314b4a-dirty` to all three phones):

```
device_info  number=2486881  pi_version=1.19.1-1-g44314b4a-dirty  local_addr=192.168.2.228
device_info  number=2456390  pi_version=1.19.1-1-g44314b4a-dirty  local_addr=192.168.2.142
device_info  number=5793721  pi_version=1.19.1-1-g44314b4a-dirty  local_addr=192.168.2.140
```

The three phones still on `1.19.1` (no `local_addr` in their build) report empty, which is the right degraded mode and resolves itself the next time they update.

## Test plan

- [x] `make test` and `make test-integration` green.
- [x] `golangci-lint run ./...` clean on both modules.
- [x] Three new `TestDeviceInfo_*` tests cover the device_info path: private value stored, public value dropped, omitted field stays empty.
- [x] Verified end to end on the live prod stack.

## Notes

- The three phones on the LAN are running this binary out of band (deployed before the PR landed) so I could verify. They will pick up the official build whenever the next pi/digitsd release goes out.
- The `httputil.{ClientIP,IsPrivateAddr}` package stays. `IsPrivateAddr` is what filters the device-reported value, and `ClientIP` is still consumed by `ratelimit`. No code is being orphaned.
- `Conn.RemoteAddr` is now empty until `device_info` arrives, a 1-2 second window after register. Page loads in that window won't show an IP. Acceptable for the "ssh into the phone" use case; the typical access is on a phone that's been up for a while.
