### PR TITLE
feat(server,digitsd): per-device auto-update toggle

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1353,7 +1353,7 @@ var updateInProgress atomic.Bool
 // delegates to runTargetedUpdate with empty targets (install whatever is
 // latest). When a call is in progress the update is deferred: pendingAutoUpdate
 // is set so HangupCall can retry once the call ends.
-func runAutoUpdate(d *daemonCallbacks, serverURL, piVersion, fwVersion string, flashCapable bool, reportStatus statusFunc, afterFirmwareUpdated func()) {
+func runAutoUpdate(d *daemonCallbacks, serverURL, piVersion, fwVersion string, flashCapable bool, afterFirmwareUpdated func()) {
 	d.mu.Lock()
 	inCall := d.callPeer != ""
 	d.mu.Unlock()
@@ -1365,7 +1365,7 @@ func runAutoUpdate(d *daemonCallbacks, serverURL, piVersion, fwVersion string, f
 	}
 
 	slog.Info("auto-update: device is idle, checking for updates")
-	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, reportStatus, afterFirmwareUpdated)
+	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, nil, afterFirmwareUpdated)
 }
 
 func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc, afterFirmwareUpdated func()) {
@@ -2149,7 +2149,7 @@ func main() {
 	// without needing direct access to those locals.
 	cb.autoUpdateEnabled.Store(cfg.AutoUpdate)
 	cb.triggerAutoUpdate = func() {
-		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), nil, requeryFirmware)
+		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), requeryFirmware)
 	}
 	if cb.autoUpdateEnabled.Load() {
 		slog.Info("auto-update: enabled, checking for updates on startup")

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -107,12 +107,34 @@ type daemonCallbacks struct {
 	// reporter. Keyed by peer phone. Protected by mu, same as mesh.
 	meshReporterCancels map[string]context.CancelFunc
 
+	// Firmware version strings, protected by mu. Read/write via
+	// getFirmwareVersion / setFirmwareVersion so that goroutines outside the
+	// main event loop (SWD probe, service-code update, auto-update) never
+	// race with the main loop's writes.
+	fwVer string
+	fwCom string
+
 	// Auto-update state. The atomic bools are safe for concurrent read from
 	// the update goroutine. triggerAutoUpdate is set once at startup and
 	// captures the run()-scoped variables needed by runAutoUpdate.
 	autoUpdateEnabled atomic.Bool
 	pendingAutoUpdate atomic.Bool
 	triggerAutoUpdate func() // set in run(), calls runAutoUpdate with captured vars
+}
+
+// getFirmwareVersion returns the current firmware version and commit under mu.
+func (d *daemonCallbacks) getFirmwareVersion() (version, commit string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fwVer, d.fwCom
+}
+
+// setFirmwareVersion stores a new firmware version and commit under mu.
+func (d *daemonCallbacks) setFirmwareVersion(version, commit string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.fwVer = version
+	d.fwCom = commit
 }
 
 // sendSignal sends a signaling message and logs failures.
@@ -2054,7 +2076,7 @@ func main() {
 	swdFilesPresent := err1 == nil && err2 == nil
 
 	if swdFilesPresent {
-		go func() {
+		go func(fwVer, fwCom string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			cmd := exec.CommandContext(ctx, "sudo", defaultOpenOCD,
@@ -2068,8 +2090,8 @@ func main() {
 				slog.Info("swd probe: Pico detected on SWD bus, enabling flash capability")
 				flashCapable.Store(true)
 			}
-			sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
-		}()
+			sendDeviceInfo(sig, fwVer, fwCom, flashCapable.Load())
+		}(fwVersion, fwCommit)
 	}
 
 	svcCodes.OnRepair = func() {
@@ -2095,10 +2117,9 @@ func main() {
 		})
 	}
 
-	svcCodes.OnUpdate = func() {
-		slog.Info("service code: *#UPDATE# (*#873283#) -- checking for updates")
-		go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion, "", "", flashCapable.Load(), nil, requeryFirmware)
-	}
+	// svcCodes.OnUpdate is set after cb is created so the closure can read
+	// fwVersion through the synchronized getter (OnUpdate runs in its own
+	// goroutine and would otherwise race with the main loop).
 
 	svcCodes.OnFactoryReset = func() {
 		slog.Info("service code: *#00000# -> awaiting confirmation")
@@ -2143,17 +2164,29 @@ func main() {
 		linkHealthDisabled:  linkHealthDisabled,
 		linkHealthInterval:  linkHealthInterval,
 		meshReporterCancels: make(map[string]context.CancelFunc),
+		fwVer:               fwVersion,
+		fwCom:               fwCommit,
 	}
 	if cfg.DeviceToken != "" {
 		cb.paired.Store(true)
 	}
 
-	// Wire auto-update. The closure captures run()-scoped variables so that
-	// HangupCall (which lives on daemonCallbacks) can trigger an update
-	// without needing direct access to those locals.
+	// Deferred from above: OnUpdate runs in its own goroutine, so it reads
+	// fwVersion through the synchronized getter to avoid racing with the
+	// main event loop.
+	svcCodes.OnUpdate = func() {
+		slog.Info("service code: *#UPDATE# (*#873283#) -- checking for updates")
+		fwVer, _ := cb.getFirmwareVersion()
+		go runTargetedUpdate(effectiveServerURL, version.Version, fwVer, "", "", flashCapable.Load(), nil, requeryFirmware)
+	}
+
+	// Wire auto-update. The closure reads fwVersion via the synchronized
+	// getter so that HangupCall (which runs off the main goroutine) never
+	// races with the main loop's writes.
 	cb.autoUpdateEnabled.Store(cfg.AutoUpdate)
 	cb.triggerAutoUpdate = func() {
-		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), requeryFirmware)
+		fwVer, _ := cb.getFirmwareVersion()
+		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVer, flashCapable.Load(), requeryFirmware)
 	}
 	if cb.autoUpdateEnabled.Load() {
 		slog.Info("auto-update: enabled, checking for updates on startup")
@@ -2464,6 +2497,7 @@ func main() {
 		case r := <-fwVersionCh:
 			if r.version != fwVersion || r.commit != fwCommit {
 				fwVersion, fwCommit = r.version, r.commit
+				cb.setFirmwareVersion(fwVersion, fwCommit)
 				slog.Info("pico: firmware version changed", "version", fwVersion, "commit", fwCommit)
 				hookFlash = hookFlashCapable(fwVersion)
 				slog.Info("firmware capability", "version", fwVersion, "flash_capable", hookFlash)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -106,6 +106,13 @@ type daemonCallbacks struct {
 	// meshReporterCancels holds one CancelFunc per mesh peer's link-health
 	// reporter. Keyed by peer phone. Protected by mu, same as mesh.
 	meshReporterCancels map[string]context.CancelFunc
+
+	// Auto-update state. The atomic bools are safe for concurrent read from
+	// the update goroutine. triggerAutoUpdate is set once at startup and
+	// captures the run()-scoped variables needed by runAutoUpdate.
+	autoUpdateEnabled atomic.Bool
+	pendingAutoUpdate atomic.Bool
+	triggerAutoUpdate func() // set in run(), calls runAutoUpdate with captured vars
 }
 
 // sendSignal sends a signaling message and logs failures.
@@ -894,6 +901,13 @@ func (d *daemonCallbacks) HangupCall() {
 	d.mu.Unlock()
 	slog.Info("call disconnected", "peer", peer, "sync_elapsed", time.Since(t0).Round(time.Microsecond))
 
+	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateEnabled.Load() {
+		slog.Info("auto-update: call ended, running deferred update")
+		if d.triggerAutoUpdate != nil {
+			go d.triggerAutoUpdate()
+		}
+	}
+
 	go func() {
 		defer recoverGoroutine("hangup-teardown")
 		teardownStart := time.Now()
@@ -971,6 +985,15 @@ func (d *daemonCallbacks) applySilentModeLive(silent bool) {
 func (d *daemonCallbacks) setSilentModeConfig(silent bool) error {
 	d.mu.Lock()
 	d.cfg.SilentMode = silent
+	d.mu.Unlock()
+	return d.cfg.Save()
+}
+
+// setAutoUpdateConfig writes the new flag to the local config cache under
+// d.mu and persists it to disk outside the lock.
+func (d *daemonCallbacks) setAutoUpdateConfig(enabled bool) error {
+	d.mu.Lock()
+	d.cfg.AutoUpdate = enabled
 	d.mu.Unlock()
 	return d.cfg.Save()
 }
@@ -1326,6 +1349,24 @@ func triggerFactoryReset(sig *sigclient.Client, deviceID string) {
 // to avoid racing (e.g. double-flashing the Pico).
 var updateInProgress atomic.Bool
 
+// runAutoUpdate checks whether the device is idle (no active call) and, if so,
+// delegates to runTargetedUpdate with empty targets (install whatever is
+// latest). When a call is in progress the update is deferred: pendingAutoUpdate
+// is set so HangupCall can retry once the call ends.
+func runAutoUpdate(d *daemonCallbacks, serverURL, piVersion, fwVersion string, flashCapable bool, reportStatus statusFunc, afterFirmwareUpdated func()) {
+	d.mu.Lock()
+	inCall := d.callPeer != ""
+	d.mu.Unlock()
+
+	if inCall {
+		slog.Info("auto-update: call in progress, deferring until idle")
+		d.pendingAutoUpdate.Store(true)
+		return
+	}
+
+	slog.Info("auto-update: device is idle, checking for updates")
+	runTargetedUpdate(serverURL, piVersion, fwVersion, "", "", flashCapable, reportStatus, afterFirmwareUpdated)
+}
 
 func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW string, flashCapable bool, reportStatus statusFunc, afterFirmwareUpdated func()) {
 	if !updateInProgress.CompareAndSwap(false, true) {
@@ -2103,6 +2144,18 @@ func main() {
 		cb.paired.Store(true)
 	}
 
+	// Wire auto-update. The closure captures run()-scoped variables so that
+	// HangupCall (which lives on daemonCallbacks) can trigger an update
+	// without needing direct access to those locals.
+	cb.autoUpdateEnabled.Store(cfg.AutoUpdate)
+	cb.triggerAutoUpdate = func() {
+		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVersion, flashCapable.Load(), nil, requeryFirmware)
+	}
+	if cb.autoUpdateEnabled.Load() {
+		slog.Info("auto-update: enabled, checking for updates on startup")
+		go cb.triggerAutoUpdate()
+	}
+
 	// 8. Create phone Controller
 	ctrl := phone.NewController(cb, effectiveNumber)
 	cb.ctrl = ctrl
@@ -2608,6 +2661,12 @@ func main() {
 				go runTargetedUpdate(effectiveServerURL, version.Version, fwVersion,
 					msg.TargetPiVersion, msg.TargetFWVersion, flashCapable.Load(), statusReporter, requeryFirmware)
 
+			case sigclient.TypeReleaseAvailable:
+				slog.Info("signal: release_available", "pi", msg.LatestPiVersion, "fw", msg.LatestFWVersion)
+				if cb.autoUpdateEnabled.Load() {
+					go cb.triggerAutoUpdate()
+				}
+
 			case sigclient.TypeFactoryReset:
 				slog.Info("factory reset: triggered by server")
 				go triggerFactoryReset(sig, deviceID)
@@ -2763,6 +2822,15 @@ func main() {
 					cb.applySilentModeLive(silent)
 					if err := cb.setSilentModeConfig(silent); err != nil {
 						slog.Warn("line_settings: silent-mode save failed", "err", err)
+					}
+				}
+
+				au := msg.LineSettings.AutoUpdate
+				if au != cb.autoUpdateEnabled.Load() {
+					cb.autoUpdateEnabled.Store(au)
+					slog.Info("line_settings applied", "auto_update", au)
+					if err := cb.setAutoUpdateConfig(au); err != nil {
+						slog.Warn("line_settings: auto-update save failed", "err", err)
 					}
 				}
 

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -64,6 +64,12 @@ type Config struct {
 	// the LED. Cached locally so the setting survives reboots while offline.
 	SilentMode bool `json:"silent_mode,omitempty"`
 
+	// AutoUpdate controls whether digitsd applies OTA updates automatically.
+	// When true, the daemon downloads and applies available updates without
+	// waiting for a manual update_trigger from the server. Cached locally so
+	// the setting survives reboots while offline.
+	AutoUpdate bool `json:"auto_update,omitempty"`
+
 	// WiFiFallback configures the WiFi auto-fallback supervisor.
 	WiFiFallback WiFiFallback `json:"wifi_fallback"`
 

--- a/pi/digitsd/internal/config/config_test.go
+++ b/pi/digitsd/internal/config/config_test.go
@@ -447,3 +447,32 @@ func TestConfigSaveRoundTripSilentMode(t *testing.T) {
 		t.Errorf("round trip did not preserve silent_mode")
 	}
 }
+
+func TestAutoUpdateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	data := `{"auto_update": true}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !loaded.AutoUpdate {
+		t.Error("AutoUpdate: got false after load, want true")
+	}
+
+	if err := loaded.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !reloaded.AutoUpdate {
+		t.Error("AutoUpdate: got false after save round-trip, want true")
+	}
+}

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -52,6 +52,10 @@ const (
 	// for the line this device is registered as. Applied live.
 	TypeLineSettings = "line_settings"
 
+	// TypeReleaseAvailable is sent by the server to notify the device that a
+	// new release is available. Carries LatestPiVersion and LatestFWVersion.
+	TypeReleaseAvailable = "release_available"
+
 	// TypeLinkHealth is sent by the phone to the server with a per-call
 	// quality telemetry snapshot. Phone → Server only.
 	TypeLinkHealth = "link_health"
@@ -116,6 +120,7 @@ type ContactEntry struct {
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 	SilentMode bool   `json:"silent_mode,omitempty"`
+	AutoUpdate bool   `json:"auto_update,omitempty"`
 }
 
 // ConferenceMemberInfo describes one participant in a conference call.
@@ -162,6 +167,10 @@ type Message struct {
 	// Update trigger fields (update_trigger messages)
 	TargetPiVersion string `json:"target_pi_version,omitempty"`
 	TargetFWVersion string `json:"target_fw_version,omitempty"`
+
+	// Release notification fields (release_available messages)
+	LatestPiVersion string `json:"latest_pi_version,omitempty"`
+	LatestFWVersion string `json:"latest_fw_version,omitempty"`
 
 	// Update status fields (update_status messages)
 	UpdateStatus string `json:"update_status,omitempty"` // downloading, applying, rebooting, success, failed

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -164,6 +164,14 @@ func run(ctx context.Context) error {
 		if len(parts) == 2 {
 			handler.Releases = updates.NewGitHubReleases(ctx, parts[0], parts[1], cfg.GitHubToken, 300) // 5 min cache
 			slog.Info("updates: release index from GitHub", "repo", cfg.GitHubRepo)
+			handler.Releases.OnChange = func(piLatest, fwLatest string) {
+				slog.Info("updates: new release detected, broadcasting", "pi", piLatest, "fw", fwLatest)
+				handler.Hub().Broadcast(&signaling.Message{
+					Type:            signaling.TypeReleaseAvailable,
+					LatestPiVersion: piLatest,
+					LatestFWVersion: fwLatest,
+				})
+			}
 		} else {
 			slog.Warn("GITHUB_REPO must be in owner/repo format, ignoring", "value", cfg.GitHubRepo)
 		}

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -162,16 +162,16 @@ func run(ctx context.Context) error {
 	case cfg.GitHubRepo != "":
 		parts := strings.SplitN(cfg.GitHubRepo, "/", 2)
 		if len(parts) == 2 {
-			handler.Releases = updates.NewGitHubReleases(ctx, parts[0], parts[1], cfg.GitHubToken, 300) // 5 min cache
-			slog.Info("updates: release index from GitHub", "repo", cfg.GitHubRepo)
-			handler.Releases.OnChange = func(piLatest, fwLatest string) {
-				slog.Info("updates: new release detected, broadcasting", "pi", piLatest, "fw", fwLatest)
-				handler.Hub().Broadcast(&signaling.Message{
-					Type:            signaling.TypeReleaseAvailable,
-					LatestPiVersion: piLatest,
-					LatestFWVersion: fwLatest,
+			handler.Releases = updates.NewGitHubReleases(ctx, parts[0], parts[1], cfg.GitHubToken, 300, // 5 min cache
+				func(piLatest, fwLatest string) {
+					slog.Info("updates: new release detected, broadcasting", "pi", piLatest, "fw", fwLatest)
+					handler.Hub().Broadcast(&signaling.Message{
+						Type:            signaling.TypeReleaseAvailable,
+						LatestPiVersion: piLatest,
+						LatestFWVersion: fwLatest,
+					})
 				})
-			}
+			slog.Info("updates: release index from GitHub", "repo", cfg.GitHubRepo)
 		} else {
 			slog.Warn("GITHUB_REPO must be in owner/repo format, ignoring", "value", cfg.GitHubRepo)
 		}

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -12,6 +12,7 @@ const (
 type Settings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 	SilentMode bool   `json:"silent_mode,omitempty"`
+	AutoUpdate bool   `json:"auto_update,omitempty"`
 }
 
 // DefaultSettings returns the settings a newly created line starts with.
@@ -29,6 +30,7 @@ func (s Settings) Merge(patch Settings) Settings {
 		s.VoiceStyle = patch.VoiceStyle
 	}
 	s.SilentMode = patch.SilentMode
+	s.AutoUpdate = patch.AutoUpdate
 	return s
 }
 

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -118,6 +118,51 @@ func TestSettingsMergeSilentModeFromPatch(t *testing.T) {
 	}
 }
 
+func TestSettingsAutoUpdateDefaultFalse(t *testing.T) {
+	s := DefaultSettings()
+	if s.AutoUpdate {
+		t.Errorf("AutoUpdate default: got true, want false")
+	}
+}
+
+func TestSettingsJSONRoundTripAutoUpdate(t *testing.T) {
+	in := Settings{VoiceStyle: VoiceStyleCopper, AutoUpdate: true}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Settings
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out != in {
+		t.Errorf("round trip: got %+v, want %+v", out, in)
+	}
+}
+
+func TestSettingsJSONOmitsAutoUpdateWhenFalse(t *testing.T) {
+	s := Settings{VoiceStyle: VoiceStyleCopper, AutoUpdate: false}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "auto_update") {
+		t.Errorf("expected auto_update omitted when false, got %s", b)
+	}
+}
+
+func TestSettingsMergeAutoUpdateFromPatch(t *testing.T) {
+	base := DefaultSettings()
+	patch := Settings{AutoUpdate: true}
+	merged := base.Merge(patch)
+	if !merged.AutoUpdate {
+		t.Errorf("Merge did not take AutoUpdate from patch")
+	}
+	if merged.VoiceStyle != VoiceStyleCopper {
+		t.Errorf("Merge clobbered VoiceStyle: got %q", merged.VoiceStyle)
+	}
+}
+
 func TestEffectiveSilent(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -141,6 +141,25 @@ func (h *Hub) SendToHardware(hardwareID string, msg *Message) error {
 	return sendToConn(conn, msg, "hardware", hardwareID)
 }
 
+// Broadcast marshals msg and sends it to every connected device without
+// blocking. Devices whose Send buffers are full are skipped with a warning.
+func (h *Hub) Broadcast(msg *Message) {
+	data, err := msg.Marshal()
+	if err != nil {
+		slog.Error("broadcast marshal failed", "type", msg.Type, "err", err)
+		return
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for number, conn := range h.conns {
+		select {
+		case conn.Send <- data:
+		default:
+			slog.Warn("broadcast: send buffer full, skipping", "number", number)
+		}
+	}
+}
+
 // sendToConn marshals msg and pushes it onto conn.Send without blocking.
 // label/id are only used to label the resulting error: "<label> <id>: <reason>".
 // Returns ErrNotConnected when conn is nil so callers can errors.Is past

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -109,6 +109,68 @@ func TestRegisterOverwritesRemoteAddrOnReconnect(t *testing.T) {
 	}
 }
 
+func TestBroadcastSendsToAllConnected(t *testing.T) {
+	hub := NewHub()
+
+	c1 := &Conn{Send: make(chan []byte, 10)}
+	c2 := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", c1)
+	hub.Register("3140002", c2)
+
+	msg := &Message{
+		Type:            TypeReleaseAvailable,
+		LatestPiVersion: "2.0.0",
+		LatestFWVersion: "1.5.0",
+	}
+	hub.Broadcast(msg)
+
+	for _, tc := range []struct {
+		name string
+		conn *Conn
+	}{
+		{"device 1", c1},
+		{"device 2", c2},
+	} {
+		select {
+		case data := <-tc.conn.Send:
+			got, err := ParseMessage(data)
+			if err != nil {
+				t.Fatalf("%s: parse: %v", tc.name, err)
+			}
+			if got.Type != TypeReleaseAvailable {
+				t.Errorf("%s: Type = %q, want %q", tc.name, got.Type, TypeReleaseAvailable)
+			}
+			if got.LatestPiVersion != "2.0.0" {
+				t.Errorf("%s: LatestPiVersion = %q, want %q", tc.name, got.LatestPiVersion, "2.0.0")
+			}
+			if got.LatestFWVersion != "1.5.0" {
+				t.Errorf("%s: LatestFWVersion = %q, want %q", tc.name, got.LatestFWVersion, "1.5.0")
+			}
+		default:
+			t.Errorf("%s: did not receive broadcast", tc.name)
+		}
+	}
+}
+
+func TestBroadcastSkipsFullBuffers(t *testing.T) {
+	hub := NewHub()
+
+	full := &Conn{Send: make(chan []byte)} // unbuffered, will be full
+	ok := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", full)
+	hub.Register("3140002", ok)
+
+	msg := &Message{Type: TypeReleaseAvailable, LatestPiVersion: "2.0.0"}
+	hub.Broadcast(msg)
+
+	select {
+	case <-ok.Send:
+		// good
+	default:
+		t.Error("buffered conn should have received broadcast")
+	}
+}
+
 func TestDeviceInfoSnapshotJSONOmitsRemoteAddr(t *testing.T) {
 	snap := DeviceInfoSnapshot{
 		PiVersion:       "1.2.3",

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -27,5 +27,6 @@ func (a *lineStoreAdapter) EffectiveLineSettings(ctx context.Context, number str
 	return &LineSettings{
 		VoiceStyle: settings.VoiceStyle,
 		SilentMode: silent,
+		AutoUpdate: settings.AutoUpdate,
 	}, nil
 }

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -26,9 +26,9 @@ const (
 	TypeRestart       = "restart"        // Server → Phone: restart service or reboot
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
-	TypeRepair        = "repair"         // Phone -> Server: invalidate pairing (used by *#0* before reboot)
+	TypeRepair        = "repair"         // Phone → Server: invalidate pairing (used by *#0* before reboot)
 
-	TypeReleaseAvailable = "release_available" // Server -> All: new release detected
+	TypeReleaseAvailable = "release_available" // Server → All: new release detected
 )
 
 // Conference message types (three-way calling)

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -26,7 +26,8 @@ const (
 	TypeRestart       = "restart"        // Server → Phone: restart service or reboot
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
-	TypeRepair           = "repair"            // Phone -> Server: invalidate pairing (used by *#0* before reboot)
+	TypeRepair        = "repair"         // Phone -> Server: invalidate pairing (used by *#0* before reboot)
+
 	TypeReleaseAvailable = "release_available" // Server -> All: new release detected
 )
 

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -26,7 +26,8 @@ const (
 	TypeRestart       = "restart"        // Server → Phone: restart service or reboot
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
-	TypeRepair        = "repair"         // Phone → Server: invalidate pairing (used by *#0* before reboot)
+	TypeRepair           = "repair"            // Phone -> Server: invalidate pairing (used by *#0* before reboot)
+	TypeReleaseAvailable = "release_available" // Server -> All: new release detected
 )
 
 // Conference message types (three-way calling)
@@ -137,6 +138,10 @@ type Message struct {
 	// Update trigger fields (update_trigger messages)
 	TargetPiVersion string `json:"target_pi_version,omitempty"`
 	TargetFWVersion string `json:"target_fw_version,omitempty"`
+
+	// Release notification fields (release_available messages)
+	LatestPiVersion string `json:"latest_pi_version,omitempty"`
+	LatestFWVersion string `json:"latest_fw_version,omitempty"`
 
 	// Update status fields (update_status messages)
 	UpdateStatus string `json:"update_status,omitempty"` // downloading, applying, rebooting, success, failed

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -57,6 +57,7 @@ const (
 type LineSettings struct {
 	VoiceStyle string `json:"voice_style,omitempty"`
 	SilentMode bool   `json:"silent_mode,omitempty"`
+	AutoUpdate bool   `json:"auto_update,omitempty"`
 }
 
 // ConferenceMemberInfo describes one participant in a conference call.

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -75,6 +75,41 @@ func TestOnRegisteredPushesSilentMode(t *testing.T) {
 	}
 }
 
+func TestOnRegisteredPushesAutoUpdate(t *testing.T) {
+	hub := NewHub()
+	store := newFakeLineStore()
+	store.set("3140003", &LineSettings{
+		VoiceStyle: "copper",
+		SilentMode: false,
+		AutoUpdate: true,
+	})
+	relay := NewRelay(hub, nil, nil, store)
+
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140003", conn)
+
+	relay.OnRegistered(context.Background(), "3140003")
+
+	select {
+	case data := <-conn.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeLineSettings {
+			t.Errorf("Type: got %q, want %q", msg.Type, TypeLineSettings)
+		}
+		if msg.LineSettings == nil {
+			t.Fatal("LineSettings: got nil, want non-nil")
+		}
+		if !msg.LineSettings.AutoUpdate {
+			t.Errorf("AutoUpdate: got false, want true")
+		}
+	default:
+		t.Fatal("device did not receive a line_settings push after OnRegistered")
+	}
+}
+
 // TestOnRegisteredPushesSilentModeFalseByDefault verifies that when
 // OnRegistered is called for a number whose stored LineSettings has
 // SilentMode: false, the pushed message also carries SilentMode: false.

--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -56,14 +56,15 @@ type GitHubReleases struct {
 
 // NewGitHubReleases creates a GitHubReleases that polls the given repo.
 // It fetches immediately in the background and refreshes every ttlSeconds.
-func NewGitHubReleases(ctx context.Context, owner, repo, token string, ttlSeconds int) *GitHubReleases {
+func NewGitHubReleases(ctx context.Context, owner, repo, token string, ttlSeconds int, onChange func(piLatest, fwLatest string)) *GitHubReleases {
 	g := &GitHubReleases{
-		owner:   owner,
-		repo:    repo,
-		apiBase: "https://api.github.com",
-		token:   token,
-		client:  &http.Client{Timeout: 15 * time.Second},
-		ttl:     time.Duration(ttlSeconds) * time.Second,
+		owner:    owner,
+		repo:     repo,
+		apiBase:  "https://api.github.com",
+		token:    token,
+		client:   &http.Client{Timeout: 15 * time.Second},
+		ttl:      time.Duration(ttlSeconds) * time.Second,
+		OnChange: onChange,
 	}
 	go g.poll(ctx)
 	return g

--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -47,6 +47,11 @@ type GitHubReleases struct {
 
 	mu     sync.RWMutex
 	cached *ReleaseIndex
+
+	// OnChange is called when refresh detects a new latest version for
+	// either component. Called synchronously from SetIndex; the callback
+	// should not block. Nil means no notification.
+	OnChange func(piLatest, fwLatest string)
 }
 
 // NewGitHubReleases creates a GitHubReleases that polls the given repo.
@@ -89,15 +94,28 @@ func (g *GitHubReleases) poll(ctx context.Context) {
 	}
 }
 
+// SetIndex replaces the cached release index. If OnChange is set and either
+// component's latest version differs from the previous index, the callback is
+// fired synchronously after the lock is released.
+func (g *GitHubReleases) SetIndex(idx *ReleaseIndex) {
+	g.mu.Lock()
+	old := g.cached
+	g.cached = idx
+	cb := g.OnChange
+	g.mu.Unlock()
+
+	if cb != nil && old != nil && (old.Pi.Latest != idx.Pi.Latest || old.Firmware.Latest != idx.Firmware.Latest) {
+		cb(idx.Pi.Latest, idx.Firmware.Latest)
+	}
+}
+
 func (g *GitHubReleases) refresh(ctx context.Context) {
 	idx, err := g.fetch(ctx)
 	if err != nil {
 		slog.Error("failed to fetch GitHub releases", "error", err)
 		return
 	}
-	g.mu.Lock()
-	g.cached = idx
-	g.mu.Unlock()
+	g.SetIndex(idx)
 }
 
 // ServeReleases returns an HTTP handler that serves the release index as JSON.

--- a/server/internal/updates/github_test.go
+++ b/server/internal/updates/github_test.go
@@ -266,6 +266,61 @@ func TestFetchPopulatesNotes(t *testing.T) {
 	}
 }
 
+func TestOnChangeCalledWhenVersionChanges(t *testing.T) {
+	idx1 := &ReleaseIndex{
+		Pi:       ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+		Firmware: ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+	}
+	g := NewGitHubReleasesWithIndex(idx1)
+
+	var called bool
+	var gotPi, gotFW string
+	g.OnChange = func(piLatest, fwLatest string) {
+		called = true
+		gotPi = piLatest
+		gotFW = fwLatest
+	}
+
+	idx2 := &ReleaseIndex{
+		Pi:       ComponentIndex{Latest: "2.0.0", Releases: map[string]*Release{"2.0.0": {Version: "2.0.0"}}},
+		Firmware: ComponentIndex{Latest: "1.5.0", Releases: map[string]*Release{"1.5.0": {Version: "1.5.0"}}},
+	}
+	g.SetIndex(idx2)
+
+	if !called {
+		t.Fatal("OnChange was not called")
+	}
+	if gotPi != "2.0.0" {
+		t.Errorf("pi version: got %q, want %q", gotPi, "2.0.0")
+	}
+	if gotFW != "1.5.0" {
+		t.Errorf("fw version: got %q, want %q", gotFW, "1.5.0")
+	}
+}
+
+func TestOnChangeNotCalledWhenVersionsSame(t *testing.T) {
+	idx := &ReleaseIndex{
+		Pi:       ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+		Firmware: ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+	}
+	g := NewGitHubReleasesWithIndex(idx)
+
+	called := false
+	g.OnChange = func(piLatest, fwLatest string) {
+		called = true
+	}
+
+	same := &ReleaseIndex{
+		Pi:       ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+		Firmware: ComponentIndex{Latest: "1.0.0", Releases: map[string]*Release{"1.0.0": {Version: "1.0.0"}}},
+	}
+	g.SetIndex(same)
+
+	if called {
+		t.Error("OnChange should not be called when versions are unchanged")
+	}
+}
+
 func TestStripGroomedSentinel(t *testing.T) {
 	tests := []struct {
 		name string

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -484,6 +484,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/name", h.handlePhoneNamePost)
 	protected.HandleFunc("POST /phones/{number}/voice-style", h.handlePhoneVoiceStylePost)
 	protected.HandleFunc("POST /phones/{number}/silent-mode", h.handlePhoneSilentModePost)
+	protected.HandleFunc("POST /phones/{number}/auto-update", h.handlePhoneAutoUpdatePost)
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)
 	protected.HandleFunc("GET /phones/{number}/online", h.handlePhoneOnline)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -417,6 +417,12 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	}, nil
 }
 
+// Hub returns the signaling Hub. Used by callers (e.g. main) that wire
+// external callbacks and need to broadcast messages to connected devices.
+func (h *Handler) Hub() *signaling.Hub {
+	return h.hub
+}
+
 func (h *Handler) Router() http.Handler {
 	mux := http.NewServeMux()
 

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -465,6 +465,17 @@ func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	autoUpdate := strings.TrimSpace(r.FormValue("auto_update")) == "on"
+	h.updateLineSetting(w, r, "auto-update-section", "am-auto-update-section", func(s *line.Settings) {
+		s.AutoUpdate = autoUpdate
+	})
+}
+
 // updateLineSetting applies a mutation to the Settings of the line identified
 // by the {number} path value, persists and pushes it if anything changed, and
 // then renders the theme-appropriate partial (or redirects to the phone detail
@@ -516,6 +527,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings, househ
 		LineSettings: &signaling.LineSettings{
 			VoiceStyle: settings.VoiceStyle,
 			SilentMode: line.EffectiveSilent(settings, householdDND),
+			AutoUpdate: settings.AutoUpdate,
 		},
 	})
 	if errors.Is(err, signaling.ErrNotConnected) {

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -177,6 +177,12 @@
           </div>
 
           {{if .Online}}
+          <div id="auto-update-section">
+            {{template "auto-update-section" .}}
+          </div>
+          {{end}}
+
+          {{if .Online}}
           <!-- Pi Software update -->
           <details class="disclosure" style="margin-bottom: 10px;">
             <summary>Update Pi software</summary>
@@ -548,6 +554,26 @@
 </div>
 {{end}}
 
+{{define "auto-update-section"}}
+<div id="auto-update-section">
+  <form hx-post="/phones/{{.Line.Number}}/auto-update"
+        hx-target="#auto-update-section"
+        hx-swap="outerHTML"
+        class="stack-sm">
+    <label class="checkbox-row">
+      <input type="checkbox" name="auto_update" value="on"
+             {{if .Line.Settings.AutoUpdate}}checked{{end}}
+             onchange="this.form.requestSubmit()">
+      <span class="checkbox-row__label">Automatic updates</span>
+    </label>
+    <p class="muted" style="font-size: 12px; margin: 4px 0 0;">
+      Install new software and firmware automatically when this
+      phone is idle. Updates wait until any active call ends.
+    </p>
+  </form>
+</div>
+{{end}}
+
 {{define "am-voice-style-section"}}
 <div id="voice-style-section">
   <form hx-post="/phones/{{.Line.Number}}/voice-style"
@@ -599,6 +625,34 @@
       <div class="am-label am-settings__toggle-title">Silent mode</div>
       <p class="am-hint am-settings__toggle-desc">
         Incoming calls won't ring. The light still flashes and you can still answer.
+      </p>
+    </div>
+  </form>
+</div>
+{{end}}
+
+{{define "am-auto-update-section"}}
+<div id="auto-update-section">
+  <form hx-post="/phones/{{.Line.Number}}/auto-update"
+        hx-target="#auto-update-section"
+        hx-swap="outerHTML"
+        class="am-settings__toggle-row">
+    <label class="am-settings__dip" aria-label="Automatic updates">
+      <input type="checkbox" name="auto_update" value="on"
+             {{if .Line.Settings.AutoUpdate}}checked{{end}}
+             onchange="this.form.requestSubmit()"
+             class="am-settings__dip-input">
+      <span class="am-settings__dip-body" aria-hidden="true">
+        <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
+        <span class="am-settings__dip-lever"></span>
+        <span class="am-settings__dip-label am-settings__dip-label--off">0</span>
+      </span>
+    </label>
+    <div class="am-settings__toggle-info">
+      <div class="am-label am-settings__toggle-title">Automatic updates</div>
+      <p class="am-hint am-settings__toggle-desc">
+        Install new software and firmware automatically when this
+        phone is idle. Updates wait until any active call ends.
       </p>
     </div>
   </form>
@@ -926,6 +980,9 @@
       </button>
     </form>
   {{else}}
+    <div id="auto-update-section" style="margin-bottom: 12px;">
+      {{template "am-auto-update-section" .}}
+    </div>
     <div class="am-update__components">
 
       <div class="am-update__component">

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -102,6 +102,9 @@
           <h2 class="panel__title">Hardware &amp; firmware</h2>
         </header>
         <div class="panel__body">
+          <div id="auto-update-section" style="margin-bottom: 12px;">
+            {{template "auto-update-section" .}}
+          </div>
           {{if .DeviceInfo}}
           <div class="stack-md" style="margin-bottom: 12px;">
             <div>
@@ -175,12 +178,6 @@
             </div>
             {{end}}
           </div>
-
-          {{if .Online}}
-          <div id="auto-update-section">
-            {{template "auto-update-section" .}}
-          </div>
-          {{end}}
 
           {{if .Online}}
           <!-- Pi Software update -->
@@ -968,6 +965,10 @@
 <section class="am-plate am-handset__plate am-handset__plate--wide am-update">
   <span class="am-plate__label">Software update</span>
 
+  <div id="auto-update-section" style="margin-bottom: 12px;">
+    {{template "am-auto-update-section" .}}
+  </div>
+
   {{if not .Online}}
     <p class="am-hint am-update__offline">Handset is offline. Updates resume when it reconnects.</p>
     {{if .LastSeenAt}}<p class="am-hint am-update__offline">Last seen {{.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}.</p>{{end}}
@@ -980,9 +981,6 @@
       </button>
     </form>
   {{else}}
-    <div id="auto-update-section" style="margin-bottom: 12px;">
-      {{template "am-auto-update-section" .}}
-    </div>
     <div class="am-update__components">
 
       <div class="am-update__component">


### PR DESCRIPTION
## Summary

- Adds an opt-in per-device "Automatic updates" toggle on the `/phones/{number}` detail page, disabled by default.
- When enabled, the device automatically installs the latest Pi software and firmware when idle (no active call).
- If a call is in progress, the update is deferred until the call ends.
- Server broadcasts a `release_available` message to all connected devices when the GitHub release cache detects a new version.

### How it works

1. `auto_update` boolean stored in the existing `line.Settings` JSONB column (no migration needed) and in digitsd's local `config.json`.
2. Server pushes the setting to the device via `LineSettings` on change and on connect.
3. On startup (if enabled) and on `release_available`, digitsd checks `callPeer` to determine if a call is active.
4. If idle: runs `runTargetedUpdate` with empty targets (install latest). If in-call: sets a `pendingAutoUpdate` flag and retries in `HangupCall` after the call ends.
5. The manual `*#873283#` service code and the web UI "Install" buttons continue to work unconditionally regardless of this setting.

### Server changes

- `line.Settings` gains `AutoUpdate bool` field
- `signaling.LineSettings` wire struct and `linestore_adapter` pass it through
- New `POST /phones/{number}/auto-update` endpoint (checkbox toggle, same pattern as silent mode)
- `Hub.Broadcast()` method sends a message to all connected devices
- `GitHubReleases.SetIndex()` with `OnChange` callback fires on version change, wired to broadcast `release_available`
- Phone detail page: auto-update checkbox for both intercom and answering-machine themes

### digitsd changes

- `config.Config` gains `AutoUpdate bool` field
- `signal.LineSettings` mirror and `TypeReleaseAvailable` message type added
- `runAutoUpdate()` with idle gate: checks `callPeer`, defers if in-call
- Post-call retry in `HangupCall()` via `pendingAutoUpdate` atomic flag
- `TypeLineSettings` handler persists the setting to local config
- `TypeReleaseAvailable` handler triggers auto-update when enabled

## Test plan

- [ ] Toggle auto-update on a device via the web UI, verify the checkbox persists on page reload
- [ ] Verify the setting is pushed to the device over WebSocket (check digitsd logs for `line_settings applied auto_update=true`)
- [ ] With auto-update enabled, verify the device checks for updates on startup
- [ ] With auto-update enabled during an active call, verify the update is deferred and runs after hangup
- [ ] With auto-update disabled, verify no automatic updates trigger
- [ ] Verify manual updates (web UI "Install" button and `*#873283#` service code) still work regardless of the toggle
- [ ] Verify both intercom and answering-machine theme toggles render correctly