### PR TITLE
fix(digitsd): keep rootfs ro after asset extraction

### DIFF
--- a/.claude/skills/deploy-phone/SKILL.md
+++ b/.claude/skills/deploy-phone/SKILL.md
@@ -49,11 +49,19 @@ For each target phone:
 # 1. Copy binary to /tmp (writable without remount)
 sshpass -p <password> scp <local-binary> <user>@<ip>:/tmp/<binary-name>
 
-# 2. Remount rw, install, remount ro, restart (single SSH session)
-sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,rw / && sudo mv /tmp/<binary-name> <install-destination> && sudo chmod 755 <install-destination> && sudo mount -o remount,ro / && sudo systemctl restart <service>'
+# 2. Remount rw, install binary, restart service, then remount ro
+#    Restart BEFORE remount ro -- the running service holds the old binary's
+#    inode via mmap and the kernel rejects remount,ro until that inode is
+#    released. Restarting the service drops the old mmap; remount ro then
+#    succeeds. digitsd's Extract() also re-attempts remount ro on startup.
+sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,rw / && sudo mv /tmp/<binary-name> <install-destination> && sudo chmod 755 <install-destination> && sudo systemctl restart <service> && sleep 2 && sudo mount -o remount,ro /'
 ```
 
-If no service restart is needed, omit the `systemctl restart` but **always remount back to ro**.
+If no service restart is needed (e.g. digits-recovery, digits-setup), just remount ro directly after the install:
+
+```bash
+sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,rw / && sudo mv /tmp/<binary-name> <install-destination> && sudo chmod 755 <install-destination> && sudo mount -o remount,ro /'
+```
 
 For diagnostic tools going to `/tmp/`, skip the remount cycle entirely -- just scp and run.
 
@@ -69,19 +77,13 @@ sshpass -p <password> ssh <user>@<ip> 'sudo systemctl status <service>'
 sshpass -p <password> ssh <user>@<ip> 'mount | grep "on / "'
 ```
 
-The `mount` output must show `ro` -- if it shows `rw`, remount immediately:
+The `mount` output must show `ro` -- if it shows `rw`, the old service process likely still holds the old binary open. Restart the service and retry:
 
 ```bash
-sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,ro /'
+sshpass -p <password> ssh <user>@<ip> 'sudo systemctl restart <service> && sleep 2 && sudo sync && sudo mount -o remount,ro /'
 ```
 
-If `remount,ro` returns `mount: /: mount point is busy.` even though `lsof` shows no writeable handles, flush systemd-journald first and retry:
-
-```bash
-sshpass -p <password> ssh <user>@<ip> 'sudo journalctl --flush --sync && sync && sudo mount -o remount,ro /'
-```
-
-journald keeps `/var/log/journal/.../*.journal` open `O_RDWR` and intermittently has dirty in-memory state that the kernel counts as a write reference. `--flush --sync` collapses it back to a clean state and the remount succeeds.
+The kernel rejects `remount,ro` on ext4 when any process has a deleted inode mmap'd on that filesystem. Replacing a running binary creates a deleted inode (link count 0) held by the running process. Once the process restarts and the old mmap is released, the remount succeeds.
 
 ## Multi-Phone Deploy
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1514,6 +1514,10 @@ func main() {
 			}
 			return exec.Command("sudo", "mount", "-o", "remount,"+mode, "/").Run()
 		},
