### PR TITLE
feat(server): multi-user household invites with multi-household support

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -58,6 +58,12 @@ var (
 		},
 	}
 
+	secondMember = seededUser{
+		Email:       "other@digits.local",
+		DisplayName: "Other",
+		Theme:       auth.ThemeIntercom,
+	}
+
 	others = []seededUser{
 		{
 			Email:         "grandma@digits.local",
@@ -157,11 +163,35 @@ func main() {
 		return
 	}
 
+	// Add a second member to the primary household
+	secondUser, err := upsertUser(ctx, s.auth, secondMember.Email, secondMember.DisplayName)
+	if err != nil {
+		log.Fatalf("seed second member: %v", err)
+	}
+	if err := s.auth.SetTheme(ctx, secondUser.ID, secondMember.Theme); err != nil {
+		log.Fatalf("set second member theme: %v", err)
+	}
+	if err := s.auth.MarkThemeChosen(ctx, secondUser.ID); err != nil {
+		log.Fatalf("mark second member theme chosen: %v", err)
+	}
+	if err := s.house.AddMember(ctx, secondUser.ID, primaryHH.ID, "admin"); err != nil {
+		log.Fatalf("add second member: %v", err)
+	}
+	seededEmails := []string{primary.Email, secondMember.Email}
+
+	// Seed a pending user invite on the primary household
+	invStore := household.NewInviteStore(database.DB)
+	pending, _ := invStore.IsPendingForHouseholdEmail(ctx, primaryHH.ID, "pending@digits.local")
+	if !pending {
+		if _, err := invStore.CreateInvite(ctx, primaryHH.ID, "pending@digits.local", primaryUser.ID); err != nil {
+			log.Fatalf("seed pending invite: %v", err)
+		}
+	}
+
 	if err := s.house.SetCallHistoryEnabled(ctx, primaryHH.ID, true); err != nil {
 		log.Fatalf("enable call history on primary: %v", err)
 	}
 
-	seededEmails := []string{primary.Email}
 	for _, o := range others {
 		otherUser, otherHH, err := ensureUser(ctx, s, o, false)
 		if err != nil {

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -197,6 +197,8 @@ func run(ctx context.Context) error {
 		HouseholdStore: householdStore,
 		PairingStore:   pairingStore,
 		LinkStore:      linkStore,
+		InviteStore:    household.NewInviteStore(database.DB),
+		Emailer:        emailSender,
 		Metrics:        mreg,
 	}, web.HandlerConfig{
 		Addr:        cfg.Addr,

--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -42,9 +43,14 @@ func (g *GoogleAuth) Enabled() bool {
 // HandleLogin redirects to Google consent screen.
 func (g *GoogleAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	state, _ := randomToken(16)
+	returnTo := r.URL.Query().Get("return_to")
+	cookieVal := state
+	if returnTo != "" {
+		cookieVal = state + "|" + returnTo
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "oauth_state",
-		Value:    state,
+		Value:    cookieVal,
 		Path:     "/",
 		MaxAge:   600,
 		HttpOnly: true,
@@ -59,7 +65,17 @@ func (g *GoogleAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	// Verify state
 	stateCookie, err := r.Cookie("oauth_state")
-	if err != nil || stateCookie.Value != r.URL.Query().Get("state") {
+	if err != nil {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	cookieVal := stateCookie.Value
+	var returnTo string
+	if idx := strings.Index(cookieVal, "|"); idx >= 0 {
+		returnTo = cookieVal[idx+1:]
+		cookieVal = cookieVal[:idx]
+	}
+	if cookieVal != r.URL.Query().Get("state") {
 		http.Error(w, "invalid state", http.StatusBadRequest)
 		return
 	}
@@ -152,5 +168,5 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, LoginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, safeReturnTo(returnTo, user), http.StatusSeeOther)
 }

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -219,6 +219,9 @@ func safeReturnTo(returnTo string, user *User) string {
 }
 
 // HandleLogout destroys the session and clears the cookie.
+// An optional "redirect" form parameter (must be a relative path) overrides
+// the default redirect to /auth/login, which the invite page uses to send the
+// user back to the invite after signing out of the wrong account.
 func (h *Handlers) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(CookieName)
 	if err == nil {
@@ -227,5 +230,11 @@ func (h *Handlers) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	clearSessionCookie(w, h.cookieDomain)
-	http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+	redirect := "/auth/login"
+	if redir := r.FormValue("redirect"); redir != "" {
+		if strings.HasPrefix(redir, "/") && !strings.HasPrefix(redir, "//") {
+			redirect = redir
+		}
+	}
+	http.Redirect(w, r, redirect, http.StatusSeeOther)
 }

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -209,7 +209,7 @@ func LoginRedirectFor(u *User) string {
 }
 
 func isSafeRedirect(path string) bool {
-	return path != "" && strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//")
+	return path != "" && strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//") && !strings.HasPrefix(path, "/\\")
 }
 
 // safeReturnTo validates a returnTo path to prevent open redirect attacks.

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/email"
@@ -63,8 +64,9 @@ func (h *Handlers) HandleMagicLinkRequest(w http.ResponseWriter, r *http.Request
 		http.Redirect(w, r, "/auth/login?error=email+required", http.StatusSeeOther)
 		return
 	}
+	returnTo := r.FormValue("return_to")
 
-	token, err := h.store.CreateMagicLink(r.Context(), emailAddr, 15*time.Minute)
+	token, err := h.store.CreateMagicLink(r.Context(), emailAddr, 15*time.Minute, returnTo)
 	if err != nil {
 		slog.Error("magic link creation failed", "err", err)
 		http.Redirect(w, r, "/auth/login?error=try+again", http.StatusSeeOther)
@@ -88,7 +90,7 @@ func (h *Handlers) HandleMagicLinkRequest(w http.ResponseWriter, r *http.Request
 // HandleMagicLinkVerify validates a magic link token and creates a session.
 func (h *Handlers) HandleMagicLinkVerify(w http.ResponseWriter, r *http.Request) {
 	token := r.PathValue("token")
-	emailAddr, err := h.store.ValidateMagicLink(r.Context(), token)
+	emailAddr, returnTo, err := h.store.ValidateMagicLink(r.Context(), token)
 	if err != nil {
 		http.Redirect(w, r, "/auth/login?error=invalid+or+expired+link", http.StatusSeeOther)
 		return
@@ -129,7 +131,7 @@ func (h *Handlers) HandleMagicLinkVerify(w http.ResponseWriter, r *http.Request)
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	http.Redirect(w, r, LoginRedirectFor(user), http.StatusSeeOther)
+	http.Redirect(w, r, safeReturnTo(returnTo, user), http.StatusSeeOther)
 }
 
 // HandleDevSession creates an authenticated session in one round-trip for e2e testing.
@@ -204,6 +206,16 @@ func LoginRedirectFor(u *User) string {
 		return "/connecting"
 	}
 	return "/"
+}
+
+// safeReturnTo validates a returnTo path to prevent open redirect attacks.
+// It only allows paths that start with "/" but not "//" (which browsers treat as
+// protocol-relative URLs). Falls back to LoginRedirectFor when the path is invalid.
+func safeReturnTo(returnTo string, user *User) string {
+	if returnTo != "" && strings.HasPrefix(returnTo, "/") && !strings.HasPrefix(returnTo, "//") {
+		return returnTo
+	}
+	return LoginRedirectFor(user)
 }
 
 // HandleLogout destroys the session and clears the cookie.

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -208,11 +208,15 @@ func LoginRedirectFor(u *User) string {
 	return "/"
 }
 
+func isSafeRedirect(path string) bool {
+	return path != "" && strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//")
+}
+
 // safeReturnTo validates a returnTo path to prevent open redirect attacks.
 // It only allows paths that start with "/" but not "//" (which browsers treat as
 // protocol-relative URLs). Falls back to LoginRedirectFor when the path is invalid.
 func safeReturnTo(returnTo string, user *User) string {
-	if returnTo != "" && strings.HasPrefix(returnTo, "/") && !strings.HasPrefix(returnTo, "//") {
+	if isSafeRedirect(returnTo) {
 		return returnTo
 	}
 	return LoginRedirectFor(user)
@@ -231,10 +235,8 @@ func (h *Handlers) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 	clearSessionCookie(w, h.cookieDomain)
 	redirect := "/auth/login"
-	if redir := r.FormValue("redirect"); redir != "" {
-		if strings.HasPrefix(redir, "/") && !strings.HasPrefix(redir, "//") {
-			redirect = redir
-		}
+	if redir := r.FormValue("redirect"); isSafeRedirect(redir) {
+		redirect = redir
 	}
 	http.Redirect(w, r, redirect, http.StatusSeeOther)
 }

--- a/server/internal/auth/handlers_test.go
+++ b/server/internal/auth/handlers_test.go
@@ -139,7 +139,7 @@ func TestHandleMagicLinkVerify_InvalidToken(t *testing.T) {
 func TestHandleMagicLinkVerify_ValidToken_NewUser(t *testing.T) {
 	h, s, _ := newTestHandlers(t)
 
-	token, err := s.CreateMagicLink(context.Background(), "newuser@test.com", 15*time.Minute)
+	token, err := s.CreateMagicLink(context.Background(), "newuser@test.com", 15*time.Minute, "")
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestHandleMagicLinkVerify_ValidToken_ExistingUser(t *testing.T) {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
-	token, err := s.CreateMagicLink(context.Background(), "existing@test.com", 15*time.Minute)
+	token, err := s.CreateMagicLink(context.Background(), "existing@test.com", 15*time.Minute, "")
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestHandleMagicLinkVerify_DialupThemeRedirectsToConnecting(t *testing.T) {
 		t.Fatalf("SetTheme: %v", err)
 	}
 
-	token, err := s.CreateMagicLink(context.Background(), "dialup@test.com", 15*time.Minute)
+	token, err := s.CreateMagicLink(context.Background(), "dialup@test.com", 15*time.Minute, "")
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -220,16 +220,17 @@ func (s *Store) RefreshSession(ctx context.Context, token string, ttl time.Durat
 }
 
 // CreateMagicLink generates a single-use login token for passwordless email auth.
-// Returns the raw token to embed in the email link.
-func (s *Store) CreateMagicLink(ctx context.Context, email string, ttl time.Duration) (string, error) {
+// Returns the raw token to embed in the email link. returnTo is an optional
+// path to redirect to after authentication; pass "" to use the default.
+func (s *Store) CreateMagicLink(ctx context.Context, email string, ttl time.Duration, returnTo string) (string, error) {
 	token, err := randomToken(32)
 	if err != nil {
 		return "", err
 	}
 	hash := device.HashToken(token)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO magic_links (email, token_hash, expires_at) VALUES ($1, $2, $3)`,
-		email, hash, time.Now().Add(ttl),
+		`INSERT INTO magic_links (email, token_hash, expires_at, return_to) VALUES ($1, $2, $3, $4)`,
+		email, hash, time.Now().Add(ttl), sql.NullString{String: returnTo, Valid: returnTo != ""},
 	)
 	if err != nil {
 		return "", fmt.Errorf("create magic link: %w", err)
@@ -238,24 +239,25 @@ func (s *Store) CreateMagicLink(ctx context.Context, email string, ttl time.Dura
 }
 
 // ValidateMagicLink checks and atomically consumes a magic link token.
-// Returns the associated email on success. Returns an error if the token
-// is invalid, expired, or has already been used.
-func (s *Store) ValidateMagicLink(ctx context.Context, token string) (string, error) {
+// Returns the associated email and optional returnTo path on success.
+// Returns an error if the token is invalid, expired, or has already been used.
+func (s *Store) ValidateMagicLink(ctx context.Context, token string) (string, string, error) {
 	hash := device.HashToken(token)
 	var email string
+	var returnTo sql.NullString
 	err := s.db.QueryRowContext(ctx,
 		`UPDATE magic_links SET used = TRUE
 		 WHERE token_hash = $1 AND expires_at > NOW() AND used = FALSE
-		 RETURNING email`,
+		 RETURNING email, return_to`,
 		hash,
-	).Scan(&email)
+	).Scan(&email, &returnTo)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("invalid, expired, or already used magic link")
+		return "", "", fmt.Errorf("invalid, expired, or already used magic link")
 	}
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return email, nil
+	return email, returnTo.String, nil
 }
 
 // CountUsers returns the total number of user accounts.

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -276,6 +276,31 @@ func (s *Store) CleanupExpired(ctx context.Context) error {
 	return err
 }
 
+// SetActiveHousehold updates the active_household_id on the user's current session.
+func (s *Store) SetActiveHousehold(ctx context.Context, sessionToken string, householdID string) error {
+	hash := device.HashToken(sessionToken)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE sessions SET active_household_id = $1 WHERE token_hash = $2 AND expires_at > NOW()`,
+		householdID, hash,
+	)
+	if err != nil {
+		return fmt.Errorf("set active household: %w", err)
+	}
+	return nil
+}
+
+// ActiveHouseholdID returns the active_household_id from the current session,
+// or empty string if not set.
+func (s *Store) ActiveHouseholdID(ctx context.Context, sessionToken string) string {
+	hash := device.HashToken(sessionToken)
+	var id sql.NullString
+	_ = s.db.QueryRowContext(ctx,
+		`SELECT active_household_id FROM sessions WHERE token_hash = $1 AND expires_at > NOW()`,
+		hash,
+	).Scan(&id)
+	return id.String
+}
+
 // randomToken generates a cryptographically random hex string of the given byte length.
 func randomToken(bytes int) (string, error) {
 	b := make([]byte, bytes)

--- a/server/internal/auth/store_test.go
+++ b/server/internal/auth/store_test.go
@@ -251,7 +251,7 @@ func TestRefreshSession(t *testing.T) {
 func TestCreateAndValidateMagicLink(t *testing.T) {
 	s := testDB(t)
 
-	token, err := s.CreateMagicLink(context.Background(), "magic@test.com", 15*time.Minute)
+	token, err := s.CreateMagicLink(context.Background(), "magic@test.com", 15*time.Minute, "")
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestCreateAndValidateMagicLink(t *testing.T) {
 	}
 
 	// First use should succeed
-	email, err := s.ValidateMagicLink(context.Background(), token)
+	email, _, err := s.ValidateMagicLink(context.Background(), token)
 	if err != nil {
 		t.Fatalf("ValidateMagicLink: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestCreateAndValidateMagicLink(t *testing.T) {
 	}
 
 	// Second use should fail (single-use enforcement)
-	_, err = s.ValidateMagicLink(context.Background(), token)
+	_, _, err = s.ValidateMagicLink(context.Background(), token)
 	if err == nil {
 		t.Error("expected error on reuse of magic link, got nil")
 	}
@@ -277,7 +277,7 @@ func TestCreateAndValidateMagicLink(t *testing.T) {
 
 func TestValidateMagicLink_InvalidToken(t *testing.T) {
 	s := testDB(t)
-	_, err := s.ValidateMagicLink(context.Background(), "fake-magic-token")
+	_, _, err := s.ValidateMagicLink(context.Background(), "fake-magic-token")
 	if err == nil {
 		t.Error("expected error for invalid magic link token, got nil")
 	}
@@ -299,7 +299,7 @@ func TestCleanupExpired(t *testing.T) {
 	_, _ = s.db.Exec(`UPDATE sessions SET expires_at = NOW() - interval '1 second' WHERE token_hash = $1`, hash)
 
 	// Create a magic link and force-expire it
-	mlToken, err := s.CreateMagicLink(context.Background(), "cleanup@test.com", 15*time.Minute)
+	mlToken, err := s.CreateMagicLink(context.Background(), "cleanup@test.com", 15*time.Minute, "")
 	if err != nil {
 		t.Fatalf("CreateMagicLink: %v", err)
 	}

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -382,6 +382,35 @@ BEGIN
         INSERT INTO schema_version (version) VALUES (25);
     END IF;
 END $$;`,
+
+		// v26: household user invites + multi-household session scoping + auth return_to
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 26) THEN
+
+        CREATE TABLE IF NOT EXISTS household_invites (
+            id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            household_id  UUID NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+            email         TEXT NOT NULL,
+            invited_by    UUID NOT NULL REFERENCES users(id),
+            token         TEXT NOT NULL UNIQUE,
+            status        TEXT NOT NULL DEFAULT 'pending',
+            created_at    TIMESTAMPTZ DEFAULT NOW(),
+            accepted_at   TIMESTAMPTZ,
+            expires_at    TIMESTAMPTZ NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_household_invites_pending
+            ON household_invites (household_id, email) WHERE status = 'pending';
+        CREATE INDEX IF NOT EXISTS idx_household_invites_token
+            ON household_invites (token);
+
+        ALTER TABLE sessions ADD COLUMN IF NOT EXISTS active_household_id UUID REFERENCES households(id);
+
+        ALTER TABLE magic_links ADD COLUMN IF NOT EXISTS return_to TEXT;
+
+        INSERT INTO schema_version (version) VALUES (26);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -1,6 +1,9 @@
 package email
 
-import "fmt"
+import (
+	"fmt"
+	"html"
+)
 
 // brandedWrap wraps email content in the Digits branded template.
 func brandedWrap(content string) string {
@@ -51,6 +54,8 @@ func MagicLinkEmail(link string) (subject, body string) {
 // HouseholdInviteEmail returns subject and HTML body for a household member invite.
 func HouseholdInviteEmail(householdName, inviterName, link string) (subject, body string) {
 	subject = fmt.Sprintf("You've been invited to join %s on Digits", householdName)
+	safeHousehold := html.EscapeString(householdName)
+	safeInviter := html.EscapeString(inviterName)
 	content := fmt.Sprintf(`<h2 style="color:#e6edf3; margin:0 0 16px 0; font-size:20px;">You're invited</h2>
   <p style="color:#8b949e; font-size:14px; margin:0 0 24px 0;">%s invited you to join <strong style="color:#e6edf3;">%s</strong> on Digits. Accept the invite to manage lines, settings, and calls together.</p>
   <p style="text-align:center; margin:0 0 24px 0;">
@@ -58,7 +63,7 @@ func HouseholdInviteEmail(householdName, inviterName, link string) (subject, bod
   </p>
   <p style="color:#484f58; font-size:12px; margin:0 0 8px 0;">This invite expires in 7 days.</p>
   <p style="color:#484f58; font-size:12px; margin:0;">If you weren&#39;t expecting this, you can safely ignore this email.</p>`,
-		inviterName, householdName, link)
+		safeInviter, safeHousehold, link)
 	body = brandedWrap(content)
 	return
 }

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -47,3 +47,18 @@ func MagicLinkEmail(link string) (subject, body string) {
 	body = brandedWrap(content)
 	return
 }
+
+// HouseholdInviteEmail returns subject and HTML body for a household member invite.
+func HouseholdInviteEmail(householdName, inviterName, link string) (subject, body string) {
+	subject = fmt.Sprintf("You've been invited to join %s on Digits", householdName)
+	content := fmt.Sprintf(`<h2 style="color:#e6edf3; margin:0 0 16px 0; font-size:20px;">You're invited</h2>
+  <p style="color:#8b949e; font-size:14px; margin:0 0 24px 0;">%s invited you to join <strong style="color:#e6edf3;">%s</strong> on Digits. Accept the invite to manage lines, settings, and calls together.</p>
+  <p style="text-align:center; margin:0 0 24px 0;">
+    <a href="%s" style="display:inline-block; background-color:#1f6feb; color:#ffffff; text-decoration:none; padding:12px 24px; border-radius:6px; font-size:14px; font-weight:600;">Accept Invite</a>
+  </p>
+  <p style="color:#484f58; font-size:12px; margin:0 0 8px 0;">This invite expires in 7 days.</p>
+  <p style="color:#484f58; font-size:12px; margin:0;">If you weren&#39;t expecting this, you can safely ignore this email.</p>`,
+		inviterName, householdName, link)
+	body = brandedWrap(content)
+	return
+}

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -27,3 +27,26 @@ func TestAllEmailsHaveFooter(t *testing.T) {
 		t.Fatal("email missing footer tagline")
 	}
 }
+
+func TestHouseholdInviteEmail(t *testing.T) {
+	subject, body := HouseholdInviteEmail("Lindh Family", "Justin", "https://app.digits.family/invite/abc123")
+
+	if !strings.Contains(subject, "Lindh Family") {
+		t.Errorf("subject should contain household name, got: %s", subject)
+	}
+	if !strings.Contains(body, "Justin") {
+		t.Error("body should contain inviter name")
+	}
+	if !strings.Contains(body, "Lindh Family") {
+		t.Error("body should contain household name")
+	}
+	if !strings.Contains(body, "https://app.digits.family/invite/abc123") {
+		t.Error("body should contain invite link")
+	}
+	if !strings.Contains(body, "Accept Invite") {
+		t.Error("body should contain CTA button text")
+	}
+	if !strings.Contains(body, "7 days") {
+		t.Error("body should mention 7-day expiry")
+	}
+}

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -77,6 +77,20 @@ func (s *InviteStore) CreateInvite(ctx context.Context, householdID, email, invi
 	return inv, nil
 }
 
+// GetByID looks up an invite by its ID.
+func (s *InviteStore) GetByID(ctx context.Context, id string) (*HouseholdInvite, error) {
+	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
+		SELECT `+inviteColumns+` FROM household_invites WHERE id = $1
+	`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("invite not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get invite by id: %w", err)
+	}
+	return inv, nil
+}
+
 func (s *InviteStore) GetByToken(ctx context.Context, token string) (*HouseholdInvite, error) {
 	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
 		SELECT `+inviteColumns+` FROM household_invites WHERE token = $1

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -13,6 +13,12 @@ import (
 
 const inviteTTL = 7 * 24 * time.Hour
 
+const (
+	InviteStatusPending   = "pending"
+	InviteStatusAccepted  = "accepted"
+	InviteStatusCancelled = "cancelled"
+)
+
 type HouseholdInvite struct {
 	ID          string
 	HouseholdID string

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -1,0 +1,153 @@
+package household
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const inviteTTL = 7 * 24 * time.Hour
+
+type HouseholdInvite struct {
+	ID          string
+	HouseholdID string
+	Email       string
+	InvitedBy   string
+	Token       string
+	Status      string // pending, accepted, cancelled
+	CreatedAt   time.Time
+	AcceptedAt  *time.Time
+	ExpiresAt   time.Time
+}
+
+type InviteStore struct {
+	db *sql.DB
+}
+
+func NewInviteStore(db *sql.DB) *InviteStore {
+	return &InviteStore{db: db}
+}
+
+func generateInviteToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate invite token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+const inviteColumns = `id, household_id, email, invited_by, token, status, created_at, accepted_at, expires_at`
+
+func scanInvite(row interface{ Scan(...any) error }) (*HouseholdInvite, error) {
+	inv := &HouseholdInvite{}
+	err := row.Scan(&inv.ID, &inv.HouseholdID, &inv.Email, &inv.InvitedBy,
+		&inv.Token, &inv.Status, &inv.CreatedAt, &inv.AcceptedAt, &inv.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	return inv, nil
+}
+
+func (s *InviteStore) CreateInvite(ctx context.Context, householdID, email, invitedByUserID string) (*HouseholdInvite, error) {
+	token, err := generateInviteToken()
+	if err != nil {
+		return nil, err
+	}
+	email = strings.ToLower(strings.TrimSpace(email))
+	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
+		INSERT INTO household_invites (household_id, email, invited_by, token, expires_at)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING `+inviteColumns,
+		householdID, email, invitedByUserID, token, time.Now().Add(inviteTTL),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("create invite: %w", err)
+	}
+	return inv, nil
+}
+
+func (s *InviteStore) GetByToken(ctx context.Context, token string) (*HouseholdInvite, error) {
+	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
+		SELECT `+inviteColumns+` FROM household_invites WHERE token = $1
+	`, token))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("invite not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get invite by token: %w", err)
+	}
+	return inv, nil
+}
+
+func (s *InviteStore) AcceptInvite(ctx context.Context, token string) (*HouseholdInvite, error) {
+	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
+		UPDATE household_invites
+		SET status = 'accepted', accepted_at = NOW()
+		WHERE token = $1 AND status = 'pending' AND expires_at > NOW()
+		RETURNING `+inviteColumns,
+		token,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("invite not found, expired, or already used")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("accept invite: %w", err)
+	}
+	return inv, nil
+}
+
+func (s *InviteStore) CancelInvite(ctx context.Context, inviteID string) error {
+	var id string
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE household_invites SET status = 'cancelled'
+		WHERE id = $1 AND status = 'pending'
+		RETURNING id
+	`, inviteID).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("invite not found or not pending")
+	}
+	if err != nil {
+		return fmt.Errorf("cancel invite: %w", err)
+	}
+	return nil
+}
+
+func (s *InviteStore) GetPendingForHousehold(ctx context.Context, householdID string) ([]*HouseholdInvite, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT `+inviteColumns+`
+		FROM household_invites
+		WHERE household_id = $1 AND status = 'pending' AND expires_at > NOW()
+		ORDER BY created_at DESC
+	`, householdID)
+	if err != nil {
+		return nil, fmt.Errorf("get pending invites: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var invites []*HouseholdInvite
+	for rows.Next() {
+		inv, err := scanInvite(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan invite: %w", err)
+		}
+		invites = append(invites, inv)
+	}
+	return invites, rows.Err()
+}
+
+func (s *InviteStore) IsPendingForHouseholdEmail(ctx context.Context, householdID, email string) (bool, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM household_invites
+		WHERE household_id = $1 AND email = $2 AND status = 'pending' AND expires_at > NOW()
+	`, householdID, email).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check pending invite: %w", err)
+	}
+	return count > 0, nil
+}

--- a/server/internal/household/invite_test.go
+++ b/server/internal/household/invite_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package household
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInviteStore_CreateAndGet(t *testing.T) {
+	store, database := testStore(t)
+	invStore := NewInviteStore(database.DB)
+	userID := createTestUser(t, database, "inviter@example.com")
+	hh, err := store.Create(context.Background(), "Test Family", userID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	inv, err := invStore.CreateInvite(context.Background(), hh.ID, "INVITED@Example.com", userID)
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+	if inv.Email != "invited@example.com" {
+		t.Errorf("email not lowercased: got %q", inv.Email)
+	}
+	if inv.Status != "pending" {
+		t.Errorf("expected status pending, got %q", inv.Status)
+	}
+
+	got, err := invStore.GetByToken(context.Background(), inv.Token)
+	if err != nil {
+		t.Fatalf("get by token: %v", err)
+	}
+	if got.ID != inv.ID {
+		t.Errorf("ID mismatch: %s vs %s", got.ID, inv.ID)
+	}
+}
+
+func TestInviteStore_AcceptInvite(t *testing.T) {
+	store, database := testStore(t)
+	invStore := NewInviteStore(database.DB)
+	userID := createTestUser(t, database, "inviter2@example.com")
+	hh, err := store.Create(context.Background(), "Accept Family", userID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	inv, err := invStore.CreateInvite(context.Background(), hh.ID, "joiner@example.com", userID)
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+
+	accepted, err := invStore.AcceptInvite(context.Background(), inv.Token)
+	if err != nil {
+		t.Fatalf("accept invite: %v", err)
+	}
+	if accepted.Status != "accepted" {
+		t.Errorf("expected accepted, got %q", accepted.Status)
+	}
+	if accepted.AcceptedAt == nil {
+		t.Error("accepted_at should be set")
+	}
+
+	_, err = invStore.AcceptInvite(context.Background(), inv.Token)
+	if err == nil {
+		t.Error("expected error on double accept")
+	}
+}
+
+func TestInviteStore_CancelInvite(t *testing.T) {
+	store, database := testStore(t)
+	invStore := NewInviteStore(database.DB)
+	userID := createTestUser(t, database, "inviter3@example.com")
+	hh, err := store.Create(context.Background(), "Cancel Family", userID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	inv, err := invStore.CreateInvite(context.Background(), hh.ID, "cancel@example.com", userID)
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+
+	if err := invStore.CancelInvite(context.Background(), inv.ID); err != nil {
+		t.Fatalf("cancel invite: %v", err)
+	}
+
+	got, err := invStore.GetByToken(context.Background(), inv.Token)
+	if err != nil {
+		t.Fatalf("get after cancel: %v", err)
+	}
+	if got.Status != "cancelled" {
+		t.Errorf("expected cancelled, got %q", got.Status)
+	}
+}
+
+func TestInviteStore_DuplicatePendingBlocked(t *testing.T) {
+	store, database := testStore(t)
+	invStore := NewInviteStore(database.DB)
+	userID := createTestUser(t, database, "inviter4@example.com")
+	hh, err := store.Create(context.Background(), "Dupe Family", userID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	_, err = invStore.CreateInvite(context.Background(), hh.ID, "same@example.com", userID)
+	if err != nil {
+		t.Fatalf("first invite: %v", err)
+	}
+	_, err = invStore.CreateInvite(context.Background(), hh.ID, "same@example.com", userID)
+	if err == nil {
+		t.Error("expected error on duplicate pending invite")
+	}
+}
+
+func TestInviteStore_GetPendingForHousehold(t *testing.T) {
+	store, database := testStore(t)
+	invStore := NewInviteStore(database.DB)
+	userID := createTestUser(t, database, "inviter5@example.com")
+	hh, err := store.Create(context.Background(), "List Family", userID)
+	if err != nil {
+		t.Fatalf("create household: %v", err)
+	}
+
+	_, err = invStore.CreateInvite(context.Background(), hh.ID, "a@example.com", userID)
+	if err != nil {
+		t.Fatalf("invite a: %v", err)
+	}
+	bInv, err := invStore.CreateInvite(context.Background(), hh.ID, "b@example.com", userID)
+	if err != nil {
+		t.Fatalf("invite b: %v", err)
+	}
+	if err := invStore.CancelInvite(context.Background(), bInv.ID); err != nil {
+		t.Fatalf("cancel b: %v", err)
+	}
+
+	pending, err := invStore.GetPendingForHousehold(context.Background(), hh.ID)
+	if err != nil {
+		t.Fatalf("get pending: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(pending))
+	}
+	if pending[0].Email != "a@example.com" {
+		t.Errorf("expected a@example.com, got %q", pending[0].Email)
+	}
+}

--- a/server/internal/household/invite_unit_test.go
+++ b/server/internal/household/invite_unit_test.go
@@ -1,0 +1,22 @@
+package household
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestGenerateInviteToken_ValidHex(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		tok, err := generateInviteToken()
+		if err != nil {
+			t.Fatalf("generateInviteToken: %v", err)
+		}
+		b, err := hex.DecodeString(tok)
+		if err != nil {
+			t.Fatalf("token %q is not valid hex: %v", tok, err)
+		}
+		if len(b) != 32 {
+			t.Fatalf("expected 32 bytes, got %d", len(b))
+		}
+	}
+}

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -154,6 +154,53 @@ func (s *Store) GetMembers(ctx context.Context, householdID string) ([]Member, e
 	return members, rows.Err()
 }
 
+// MemberWithUser includes user profile data alongside membership info.
+type MemberWithUser struct {
+	UserID string
+	Email  string
+	Name   string
+	Role   string
+}
+
+// GetMembersWithUsers returns all members of a household with their user profile data.
+func (s *Store) GetMembersWithUsers(ctx context.Context, householdID string) ([]MemberWithUser, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT hm.user_id, u.email, u.name, hm.role
+		 FROM household_members hm
+		 JOIN users u ON u.id = hm.user_id
+		 WHERE hm.household_id = $1`,
+		householdID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var members []MemberWithUser
+	for rows.Next() {
+		var m MemberWithUser
+		if err := rows.Scan(&m.UserID, &m.Email, &m.Name, &m.Role); err != nil {
+			return nil, err
+		}
+		members = append(members, m)
+	}
+	return members, rows.Err()
+}
+
+// IsMemberByEmail checks if a user with the given email is a member of the household.
+func (s *Store) IsMemberByEmail(ctx context.Context, householdID, email string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM household_members hm
+		 JOIN users u ON u.id = hm.user_id
+		 WHERE hm.household_id = $1 AND lower(u.email) = lower($2)`,
+		householdID, email,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check member by email: %w", err)
+	}
+	return count > 0, nil
+}
+
 // CountHouseholds returns the total number of households.
 func (s *Store) CountHouseholds(ctx context.Context) (int, error) {
 	var count int

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -187,6 +187,32 @@ func (h *Household) Location() *time.Location {
 	return loc
 }
 
+// RemoveMember removes a user from a household.
+func (s *Store) RemoveMember(ctx context.Context, userID, householdID string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM household_members WHERE user_id = $1 AND household_id = $2`,
+		userID, householdID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove member: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("user is not a member of this household")
+	}
+	return nil
+}
+
+// MemberCount returns the number of members in a household.
+func (s *Store) MemberCount(ctx context.Context, householdID string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM household_members WHERE household_id = $1`,
+		householdID,
+	).Scan(&count)
+	return count, err
+}
+
 // SetCallHistoryEnabled toggles call history for a household.
 func (s *Store) SetCallHistoryEnabled(ctx context.Context, householdID string, enabled bool) error {
 	_, err := s.db.ExecContext(ctx,

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -279,6 +279,58 @@ func TestUpdateName(t *testing.T) {
 	}
 }
 
+func TestRemoveMember(t *testing.T) {
+	s, database := testStore(t)
+	ownerID := createTestUser(t, database, "owner-rm@example.com")
+	memberID := createTestUser(t, database, "member-rm@example.com")
+
+	hh, err := s.Create(context.Background(), "Remove Test", ownerID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.AddMember(context.Background(), memberID, hh.ID, "admin"); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	members, err := s.GetMembers(context.Background(), hh.ID)
+	if err != nil {
+		t.Fatalf("GetMembers: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+
+	if err := s.RemoveMember(context.Background(), memberID, hh.ID); err != nil {
+		t.Fatalf("RemoveMember: %v", err)
+	}
+
+	members, err = s.GetMembers(context.Background(), hh.ID)
+	if err != nil {
+		t.Fatalf("GetMembers after remove: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member after remove, got %d", len(members))
+	}
+}
+
+func TestMemberCount(t *testing.T) {
+	s, database := testStore(t)
+	ownerID := createTestUser(t, database, "owner-cnt@example.com")
+
+	hh, err := s.Create(context.Background(), "Count Test", ownerID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	count, err := s.MemberCount(context.Background(), hh.ID)
+	if err != nil {
+		t.Fatalf("MemberCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+}
+
 func TestSetDoNotDisturb(t *testing.T) {
 	s, database := testStore(t)
 	userID := createTestUser(t, database, "dnd@example.com")

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -25,6 +25,7 @@ func testStore(t *testing.T) (*Store, *db.Database) {
 	}
 	s := NewStore(database.DB)
 	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM household_invites")
 		_, _ = database.DB.Exec("DELETE FROM household_members")
 		_, _ = database.DB.Exec("DELETE FROM households")
 		_, _ = database.DB.Exec("DELETE FROM sessions")

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -240,6 +240,7 @@ type Handler struct {
 	magicVerifyLimiter *ratelimit.Limiter // GET  /auth/magic/{token}
 	googleLoginLimiter *ratelimit.Limiter // GET  /auth/google/login
 	pairingLimiter     *ratelimit.Limiter // POST /phones/pair
+	inviteLimiter      *ratelimit.Limiter // POST /settings/household/invite
 	// Updates
 	Releases *updates.GitHubReleases
 	// Metrics is the optional Prometheus registry. When set, a request
@@ -437,6 +438,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		magicVerifyLimiter: ratelimit.New(10, time.Minute),
 		googleLoginLimiter: ratelimit.New(10, time.Minute),
 		pairingLimiter:     ratelimit.New(5, time.Minute),
+		inviteLimiter:      ratelimit.New(5, time.Minute),
 		metrics:            deps.Metrics,
 	}, nil
 }
@@ -533,7 +535,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /settings/theme", h.handleSettingsTheme)
 	protected.HandleFunc("POST /settings/crt-mode", h.handleSettingsCRTMode)
 	protected.HandleFunc("POST /settings/appearance", h.handleSettingsAppearance)
-	protected.HandleFunc("POST /settings/household/invite", h.handleHouseholdInvitePost)
+	protected.Handle("POST /settings/household/invite", h.inviteLimiter.Middleware(http.HandlerFunc(h.handleHouseholdInvitePost)))
 	protected.HandleFunc("POST /settings/household/invite/{id}/cancel", h.handleHouseholdInviteCancelPost)
 	protected.HandleFunc("POST /settings/household/members/{id}/remove", h.handleHouseholdMemberRemovePost)
 	protected.HandleFunc("POST /settings/household/switch", h.handleHouseholdSwitchPost)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/justinlindh/digits/server/internal/calls"
 	"github.com/justinlindh/digits/server/internal/dashboard/events"
 	"github.com/justinlindh/digits/server/internal/device"
+	"github.com/justinlindh/digits/server/internal/email"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/httputil"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -212,6 +213,7 @@ type Handler struct {
 	tmplLinks          *template.Template
 	tmplConnecting     *template.Template
 	tmplWelcome        *template.Template
+	tmplInvite         *template.Template
 	tmplCallLivePanel          *template.Template
 	tmplCallLiveDetail         *template.Template
 	tmplConferenceLivePanel    *template.Template
@@ -227,7 +229,9 @@ type Handler struct {
 	// Pairing
 	pairingStore *pairing.Store
 	// Household links
-	linkStore *household.LinkStore
+	linkStore   *household.LinkStore
+	inviteStore *household.InviteStore
+	emailer     email.Sender
 	// Rate limiters. All four are Handler fields so Router() has a single
 	// construction pattern; previously the magic-link verify and Google
 	// login limiters were instantiated inline inside Router(), which made
@@ -289,6 +293,8 @@ type Deps struct {
 	HouseholdStore *household.Store
 	PairingStore   *pairing.Store
 	LinkStore      *household.LinkStore
+	InviteStore    *household.InviteStore
+	Emailer        email.Sender
 	Metrics        *metrics.Registry
 }
 
@@ -354,6 +360,10 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	tmplInvite, err := parsePage("invite.html")
+	if err != nil {
+		return nil, err
+	}
 	tmplCallLivePanel, err := template.New("call-live-panel").Funcs(funcMap).ParseFS(templateFS, "templates/_call-live-panel.html")
 	if err != nil {
 		return nil, fmt.Errorf("parse call-live-panel: %w", err)
@@ -408,6 +418,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplLinks:          tmplLinks,
 		tmplConnecting:     tmplConnecting,
 		tmplWelcome:        tmplWelcome,
+		tmplInvite:         tmplInvite,
 		tmplCallLivePanel:          tmplCallLivePanel,
 		tmplCallLiveDetail:         tmplCallLiveDetail,
 		tmplConferenceLivePanel:    tmplConferenceLivePanel,
@@ -420,6 +431,8 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		householdStore:     deps.HouseholdStore,
 		pairingStore:       deps.PairingStore,
 		linkStore:          deps.LinkStore,
+		inviteStore:        deps.InviteStore,
+		emailer:            deps.Emailer,
 		authLimiter:        ratelimit.New(5, time.Minute),
 		magicVerifyLimiter: ratelimit.New(10, time.Minute),
 		googleLoginLimiter: ratelimit.New(10, time.Minute),
@@ -453,6 +466,8 @@ func (h *Handler) Router() http.Handler {
 	mux.HandleFunc("GET /auth/dev-session", h.authHandlers.HandleDevSession)
 	mux.Handle("GET /auth/google/login", h.googleLoginLimiter.Middleware(http.HandlerFunc(h.googleAuth.HandleLogin)))
 	mux.HandleFunc("GET /auth/google/callback", h.googleAuth.HandleCallback)
+	mux.HandleFunc("GET /invite/{token}", h.handleInviteGet)
+	mux.HandleFunc("POST /invite/{token}/accept", h.handleInviteAcceptPost)
 	mux.HandleFunc("GET /api/version", h.handleAPIVersion)
 	mux.HandleFunc("GET /internal/stats", h.handleInternalStats)
 	mux.HandleFunc("GET /ws", h.handleWS)
@@ -518,6 +533,10 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /settings/theme", h.handleSettingsTheme)
 	protected.HandleFunc("POST /settings/crt-mode", h.handleSettingsCRTMode)
 	protected.HandleFunc("POST /settings/appearance", h.handleSettingsAppearance)
+	protected.HandleFunc("POST /settings/household/invite", h.handleHouseholdInvitePost)
+	protected.HandleFunc("POST /settings/household/invite/{id}/cancel", h.handleHouseholdInviteCancelPost)
+	protected.HandleFunc("POST /settings/household/members/{id}/remove", h.handleHouseholdMemberRemovePost)
+	protected.HandleFunc("POST /settings/household/switch", h.handleHouseholdSwitchPost)
 	protected.HandleFunc("GET /links", h.handleLinksGet)
 	protected.HandleFunc("POST /links/invite", h.handleLinksInvitePost)
 	protected.HandleFunc("POST /links/accept", h.handleLinksAcceptPost)

--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -86,7 +86,7 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 
 
 func (h *Handler) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 	ld := h.buildLinesData(r, hh, "")
 
 	nums := make(map[string]bool, len(ld.Lines))

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
 )
 
@@ -20,7 +19,6 @@ type callsData struct {
 const callsPageSize = 50
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
 	hh := h.activeHousehold(r)
 	if hh == nil || !hh.CallHistoryEnabled {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
@@ -78,7 +76,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 	}
 
 	renderWith(w, h.tmplCalls, layoutFor(r), callsData{
-		chromeData:  newChromeData("calls", user, hh),
+		chromeData:  h.newChromeDataWithHouseholds(r, "calls"),
 		Entries:     entries,
 		OlderCursor: olderCursor,
 		IsPaged:     cursor != nil,
@@ -105,12 +103,11 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	call, ownedLines, hh, ok := h.requireCallEndpointOwnership(w, r, callID)
+	call, ownedLines, _, ok := h.requireCallEndpointOwnership(w, r, callID)
 	if !ok {
 		return
 	}
 
-	user := auth.UserFromContext(r.Context())
 	linkedIndex := h.linkedIndexForCall(r.Context(), ownedLines)
 	callerEp, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex, ownedLines)
 	if err != nil {
@@ -126,7 +123,7 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := callLiveDetailData{
-		chromeData:   newChromeData("call-live", user, hh),
+		chromeData:   h.newChromeDataWithHouseholds(r, "call-live"),
 		Call:         call,
 		Caller:       callerEp,
 		Callee:       calleeEp,

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -21,7 +21,7 @@ const callsPageSize = 50
 
 func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 	if hh == nil || !hh.CallHistoryEnabled {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -65,7 +65,6 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	active := h.tracker.Active()
-	user := auth.UserFromContext(ctx)
 	hh := h.activeHousehold(r)
 	ld := h.buildLinesData(r, hh, "")
 	loc := hh.Location()
@@ -185,7 +184,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		ActiveCalls: activeCount,
 	}
 	data := dashboardData{
-		chromeData:         newChromeData("dashboard", user, hh),
+		chromeData:         h.newChromeDataWithHouseholds(r, "dashboard"),
 		Stats:              stats,
 		Lines:              ld.Lines,
 		CallsTodayRecent:   callsTodayRecent,
@@ -306,6 +305,6 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
-		chromeData: newChromeData("connecting", user, h.activeHousehold(r)),
+		chromeData: h.newChromeDataWithHouseholds(r, "connecting"),
 	})
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -66,7 +66,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	active := h.tracker.Active()
 	user := auth.UserFromContext(ctx)
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 	ld := h.buildLinesData(r, hh, "")
 	loc := hh.Location()
 	now := time.Now().In(loc)
@@ -306,6 +306,6 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
-		chromeData: newChromeData("connecting", user, h.primaryHousehold(r)),
+		chromeData: newChromeData("connecting", user, h.activeHousehold(r)),
 	})
 }

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -38,7 +38,7 @@ func (h *Handler) handleDashboardStream(w http.ResponseWriter, r *http.Request) 
 		http.NotFound(w, r)
 		return
 	}
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -227,15 +227,11 @@ func userDisplayLabel(u *auth.User) string {
 // householdNumbers returns the set of phone numbers belonging to the
 // authenticated user's household. Returns nil if the user has no household.
 func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
-	user := auth.UserFromContext(r.Context())
-	if user == nil || h.householdStore == nil {
+	hh := h.activeHousehold(r)
+	if hh == nil {
 		return nil
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
-		return nil
-	}
-	lines, err := h.lineStore.ListByHousehold(r.Context(), households[0].ID)
+	lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	if err != nil {
 		return nil
 	}

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -282,10 +282,11 @@ func (h *Handler) activeHousehold(r *http.Request) *household.Household {
 // HouseholdName/HouseholdDND/CallHistoryEnabled methods read through the
 // Household pointer so templates hit one source of truth per request.
 type chromeData struct {
-	Page      string
-	Version   string
-	User      *auth.User
-	Household *household.Household
+	Page       string
+	Version    string
+	User       *auth.User
+	Household  *household.Household
+	Households []*household.Household
 }
 
 func (c chromeData) HouseholdName() string {
@@ -316,6 +317,16 @@ func newChromeData(page string, user *auth.User, hh *household.Household) chrome
 		User:      user,
 		Household: hh,
 	}
+}
+
+func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chromeData {
+	user := auth.UserFromContext(r.Context())
+	hh := h.activeHousehold(r)
+	cd := newChromeData(page, user, hh)
+	if user != nil && h.householdStore != nil {
+		cd.Households, _ = h.householdStore.GetForUser(r.Context(), user.ID)
+	}
+	return cd
 }
 
 func jsonError(w http.ResponseWriter, msg string, code int) {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -246,10 +246,10 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 	return nums
 }
 
-// primaryHousehold returns the first household the authenticated user belongs
-// to, or nil when the user is unauthenticated, the store is not wired, lookup
-// fails, or the user has no households.
-func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
+// activeHousehold returns the household the user is currently viewing. Reads
+// active_household_id from the session; falls back to the first household
+// when unset or when the user is no longer a member.
+func (h *Handler) activeHousehold(r *http.Request) *household.Household {
 	if h.householdStore == nil {
 		return nil
 	}
@@ -261,6 +261,19 @@ func (h *Handler) primaryHousehold(r *http.Request) *household.Household {
 	if err != nil || len(households) == 0 {
 		return nil
 	}
+
+	cookie, err := r.Cookie(auth.CookieName)
+	if err == nil && h.authStore != nil {
+		activeID := h.authStore.ActiveHouseholdID(r.Context(), cookie.Value)
+		if activeID != "" {
+			for _, hh := range households {
+				if hh.ID == activeID {
+					return hh
+				}
+			}
+		}
+	}
+
 	return households[0]
 }
 

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -321,11 +321,28 @@ func newChromeData(page string, user *auth.User, hh *household.Household) chrome
 
 func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chromeData {
 	user := auth.UserFromContext(r.Context())
-	hh := h.activeHousehold(r)
-	cd := newChromeData(page, user, hh)
-	if user != nil && h.householdStore != nil {
-		cd.Households, _ = h.householdStore.GetForUser(r.Context(), user.ID)
+	if user == nil || h.householdStore == nil {
+		return newChromeData(page, user, nil)
 	}
+	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
+	if err != nil || len(households) == 0 {
+		return newChromeData(page, user, nil)
+	}
+	active := households[0]
+	cookie, cookieErr := r.Cookie(auth.CookieName)
+	if cookieErr == nil && h.authStore != nil {
+		activeID := h.authStore.ActiveHouseholdID(r.Context(), cookie.Value)
+		if activeID != "" {
+			for _, hh := range households {
+				if hh.ID == activeID {
+					active = hh
+					break
+				}
+			}
+		}
+	}
+	cd := newChromeData(page, user, active)
+	cd.Households = households
 	return cd
 }
 

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -8,20 +8,16 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/household"
-	"github.com/justinlindh/digits/server/internal/version"
 )
 
 type inviteData struct {
-	Page          string
-	Version       string
+	chromeData
 	Token         string
-	HouseholdName string
 	InviterName   string
 	InviteEmail   string
 	State         string
 	CurrentEmail  string
 	GoogleEnabled bool
-	LogoutURL     string
 }
 
 func (h *Handler) userFromSessionCookie(r *http.Request) (*auth.User, string) {
@@ -43,9 +39,8 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 	inv, err := h.inviteStore.GetByToken(r.Context(), token)
 	if err != nil || inv.Status != household.InviteStatusPending || inv.ExpiresAt.Before(time.Now()) {
 		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
-			Page:    "invite",
-			Version: version.Version,
-			State:   "invalid",
+			chromeData: newChromeData("invite", nil, nil),
+			State:      "invalid",
 		})
 		return
 	}
@@ -54,7 +49,8 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		slog.Error("invite: household lookup failed", "err", err)
 		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
-			Page: "invite", Version: version.Version, State: "invalid",
+			chromeData: newChromeData("invite", nil, nil),
+			State:      "invalid",
 		})
 		return
 	}
@@ -65,17 +61,15 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 		inviterName = userDisplayLabel(inviter)
 	}
 
+	user, _ := h.userFromSessionCookie(r)
+
 	data := inviteData{
-		Page:          "invite",
-		Version:       version.Version,
+		chromeData:    newChromeData("invite", user, hh),
 		Token:         token,
-		HouseholdName: hh.Name,
 		InviterName:   inviterName,
 		InviteEmail:   inv.Email,
 		GoogleEnabled: h.googleAuth != nil && h.googleAuth.Enabled(),
 	}
-
-	user, _ := h.userFromSessionCookie(r)
 
 	if user == nil {
 		data.State = "login"

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -110,16 +110,14 @@ func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if _, err := h.inviteStore.AcceptInvite(r.Context(), token); err != nil {
-		slog.Error("accept invite failed", "err", err)
+	if err := h.householdStore.AddMember(r.Context(), user.ID, inv.HouseholdID, "admin"); err != nil {
+		slog.Error("add member failed", "err", err)
 		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
 		return
 	}
 
-	if err := h.householdStore.AddMember(r.Context(), user.ID, inv.HouseholdID, "admin"); err != nil {
-		slog.Error("add member failed", "err", err)
-		http.Redirect(w, r, "/", http.StatusSeeOther)
-		return
+	if _, err := h.inviteStore.AcceptInvite(r.Context(), token); err != nil {
+		slog.Error("accept invite failed", "err", err)
 	}
 
 	if err := h.authStore.SetActiveHousehold(r.Context(), sessionToken, inv.HouseholdID); err != nil {

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -1,11 +1,128 @@
 package web
 
-import "net/http"
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/version"
+)
+
+type inviteData struct {
+	Page          string
+	Version       string
+	Token         string
+	HouseholdName string
+	InviterName   string
+	InviteEmail   string
+	State         string
+	CurrentEmail  string
+	GoogleEnabled bool
+	LogoutURL     string
+}
 
 func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	token := r.PathValue("token")
+
+	inv, err := h.inviteStore.GetByToken(r.Context(), token)
+	if err != nil || inv.Status != "pending" || inv.ExpiresAt.Before(time.Now()) {
+		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
+			Page:    "invite",
+			Version: version.Version,
+			State:   "invalid",
+		})
+		return
+	}
+
+	hh, err := h.householdStore.GetByID(r.Context(), inv.HouseholdID)
+	if err != nil {
+		slog.Error("invite: household lookup failed", "err", err)
+		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
+			Page: "invite", Version: version.Version, State: "invalid",
+		})
+		return
+	}
+
+	inviter, _ := h.authStore.GetUserByID(r.Context(), inv.InvitedBy)
+	inviterName := ""
+	if inviter != nil {
+		inviterName = userDisplayLabel(inviter)
+	}
+
+	data := inviteData{
+		Page:          "invite",
+		Version:       version.Version,
+		Token:         token,
+		HouseholdName: hh.Name,
+		InviterName:   inviterName,
+		InviteEmail:   inv.Email,
+		GoogleEnabled: h.googleAuth != nil && h.googleAuth.Enabled(),
+	}
+
+	// This is a public route; try to load user from session cookie if present
+	var user *auth.User
+	if cookie, cookieErr := r.Cookie(auth.CookieName); cookieErr == nil {
+		if sess, sessErr := h.authStore.ValidateSession(r.Context(), cookie.Value); sessErr == nil {
+			user, _ = h.authStore.GetUserByID(r.Context(), sess.UserID)
+		}
+	}
+
+	if user == nil {
+		data.State = "login"
+	} else if !strings.EqualFold(user.Email, inv.Email) {
+		data.State = "wrong_email"
+		data.CurrentEmail = user.Email
+	} else {
+		data.State = "accept"
+		data.CurrentEmail = user.Email
+	}
+
+	renderWith(w, h.tmplInvite, "layout-v2.html", data)
 }
 
 func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	token := r.PathValue("token")
+
+	var user *auth.User
+	cookie, err := r.Cookie(auth.CookieName)
+	if err == nil {
+		if sess, sessErr := h.authStore.ValidateSession(r.Context(), cookie.Value); sessErr == nil {
+			user, _ = h.authStore.GetUserByID(r.Context(), sess.UserID)
+		}
+	}
+	if user == nil {
+		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
+		return
+	}
+
+	inv, err := h.inviteStore.GetByToken(r.Context(), token)
+	if err != nil || inv.Status != "pending" || inv.ExpiresAt.Before(time.Now()) {
+		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
+		return
+	}
+
+	if !strings.EqualFold(user.Email, inv.Email) {
+		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
+		return
+	}
+
+	if _, err := h.inviteStore.AcceptInvite(r.Context(), token); err != nil {
+		slog.Error("accept invite failed", "err", err)
+		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
+		return
+	}
+
+	if err := h.householdStore.AddMember(r.Context(), user.ID, inv.HouseholdID, "admin"); err != nil {
+		slog.Error("add member failed", "err", err)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
+	if err := h.authStore.SetActiveHousehold(r.Context(), cookie.Value, inv.HouseholdID); err != nil {
+		slog.Error("set active household failed", "err", err)
+	}
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
+	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/version"
 )
 
@@ -23,11 +24,24 @@ type inviteData struct {
 	LogoutURL     string
 }
 
+func (h *Handler) userFromSessionCookie(r *http.Request) (*auth.User, string) {
+	cookie, err := r.Cookie(auth.CookieName)
+	if err != nil {
+		return nil, ""
+	}
+	sess, err := h.authStore.ValidateSession(r.Context(), cookie.Value)
+	if err != nil {
+		return nil, ""
+	}
+	user, _ := h.authStore.GetUserByID(r.Context(), sess.UserID)
+	return user, cookie.Value
+}
+
 func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 	token := r.PathValue("token")
 
 	inv, err := h.inviteStore.GetByToken(r.Context(), token)
-	if err != nil || inv.Status != "pending" || inv.ExpiresAt.Before(time.Now()) {
+	if err != nil || inv.Status != household.InviteStatusPending || inv.ExpiresAt.Before(time.Now()) {
 		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
 			Page:    "invite",
 			Version: version.Version,
@@ -61,13 +75,7 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 		GoogleEnabled: h.googleAuth != nil && h.googleAuth.Enabled(),
 	}
 
-	// This is a public route; try to load user from session cookie if present
-	var user *auth.User
-	if cookie, cookieErr := r.Cookie(auth.CookieName); cookieErr == nil {
-		if sess, sessErr := h.authStore.ValidateSession(r.Context(), cookie.Value); sessErr == nil {
-			user, _ = h.authStore.GetUserByID(r.Context(), sess.UserID)
-		}
-	}
+	user, _ := h.userFromSessionCookie(r)
 
 	if user == nil {
 		data.State = "login"
@@ -85,20 +93,14 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request) {
 	token := r.PathValue("token")
 
-	var user *auth.User
-	cookie, err := r.Cookie(auth.CookieName)
-	if err == nil {
-		if sess, sessErr := h.authStore.ValidateSession(r.Context(), cookie.Value); sessErr == nil {
-			user, _ = h.authStore.GetUserByID(r.Context(), sess.UserID)
-		}
-	}
+	user, sessionToken := h.userFromSessionCookie(r)
 	if user == nil {
 		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
 		return
 	}
 
 	inv, err := h.inviteStore.GetByToken(r.Context(), token)
-	if err != nil || inv.Status != "pending" || inv.ExpiresAt.Before(time.Now()) {
+	if err != nil || inv.Status != household.InviteStatusPending || inv.ExpiresAt.Before(time.Now()) {
 		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
 		return
 	}
@@ -120,7 +122,7 @@ func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err := h.authStore.SetActiveHousehold(r.Context(), cookie.Value, inv.HouseholdID); err != nil {
+	if err := h.authStore.SetActiveHousehold(r.Context(), sessionToken, inv.HouseholdID); err != nil {
 		slog.Error("set active household failed", "err", err)
 	}
 

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -1,0 +1,11 @@
+package web
+
+import "net/http"
+
+func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -87,12 +87,11 @@ func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) 
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.activeHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	link, err := h.linkStore.CreateInvite(r.Context(), myHousehold.ID, user.ID)
 	if err != nil {
@@ -110,12 +109,11 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	myHousehold := h.activeHousehold(r)
+	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
-	myHousehold := households[0]
 
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -46,7 +46,7 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	myHousehold := h.primaryHousehold(r)
+	myHousehold := h.activeHousehold(r)
 	if myHousehold == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -53,7 +53,7 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := linksData{
-		chromeData:  newChromeData("links", user, myHousehold),
+		chromeData:  h.newChromeDataWithHouseholds(r, "links"),
 		CreatedCode: r.URL.Query().Get("created"),
 		Accepted:    r.URL.Query().Get("accepted") == "1",
 		Revoked:     r.URL.Query().Get("revoked") == "1",

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -20,7 +20,7 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 		suggested = user.Name + "'s Family"
 	}
 	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
-		chromeData:    newChromeData("onboard", user, h.primaryHousehold(r)),
+		chromeData:    newChromeData("onboard", user, h.activeHousehold(r)),
 		SuggestedName: suggested,
 	})
 }

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -20,7 +20,7 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 		suggested = user.Name + "'s Family"
 	}
 	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
-		chromeData:    newChromeData("onboard", user, h.activeHousehold(r)),
+		chromeData:    h.newChromeDataWithHouseholds(r, "onboard"),
 		SuggestedName: suggested,
 	})
 }

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -118,7 +118,7 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 }
 
 func (h *Handler) handlePhonesGet(w http.ResponseWriter, r *http.Request) {
-	data := h.buildLinesData(r, h.primaryHousehold(r), "")
+	data := h.buildLinesData(r, h.activeHousehold(r), "")
 	if pairedName := r.URL.Query().Get("paired"); pairedName != "" {
 		data.PairSuccess = &pairSuccess{
 			Name:            pairedName,
@@ -136,7 +136,7 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 	var householdID string
 	if hh != nil {
 		householdID = hh.ID
@@ -175,7 +175,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 
 	if err := line.ValidateNumber(number); err != nil {
 		data := h.buildLinesData(r, hh, "")

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -10,7 +10,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -62,11 +61,6 @@ type lineRow struct {
 // nil or lookup fails the handler shows an empty list rather than leaking
 // every line on the server.
 func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMsg string) linesData {
-	var user *auth.User
-	if r != nil {
-		user = auth.UserFromContext(r.Context())
-	}
-
 	var lines []line.Line
 	if hh != nil && h.lineStore != nil {
 		lines, _ = h.lineStore.ListByHousehold(r.Context(), hh.ID)
@@ -109,7 +103,7 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 		rows[i] = row
 	}
 	return linesData{
-		chromeData:            newChromeData("phones", user, hh),
+		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
 		Lines:                 rows,
 		Error:                 errMsg,
 		LatestPiVersion:       latestPi,
@@ -302,10 +296,8 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	user := auth.UserFromContext(r.Context())
-
 	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
-		chromeData:            newChromeData("phones", user, hh),
+		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
 		Line:                  *ln,
 		Online:                online,
 		Devices:               devices,

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -205,3 +205,19 @@ func (h *Handler) handleSettingsAppearance(w http.ResponseWriter, r *http.Reques
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
+
+func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) handleHouseholdMemberRemovePost(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+func (h *Handler) handleHouseholdSwitchPost(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -1,11 +1,13 @@
 package web
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/justinlindh/digits/server/internal/auth"
+	emailpkg "github.com/justinlindh/digits/server/internal/email"
 )
 
 type settingsData struct {
@@ -207,17 +209,133 @@ func (h *Handler) handleSettingsAppearance(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	hh := h.activeHousehold(r)
+	if hh == nil {
+		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	inviteEmail := strings.TrimSpace(strings.ToLower(r.FormValue("email")))
+	if inviteEmail == "" || !strings.Contains(inviteEmail, "@") {
+		http.Redirect(w, r, "/settings?error=invalid+email", http.StatusSeeOther)
+		return
+	}
+
+	members, err := h.householdStore.GetMembers(r.Context(), hh.ID)
+	if err != nil {
+		slog.Error("list members failed", "err", err)
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
+	for _, m := range members {
+		u, _ := h.authStore.GetUserByID(r.Context(), m.UserID)
+		if u != nil && strings.EqualFold(u.Email, inviteEmail) {
+			http.Redirect(w, r, "/settings?error=already+a+member", http.StatusSeeOther)
+			return
+		}
+	}
+
+	inv, err := h.inviteStore.CreateInvite(r.Context(), hh.ID, inviteEmail, user.ID)
+	if err != nil {
+		slog.Error("create invite failed", "err", err)
+		http.Redirect(w, r, "/settings?error=invite+failed", http.StatusSeeOther)
+		return
+	}
+
+	link := fmt.Sprintf("%s/invite/%s", h.cfg.BaseURL, inv.Token)
+	subject, body := emailpkg.HouseholdInviteEmail(hh.Name, userDisplayLabel(user), link)
+	if err := h.emailer.Send(inviteEmail, subject, body); err != nil {
+		slog.Error("invite email failed", "email", inviteEmail, "err", err)
+	}
+
+	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
 
 func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	inviteID := r.PathValue("id")
+	if err := h.inviteStore.CancelInvite(r.Context(), inviteID); err != nil {
+		slog.Error("cancel invite failed", "err", err)
+	}
+	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
 
 func (h *Handler) handleHouseholdMemberRemovePost(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	hh := h.activeHousehold(r)
+	if hh == nil {
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
+	targetUserID := r.PathValue("id")
+
+	count, err := h.householdStore.MemberCount(r.Context(), hh.ID)
+	if err != nil {
+		slog.Error("member count failed", "err", err)
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
+	if count <= 1 {
+		http.Redirect(w, r, "/settings?error=last+member", http.StatusSeeOther)
+		return
+	}
+
+	if err := h.householdStore.RemoveMember(r.Context(), targetUserID, hh.ID); err != nil {
+		slog.Error("remove member failed", "err", err)
+	}
+	if targetUserID == user.ID {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
 
 func (h *Handler) handleHouseholdSwitchPost(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	householdID := r.FormValue("household_id")
+
+	_, err := h.householdStore.GetRole(r.Context(), user.ID, householdID)
+	if err != nil {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
+	cookie, err := r.Cookie(auth.CookieName)
+	if err != nil {
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+	if err := h.authStore.SetActiveHousehold(r.Context(), cookie.Value, householdID); err != nil {
+		slog.Error("switch household failed", "err", err)
+	}
+
+	referer := r.Header.Get("Referer")
+	if referer == "" {
+		referer = "/"
+	}
+	http.Redirect(w, r, referer, http.StatusSeeOther)
 }

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -24,34 +24,31 @@ type settingsData struct {
 	Error          string
 	Members        []settingsMember
 	PendingInvites []*household.HouseholdInvite
-	Households     []*household.Household
 }
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	hh := h.activeHousehold(r)
 
 	data := settingsData{
-		chromeData: newChromeData("settings", user, hh),
+		chromeData: h.newChromeDataWithHouseholds(r, "settings"),
 		Saved:      r.URL.Query().Get("saved") == "1",
 		Error:      r.URL.Query().Get("error"),
 	}
 
+	hh := data.Household
 	if hh != nil && user != nil {
-		members, _ := h.householdStore.GetMembers(r.Context(), hh.ID)
+		members, _ := h.householdStore.GetMembersWithUsers(r.Context(), hh.ID)
 		for _, m := range members {
-			u, _ := h.authStore.GetUserByID(r.Context(), m.UserID)
-			sm := settingsMember{UserID: m.UserID, IsYou: m.UserID == user.ID}
-			if u != nil {
-				sm.Email = u.Email
-				sm.Name = u.Name
-			}
-			data.Members = append(data.Members, sm)
+			data.Members = append(data.Members, settingsMember{
+				UserID: m.UserID,
+				Email:  m.Email,
+				Name:   m.Name,
+				IsYou:  m.UserID == user.ID,
+			})
 		}
 		if h.inviteStore != nil {
 			data.PendingInvites, _ = h.inviteStore.GetPendingForHousehold(r.Context(), hh.ID)
 		}
-		data.Households, _ = h.householdStore.GetForUser(r.Context(), user.ID)
 	}
 
 	renderWith(w, h.tmplSettings, layoutFor(r), data)
@@ -82,7 +79,6 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
-
 
 func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Request) {
 	if h.householdStore == nil {
@@ -262,18 +258,15 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	members, err := h.householdStore.GetMembers(r.Context(), hh.ID)
+	isMember, err := h.householdStore.IsMemberByEmail(r.Context(), hh.ID, inviteEmail)
 	if err != nil {
-		slog.Error("list members failed", "err", err)
+		slog.Error("check member email failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	for _, m := range members {
-		u, _ := h.authStore.GetUserByID(r.Context(), m.UserID)
-		if u != nil && strings.EqualFold(u.Email, inviteEmail) {
-			http.Redirect(w, r, "/settings?error=already+a+member", http.StatusSeeOther)
-			return
-		}
+	if isMember {
+		http.Redirect(w, r, "/settings?error=already+a+member", http.StatusSeeOther)
+		return
 	}
 
 	inv, err := h.inviteStore.CreateInvite(r.Context(), hh.ID, inviteEmail, user.ID)

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -15,7 +15,7 @@ type settingsData struct {
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	hh := h.primaryHousehold(r)
+	hh := h.activeHousehold(r)
 	renderWith(w, h.tmplSettings, layoutFor(r), settingsData{
 		chromeData: newChromeData("settings", user, hh),
 		Saved:      r.URL.Query().Get("saved") == "1",

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -269,6 +269,17 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	pending, err := h.inviteStore.IsPendingForHouseholdEmail(r.Context(), hh.ID, inviteEmail)
+	if err != nil {
+		slog.Error("check pending invite failed", "err", err)
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
+	if pending {
+		http.Redirect(w, r, "/settings?error=already+invited", http.StatusSeeOther)
+		return
+	}
+
 	inv, err := h.inviteStore.CreateInvite(r.Context(), hh.ID, inviteEmail, user.ID)
 	if err != nil {
 		slog.Error("create invite failed", "err", err)
@@ -291,7 +302,17 @@ func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
+	hh := h.activeHousehold(r)
+	if hh == nil {
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
 	inviteID := r.PathValue("id")
+	inv, err := h.inviteStore.GetByID(r.Context(), inviteID)
+	if err != nil || inv.HouseholdID != hh.ID {
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+		return
+	}
 	if err := h.inviteStore.CancelInvite(r.Context(), inviteID); err != nil {
 		slog.Error("cancel invite failed", "err", err)
 	}
@@ -359,9 +380,5 @@ func (h *Handler) handleHouseholdSwitchPost(w http.ResponseWriter, r *http.Reque
 		slog.Error("switch household failed", "err", err)
 	}
 
-	referer := r.Header.Get("Referer")
-	if referer == "" {
-		referer = "/"
-	}
-	http.Redirect(w, r, referer, http.StatusSeeOther)
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -8,20 +8,53 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	emailpkg "github.com/justinlindh/digits/server/internal/email"
+	"github.com/justinlindh/digits/server/internal/household"
 )
+
+type settingsMember struct {
+	UserID string
+	Email  string
+	Name   string
+	IsYou  bool
+}
 
 type settingsData struct {
 	chromeData
-	Saved bool
+	Saved          bool
+	Error          string
+	Members        []settingsMember
+	PendingInvites []*household.HouseholdInvite
+	Households     []*household.Household
 }
 
 func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	hh := h.activeHousehold(r)
-	renderWith(w, h.tmplSettings, layoutFor(r), settingsData{
+
+	data := settingsData{
 		chromeData: newChromeData("settings", user, hh),
 		Saved:      r.URL.Query().Get("saved") == "1",
-	})
+		Error:      r.URL.Query().Get("error"),
+	}
+
+	if hh != nil && user != nil {
+		members, _ := h.householdStore.GetMembers(r.Context(), hh.ID)
+		for _, m := range members {
+			u, _ := h.authStore.GetUserByID(r.Context(), m.UserID)
+			sm := settingsMember{UserID: m.UserID, IsYou: m.UserID == user.ID}
+			if u != nil {
+				sm.Email = u.Email
+				sm.Name = u.Name
+			}
+			data.Members = append(data.Members, sm)
+		}
+		if h.inviteStore != nil {
+			data.PendingInvites, _ = h.inviteStore.GetPendingForHousehold(r.Context(), hh.ID)
+		}
+		data.Households, _ = h.householdStore.GetForUser(r.Context(), user.ID)
+	}
+
+	renderWith(w, h.tmplSettings, layoutFor(r), data)
 }
 
 func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -60,8 +60,8 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	households, _ := h.householdStore.GetForUser(r.Context(), user.ID)
-	if len(households) == 0 {
+	hh := h.activeHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
@@ -71,8 +71,8 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
 	if name != "" {
-		if err := h.householdStore.UpdateName(r.Context(), households[0].ID, name); err != nil {
-			slog.Error("update household name failed", "household_id", households[0].ID, "err", err)
+		if err := h.householdStore.UpdateName(r.Context(), hh.ID, name); err != nil {
+			slog.Error("update household name failed", "household_id", hh.ID, "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
@@ -81,22 +81,13 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Request) {
-	if h.householdStore == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.activeHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
-	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), households[0].ID, enabled); err != nil {
+	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), hh.ID, enabled); err != nil {
 		slog.Error("set call history failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
@@ -109,30 +100,20 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	if h.householdStore == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.activeHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
-	householdID := households[0].ID
-	if err := h.householdStore.SetDoNotDisturb(r.Context(), householdID, enabled); err != nil {
-		slog.Error("set do not disturb failed", "err", err, "household_id", householdID)
+	if err := h.householdStore.SetDoNotDisturb(r.Context(), hh.ID, enabled); err != nil {
+		slog.Error("set do not disturb failed", "err", err, "household_id", hh.ID)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	lines, err := h.lineStore.ListByHousehold(r.Context(), householdID)
+	lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	if err != nil {
-		slog.Error("list lines for DND fan-out failed", "err", err, "household_id", householdID)
+		slog.Error("list lines for DND fan-out failed", "err", err, "household_id", hh.ID)
 		http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 		return
 	}
@@ -142,8 +123,8 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 		}
 	}
 	if isHTMX(r) {
-		households[0].DoNotDisturb = enabled
-		data := h.buildLinesData(r, households[0], "")
+		hh.DoNotDisturb = enabled
+		data := h.buildLinesData(r, hh, "")
 		renderWith(w, h.tmplPhones, partialFor(r, "dnd-response", "dnd-response-am"), data)
 		return
 	}
@@ -151,17 +132,8 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request) {
-	if h.householdStore == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
-		return
-	}
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
+	hh := h.activeHousehold(r)
+	if hh == nil {
 		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
 		return
 	}
@@ -171,7 +143,7 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 	}
 	tz := strings.TrimSpace(r.FormValue("timezone"))
 	if tz != "" {
-		if err := h.householdStore.SetTimezone(r.Context(), households[0].ID, tz); err != nil {
+		if err := h.householdStore.SetTimezone(r.Context(), hh.ID, tz); err != nil {
 			slog.Warn("set timezone failed", "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2191,3 +2191,23 @@ body.am .deck-kick-confirm .deck-confirm__go {
   .am-transport { padding: 5px 10px 5px 8px; gap: 6px; }
 }
 
+/* Household switcher */
+.am-hh-switcher { position: relative; }
+.am-hh-switcher summary { cursor: pointer; list-style: none; }
+.am-hh-switcher summary::-webkit-details-marker { display: none; }
+.am-hh-arrow { font-size: 8px; opacity: 0.6; }
+.am-hh-menu {
+  position: absolute; top: 100%; left: 0; z-index: 100;
+  background: var(--case); border: 1px solid var(--bezel);
+  border-radius: 4px; min-width: 180px; margin-top: 4px; overflow: hidden;
+}
+.am-hh-option {
+  display: block; width: 100%; padding: 6px 10px;
+  border: none; background: transparent; color: var(--led-amber);
+  font-family: var(--font-label); font-size: 11px;
+  text-align: left; cursor: pointer; text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.am-hh-option:hover { background: var(--bezel); }
+.am-hh-option.is-active { font-weight: 700; }
+

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2711,3 +2711,22 @@ body.dialup .phone-silent__text {
   background: var(--dialup-chrome);
   color: var(--dialup-chrome-d);
 }
+
+/* Household switcher */
+.dialup-hh-switcher { position: relative; display: inline-block; }
+.dialup-hh-switcher summary { cursor: pointer; list-style: none; }
+.dialup-hh-switcher summary::-webkit-details-marker { display: none; }
+.dialup-hh-arrow { font-size: 8px; }
+.dialup-hh-menu {
+  position: absolute; top: 100%; left: 0; z-index: 100;
+  background: var(--dialup-chrome); border: 2px outset var(--dialup-chrome);
+  min-width: 200px; margin-top: 2px;
+}
+.dialup-hh-option {
+  display: block; width: 100%; padding: 4px 8px;
+  border: none; background: transparent; color: var(--dialup-text);
+  font-family: var(--dialup-font); font-size: 11px;
+  text-align: left; cursor: pointer;
+}
+.dialup-hh-option:hover { background: var(--dialup-blue); color: #fff; }
+.dialup-hh-option.is-active { font-weight: 700; }

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -2094,3 +2094,21 @@ html[data-theme="dark"] .confirm-dialog {
   cursor: default;
   pointer-events: none;
 }
+
+/* Household switcher */
+.rail__hh-switcher { position: relative; }
+.rail__hh-switcher summary { cursor: pointer; list-style: none; }
+.rail__hh-switcher summary::-webkit-details-marker { display: none; }
+.rail__hh-arrow { font-size: 8px; opacity: 0.5; }
+.rail__hh-menu {
+  position: absolute; top: 100%; left: 0; z-index: 100;
+  background: var(--panel); border: 1px solid var(--line);
+  border-radius: 6px; min-width: 180px; margin-top: 4px; overflow: hidden;
+}
+.rail__hh-option {
+  display: block; width: 100%; padding: 8px 12px;
+  border: none; background: transparent; color: var(--ink);
+  font-size: 13px; text-align: left; cursor: pointer;
+}
+.rail__hh-option:hover { background: var(--line); }
+.rail__hh-option.is-active { font-weight: 600; }

--- a/server/internal/web/templates/invite.html
+++ b/server/internal/web/templates/invite.html
@@ -1,6 +1,71 @@
 {{define "title"}}Invite{{end}}
+
 {{define "content"}}
 <div class="page" style="max-width: 480px; margin: 0 auto; padding-top: 80px;">
-  <p>Invite page placeholder</p>
+
+  {{if eq .State "invalid"}}
+  <div class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">Invite not found</h2>
+    </header>
+    <div class="panel__body">
+      <p class="muted">This invite is no longer valid. It may have expired or been cancelled.</p>
+      <a href="/auth/login" class="btn btn--primary" style="margin-top: 16px;">Sign in</a>
+    </div>
+  </div>
+  {{end}}
+
+  {{if eq .State "login"}}
+  <div class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">You're invited</h2>
+    </header>
+    <div class="panel__body">
+      <p style="margin: 0 0 8px 0;">{{if .InviterName}}{{.InviterName}} invited you to join{{else}}You've been invited to join{{end}} <strong>{{.HouseholdName}}</strong> on Digits.</p>
+      <p class="muted" style="margin: 0 0 24px 0;">Sign in as <strong>{{.InviteEmail}}</strong> to accept.</p>
+
+      <form action="/auth/magic" method="POST" style="margin-bottom: 16px;">
+        <input type="hidden" name="email" value="{{.InviteEmail}}">
+        <input type="hidden" name="return_to" value="/invite/{{.Token}}">
+        <button type="submit" class="btn btn--primary" style="width: 100%;">Send sign-in link to {{.InviteEmail}}</button>
+      </form>
+
+      {{if .GoogleEnabled}}
+      <a href="/auth/google/login?return_to=/invite/{{.Token}}" class="btn" style="width: 100%; text-align: center; display: block;">Sign in with Google</a>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if eq .State "wrong_email"}}
+  <div class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">Wrong account</h2>
+    </header>
+    <div class="panel__body">
+      <p style="margin: 0 0 8px 0;">This invite was sent to <strong>{{.InviteEmail}}</strong>.</p>
+      <p class="muted" style="margin: 0 0 24px 0;">You're signed in as <strong>{{.CurrentEmail}}</strong>.</p>
+      <form action="/auth/logout" method="POST">
+        <input type="hidden" name="redirect" value="/invite/{{.Token}}">
+        <button type="submit" class="btn btn--primary">Sign out and try again</button>
+      </form>
+    </div>
+  </div>
+  {{end}}
+
+  {{if eq .State "accept"}}
+  <div class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">Join {{.HouseholdName}}</h2>
+    </header>
+    <div class="panel__body">
+      <p style="margin: 0 0 24px 0;">{{if .InviterName}}{{.InviterName}} invited you to join{{else}}You've been invited to join{{end}} <strong>{{.HouseholdName}}</strong>. You'll be able to manage lines, settings, and calls.</p>
+      <form action="/invite/{{.Token}}/accept" method="POST">
+        <button type="submit" class="btn btn--primary" style="width: 100%;">Accept Invite</button>
+      </form>
+    </div>
+  </div>
+  {{end}}
+
 </div>
 {{end}}

--- a/server/internal/web/templates/invite.html
+++ b/server/internal/web/templates/invite.html
@@ -1,0 +1,6 @@
+{{define "title"}}Invite{{end}}
+{{define "content"}}
+<div class="page" style="max-width: 480px; margin: 0 auto; padding-top: 80px;">
+  <p>Invite page placeholder</p>
+</div>
+{{end}}

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -41,7 +41,7 @@
           {{range .Households}}
           <form action="/settings/household/switch" method="POST">
             <input type="hidden" name="household_id" value="{{.ID}}">
-            <button type="submit" class="am-hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+            <button type="submit" class="am-hh-option{{if eq .ID $.Household.ID}} is-active{{end}}">{{.Name}}</button>
           </form>
           {{end}}
         </div>

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -33,7 +33,23 @@
         <a class="am-tab {{if eq .Page "settings"}}is-active{{end}}" href="/settings">Settings</a>
       </nav>
 
-      {{if .HouseholdName}}<span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>{{end}}
+      {{if .HouseholdName}}
+      {{if and .Households (gt (len .Households) 1)}}
+      <details class="am-hh-switcher">
+        <summary class="am-shell__household">Household &middot; {{.HouseholdName}} <span class="am-hh-arrow">&#9660;</span></summary>
+        <div class="am-hh-menu">
+          {{range .Households}}
+          <form action="/settings/household/switch" method="POST">
+            <input type="hidden" name="household_id" value="{{.ID}}">
+            <button type="submit" class="am-hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+          </form>
+          {{end}}
+        </div>
+      </details>
+      {{else}}
+      <span class="am-shell__household">Household &middot; {{.HouseholdName}}</span>
+      {{end}}
+      {{end}}
 
       <span id="dnd-indicator">{{template "dnd-indicator-content" .}}</span>
 

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -19,7 +19,21 @@
   <div class="dialup-title">
     <div class="dialup-title__app">
       <span class="dialup-title__icon" aria-hidden="true"></span>
+      {{if and .Households (gt (len .Households) 1)}}
+      <details class="dialup-hh-switcher">
+        <summary><span>Digits: {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span> <span class="dialup-hh-arrow">&#9660;</span></summary>
+        <div class="dialup-hh-menu">
+          {{range .Households}}
+          <form action="/settings/household/switch" method="POST">
+            <input type="hidden" name="household_id" value="{{.ID}}">
+            <button type="submit" class="dialup-hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+          </form>
+          {{end}}
+        </div>
+      </details>
+      {{else}}
       <span>Digits: {{if .HouseholdName}}{{.HouseholdName}}{{else}}Phone Network{{end}}</span>
+      {{end}}
     </div>
     <div class="dialup-title__controls" aria-hidden="true">
       <span class="dialup-title__btn">_</span>

--- a/server/internal/web/templates/layout-dialup.html
+++ b/server/internal/web/templates/layout-dialup.html
@@ -26,7 +26,7 @@
           {{range .Households}}
           <form action="/settings/household/switch" method="POST">
             <input type="hidden" name="household_id" value="{{.ID}}">
-            <button type="submit" class="dialup-hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+            <button type="submit" class="dialup-hh-option{{if eq .ID $.Household.ID}} is-active{{end}}">{{.Name}}</button>
           </form>
           {{end}}
         </div>

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -26,7 +26,7 @@
         {{range .Households}}
         <form action="/settings/household/switch" method="POST">
           <input type="hidden" name="household_id" value="{{.ID}}">
-          <button type="submit" class="rail__hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+          <button type="submit" class="rail__hh-option{{if eq .ID $.Household.ID}} is-active{{end}}">{{.Name}}</button>
         </form>
         {{end}}
       </div>

--- a/server/internal/web/templates/layout-v2.html
+++ b/server/internal/web/templates/layout-v2.html
@@ -18,7 +18,23 @@
   <div class="rail__brand">
     <svg class="rail__brand-icon" viewBox="0 0 36 48" fill="currentColor" aria-hidden="true">{{template "keypad-icon"}}</svg>
     <span class="rail__mark">Digits</span>
-    {{if .HouseholdName}}<span class="rail__household">{{.HouseholdName}}</span>{{end}}
+    {{if .HouseholdName}}
+    {{if and .Households (gt (len .Households) 1)}}
+    <details class="rail__hh-switcher">
+      <summary class="rail__household">{{.HouseholdName}} <span class="rail__hh-arrow">&#9660;</span></summary>
+      <div class="rail__hh-menu">
+        {{range .Households}}
+        <form action="/settings/household/switch" method="POST">
+          <input type="hidden" name="household_id" value="{{.ID}}">
+          <button type="submit" class="rail__hh-option{{if eq .Name $.HouseholdName}} is-active{{end}}">{{.Name}}</button>
+        </form>
+        {{end}}
+      </div>
+    </details>
+    {{else}}
+    <span class="rail__household">{{.HouseholdName}}</span>
+    {{end}}
+    {{end}}
     <span id="dnd-indicator">{{template "dnd-indicator-content" .}}</span>
   </div>
 

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -13,12 +13,16 @@
   {{if .Saved}}
   <div class="banner banner--ok">Settings saved.</div>
   {{end}}
+  {{if .Error}}
+  <div class="banner banner--err">{{.Error}}</div>
+  {{end}}
 
   <div class="settings-layout">
     <nav class="settings-nav" aria-label="Settings sections">
       <a href="#account" class="settings-nav__item is-active">Account</a>
       {{if .Household}}
       <a href="#household" class="settings-nav__item">Household</a>
+      <a href="#members" class="settings-nav__item">Members</a>
       <a href="#timezone" class="settings-nav__item">Timezone</a>
       {{if .User}}<a href="#theme" class="settings-nav__item">Theme</a>{{end}}
       <a href="#privacy" class="settings-nav__item">Privacy</a>
@@ -67,6 +71,70 @@
           <input type="text" id="household-name" name="name" value="{{.Household.Name}}" required class="field__input">
         </div>
         <button type="submit" class="btn btn--primary" style="align-self: end;">Save</button>
+      </form>
+    </div>
+  </section>
+
+  <!-- Members -->
+  <section id="members" class="panel" style="margin-bottom: 18px;">
+    <header class="panel__head">
+      <h2 class="panel__title">Members</h2>
+    </header>
+    <div class="panel__body" style="padding: 0;">
+      {{range .Members}}
+      <div class="kv__row" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 16px;">
+        <div>
+          <div style="font-size: 14px;">{{if .Name}}{{.Name}}{{else}}{{.Email}}{{end}}{{if .IsYou}} <span class="muted" style="font-size: 12px;">(you)</span>{{end}}</div>
+          {{if .Name}}<div class="muted" style="font-size: 12px;">{{.Email}}</div>{{end}}
+        </div>
+        {{if .IsYou}}
+        <form action="/settings/household/members/{{.UserID}}/remove" method="POST" onsubmit="return confirm('Leave this household?')">
+          <button type="submit" class="btn btn--danger btn--sm">Leave</button>
+        </form>
+        {{else}}
+        <form action="/settings/household/members/{{.UserID}}/remove" method="POST" onsubmit="return confirm('Remove this member?')">
+          <button type="submit" class="btn btn--danger btn--sm">Remove</button>
+        </form>
+        {{end}}
+      </div>
+      {{end}}
+    </div>
+  </section>
+
+  {{if .PendingInvites}}
+  <!-- Pending Invites -->
+  <section class="panel" style="margin-bottom: 18px;">
+    <header class="panel__head">
+      <h2 class="panel__title">Pending Invites</h2>
+    </header>
+    <div class="panel__body" style="padding: 0;">
+      {{range .PendingInvites}}
+      <div class="kv__row" style="display: flex; align-items: center; justify-content: space-between; padding: 10px 16px;">
+        <div>
+          <div style="font-size: 14px;">{{.Email}}</div>
+          <div class="muted" style="font-size: 12px;">Sent {{.CreatedAt.Format "Jan 2"}} · Expires {{.ExpiresAt.Format "Jan 2"}}</div>
+        </div>
+        <form action="/settings/household/invite/{{.ID}}/cancel" method="POST">
+          <button type="submit" class="btn btn--danger btn--sm">Cancel</button>
+        </form>
+      </div>
+      {{end}}
+    </div>
+  </section>
+  {{end}}
+
+  <!-- Invite Form -->
+  <section class="panel" style="margin-bottom: 18px;">
+    <header class="panel__head">
+      <h2 class="panel__title">Invite Someone</h2>
+    </header>
+    <div class="panel__body">
+      <form action="/settings/household/invite" method="POST" class="hstack hstack--wrap" style="gap: 10px;">
+        <div class="field" style="flex: 1; min-width: 200px; margin: 0;">
+          <label for="invite-email" class="field__label">Email address</label>
+          <input type="email" id="invite-email" name="email" required placeholder="email@example.com" class="field__input">
+        </div>
+        <button type="submit" class="btn btn--primary" style="align-self: end;">Send Invite</button>
       </form>
     </div>
   </section>
@@ -482,6 +550,9 @@
   {{if .Saved}}
   <div class="banner banner--ok">Settings saved.</div>
   {{end}}
+  {{if .Error}}
+  <div class="banner banner--err">{{.Error}}</div>
+  {{end}}
 
   <div class="am-plate am-page-header">
     <div class="am-page-header__info">
@@ -502,6 +573,7 @@
       <a href="#account" class="settings-nav__item is-active">Account</a>
       {{if .Household}}
       <a href="#household" class="settings-nav__item">Household</a>
+      <a href="#members" class="settings-nav__item">Members</a>
       <a href="#timezone" class="settings-nav__item">Timezone</a>
       <a href="#theme" class="settings-nav__item">Theme</a>
       <a href="#privacy" class="settings-nav__item">Privacy</a>
@@ -553,6 +625,58 @@
           <button type="submit" class="am-key am-settings__submit">
             <span class="am-key__symbol">&#x25B6;</span>
             <span class="am-key__label">Save</span>
+          </button>
+        </form>
+      </section>
+
+      <section id="members" class="am-plate am-settings__section">
+        <div class="am-plate__label">Members</div>
+        {{range .Members}}
+        <div class="am-settings__toggle-row" style="padding: 8px 0;">
+          <div style="flex: 1;">
+            <div class="am-led">{{if .Name}}{{.Name}}{{else}}{{.Email}}{{end}}{{if .IsYou}} <span class="am-led am-led--dim">(you)</span>{{end}}</div>
+            {{if .Name}}<div class="am-hint">{{.Email}}</div>{{end}}
+          </div>
+          {{if .IsYou}}
+          <form action="/settings/household/members/{{.UserID}}/remove" method="POST" onsubmit="return confirm('Leave this household?')">
+            <button type="submit" class="am-key am-key--red"><span class="am-key__label">Leave</span></button>
+          </form>
+          {{else}}
+          <form action="/settings/household/members/{{.UserID}}/remove" method="POST" onsubmit="return confirm('Remove this member?')">
+            <button type="submit" class="am-key am-key--red"><span class="am-key__label">Remove</span></button>
+          </form>
+          {{end}}
+        </div>
+        {{end}}
+      </section>
+
+      {{if .PendingInvites}}
+      <section class="am-plate am-settings__section">
+        <div class="am-plate__label">Pending Invites</div>
+        {{range .PendingInvites}}
+        <div class="am-settings__toggle-row" style="padding: 8px 0;">
+          <div style="flex: 1;">
+            <div class="am-led">{{.Email}}</div>
+            <div class="am-hint">Sent {{.CreatedAt.Format "Jan 2"}} · Expires {{.ExpiresAt.Format "Jan 2"}}</div>
+          </div>
+          <form action="/settings/household/invite/{{.ID}}/cancel" method="POST">
+            <button type="submit" class="am-key am-key--red"><span class="am-key__label">Cancel</span></button>
+          </form>
+        </div>
+        {{end}}
+      </section>
+      {{end}}
+
+      <section class="am-plate am-settings__section">
+        <div class="am-plate__label">Invite Someone</div>
+        <form action="/settings/household/invite" method="POST" class="am-settings__form">
+          <div class="am-settings__field">
+            <label for="invite-email-am" class="am-label am-settings__field-label">Email address</label>
+            <input type="email" id="invite-email-am" name="email" required placeholder="email@example.com" class="am-settings__input" autocomplete="off">
+          </div>
+          <button type="submit" class="am-key am-settings__submit">
+            <span class="am-key__symbol">&#x25B6;</span>
+            <span class="am-key__label">Send Invite</span>
           </button>
         </form>
       </section>

--- a/server/internal/web/templates/settings.html
+++ b/server/internal/web/templates/settings.html
@@ -126,7 +126,8 @@
   <!-- Invite Form -->
   <section class="panel" style="margin-bottom: 18px;">
     <header class="panel__head">
-      <h2 class="panel__title">Invite Someone</h2>
+      <h2 class="panel__title">Invite to {{.HouseholdName}}</h2>
+      <span class="panel__title-sub">They'll be able to manage lines and settings for this household.</span>
     </header>
     <div class="panel__body">
       <form action="/settings/household/invite" method="POST" class="hstack hstack--wrap" style="gap: 10px;">
@@ -668,7 +669,8 @@
       {{end}}
 
       <section class="am-plate am-settings__section">
-        <div class="am-plate__label">Invite Someone</div>
+        <div class="am-plate__label">Invite to {{.HouseholdName}}</div>
+        <p class="am-hint am-settings__hint">They'll be able to manage lines and settings for this household.</p>
         <form action="/settings/household/invite" method="POST" class="am-settings__form">
           <div class="am-settings__field">
             <label for="invite-email-am" class="am-label am-settings__field-label">Email address</label>

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -164,6 +164,8 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 		HouseholdStore: householdStore,
 		PairingStore:   pairingStore,
 		LinkStore:      linkStore,
+		InviteStore:    household.NewInviteStore(database.DB),
+		Emailer:        emailSender,
 	}, authStore
 }
 


### PR DESCRIPTION
## Summary

- Household members can invite other users by email to join their household
- Invited users accept via a branded email link, with magic link and Google OAuth sign-in support
- All household members have equal admin permissions
- Users who belong to multiple households can switch between them via a dropdown in the sidebar
- Settings page gains a Members section (list, invite form, pending invites)
- All three themes (intercom, dialup, answering-machine) render the new UI surfaces

## What changed

**Data layer:**
- Migration v26: `household_invites` table, `sessions.active_household_id`, `magic_links.return_to`
- `InviteStore` with create, accept, cancel, list, duplicate-prevention
- `RemoveMember` and `MemberCount` on household store
- Branded invite email template matching the existing magic link style

**Auth:**
- `returnTo` redirect support in both magic link and Google OAuth flows (safe relative URL validation)
- Logout handler accepts a `redirect` form param for the invite wrong-email flow

**Multi-household:**
- `primaryHousehold()` replaced with `activeHousehold()` that reads `active_household_id` from the session
- `POST /settings/household/switch` to change active household
- Household switcher dropdown in all three layout templates (only shows when user has 2+ households)

**Settings UI:**
- Members list with Leave/Remove buttons
- Pending invites with Cancel button (hidden when empty)
- Invite form (email input + send)
- Error banner support
- All sections themed for intercom, dialup, and answering-machine

**Invite accept page:**
- `GET /invite/{token}` (public route) with four states: login, wrong email, accept, invalid
- `POST /invite/{token}/accept` validates auth + email match, adds member, sets active household

**Dev seed:**
- Second user (`other@digits.local`) as member of primary household
- Pending user invite (`pending@digits.local`) for Settings UI testing

## Test plan

- [ ] `make test` passes (unit tests)
- [ ] `make test-integration` passes
- [ ] `golangci-lint run ./...` clean
- [ ] `make dev-up`, sign in as `dev@digits.local`, verify Settings shows members + pending invite + invite form
- [ ] Sign in as `other@digits.local`, verify they see the same household with "(you)" on their row
- [ ] Switch themes and verify all three render the new sections
- [ ] Test invite flow end-to-end (send invite, check email, accept)