### PR TITLE
refactor(server): drop unused ctx from in-memory Tracker lookups

### DIFF
--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -30,7 +30,7 @@ func TestTrackerBusyWithConference_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OnCallInitiated: %v", err)
 	}
-	if !tr.Busy(context.Background(), "5550001") {
+	if !tr.Busy("5550001") {
 		t.Fatalf("expected 5550001 busy from 2-party call")
 	}
 
@@ -39,7 +39,7 @@ func TestTrackerBusyWithConference_Integration(t *testing.T) {
 	if err := tr.OnCallEnded(context.Background(), "5550001", "5550002"); err != nil {
 		t.Fatalf("OnCallEnded: %v", err)
 	}
-	if tr.Busy(context.Background(), "5550001") {
+	if tr.Busy("5550001") {
 		t.Fatalf("expected 5550001 NOT busy after call ended")
 	}
 
@@ -47,13 +47,13 @@ func TestTrackerBusyWithConference_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateConference: %v", err)
 	}
-	if !tr.Busy(context.Background(), "5550001") {
+	if !tr.Busy("5550001") {
 		t.Fatalf("expected 5550001 busy via conference")
 	}
-	if !tr.Busy(context.Background(), "5550010") {
+	if !tr.Busy("5550010") {
 		t.Fatalf("expected 5550010 busy via conference")
 	}
-	if tr.Busy(context.Background(), "5550099") {
+	if tr.Busy("5550099") {
 		t.Fatalf("unexpected busy for 5550099")
 	}
 }
@@ -143,12 +143,12 @@ func TestDropMemberCreatesContinuationCall_Integration(t *testing.T) {
 
 	// Verify surviving members are busy via tr.active and Tracker.Busy reports them so.
 	for _, p := range remaining {
-		if !tr.Busy(context.Background(), p) {
+		if !tr.Busy(p) {
 			t.Fatalf("expected surviving member %s to be busy after continuation", p)
 		}
 	}
 	// The dropped member is not busy.
-	if tr.Busy(context.Background(), "5550101") {
+	if tr.Busy("5550101") {
 		t.Fatalf("dropped member should not be busy")
 	}
 }
@@ -174,7 +174,7 @@ func TestConferenceLifecycleHooks(t *testing.T) {
 		}
 	}
 
-	originatingCallID := tr.CallIDForPair(ctx, hostNum, m2)
+	originatingCallID := tr.CallIDForPair(hostNum, m2)
 	if originatingCallID == 0 {
 		t.Fatal("CallIDForPair returned 0 for originating pair")
 	}
@@ -228,7 +228,7 @@ func TestDropMemberFiresEvictConference(t *testing.T) {
 			t.Fatalf("OnCallAnswered: %v", err)
 		}
 	}
-	originatingCallID := tr.CallIDForPair(ctx, hostNum, m2)
+	originatingCallID := tr.CallIDForPair(hostNum, m2)
 	conf, err := tr.CreateConferencePersistent(ctx, hostNum, originatingCallID, []string{m2, m3})
 	if err != nil {
 		t.Fatalf("CreateConferencePersistent: %v", err)
@@ -257,11 +257,11 @@ func TestCreateConferenceEvictsActiveEntries_Integration(t *testing.T) {
 	}
 
 	// Pre-condition: 2-party call is active, both phones busy, InCall true.
-	if !tr.InCall(context.Background(), "5550200", "5550201") {
+	if !tr.InCall("5550200", "5550201") {
 		t.Fatalf("expected InCall true before conference")
 	}
 	for _, p := range []string{"5550200", "5550201"} {
-		if !tr.Busy(context.Background(), p) {
+		if !tr.Busy(p) {
 			t.Fatalf("expected %s busy before conference", p)
 		}
 	}
@@ -282,16 +282,16 @@ func TestCreateConferenceEvictsActiveEntries_Integration(t *testing.T) {
 	}
 
 	// After merge: the 2-party A<->B entry must be gone from the active map.
-	if tr.InCall(context.Background(), "5550200", "5550201") {
+	if tr.InCall("5550200", "5550201") {
 		t.Fatalf("expected 2-party A<->B entry evicted from active map")
 	}
 	// Unrelated 2-party call must still be present.
-	if !tr.InCall(context.Background(), "5550300", "5550301") {
+	if !tr.InCall("5550300", "5550301") {
 		t.Fatalf("expected unrelated 2-party call to survive")
 	}
 	// All three conference members should be Busy (via conference).
 	for _, p := range []string{"5550200", "5550201", "5550202"} {
-		if !tr.Busy(context.Background(), p) {
+		if !tr.Busy(p) {
 			t.Fatalf("expected conference member %s busy", p)
 		}
 	}
@@ -390,7 +390,7 @@ func TestRecordKick_Integration(t *testing.T) {
 	}
 	_ = tr.OnCallAnswered(ctx, "+15555550101", "+15555550102")
 	_ = tr.OnCallAnswered(ctx, "+15555550101", "+15555550103")
-	originatingCallID := tr.CallIDForPair(ctx, "+15555550101", "+15555550102")
+	originatingCallID := tr.CallIDForPair("+15555550101", "+15555550102")
 	conf, err := tr.CreateConferencePersistent(ctx, "+15555550101", originatingCallID, []string{"+15555550102", "+15555550103"})
 	if err != nil {
 		t.Fatalf("CreateConferencePersistent: %v", err)
@@ -450,7 +450,7 @@ func TestGetConferenceByID_Integration(t *testing.T) {
 	if err := tr.OnCallAnswered(ctx, "+15555550001", "+15555550003"); err != nil {
 		t.Fatalf("answer call 2: %v", err)
 	}
-	originatingCallID := tr.CallIDForPair(ctx, "+15555550001", "+15555550002")
+	originatingCallID := tr.CallIDForPair("+15555550001", "+15555550002")
 	conf, err := tr.CreateConferencePersistent(ctx, "+15555550001", originatingCallID, []string{"+15555550002", "+15555550003"})
 	if err != nil {
 		t.Fatalf("create conference: %v", err)

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -230,7 +230,7 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 	}
 }
 
-func (t *Tracker) Busy(ctx context.Context, number string) bool {
+func (t *Tracker) Busy(number string) bool {
 	if t.conferences.IsBusy(number) {
 		return true
 	}
@@ -252,7 +252,7 @@ func (t *Tracker) Busy(ctx context.Context, number string) bool {
 //
 // Together with the normal Busy(to) check, this lets the 5ESS-style three-way
 // flow work without allowing arbitrary multi-call spam.
-func (t *Tracker) CanAddAsHost(ctx context.Context, number string) bool {
+func (t *Tracker) CanAddAsHost(number string) bool {
 	if t.conferences.IsBusy(number) {
 		return false
 	}
@@ -272,7 +272,7 @@ func (t *Tracker) CanAddAsHost(ctx context.Context, number string) bool {
 
 // AllPeersOf returns all remote parties that number has active 2-party calls
 // with. Empty if number has no active calls.
-func (t *Tracker) AllPeersOf(ctx context.Context, number string) []string {
+func (t *Tracker) AllPeersOf(number string) []string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	var peers []string
@@ -288,7 +288,7 @@ func (t *Tracker) AllPeersOf(ctx context.Context, number string) []string {
 
 // PeerOf returns the other party in an active call involving number,
 // or "" if number is not in any active call.
-func (t *Tracker) PeerOf(ctx context.Context, number string) string {
+func (t *Tracker) PeerOf(number string) string {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, c := range t.active {
@@ -305,7 +305,7 @@ func (t *Tracker) PeerOf(ctx context.Context, number string) string {
 // CallIDForPair returns the database call ID for an active call between a and
 // b, or 0 if no such call exists. Used by conference setup to find the
 // originating 2-party call id before migrating to mesh.
-func (t *Tracker) CallIDForPair(ctx context.Context, a, b string) int64 {
+func (t *Tracker) CallIDForPair(a, b string) int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if c, ok := t.active[callKey(a, b)]; ok {
@@ -319,7 +319,7 @@ func (t *Tracker) CallIDForPair(ctx context.Context, a, b string) int64 {
 
 // CallIDFor returns the active call id for an endpoint phone number.
 // Returns (0, false) if the number is not currently in a call.
-func (t *Tracker) CallIDFor(ctx context.Context, number string) (int64, bool) {
+func (t *Tracker) CallIDFor(number string) (int64, bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, c := range t.active {
@@ -330,7 +330,7 @@ func (t *Tracker) CallIDFor(ctx context.Context, number string) (int64, bool) {
 	return 0, false
 }
 
-func (t *Tracker) InCall(ctx context.Context, a, b string) bool {
+func (t *Tracker) InCall(a, b string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	_, fwd := t.active[callKey(a, b)]
@@ -405,7 +405,7 @@ func (t *Tracker) CreateConferencePersistent(ctx context.Context, host string, o
 	// creating the conference so the active map is still intact.
 	addedCallIDs := make([]int64, 0, len(addedMembers))
 	for _, member := range addedMembers {
-		cid := t.CallIDForPair(ctx, host, member)
+		cid := t.CallIDForPair(host, member)
 		if cid == 0 {
 			return nil, fmt.Errorf("no active call between %s and %s", host, member)
 		}

--- a/server/internal/calls/tracker_test.go
+++ b/server/internal/calls/tracker_test.go
@@ -76,10 +76,10 @@ func TestOnCallInitiatedReturnsCallID(t *testing.T) {
 	if id <= 0 {
 		t.Fatalf("want positive id, got %d", id)
 	}
-	if got, ok := tr.CallIDFor(context.Background(), "555-1111"); !ok || got != id {
+	if got, ok := tr.CallIDFor("555-1111"); !ok || got != id {
 		t.Fatalf("CallIDFor caller: got (%d,%v), want (%d,true)", got, ok, id)
 	}
-	if got, ok := tr.CallIDFor(context.Background(), "555-2222"); !ok || got != id {
+	if got, ok := tr.CallIDFor("555-2222"); !ok || got != id {
 		t.Fatalf("CallIDFor callee: got (%d,%v), want (%d,true)", got, ok, id)
 	}
 }

--- a/server/internal/signaling/conference.go
+++ b/server/internal/signaling/conference.go
@@ -15,7 +15,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	slog.Info("conference: merge requested", "host", host, "held", held, "active", active)
 
 	// 1. Validate: host is in both calls.
-	if !r.Tracker.InCall(ctx, host, held) || !r.Tracker.InCall(ctx, host, active) {
+	if !r.Tracker.InCall(host, held) || !r.Tracker.InCall(host, active) {
 		slog.Warn("conference: merge rejected", "host", host, "reason", "host_not_in_both_calls", "held", held, "active", active)
 		r.sendRejection(ctx, host, msg.ConfID, "host_not_in_both_calls")
 		return
@@ -31,7 +31,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	}
 
 	// 3. Look up the originating call id (A-held).
-	callID := r.Tracker.CallIDForPair(ctx, host, held)
+	callID := r.Tracker.CallIDForPair(host, held)
 	if callID == 0 {
 		slog.Warn("conference: merge rejected", "host", host, "reason", "call_id_unknown", "held", held)
 		r.sendRejection(ctx, host, msg.ConfID, "call_id_unknown")

--- a/server/internal/signaling/conference_integration_test.go
+++ b/server/internal/signaling/conference_integration_test.go
@@ -254,10 +254,10 @@ func TestHangupDuringADDCalling_Integration(t *testing.T) {
 	}
 
 	// Verify both calls are tracked before hangup.
-	if !tr.InCall(context.Background(), "5550001", "5550002") {
+	if !tr.InCall("5550001", "5550002") {
 		t.Fatal("expected A-B to be an active call before hangup")
 	}
-	if !tr.InCall(context.Background(), "5550001", "5550003") {
+	if !tr.InCall("5550001", "5550003") {
 		t.Fatal("expected A-C to be an active call before hangup")
 	}
 
@@ -269,10 +269,10 @@ func TestHangupDuringADDCalling_Integration(t *testing.T) {
 	})
 
 	// Both calls must be gone from the in-memory tracker.
-	if tr.InCall(context.Background(), "5550001", "5550002") {
+	if tr.InCall("5550001", "5550002") {
 		t.Error("A-B call still active in tracker after hangup")
 	}
-	if tr.InCall(context.Background(), "5550001", "5550003") {
+	if tr.InCall("5550001", "5550003") {
 		t.Error("A-C call still active in tracker after hangup")
 	}
 
@@ -323,7 +323,7 @@ func TestDisconnectNonHostConferenceParticipant_Integration(t *testing.T) {
 	if err := tr.OnCallAnswered(context.Background(), "5550001", "5550002"); err != nil {
 		t.Fatalf("OnCallAnswered A->B: %v", err)
 	}
-	callID := tr.CallIDForPair(context.Background(), "5550001", "5550002")
+	callID := tr.CallIDForPair("5550001", "5550002")
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550003"); err != nil {
 		t.Fatalf("OnCallInitiated A->C: %v", err)
 	}
@@ -379,13 +379,13 @@ func TestDisconnectNonHostConferenceParticipant_Integration(t *testing.T) {
 	}
 
 	// IsBusy must return false for all three after cleanup.
-	if tr.Busy(context.Background(), "5550001") {
+	if tr.Busy("5550001") {
 		t.Error("A should not be busy after non-host conference disconnect")
 	}
-	if tr.Busy(context.Background(), "5550002") {
+	if tr.Busy("5550002") {
 		t.Error("B should not be busy after conference disconnect")
 	}
-	if tr.Busy(context.Background(), "5550003") {
+	if tr.Busy("5550003") {
 		t.Error("C should not be busy after non-host conference disconnect")
 	}
 }
@@ -410,7 +410,7 @@ func TestKickMember_SendsConferenceEndToKickedAndRemaining_Integration(t *testin
 	if err := tr.OnCallAnswered(context.Background(), "5550001", "5550002"); err != nil {
 		t.Fatalf("OnCallAnswered A->B: %v", err)
 	}
-	callID := tr.CallIDForPair(context.Background(), "5550001", "5550002")
+	callID := tr.CallIDForPair("5550001", "5550002")
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550003"); err != nil {
 		t.Fatalf("OnCallInitiated A->C: %v", err)
 	}
@@ -468,7 +468,7 @@ func TestDisconnectConferenceParticipant_Integration(t *testing.T) {
 	if err := tr.OnCallAnswered(context.Background(), "5550001", "5550002"); err != nil {
 		t.Fatalf("OnCallAnswered A->B: %v", err)
 	}
-	callID := tr.CallIDForPair(context.Background(), "5550001", "5550002")
+	callID := tr.CallIDForPair("5550001", "5550002")
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550003"); err != nil {
 		t.Fatalf("OnCallInitiated A->C: %v", err)
 	}
@@ -507,10 +507,10 @@ func TestDisconnectConferenceParticipant_Integration(t *testing.T) {
 	}
 
 	// IsBusy must return false for B and C after cleanup.
-	if tr.Busy(context.Background(), "5550002") {
+	if tr.Busy("5550002") {
 		t.Error("B should not be busy after conference disconnect")
 	}
-	if tr.Busy(context.Background(), "5550003") {
+	if tr.Busy("5550003") {
 		t.Error("C should not be busy after conference disconnect")
 	}
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -16,15 +16,15 @@ type CallTracker interface {
 	OnCallAnswered(ctx context.Context, caller, callee string) error
 	OnCallEnded(ctx context.Context, caller, callee string) error
 	ClearByNumber(ctx context.Context, number string)
-	InCall(ctx context.Context, a, b string) bool
-	Busy(ctx context.Context, number string) bool
-	CanAddAsHost(ctx context.Context, number string) bool
-	PeerOf(ctx context.Context, number string) string
-	AllPeersOf(ctx context.Context, number string) []string
+	InCall(a, b string) bool
+	Busy(number string) bool
+	CanAddAsHost(number string) bool
+	PeerOf(number string) string
+	AllPeersOf(number string) []string
 	Conferences() *calls.ConferenceTracker
 	CreateConferencePersistent(ctx context.Context, host string, originatingCallID int64, addedMembers []string) (*calls.Conference, error)
-	CallIDForPair(ctx context.Context, a, b string) int64
-	CallIDFor(ctx context.Context, number string) (int64, bool)
+	CallIDForPair(a, b string) int64
+	CallIDFor(number string) (int64, bool)
 	EndConferencePersistent(ctx context.Context, confID uuid.UUID, reason string) error
 	DropMemberPersistent(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, ended bool, err error)
 }
@@ -135,11 +135,11 @@ func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 		// except for the party-line add-dial case: a host already in one
 		// 2-party call (as caller) may initiate a second call to a third
 		// party, which a subsequent conference_merge will bond into a 3-way.
-		if r.Tracker.Busy(ctx, msg.To) {
+		if r.Tracker.Busy(msg.To) {
 			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}
-		if r.Tracker.Busy(ctx, from) && !r.Tracker.CanAddAsHost(ctx, from) {
+		if r.Tracker.Busy(from) && !r.Tracker.CanAddAsHost(from) {
 			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}
@@ -155,7 +155,7 @@ func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
-	if r.Tracker != nil && !r.Tracker.InCall(ctx, from, msg.To) {
+	if r.Tracker != nil && !r.Tracker.InCall(from, msg.To) {
 		slog.Warn("ice_restart without active call", "from", from, "to", msg.To)
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
 		return
@@ -195,7 +195,7 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 	// single hook-on ends both. For the normal 2-party case this is one peer.
 	var peers []string
 	if r.Tracker != nil {
-		peers = r.Tracker.AllPeersOf(ctx, from)
+		peers = r.Tracker.AllPeersOf(from)
 	}
 	if len(peers) == 0 && msg.To != "" {
 		peers = []string{msg.To}
@@ -358,7 +358,7 @@ func (r *Relay) handleLinkHealth(ctx context.Context, from string, msg *Message)
 	}
 
 	if p.Peer == "" {
-		callID, ok := r.Tracker.CallIDFor(ctx, from)
+		callID, ok := r.Tracker.CallIDFor(from)
 		if !ok {
 			slog.Debug("link_health for endpoint not in active call", "endpoint", from)
 			return

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -65,7 +65,7 @@ func (m *mockTracker) ClearByNumber(ctx context.Context, number string) {
 		}
 	}
 }
-func (m *mockTracker) Busy(ctx context.Context, number string) bool {
+func (m *mockTracker) Busy(number string) bool {
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number || b == number {
@@ -75,7 +75,7 @@ func (m *mockTracker) Busy(ctx context.Context, number string) bool {
 	return false
 }
 
-func (m *mockTracker) CanAddAsHost(ctx context.Context, number string) bool {
+func (m *mockTracker) CanAddAsHost(number string) bool {
 	callerCount := 0
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
@@ -89,11 +89,11 @@ func (m *mockTracker) CanAddAsHost(ctx context.Context, number string) bool {
 	return callerCount == 1
 }
 
-func (m *mockTracker) InCall(ctx context.Context, a, b string) bool {
+func (m *mockTracker) InCall(a, b string) bool {
 	return m.calls[a+"→"+b] || m.calls[b+"→"+a]
 }
 
-func (m *mockTracker) PeerOf(ctx context.Context, number string) string {
+func (m *mockTracker) PeerOf(number string) string {
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number {
@@ -106,7 +106,7 @@ func (m *mockTracker) PeerOf(ctx context.Context, number string) string {
 	return ""
 }
 
-func (m *mockTracker) AllPeersOf(ctx context.Context, number string) []string {
+func (m *mockTracker) AllPeersOf(number string) []string {
 	var peers []string
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
@@ -127,7 +127,7 @@ func (m *mockTracker) CreateConferencePersistent(ctx context.Context, host strin
 	return m.conferences.CreateConference(host, originatingCallID, addedMembers)
 }
 
-func (m *mockTracker) CallIDForPair(ctx context.Context, a, b string) int64 {
+func (m *mockTracker) CallIDForPair(a, b string) int64 {
 	if id, ok := m.callIDs[a+"→"+b]; ok {
 		return id
 	}
@@ -137,7 +137,7 @@ func (m *mockTracker) CallIDForPair(ctx context.Context, a, b string) int64 {
 	return 0
 }
 
-func (m *mockTracker) CallIDFor(ctx context.Context, number string) (int64, bool) {
+func (m *mockTracker) CallIDFor(number string) (int64, bool) {
 	for k, id := range m.callIDs {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number || b == number {
@@ -505,7 +505,7 @@ func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
 	<-conn2.Send // drain ring
 
-	if !tracker.Busy(context.Background(), "3140001") {
+	if !tracker.Busy("3140001") {
 		t.Fatal("expected 3140001 to be busy after call initiated")
 	}
 
@@ -513,10 +513,10 @@ func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeHangup})
 
 	// Tracker should have resolved the peer and ended the call
-	if tracker.Busy(context.Background(), "3140001") {
+	if tracker.Busy("3140001") {
 		t.Fatal("expected 3140001 to no longer be busy after hangup")
 	}
-	if tracker.Busy(context.Background(), "3140002") {
+	if tracker.Busy("3140002") {
 		t.Fatal("expected 3140002 to no longer be busy after hangup")
 	}
 
@@ -570,7 +570,7 @@ func TestRegression_HangupBeforeAnswer_StopsRing(t *testing.T) {
 		t.Fatal("REGRESSION: D3 did not receive hangup, will keep ringing")
 	}
 
-	if tracker.Busy(context.Background(), "5550001") {
+	if tracker.Busy("5550001") {
 		t.Fatal("D1 still busy after hangup")
 	}
 }
@@ -677,7 +677,7 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	<-conn2.Send // drain ring
 
 	// Verify Phone 2 is busy
-	if !tracker.Busy(context.Background(), "3140002") {
+	if !tracker.Busy("3140002") {
 		t.Fatal("expected phone 2 to be busy after call initiated")
 	}
 
@@ -685,11 +685,11 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	relay.OnDisconnect(context.Background(), "3140002")
 
 	// Phone 2 should no longer be busy
-	if tracker.Busy(context.Background(), "3140002") {
+	if tracker.Busy("3140002") {
 		t.Fatal("expected phone 2 to not be busy after disconnect cleanup")
 	}
 	// Phone 1 should also be freed (its call was with Phone 2)
-	if tracker.Busy(context.Background(), "3140001") {
+	if tracker.Busy("3140001") {
 		t.Fatal("expected phone 1 to not be busy after peer disconnected")
 	}
 
@@ -755,13 +755,13 @@ func TestHandleHangup_EndsAllActivePeers(t *testing.T) {
 	}
 
 	// Both calls must be removed from the tracker.
-	if tracker.Busy(context.Background(), "5550001") {
+	if tracker.Busy("5550001") {
 		t.Error("A should no longer be busy after hangup")
 	}
-	if tracker.Busy(context.Background(), "5550002") {
+	if tracker.Busy("5550002") {
 		t.Error("B should no longer be busy after hangup")
 	}
-	if tracker.Busy(context.Background(), "5550003") {
+	if tracker.Busy("5550003") {
 		t.Error("C should no longer be busy after hangup")
 	}
 

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -112,7 +112,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			} else {
 				callerRow.OnCallPeerName = resolvePeerName(pair.Callee, linkedLineIndex)
 			}
-			if id, ok := h.tracker.CallIDFor(ctx, callerRow.Line.Number); ok {
+			if id, ok := h.tracker.CallIDFor(callerRow.Line.Number); ok {
 				callerRow.OnCallID = id
 			}
 		}
@@ -124,7 +124,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			} else {
 				calleeRow.OnCallPeerName = resolvePeerName(pair.Caller, linkedLineIndex)
 			}
-			if id, ok := h.tracker.CallIDFor(ctx, calleeRow.Line.Number); ok {
+			if id, ok := h.tracker.CallIDFor(calleeRow.Line.Number); ok {
 				calleeRow.OnCallID = id
 			}
 		}

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -237,7 +237,7 @@ func (h *Handler) handleTestStartConference(w http.ResponseWriter, r *http.Reque
 			return
 		}
 	}
-	originatingCallID := h.tracker.CallIDForPair(ctx, body.Host, body.Added[0])
+	originatingCallID := h.tracker.CallIDForPair(body.Host, body.Added[0])
 	if originatingCallID == 0 {
 		http.Error(w, "originating call not found", http.StatusInternalServerError)
 		return

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -358,7 +358,7 @@ func startConference(t *testing.T, s lhSetup) uuid.UUID {
 	if err := tr.OnCallAnswered(ctx, s.numA, s.numC); err != nil {
 		t.Fatalf("OnCallAnswered A->C: %v", err)
 	}
-	originatingCallID := tr.CallIDForPair(ctx, s.numA, s.numB)
+	originatingCallID := tr.CallIDForPair(s.numA, s.numB)
 	conf, err := tr.CreateConferencePersistent(ctx, s.numA, originatingCallID, []string{s.numB, s.numC})
 	if err != nil {
 		t.Fatalf("CreateConferencePersistent: %v", err)


### PR DESCRIPTION
`Tracker.Busy`, `CanAddAsHost`, `AllPeersOf`, `PeerOf`, `CallIDForPair`, `CallIDFor`, and `InCall` are pure in-memory map reads. They take `t.mu` and return without ever touching the database. The `context.Context` they accepted went unused in every implementation, and the `mockTracker` and `CallTracker` interface stub matched. The result was an interface signature that lied about whether ctx mattered.

Drop `ctx` from all seven methods, the matching `CallTracker` interface declarations, the relay / conference call sites that were threading ctx through purely to satisfy the signature, the dashboard and ws handler sites, and the unit + integration test mocks.

The persistent / DB-backed tracker methods (`OnCallInitiated`, `OnCallAnswered`, `OnCallEnded`, `ClearByNumber`, `*ConferencePersistent`, `DropMemberPersistent`) keep their `ctx` since they actually use it on the SQL exec/query path.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (pre-existing root-only autodeploy fixture failure unrelated)
- [x] `go vet -tags=integration ./...`
- [x] `golangci-lint run ./...`
- [x] `golangci-lint run --build-tags=integration ./...`