### PR TITLE
feat(server): per-device ring test button

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2734,6 +2734,15 @@ func main() {
 					slog.Warn("unknown restart mode", "mode", mode)
 				}
 
+			case sigclient.TypeRingTest:
+				slog.Info("ring test: triggering 1s bell")
+				sp.SendFire("RING:TEST")
+				go func() {
+					time.Sleep(1 * time.Second)
+					sp.SendFire("RING:STOP")
+					slog.Info("ring test: stopped")
+				}()
+
 			case sigclient.TypeLineSettings:
 				if msg.LineSettings == nil {
 					slog.Warn("line_settings message missing payload", "from", msg.From)

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -48,6 +48,9 @@ const (
 	// TypeRestart is sent by the server to restart the service or reboot the device.
 	TypeRestart = "restart"
 
+	// TypeRingTest is sent by the server to briefly ring the bell for hardware verification.
+	TypeRingTest = "ring_test"
+
 	// TypeLineSettings is sent by the server to push an updated Settings blob
 	// for the line this device is registered as. Applied live.
 	TypeLineSettings = "line_settings"

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -24,6 +24,7 @@ const (
 	TypeICERestart    = "ice_restart"    // Bidirectional: ICE restart offer with new credentials
 	TypeFactoryReset  = "factory_reset"  // Server → Phone: trigger factory reset
 	TypeRestart       = "restart"        // Server → Phone: restart service or reboot
+	TypeRingTest      = "ring_test"      // Server → Phone: brief ring for hardware verification
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
 	TypeRepair        = "repair"         // Phone → Server: invalidate pairing (used by *#0* before reboot)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -493,6 +493,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("GET /phones/{number}/update-status", h.handlePhoneUpdateStatus)
 	protected.HandleFunc("POST /phones/{number}/factory-reset", h.handlePhoneFactoryReset)
 	protected.HandleFunc("POST /phones/{number}/restart", h.handlePhoneRestart)
+	protected.HandleFunc("POST /phones/{number}/ring-test", h.handlePhoneRingTest)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -574,6 +574,27 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 	}
 }
 
+func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if h.requireLineOwnership(w, r, number) == nil {
+		return
+	}
+
+	msg := &signaling.Message{
+		Type: signaling.TypeRingTest,
+	}
+
+	var sendErr string
+	if err := h.hub.SendTo(number, msg); err != nil {
+		slog.Warn("ring test trigger failed", "number", number, "err", err)
+		sendErr = err.Error()
+	} else {
+		slog.Info("ring test triggered", "number", number)
+	}
+
+	h.respondPhoneCommandResult(w, r, number, sendErr)
+}
+
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
 	if h.requireLineOwnership(w, r, number) == nil {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -576,6 +576,59 @@ func TestPhoneRestartInvalidMode(t *testing.T) {
 	}
 }
 
