### PR TITLE
docs: document numpad panic button as a recovery-mode trigger

### DIFF
--- a/docs/architecture/updates-and-recovery.md
+++ b/docs/architecture/updates-and-recovery.md
@@ -68,10 +68,11 @@ Recovery mode is a minimal environment that runs before the main rootfs is mount
 
 ### Triggers
 
-Recovery mode activates in two situations:
+Recovery mode activates in three situations:
 
 - **Boot failure:** The initramfs maintains a boot counter on the data partition. If the counter reaches 3 consecutive failed boots, recovery mode starts automatically. If the data partition cannot be mounted at all, recovery mode starts as a safety fallback.
 - **Factory reset request:** When a factory reset is initiated (via web UI or service code), `digitsd` sets the boot counter to the threshold value and reboots. The initramfs sees the counter at threshold and enters recovery mode.
+- **Numpad panic button:** Hold the keypad's `*` key while the phone boots. The `digits-panic-check` early-boot service reads the keypad matrix from the Pico over UART and, if `*` is held, writes `/data/digits/recovery-mode` and reboots. The initramfs sees the persistent flag and enters recovery mode. This is the user-facing escape hatch when the device is unreachable over the network or the web UI.
 
 ### Boot Counter
 

--- a/pi/digits-recovery/README.md
+++ b/pi/digits-recovery/README.md
@@ -4,10 +4,11 @@ Minimal recovery server that runs when the phone fails to boot. Provides factory
 
 ## When it runs
 
-Recovery mode activates in two situations:
+Recovery mode activates in three situations:
 
 - **Boot failure:** The initramfs tracks a boot counter on the data partition. If it reaches 3 consecutive failed boots, recovery starts automatically.
 - **Factory reset:** When triggered from the web UI or by dialing `*#00000#`, digitsd sets the counter to the threshold and reboots into recovery.
+- **Numpad panic button:** Holding the keypad's `*` key during boot causes `digits-panic-check` to write `/data/digits/recovery-mode` and reboot; the initramfs sees the flag and enters recovery mode on the next boot.
 
 See [docs/architecture/updates-and-recovery.md](../../docs/architecture/updates-and-recovery.md) for the full design.
 

--- a/pi/image/initramfs/boot-check.sh
+++ b/pi/image/initramfs/boot-check.sh
@@ -31,7 +31,11 @@ if [ $? -ne 0 ]; then
     exit 0
 fi
 
-# Check for persistent recovery flag (set by service code or web UI factory reset)
+# Check for persistent recovery flag. Writers:
+#   - digits-panic-check (early boot) when * is held on the keypad
+#   - this script itself (below) once the boot counter reaches threshold
+# Note: the *#00000# service code and web UI factory reset use the boot counter
+# instead of this flag (see bootcount.SetThreshold).
 if [ -f "$DATA_MNT/digits/recovery-mode" ]; then
     echo "boot-check: persistent recovery flag found, entering recovery mode"
     touch "$RECOVERY_FLAG"


### PR DESCRIPTION
## Summary

Daily holistic-coherence sweep across PRs merged in the last 24h surfaced one cross-PR documentation drift.

PR #389 added the `digits-panic-check` early-boot service, which writes `/data/digits/recovery-mode` when the keypad's `*` key is held during boot. Three documentation surfaces still describe the recovery-mode entry paths as if that service did not exist:

1. `docs/architecture/updates-and-recovery.md` "Triggers" section listed only boot failure and factory reset.
2. `pi/digits-recovery/README.md` "When it runs" section had the same gap.
3. `pi/image/initramfs/boot-check.sh` comment claimed the persistent flag was set by "service code or web UI factory reset", which has never been accurate. Those paths use the boot counter via `bootcount.SetThreshold` (see `pi/digitsd/cmd/digitsd/main.go:1297`), not the persistent flag. After #389 the actual writers are `digits-panic-check` and `boot-check.sh` itself once the threshold is reached.

## Motivated by (last 24h)

- #389 feat(pi): add numpad panic button for recovery mode

## Changes

- `docs/architecture/updates-and-recovery.md`: add the panic-button trigger as a third entry alongside boot failure and factory reset.
- `pi/digits-recovery/README.md`: same addition in the recovery binary's local README.
- `pi/image/initramfs/boot-check.sh`: rewrite the misleading comment so it accurately enumerates writers of the persistent recovery flag.

Doc-only. No code paths changed; no Go modules touched.

## Test plan

- [x] `git diff --stat` shows only the three documentation files
- [ ] CI passes (no test changes expected, this is doc-only)
