### PR TITLE
fix(server): make admind bootstrap INSERT idempotent

### DIFF
--- a/server/cmd/admind/main.go
+++ b/server/cmd/admind/main.go
@@ -85,7 +85,9 @@ func main() {
 		}
 		id, err := authStore.CreateAdmin(context.Background(), cfg.InitialAdmin, hash)
 		if err != nil {
-			slog.Warn("initial admin creation skipped", "username", cfg.InitialAdmin, "err", err)
+			slog.Warn("initial admin creation failed", "username", cfg.InitialAdmin, "err", err)
+		} else if id == "" {
+			slog.Info("initial admin already exists", "username", cfg.InitialAdmin)
 		} else {
 			slog.Info("initial admin created", "username", cfg.InitialAdmin, "id", id)
 		}

--- a/server/internal/admin/auth.go
+++ b/server/internal/admin/auth.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -35,9 +36,12 @@ func VerifySecret(hash, password string) error {
 func (s *AuthStore) CreateAdmin(ctx context.Context, username, secretHash string) (string, error) {
 	var id string
 	err := s.db.DB.QueryRowContext(ctx,
-		"INSERT INTO admin_users (username, secret_hash) VALUES ($1, $2) RETURNING id",
+		"INSERT INTO admin_users (username, secret_hash) VALUES ($1, $2) ON CONFLICT (username) DO NOTHING RETURNING id",
 		username, secretHash,
 	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
 	return id, err
 }
 


### PR DESCRIPTION
## Summary

- admind's initial-admin bootstrap ran a bare `INSERT INTO admin_users` on every startup, causing `duplicate key value violates unique constraint "admin_users_username_key"` errors every time the container restarted after the first boot
- Adds `ON CONFLICT (username) DO NOTHING` to `CreateAdmin` so the INSERT is a no-op when the user already exists
- Bootstrap logging now distinguishes "already exists" (info) from actual DB failures (warn)

Surfaced by the new tracing stack: `traces_spanmetrics_calls_total{service="admind",span_name="sql.conn.query",status_code="STATUS_CODE_ERROR"}` was firing every 10-20 minutes from the k8s shadow admind.

## Test plan

- [x] `go build ./cmd/admind/` compiles cleanly
- [x] `go test ./internal/admin/` passes
- [x] `golangci-lint run` reports 0 issues
- [ ] Deploy to shadow k8s admind, confirm constraint violations stop in traces