+func TestPhoneRingTestOnline(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', $1) ON CONFLICT DO NOTHING`, hh.ID)
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+	})
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	h.hub.Register("3140001", conn)
+
+	req := httptest.NewRequest("POST", "/phones/3140001/ring-test", nil)
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, _ := signaling.ParseMessage(data)
+		if msg.Type != signaling.TypeRingTest {
+			t.Fatalf("expected ring_test message, got %s", msg.Type)
+		}
+	default:
+		t.Fatal("device did not receive ring_test message")
+	}
+}
+
+func TestPhoneRingTestOffline(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	_, _ = database.DB.Exec(`INSERT INTO lines (number, name, household_id) VALUES ('3140001', 'Test Phone', $1) ON CONFLICT DO NOTHING`, hh.ID)
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE number = '3140001'")
+	})
+
+	req := httptest.NewRequest("POST", "/phones/3140001/ring-test", nil)
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != 502 {
+		t.Fatalf("expected 502 for offline device, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestPhoneOnlineStatus(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -277,8 +277,16 @@
         <div class="panel__body">
 
           <div id="restart-buttons" class="hstack hstack--wrap" style="gap: 8px;">
+            <button type="button" id="ring-test-btn" onclick="doRingTest()" class="btn">Ring test</button>
             <button type="button" onclick="showRestartConfirm('service')" class="btn">Restart service</button>
             <button type="button" onclick="showRestartConfirm('reboot')" class="btn">Reboot device</button>
+          </div>
+
+          <div id="ring-test-status" class="hidden" style="margin-bottom: 10px;">
+            <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+              <div id="ring-test-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+              <span id="ring-test-text" style="font-size: 13px; color: var(--ink);">Ringing...</span>
+            </div>
           </div>
 
           <div id="restart-confirm" class="hidden">
@@ -333,6 +341,41 @@
   var fwPollTimer = null;
   var restartPollTimer = null;
   var restartMode = null;
+
+  function doRingTest() {
+    var btn = document.getElementById('ring-test-btn');
+    var status = document.getElementById('ring-test-status');
+    var spinner = document.getElementById('ring-test-spinner');
+    var text = document.getElementById('ring-test-text');
+    btn.disabled = true;
+    status.classList.remove('hidden');
+    spinner.classList.remove('hidden');
+    text.textContent = 'Ringing...';
+    text.style.color = 'var(--ink)';
+    fetch('/phones/' + phoneNumber + '/ring-test', {
+      method: 'POST',
+      headers: {'Accept': 'application/json'}
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      spinner.classList.add('hidden');
+      if (data.error) {
+        text.textContent = 'Failed: ' + data.error;
+        text.style.color = 'var(--rust)';
+        btn.disabled = false;
+      } else {
+        text.textContent = 'Done';
+        text.style.color = 'var(--forest)';
+        setTimeout(function() { status.classList.add('hidden'); btn.disabled = false; }, 2000);
+      }
+    })
+    .catch(function(err) {
+      spinner.classList.add('hidden');
+      text.textContent = 'Error: ' + err.message;
+      text.style.color = 'var(--rust)';
+      btn.disabled = false;
+    });
+  }
 
   function triggerComponentUpdate(prefix, paramName) {
     var btn = document.getElementById(prefix + '-install-btn');

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -830,16 +830,71 @@
     {{if .Online}}
     <section class="am-plate am-handset__plate am-handset__plate--wide">
       <span class="am-plate__label">Device controls</span>
-      <div class="am-handset__actions-row" style="gap: 8px; flex-wrap: wrap;">
+      <div id="am-ctrl-buttons" class="am-handset__actions-row" style="gap: 8px; flex-wrap: wrap;">
         <button type="button" id="am-ring-test-btn" onclick="amDoRingTest()" class="am-key">
           <span class="am-key__symbol">&#x266A;</span>
           <span class="am-key__label">Ring test</span>
+        </button>
+        <button type="button" onclick="amShowRestartConfirm('service')" class="am-key">
+          <span class="am-key__symbol">&#x21BB;</span>
+          <span class="am-key__label">Restart service</span>
+        </button>
+        <button type="button" onclick="amShowRestartConfirm('reboot')" class="am-key">
+          <span class="am-key__symbol">&#x23FB;</span>
+          <span class="am-key__label">Reboot device</span>
         </button>
       </div>
       <div id="am-ring-test-status" class="hidden" style="margin-top: 10px;">
         <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
           <span id="am-ring-test-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
           <span id="am-ring-test-text" class="am-led">Ringing...</span>
+        </div>
+      </div>
+      <div id="am-restart-confirm" class="hidden" style="margin-top: 10px;">
+        <p id="am-restart-confirm-text" class="am-hint" style="margin: 0 0 10px;"></p>
+        <div class="am-handset__actions-row" style="gap: 8px;">
+          <button type="button" id="am-restart-confirm-btn" onclick="amDoRestart()" class="am-key am-key--accent">
+            <span class="am-key__symbol">&#x2713;</span>
+            <span class="am-key__label">Confirm</span>
+          </button>
+          <button type="button" onclick="amCancelRestartConfirm()" class="am-key">
+            <span class="am-key__symbol">&#x2715;</span>
+            <span class="am-key__label">Cancel</span>
+          </button>
+        </div>
+      </div>
+      <div id="am-restart-progress" class="hidden" style="margin-top: 10px;">
+        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+          <span id="am-restart-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+          <span id="am-restart-text" class="am-led">Sending command...</span>
+        </div>
+      </div>
+      <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+        <div id="am-recovery-default">
+          <button type="button" onclick="amShowRecoveryConfirm()" class="am-key am-key--red">
+            <span class="am-key__symbol">&#x26A0;</span>
+            <span class="am-key__label">Recovery mode</span>
+          </button>
+          <p class="am-hint" style="margin: 6px 0 0;">Reboots the device into recovery mode. Connect to the device's recovery Wi-Fi network to try again or perform a factory reset.</p>
+        </div>
+        <div id="am-recovery-confirm" class="hidden">
+          <p class="am-hint" style="margin: 0 0 10px;">The device will reboot into recovery mode. You'll need to connect to its recovery Wi-Fi network to choose an action. Continue?</p>
+          <div class="am-handset__actions-row" style="gap: 8px;">
+            <button type="button" onclick="amDoRecovery()" class="am-key am-key--red">
+              <span class="am-key__symbol">&#x2713;</span>
+              <span class="am-key__label">Confirm</span>
+            </button>
+            <button type="button" onclick="amCancelRecovery()" class="am-key">
+              <span class="am-key__symbol">&#x2715;</span>
+              <span class="am-key__label">Cancel</span>
+            </button>
+          </div>
+        </div>
+        <div id="am-recovery-progress" class="hidden" style="margin-top: 10px;">
+          <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+            <span id="am-recovery-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+            <span id="am-recovery-text" class="am-led">Sending reset command...</span>
+          </div>
         </div>
       </div>
     </section>
@@ -978,7 +1033,122 @@
       });
     };
 