+		Sync: func() error {
+			syscall.Sync()
+			return nil
+		},
 		RootfsWriteFile: func(data []byte, dest string, perm os.FileMode) error {
 			// Write to a temp file, then sudo cp + chmod to the rootfs destination.
 			// This matches the pattern used by the existing updater for binary replacement.
@@ -1568,7 +1572,7 @@ func main() {
 		} else {
 			slog.Info("swd render: installed config", "pcb_rev", pcbRev)
 		}
-		if err := extractor.Remount(false); err != nil {
+		if err := extractor.RemountReadOnly(); err != nil {
 			slog.Warn("swd render: remount ro failed", "err", err)
 		}
 	}

--- a/pi/digitsd/internal/assets/assets.go
+++ b/pi/digitsd/internal/assets/assets.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 var permOverrides = []struct {
@@ -35,6 +36,46 @@ type Extractor struct {
 	// that systemd picks up rewritten unit files without requiring a reboot.
 	// Typically wired to `sudo systemctl daemon-reload`.
 	ReloadSystemd func() error
+	// Sync, if set, is called before each remount-ro attempt. Intended to
+	// flush dirty pages so the kernel accepts the read-only transition.
+	// Typically wired to syscall.Sync or `sudo sync`.
+	Sync func() error
+}
+
+// defaultRemountRORetryDelay is the wait between remount-ro retry attempts.
+// It is a package-level variable so tests can set it to zero.
+var defaultRemountRORetryDelay = 300 * time.Millisecond
+
+// RemountReadOnly calls Sync (if set) then Remount(false), retrying a small
+// number of times with a short delay. The retry handles the window where a
+// just-replaced binary's deleted inode is still held by the outgoing process;
+// that inode is released once the process exits and the kernel will then
+// accept the ro transition.
+//
+// Callers outside Extract (e.g. one-off rootfs writes in main) should use
+// this instead of calling Remount(false) directly so they get the same
+// sync-and-retry semantics.
+func (e *Extractor) RemountReadOnly() error {
+	const maxAttempts = 4
+	retryDelay := defaultRemountRORetryDelay
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if e.Sync != nil {
+			if err := e.Sync(); err != nil {
+				log.Printf("assets: WARNING: sync before remount ro failed (attempt %d): %v", attempt, err)
+			}
+		}
+		if err := e.Remount(false); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			if attempt < maxAttempts {
+				log.Printf("assets: remount ro failed (attempt %d/%d): %v -- retrying in %v", attempt, maxAttempts, err, retryDelay)
+				time.Sleep(retryDelay)
+			}
+		}
+	}
+	return fmt.Errorf("remount ro failed after %d attempts: %w", maxAttempts, lastErr)
 }
 
 func (e *Extractor) Extract(currentVersion string) error {
@@ -76,8 +117,8 @@ func (e *Extractor) Extract(currentVersion string) error {
 			}
 			rootfsWritten++
 		}
