### PR TITLE
fix(server): sync navbar DND indicator with phones page toggle

### DIFF
--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -113,7 +113,7 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 	if isHTMX(r) {
 		households[0].DoNotDisturb = enabled
 		data := h.buildLinesData(r, households[0], "")
-		renderWith(w, h.tmplPhones, partialFor(r, "dnd-toggle", "dnd-toggle-am"), data)
+		renderWith(w, h.tmplPhones, partialFor(r, "dnd-response", "dnd-response-am"), data)
 		return
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -1,5 +1,27 @@
 {{/* Shared template partials parsed alongside every page set. */}}
 
+{{/* dnd-indicator-content renders the navbar DND chip/lamp appropriate for
+     the user's theme. Empty when DND is off. Used by layout wrappers and
+     htmx OOB swaps so a single define controls the indicator everywhere. */}}
+{{define "dnd-indicator-content"}}
+{{if .HouseholdDND}}
+{{if and .User (eq .User.Theme "answering-machine")}}
+<a href="/phones" class="am-shell__dnd" title="Do Not Disturb is on" aria-label="Do Not Disturb is on">
+  <span class="am-lamp am-lamp--on-red am-shell__dnd-lamp" aria-hidden="true"></span>
+  <span class="am-led am-led--red am-shell__dnd-cap">DND</span>
+</a>
+{{else if and .User (eq .User.Theme "dialup")}}
+<a href="/phones" class="chip chip--err" title="Do Not Disturb is on" style="margin-left: 10px;">
+  <span class="chip__dot"></span>DND
+</a>
+{{else}}
+<a href="/phones" class="chip chip--err" title="Do Not Disturb is on">
+  <span class="chip__dot"></span>Do Not Disturb
+</a>
+{{end}}
+{{end}}
+{{end}}
+
 {{define "page-footer"}}
 {{if .Version}}
 <footer class="page__foot">

--- a/server/internal/web/templates/dnd-toggle.html
+++ b/server/internal/web/templates/dnd-toggle.html
@@ -17,6 +17,18 @@
 {{end}}
 {{end}}
 
+{{/* htmx response wrappers: toggle partial + OOB swap for the navbar
+     indicator so both update in a single response. */}}
+{{define "dnd-response"}}
+{{template "dnd-toggle" .}}
+<span id="dnd-indicator" hx-swap-oob="true">{{template "dnd-indicator-content" .}}</span>
+{{end}}
+
+{{define "dnd-response-am"}}
+{{template "dnd-toggle-am" .}}
+<span id="dnd-indicator" hx-swap-oob="true">{{template "dnd-indicator-content" .}}</span>
+{{end}}
+
 {{/* DND toggle partial for the phones page header (answering-machine theme).
      Uses the AM dip-switch visual for consistency with settings. */}}
 {{define "dnd-toggle-am"}}

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -35,12 +35,7 @@
 
       {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
 
-      {{if .HouseholdDND}}
-      <a href="/settings#do-not-disturb" class="am-shell__dnd" title="Household Do Not Disturb is on" aria-label="Do Not Disturb is on">
-        <span class="am-lamp am-lamp--on-red am-shell__dnd-lamp" aria-hidden="true"></span>
-        <span class="am-led am-led--red am-shell__dnd-cap">DND</span>
-      </a>
-      {{end}}
+      <span id="dnd-indicator">{{template "dnd-indicator-content" .}}</span>
 
       <form class="am-shell__signout-form" method="POST" action="/auth/logout">
         <button class="am-key am-key--nav" type="submit">

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -72,11 +72,7 @@
       </button>
     </form>
     <div class="dialup-toolbar__welcome">Welcome, <b>{{if .HouseholdName}}{{.HouseholdName}}{{else}}LindhFamily{{end}}</b>!</div>
-    {{if .HouseholdDND}}
-    <a href="/settings#do-not-disturb" class="chip chip--err" title="Household Do Not Disturb is on" style="margin-left: 10px;">
-      <span class="chip__dot"></span>DND
-    </a>
-    {{end}}
+    <span id="dnd-indicator">{{template "dnd-indicator-content" .}}</span>
   </div>
 
   <!-- Keyword bar -->

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -19,11 +19,7 @@
     <svg class="rail__brand-icon" viewBox="0 0 36 48" fill="currentColor" aria-hidden="true">{{template "keypad-icon"}}</svg>
     <span class="rail__mark">Digits</span>
     {{if .HouseholdName}}<span class="rail__household">{{.HouseholdName}}</span>{{end}}
-    {{if .HouseholdDND}}
-    <a href="/settings#do-not-disturb" class="chip chip--err" title="Household Do Not Disturb is on">
-      <span class="chip__dot"></span>Do Not Disturb
-    </a>
-    {{end}}
+    <span id="dnd-indicator">{{template "dnd-indicator-content" .}}</span>
   </div>
 
   <button class="rail__toggle" type="button" aria-label="Open navigation" onclick="document.querySelector('.rail__nav').classList.toggle('is-open')">Menu</button>


### PR DESCRIPTION
## What

The phones page DND toggle (PR #395) used htmx to swap only `#dnd-toggle`, leaving the navbar indicator stale until a full page reload. The settings page toggle did a full POST redirect so the navbar updated naturally, but the two surfaces felt disconnected: toggling DND on `/phones` changed state without visual feedback in the chrome.

## Changes

- Extract the navbar DND indicator into a shared `dnd-indicator-content` partial in `_partials.html`, rendered by all three layout templates inside a stable `<span id="dnd-indicator">` wrapper that always exists in the DOM (empty when DND is off).
- Add `dnd-response` / `dnd-response-am` wrapper templates in `dnd-toggle.html` that return the toggle partial plus an htmx OOB swap for `#dnd-indicator` in a single response.
- Handler renders the new response templates instead of the bare toggle partials.
- Navbar indicator now links to `/phones` (where the toggle lives) instead of `/settings#do-not-disturb` (the AM settings page has no DND section, so the old link landed on a nonexistent anchor).

## Screenshots

### Intercom: DND on (chip appears in navbar via OOB swap)
![intercom](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-402-intercom-dnd-on.png)

### Dialup: DND on
![dialup on](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-402-dialup-dnd-on.png)

### Dialup: DND off (chip gone, toggle unchecked)
![dialup off](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-402-dialup-dnd-off.png)

### Answering Machine: DND on (red lamp appears in header)
![am](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-402-am-dnd-on.png)

## Test plan

- [x] `make test` passes
- [x] `make test-integration` passes
- [x] `golangci-lint run ./...` clean
- [x] Visual verification: toggling DND on `/phones` updates both the toggle and the navbar indicator in all three themes
- [x] Visual verification: toggling DND off removes the navbar indicator via OOB swap
- [x] Settings page DND toggle (full POST redirect) still works unchanged
- [x] E2e chip selectors (`.rail .chip--err`, `.dialup-toolbar .chip--err`) still match through the new `<span>` wrapper