+    var amRestartMode = null;
+    var amRestartPollTimer = null;
+
+    window.amShowRestartConfirm = function(mode) {
+      amRestartMode = mode;
+      document.getElementById('am-ctrl-buttons').classList.add('hidden');
+      var c = document.getElementById('am-restart-confirm');
+      c.classList.remove('hidden');
+      var text = document.getElementById('am-restart-confirm-text');
+      if (mode === 'reboot') {
+        text.textContent = 'Reboot the entire device? This will take about 30 seconds.';
+      } else {
+        text.textContent = 'Restart the service on this device? It will reconnect in a few seconds.';
+      }
+    };
+
+    window.amCancelRestartConfirm = function() {
+      amRestartMode = null;
+      document.getElementById('am-restart-confirm').classList.add('hidden');
+      document.getElementById('am-ctrl-buttons').classList.remove('hidden');
+    };
+
+    window.amDoRestart = function() {
+      var mode = amRestartMode;
+      document.getElementById('am-restart-confirm').classList.add('hidden');
+      var progress = document.getElementById('am-restart-progress');
+      var lamp = document.getElementById('am-restart-lamp');
+      var text = document.getElementById('am-restart-text');
+      progress.classList.remove('hidden');
+      lamp.classList.remove('am-lamp--on-green', 'am-lamp--on-red');
+      lamp.classList.add('am-lamp--on-amber');
+      text.classList.remove('am-led--green', 'am-led--red');
+      text.textContent = mode === 'reboot' ? 'Sending reboot command...' : 'Sending restart command...';
+      var body = new URLSearchParams({mode: mode});
+      fetch('/phones/' + phoneNumber + '/restart', {
+        method: 'POST',
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: body.toString()
+      })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.error) { amShowRestartResult('failed', 'Failed: ' + data.error); return; }
+        var maxAttempts = mode === 'reboot' ? 90 : 15;
+        text.textContent = mode === 'reboot' ? 'Rebooting device...' : 'Restarting service...';
+        amPollOnline(maxAttempts);
+      })
+      .catch(function(err) { amShowRestartResult('failed', 'Network error: ' + err.message); });
+    };
+
+    function amPollOnline(maxAttempts) {
+      if (amRestartPollTimer) clearInterval(amRestartPollTimer);
+      var attempts = 0;
+      var sawOffline = false;
+      setTimeout(function() {
+        amRestartPollTimer = setInterval(function() {
+          attempts++;
+          if (attempts > maxAttempts) { clearInterval(amRestartPollTimer); amShowRestartResult('failed', 'Timed out waiting for device to come back online'); return; }
+          fetch('/phones/' + phoneNumber + '/online')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (!data.online) { sawOffline = true; document.getElementById('am-restart-text').textContent = 'Waiting for device to reconnect...'; }
+            else if (sawOffline) { clearInterval(amRestartPollTimer); amShowRestartResult('success', 'Device is back online'); setTimeout(function() { location.reload(); }, 1500); }
+          }).catch(function() {});
+        }, 1000);
+      }, 2000);
+    }
+
+    function amShowRestartResult(kind, msg) {
+      var lamp = document.getElementById('am-restart-lamp');
+      var text = document.getElementById('am-restart-text');
+      lamp.classList.remove('am-lamp--on-amber', 'am-lamp--on-green', 'am-lamp--on-red');
+      lamp.classList.add(kind === 'success' ? 'am-lamp--on-green' : 'am-lamp--on-red');
+      text.classList.remove('am-led--green', 'am-led--red');
+      text.classList.add(kind === 'success' ? 'am-led--green' : 'am-led--red');
+      text.textContent = msg;
+    }
+
+    window.amShowRecoveryConfirm = function() {
+      document.getElementById('am-recovery-default').classList.add('hidden');
+      document.getElementById('am-recovery-confirm').classList.remove('hidden');
+    };
+
+    window.amCancelRecovery = function() {
+      document.getElementById('am-recovery-confirm').classList.add('hidden');
+      document.getElementById('am-recovery-default').classList.remove('hidden');
+    };
+
+    window.amDoRecovery = function() {
+      document.getElementById('am-recovery-confirm').classList.add('hidden');
+      var progress = document.getElementById('am-recovery-progress');
+      var lamp = document.getElementById('am-recovery-lamp');
+      var text = document.getElementById('am-recovery-text');
+      progress.classList.remove('hidden');
+      fetch('/phones/' + phoneNumber + '/factory-reset', { method: 'POST', headers: {'Accept': 'application/json'} })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        lamp.classList.remove('am-lamp--on-amber');
+        if (data.error) {
+          lamp.classList.add('am-lamp--on-red');
+          text.classList.add('am-led--red');
+          text.textContent = 'Failed: ' + data.error;
+        } else {
+          lamp.classList.add('am-lamp--on-amber');
+          text.textContent = 'Device is rebooting into recovery mode. Connect to the Digits-Recovery Wi-Fi network to continue.';
+        }
+      })
+      .catch(function(err) {
+        lamp.classList.remove('am-lamp--on-amber');
+        lamp.classList.add('am-lamp--on-red');
+        text.classList.add('am-led--red');
+        text.textContent = 'Error: ' + err.message;
+      });
+    };
+
     window.addEventListener('pagehide', function() {
+      if (amRestartPollTimer) clearInterval(amRestartPollTimer);
       Object.keys(pollers).forEach(function(p) { if (pollers[p]) clearInterval(pollers[p]); });
     });
   })();

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -827,6 +827,24 @@
 
     {{template "am-software-update-section" .}}
 
