### PR TITLE
fix(ci,digitsd): replace expired PAT with GitHub App token, trigger update on toggle

### DIFF
--- a/.github/workflows/fw-release.yml
+++ b/.github/workflows/fw-release.yml
@@ -34,10 +34,16 @@ jobs:
       run:
         working-directory: firmware
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.ADMIN_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -83,7 +89,7 @@ jobs:
             npx semantic-release --extends "$RELEASERC"
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect released tag
         id: released_tag

--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -30,10 +30,16 @@ jobs:
     outputs:
       tag: ${{ steps.released_tag.outputs.tag }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.ADMIN_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@v6
         with:
@@ -91,7 +97,7 @@ jobs:
             npx semantic-release --extends ./pi/.releaserc.cjs
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.ADMIN_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect released tag
         id: released_tag

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2870,6 +2870,9 @@ func main() {
 					if err := cb.setAutoUpdateConfig(au); err != nil {
 						slog.Warn("line_settings: auto-update save failed", "err", err)
 					}
+					if au && cb.triggerAutoUpdate != nil {
+						go cb.triggerAutoUpdate()
+					}
 				}
 
 			case sigclient.TypeConferenceMember:


### PR DESCRIPTION
## Summary

- Replace `ADMIN_PAT` with `actions/create-github-app-token` in pi-release and fw-release workflows. Tokens are minted fresh each run, eliminating silent expiry (which broke releases for #398 and #399).
- Trigger an immediate auto-update check when the toggle flips to enabled via `line_settings`, so devices catch up without waiting for the next `release_available` broadcast or reboot.

## Test plan

- [ ] Pi-release workflow succeeds on merge (will cut pi/v1.20.0 for the backlog of unreleased commits)
- [ ] Verify devices with auto-update enabled receive the update without manual intervention