### PR TITLE
chore(digitsd): drop unused Config.SetDeviceToken

### DIFF
--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -272,14 +272,6 @@ func atomicWrite(path string, data []byte, perm os.FileMode) error {
 	return nil
 }
 
-// SetDeviceToken records a device token returned after pairing and clears the
-// pairing code, then saves the config to disk.
-func (c *Config) SetDeviceToken(token string) error {
-	c.DeviceToken = token
-	c.PairingCode = ""
-	return c.Save()
-}
-
 // Path returns the file path this config was loaded from.
 func (c *Config) Path() string {
 	return c.path

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -204,40 +204,6 @@ func TestSaveAndReload(t *testing.T) {
 	}
 }
 
-func TestSetDeviceTokenClearsPairingCode(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-
-	initial := `{"server_url":"wss://x/ws","pairing_code":"XY12","phone_number":"1000001"}`
-	if err := os.WriteFile(path, []byte(initial), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	c, err := Load(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := c.SetDeviceToken("tok-newtoken"); err != nil {
-		t.Fatalf("SetDeviceToken: %v", err)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var saved Config
-	if err := json.Unmarshal(data, &saved); err != nil {
-		t.Fatal(err)
-	}
-	if saved.DeviceToken != "tok-newtoken" {
-		t.Errorf("DeviceToken on disk = %q, want %q", saved.DeviceToken, "tok-newtoken")
-	}
-	if saved.PairingCode != "" {
-		t.Errorf("PairingCode should be cleared after SetDeviceToken, got %q", saved.PairingCode)
-	}
-}
-
 func TestHookInvertedDefault(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")


### PR DESCRIPTION
`Config.SetDeviceToken` set `DeviceToken`, cleared `PairingCode`, and called `Save()`. Production never calls it: the `TypePaired` handler in `cmd/digitsd/main.go` writes the fields inline (and also writes `PhoneNumber` and updates the in-memory phone number, which `SetDeviceToken` does not cover). The only thing left exercising the helper was its own test. Same shape as #373's drop of `NeedsPairing` / `IsConfigured`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`