+    {{if .Online}}
+    <section class="am-plate am-handset__plate am-handset__plate--wide">
+      <span class="am-plate__label">Device controls</span>
+      <div class="am-handset__actions-row" style="gap: 8px; flex-wrap: wrap;">
+        <button type="button" id="am-ring-test-btn" onclick="amDoRingTest()" class="am-key">
+          <span class="am-key__symbol">&#x266A;</span>
+          <span class="am-key__label">Ring test</span>
+        </button>
+      </div>
+      <div id="am-ring-test-status" class="hidden" style="margin-top: 10px;">
+        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+          <span id="am-ring-test-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+          <span id="am-ring-test-text" class="am-led">Ringing...</span>
+        </div>
+      </div>
+    </section>
+    {{end}}
+
     <section class="am-plate am-handset__plate am-handset__plate--wide am-handset__plate--danger am-handset__actions">
       <span class="am-plate__label">Actions</span>
       <p class="am-hint am-handset__action-desc">Removing a handset is permanent. The device will need to be re-paired to come back online.</p>
@@ -919,6 +937,46 @@
       }
       if (kind !== 'success' && btn) btn.disabled = false;
     }
+
+    window.amDoRingTest = function() {
+      var btn = document.getElementById('am-ring-test-btn');
+      var status = document.getElementById('am-ring-test-status');
+      var lamp = document.getElementById('am-ring-test-lamp');
+      var text = document.getElementById('am-ring-test-text');
+      btn.disabled = true;
+      status.classList.remove('hidden');
+      lamp.classList.remove('am-lamp--on-green', 'am-lamp--on-red');
+      lamp.classList.add('am-lamp--on-amber');
+      text.classList.remove('am-led--green', 'am-led--red');
+      text.textContent = 'Ringing...';
+      fetch('/phones/' + phoneNumber + '/ring-test', {
+        method: 'POST',
+        headers: {'Accept': 'application/json'}
+      })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.error) {
+          lamp.classList.remove('am-lamp--on-amber');
+          lamp.classList.add('am-lamp--on-red');
+          text.classList.add('am-led--red');
+          text.textContent = 'Failed: ' + data.error;
+          btn.disabled = false;
+        } else {
+          lamp.classList.remove('am-lamp--on-amber');
+          lamp.classList.add('am-lamp--on-green');
+          text.classList.add('am-led--green');
+          text.textContent = 'Done';
+          setTimeout(function() { status.classList.add('hidden'); btn.disabled = false; }, 2000);
+        }
+      })
+      .catch(function(err) {
+        lamp.classList.remove('am-lamp--on-amber');
+        lamp.classList.add('am-lamp--on-red');
+        text.classList.add('am-led--red');
+        text.textContent = 'Error: ' + err.message;
+        btn.disabled = false;
+      });
+    };
 
     window.addEventListener('pagehide', function() {
       Object.keys(pollers).forEach(function(p) { if (pollers[p]) clearInterval(pollers[p]); });


### PR DESCRIPTION
## Summary

- Adds a "Ring test" button to the phone detail page that sends a 1-second ring to the physical bell
- Server sends a `ring_test` WebSocket message to digitsd, which sends `RING:TEST` over UART to firmware, waits 1 second, then sends `RING:STOP`
- Firmware already handles `RING:TEST` natively (bypasses FSM, drives ringer + LED)
- Button appears in the Device controls panel for all three themes when the device is online
- No confirmation dialog (non-destructive), no DND/silent-mode check (explicit hardware verification)
- Also adds the missing Restart service, Reboot device, and Recovery mode controls to the AM theme phone detail page (these existed in the default/dialup theme but were never ported)

Closes #271

## Screenshots

### Intercom (default)

| Desktop | Mobile |
|---------|--------|
| ![intercom desktop](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-intercom-desktop.png) | ![intercom mobile](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-intercom-mobile.png) |

### Dialup

| Desktop | Mobile |
|---------|--------|
| ![dialup desktop](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-dialup-desktop.png) | ![dialup mobile](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-dialup-mobile.png) |

### Answering Machine

| Desktop | Mobile |
|---------|--------|
| ![am desktop](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-am-desktop.png) | ![am mobile](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/ring-test-am-mobile.png) |

## Test plan

- [x] `golangci-lint run ./...` passes for server and digitsd
- [x] `make test` passes for server and digitsd
- [x] Integration tests pass (`TestPhoneRingTestOnline`, `TestPhoneRingTestOffline`)
- [ ] Manual: click Ring test on an online device, confirm bell chimes for ~1 second
- [ ] Manual: verify Restart/Reboot/Recovery work in AM theme