-		if err := e.Remount(false); err != nil {
-			log.Printf("assets: WARNING: remount ro failed: %v", err)
+		if err := e.RemountReadOnly(); err != nil {
+			return fmt.Errorf("remount ro after rootfs writes: %w", err)
 		}
 		// Rewritten systemd units won't take effect until systemd re-reads
 		// its unit files, so tell it to reload if we touched anything on

--- a/pi/digitsd/internal/assets/assets_test.go
+++ b/pi/digitsd/internal/assets/assets_test.go
@@ -1,6 +1,7 @@
 package assets
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -230,6 +231,125 @@ func TestExtract_SkipsReloadWhenNoRootfsFiles(t *testing.T) {
 	}
 	if reloadCalls != 0 {
 		t.Errorf("ReloadSystemd called %d times, want 0 (no rootfs writes)", reloadCalls)
+	}
+}
+
+func init() {
+	// Speed up retry tests: zero delay so they don't sleep for 900ms in CI.
+	defaultRemountRORetryDelay = 0
+}
+
+// TestRemountReadOnly_RetriesOnFailure verifies that RemountReadOnly retries
+// up to maxAttempts times and returns an error only after all attempts fail.
+func TestRemountReadOnly_RetriesOnFailure(t *testing.T) {
+	calls := 0
+	e := &Extractor{
+		Remount: func(rw bool) error {
+			if rw {
+				return nil
+			}
+			calls++
+			return fmt.Errorf("mount point is busy")
+		},
+	}
+	err := e.RemountReadOnly()
+	if err == nil {
+		t.Fatal("expected error from RemountReadOnly, got nil")
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 remount attempts, got %d", calls)
+	}
+	if !strings.Contains(err.Error(), "mount point is busy") {
+		t.Errorf("error should include underlying cause: %v", err)
+	}
+}
+
+// TestRemountReadOnly_SucceedsOnSecondAttempt verifies that RemountReadOnly
+// returns nil as soon as one attempt succeeds, without exhausting all retries.
+func TestRemountReadOnly_SucceedsOnSecondAttempt(t *testing.T) {
+	calls := 0
+	e := &Extractor{
+		Remount: func(rw bool) error {
+			if rw {
+				return nil
+			}
+			calls++
+			if calls < 2 {
+				return fmt.Errorf("mount point is busy")
+			}
+			return nil
+		},
+	}
+	if err := e.RemountReadOnly(); err != nil {
+		t.Fatalf("expected success on second attempt, got: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 remount attempts, got %d", calls)
+	}
+}
+
+// TestRemountReadOnly_CallsSyncBeforeEachAttempt verifies that Sync is called
+// before each remount-ro attempt.
+func TestRemountReadOnly_CallsSyncBeforeEachAttempt(t *testing.T) {
+	syncCalls := 0
+	remountCalls := 0
+	e := &Extractor{
+		Sync: func() error {
+			syncCalls++
+			return nil
+		},
+		Remount: func(rw bool) error {
+			if rw {
+				return nil
+			}
+			remountCalls++
+			if remountCalls < 3 {
+				return fmt.Errorf("busy")
+			}
+			return nil
+		},
+	}
+	if err := e.RemountReadOnly(); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if syncCalls != remountCalls {
+		t.Errorf("sync called %d times, remount called %d times; want equal", syncCalls, remountCalls)
+	}
+}
+
+// TestExtract_FailsWhenRemountROFails verifies that Extract returns an error
+// when all remount-ro attempts fail, and withholds the marker so the next
+// boot will retry extraction.
+func TestExtract_FailsWhenRemountROFails(t *testing.T) {
+	root := t.TempDir()
+	dataDir := t.TempDir()
+	markerPath := filepath.Join(dataDir, "asset-version")
+
+	e := &Extractor{
+		FS: fstest.MapFS{
+			"rootfs/etc/systemd/system/x.service": &fstest.MapFile{Data: []byte("unit")},
+		},
+		RootDir:    root,
+		DataDir:    dataDir,
+		MarkerPath: markerPath,
+		Remount: func(rw bool) error {
+			if rw {
+				return nil // remount rw succeeds
+			}
+			return fmt.Errorf("mount point is busy")
+		},
+	}
+
+	err := e.Extract("1.0.0")
+	if err == nil {
+		t.Fatal("expected error when remount ro fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "remount ro") {
+		t.Errorf("error should mention remount ro: %v", err)
+	}
+	// Marker must not be written so the next boot retries.
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Errorf("marker should not exist when remount ro failed, stat err=%v", err)
 	}
 }
 

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -247,9 +247,14 @@ func (u *Updater) ApplyPiUpdate(stagedBinary, expectedVersion string) error {
 		}
 	}
 
-	// Restore read-only rootfs.
+	// Restore read-only rootfs. This remount may fail: the running process has
+	// the old binary's inode mmap'd (link count 0 after the mv), and the
+	// kernel rejects remount,ro while a deleted inode is still open. That is
+	// expected here -- os.Exit(0) follows immediately, which releases the
+	// mmap. Systemd then starts the new binary, whose Extract() call will
+	// remount ro once it is safely running from the replacement inode.
 	if err := exec.Command("sudo", "mount", "-o", "remount,ro", "/").Run(); err != nil {
-		slog.Warn("updater: failed to remount ro", "error", err)
+		slog.Warn("updater: remount ro failed (expected when replacing running binary; next startup will fix)", "error", err)
 	}
 
 	slog.Info("updater: Pi binary updated -- exiting for restart")

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -3,6 +3,7 @@
 #   - copy, chmod, mkdir, mv, rm for binary replacement and asset extraction
 #   - run openocd for SWD firmware flashing
 #   - stop/start digitsd service
