### PR TITLE
refactor(server): drop unused ctx from Relay internal helpers

### DIFF
--- a/server/internal/signaling/conference.go
+++ b/server/internal/signaling/conference.go
@@ -17,7 +17,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	// 1. Validate: host is in both calls.
 	if !r.Tracker.InCall(ctx, host, held) || !r.Tracker.InCall(ctx, host, active) {
 		slog.Warn("conference: merge rejected", "host", host, "reason", "host_not_in_both_calls", "held", held, "active", active)
-		r.sendRejection(ctx, host, msg.ConfID, "host_not_in_both_calls")
+		r.sendRejection(host, msg.ConfID, "host_not_in_both_calls")
 		return
 	}
 
@@ -25,7 +25,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	for _, p := range []string{held, active} {
 		if r.Tracker.Conferences().IsBusy(p) {
 			slog.Warn("conference: merge rejected", "host", host, "reason", "member_already_in_conference", "busy_member", p)
-			r.sendRejection(ctx, host, msg.ConfID, "member_already_in_conference")
+			r.sendRejection(host, msg.ConfID, "member_already_in_conference")
 			return
 		}
 	}
@@ -34,14 +34,14 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	callID := r.Tracker.CallIDForPair(ctx, host, held)
 	if callID == 0 {
 		slog.Warn("conference: merge rejected", "host", host, "reason", "call_id_unknown", "held", held)
-		r.sendRejection(ctx, host, msg.ConfID, "call_id_unknown")
+		r.sendRejection(host, msg.ConfID, "call_id_unknown")
 		return
 	}
 
 	conf, err := r.Tracker.CreateConferencePersistent(ctx, host, callID, []string{held, active})
 	if err != nil {
 		slog.Error("create conference", "err", err)
-		r.sendRejection(ctx, host, msg.ConfID, "create_failed")
+		r.sendRejection(host, msg.ConfID, "create_failed")
 		return
 	}
 	slog.Info("conference: created", "conf_id", conf.ID.String(), "host", host, "held", held, "active", active, "originating_call_id", callID)
@@ -82,7 +82,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	slog.Info("conference: ConferenceConnect dispatched", "conf_id", conf.ID.String(), "held", held, "active", active, "held_is_initiator", heldIsInitiator)
 }
 
-func (r *Relay) sendRejection(ctx context.Context, host, confID, reason string) {
+func (r *Relay) sendRejection(host, confID, reason string) {
 	_ = r.Hub.SendTo(host, &Message{
 		Type:   TypeConferenceRejected,
 		ConfID: confID,

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -79,9 +79,9 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeConferenceMerge:
 		r.handleConferenceMerge(ctx, from, msg)
 	case TypeDTMF:
-		r.forward(ctx, msg)
+		r.forward(msg)
 	case TypeRequestICE:
-		r.handleRequestICE(ctx, from, msg)
+		r.handleRequestICE(from)
 	case TypeDeviceInfo:
 		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr) {
 			slog.Info("device_info", "number", from,
@@ -160,7 +160,7 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
 		return
 	}
-	r.forward(ctx, msg)
+	r.forward(msg)
 }
 
 func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
@@ -169,7 +169,7 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 			slog.Error("failed to track call answer", "err", err)
 		}
 	}
-	r.forward(ctx, msg)
+	r.forward(msg)
 }
 
 func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
@@ -224,7 +224,7 @@ func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
 			return
 		}
 	}
-	r.forward(ctx, msg)
+	r.forward(msg)
 }
 
 func (r *Relay) handleICE(ctx context.Context, from string, msg *Message) {
@@ -241,10 +241,10 @@ func (r *Relay) handleICE(ctx context.Context, from string, msg *Message) {
 			return
 		}
 	}
-	r.forward(ctx, msg)
+	r.forward(msg)
 }
 
-func (r *Relay) handleRequestICE(ctx context.Context, from string, _ *Message) {
+func (r *Relay) handleRequestICE(from string) {
 	resp := &Message{Type: TypeICEServers}
 
 	// Always include a STUN server
@@ -314,7 +314,7 @@ func (r *Relay) OnDisconnect(ctx context.Context, number string) {
 	r.Tracker.ClearByNumber(ctx, number)
 }
 
-func (r *Relay) forward(ctx context.Context, msg *Message) {
+func (r *Relay) forward(msg *Message) {
 	if msg.To == "" {
 		slog.Warn("no destination for message", "type", msg.Type, "from", msg.From)
 		return


### PR DESCRIPTION
`sendRejection`, `handleRequestICE`, and `forward` are private helpers on `Relay`, and none of them ever read the `context.Context` they accepted (`unparam` flagged all three). They also can't usefully use one: `forward` and `sendRejection` just call `Hub.SendTo`, which is itself ctx-less, and `handleRequestICE` only reads in-memory TURN config and writes a synchronous reply. Drop the parameter from the signatures and the seven call sites in `relay.go`/`conference.go`. While there, drop `handleRequestICE`'s `*Message` parameter, which was already discarded with `_`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/signaling/...`
- [x] `golangci-lint run ./...`