### PR TITLE
docs(server): document tracing and profiling env vars in README

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -152,6 +152,32 @@ no per-user or per-call data, no caller/callee identifiers). See
 [`docs/metrics.md`](docs/metrics.md) for the full list and the rules
 around what is and is not collected.
 
+### Tracing and Profiling
+
+| Variable                       | Description                                |
+|--------------------------------|--------------------------------------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | OTLP collector host:port. Empty disables the trace exporter. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL`  | `grpc` (default) or `http`.                |
+| `OTEL_EXPORTER_OTLP_INSECURE`  | `false` to require TLS. Defaults to `true` for in-cluster collectors. |
+| `OTEL_TRACES_SAMPLER_ARG`      | Head-based sample ratio, 0..1. Default `1.0`. |
+| `OTEL_RESOURCE_ATTRIBUTES`     | `k=v[,k=v...]` resource attributes.        |
+| `OTEL_SERVICE_NAME`            | Override service name; the binary supplies `signald` / `admind` by default. |
+| `PYROSCOPE_SERVER_ADDRESS`     | Pyroscope HTTP ingest URL. Empty disables the profiler. |
+| `PYROSCOPE_AUTH_TOKEN`         | Bearer token for hosted Pyroscope. Empty for in-cluster.  |
+| `PYROSCOPE_TENANT_ID`          | `X-Scope-OrgID` for multi-tenant Pyroscope. |
+| `DEPLOYMENT_ENV`               | Operator-supplied environment tag (e.g. `k8s`, `docker`). |
+
+OpenTelemetry traces and Pyroscope continuous profiles share the
+privacy posture documented in `docs/metrics.md`: span attributes,
+events, and profile labels are a closed set, with HTTP routes bucketed
+through the same `metrics.RouteOf` helper so phone numbers, call IDs,
+magic-link tokens, and household IDs never reach a span. The W3C Trace
+Context propagator is installed unconditionally, so leaving the
+exporter off still propagates inbound `traceparent` headers; turning
+exporters on later requires no code change. See
+[`docs/tracing.md`](docs/tracing.md) for the full attribute list and
+the rules around what is and is not collected.
+
 ### Development
 
 | Variable     | Description                                      |


### PR DESCRIPTION
## Motivated by (last 24h)

- #402 `feat(server): expose privacy-respecting Prometheus metrics`
- #404 `feat(server): add OpenTelemetry tracing and continuous profiling`

## Cross-PR drift

#402 added an "Environment Variables / Metrics" section to `server/README.md` documenting `SIGNALD_METRICS_ADDR` / `ADMIN_METRICS_ADDR` and linking `docs/metrics.md`. #404 merged about thirty minutes later and shipped a full second observability surface: a 490-line `internal/tracing` package, a 214-line `internal/profiling` package, ten new env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_INSECURE`, `OTEL_TRACES_SAMPLER_ARG`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME`, `PYROSCOPE_SERVER_ADDRESS`, `PYROSCOPE_AUTH_TOKEN`, `PYROSCOPE_TENANT_ID`, `DEPLOYMENT_ENV`), and a 222-line `server/docs/tracing.md`, but did not touch `server/README.md`. An operator reading the README sees only the metrics half of the observability picture.

## What this PR does

Adds a sibling `### Tracing and Profiling` section under the existing `## Environment Variables` heading, between Metrics and Development. It mirrors the Metrics section's shape: env-var table plus a short paragraph linking the deeper doc and restating the shared privacy posture. No code changes; no new behavior; doc-only.

## Verification

- No em dashes in the diff (CLAUDE.md hard rule).
- `go build ./...` and `go test ./...` from `server/` are unaffected: the only failure (`TestLoadConfigOptionalTokenFileUnreadable` in `internal/autodeploy`) reproduces on `main` with no diff and is the pre-existing root-can-read-anything sandbox quirk.