+#   - reload systemd unit definitions after the asset extractor rewrites them
 #   - reboot the device (remote restart, factory reset, or service code)
 #   - clear /data/wifi-configured flag for *#SETUP# Wi-Fi re-provisioning
 digits ALL=(root) NOPASSWD: /usr/bin/mount -o remount\,rw /, /usr/bin/mount -o remount\,ro /
@@ -14,5 +15,5 @@ digits ALL=(root) NOPASSWD: /usr/bin/mv /usr/local/bin/digitsd.tmp /usr/local/bi
 digits ALL=(root) NOPASSWD: /usr/bin/rm -f /usr/local/bin/digitsd.tmp
 digits ALL=(root) NOPASSWD: /usr/bin/rm -f /data/wifi-configured
 digits ALL=(root) NOPASSWD: /usr/bin/openocd
-digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service
+digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service, /usr/bin/systemctl daemon-reload
 digits ALL=(root) NOPASSWD: /usr/sbin/reboot


### PR DESCRIPTION
## The bug

After deploying a new `digitsd` binary, five of six phones came up with the rootfs in `rw` state instead of `ro`. The `Remount(false)` call in `Extract()` and `ApplyPiUpdate` logged a WARNING and silently continued, leaving the filesystem permanently writable.

## Root cause (confirmed on hardware)

When a running binary is replaced via `mv` (whether from the deploy-phone skill or OTA), the old binary's inode is unlinked but kept alive by the still-running process's `rw-p` mmap. The Linux kernel rejects `mount -o remount,ro` on ext4 while any process holds a deleted inode open on that filesystem:

```
$ sudo cat /proc/<digitsd-pid>/maps | grep digitsd
... /usr/local/bin/digitsd (deleted)    # rw-p mapping blocks remount,ro
```

Reproduced on-device: `cp + mv` the running binary, then `mount -o remount,ro /` returns "mount point is busy". After `systemctl restart digitsd` (releasing the mmap), the remount succeeds immediately.

The previous troubleshooting note in the deploy-phone skill blamed journald, but the journal files live on `/data` (device `179,4`, not `179,2`), confirmed via `stat /var/log/journal/*/system.journal`. Stopping journald happened to work as a workaround only because it caused digitsd's stdout socket (connected to journald via `StandardOutput=journal`) to break, which terminated the old process and released the mmap.

## What I tried

- Confirmed `sync` alone does not fix the deleted-inode case (the blocker is the open mmap reference, not dirty pages).
- Confirmed small file writes + `remount,ro` work fine when no running binary is being replaced.
- Confirmed the remount succeeds cleanly once the old process exits.

## The fix

**`assets.go`**:
- New `Sync func() error` field on `Extractor`. Called before each remount-ro attempt. Wired to `syscall.Sync` in `main.go`.
- New `RemountReadOnly()` exported method: sync, then `Remount(false)`, up to 4 attempts with 300ms delays. This gives a dying predecessor process time to exit and release its inode.
- `Extract()` now calls `RemountReadOnly()` instead of bare `Remount(false)`. Failure is a hard error (not a WARNING), so the marker is withheld and the next boot retries from scratch.

**`main.go`**: SWD config render path uses `RemountReadOnly()` for the same robustness.

**`updater.go`**: Added a comment explaining why the `remount,ro` at the end of `ApplyPiUpdate` is expected to fail (running process still holds the old inode) and that `Extract()` on the next startup corrects the state.

**`deploy-phone/SKILL.md`**: Fixed the deploy sequence to restart the service BEFORE attempting `remount,ro`, so the old mmap is released first. Corrected the troubleshooting section.

## Test plan

- `go test ./...` from `pi/digitsd/`: all pass.
- `go build ./...` from `pi/digitsd/`: clean.
- `golangci-lint run ./...`: 0 issues.
- New tests: `TestRemountReadOnly_RetriesOnFailure`, `TestRemountReadOnly_SucceedsOnSecondAttempt`, `TestRemountReadOnly_CallsSyncBeforeEachAttempt`, `TestExtract_FailsWhenRemountROFails`.
- On-device: verified rw/ro remount cycle works, confirmed deleted-inode scenario via `/proc/<pid>/maps`, confirmed remount succeeds after service restart.