### PR TITLE
fix(server): unpaired devices no longer show as online in UI

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -292,6 +292,16 @@ func (h *Hub) LastSeenAt(number string) *time.Time {
 	return &t
 }
 
+// IsOnline returns true if number has an active hub connection and is not in
+// pairing mode. Unpaired devices connect under the sentinel "unpaired" number
+// and must not be presented as online in the UI.
+func (h *Hub) IsOnline(number string) bool {
+	if number == "unpaired" {
+		return false
+	}
+	return h.Get(number) != nil
+}
+
 func (h *Hub) OnlineNumbers() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -32,6 +32,33 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 	}
 }
 
+func TestIsOnlineReturnsFalseForUnpaired(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("unpaired", conn)
+	// A device in pairing mode is connected under "unpaired" but must not
+	// report as online for UI purposes.
+	if hub.IsOnline("unpaired") {
+		t.Fatal("IsOnline should return false for the unpaired sentinel number")
+	}
+}
+
+func TestIsOnlineReturnsTrueForPairedConnected(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{Send: make(chan []byte, 10)}
+	hub.Register("3140001", conn)
+	if !hub.IsOnline("3140001") {
+		t.Fatal("IsOnline should return true for a paired, connected device")
+	}
+}
+
+func TestIsOnlineReturnsFalseForOffline(t *testing.T) {
+	hub := NewHub()
+	if hub.IsOnline("3140099") {
+		t.Fatal("IsOnline should return false for a number with no connection")
+	}
+}
+
 func TestHubGetReturnsNilForOffline(t *testing.T) {
 	hub := NewHub()
 	if hub.Get("3140099") != nil {

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -240,7 +240,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	if ln == nil {
 		return
 	}
-	online := h.hub.Get(number) != nil
+	online := h.hub.IsOnline(number)
 
 	var devices []device.Device
 	if h.deviceStore != nil {
@@ -317,7 +317,7 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
-	online := h.hub.Get(number) != nil
+	online := h.hub.IsOnline(number)
 	if isHTMX(r) {
 		renderWith(w, h.tmplPhoneDetail, partialFor(r, "phone-status", "am-phone-status"), struct {
 			Online bool
@@ -336,7 +336,7 @@ func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {
 	if ln == nil {
 		return
 	}
-	online := h.hub.Get(number) != nil
+	online := h.hub.IsOnline(number)
 	renderWith(w, h.tmplPhones, partialFor(r, "phone-edit-row", "am-phone-edit-row"), lineRow{Line: *ln, Online: online})
 }
 


### PR DESCRIPTION
## Summary

- Devices in pairing mode connect under the sentinel number `"unpaired"`. `Hub.OnlineNumbers()` already filtered this, but three call sites in the phone-detail handlers used `hub.Get(number) != nil` directly, bypassing the filter.
- Added `Hub.IsOnline(number string) bool` that explicitly returns `false` for the `"unpaired"` sentinel and otherwise delegates to `Get`.
- Updated `handlePhoneDetail`, `handlePhoneOnline`, and `handlePhoneEditGet` to call `hub.IsOnline(number)` instead of `hub.Get(number) != nil`.

## Root cause

After a device sends `TypeRepair` (triggered by the `*#0` service code), it stays registered in the hub under its old number until it disconnects and reconnects as `"unpaired"`. During that window the three direct `Get` calls would still return a non-nil connection and flag the line as online. The phones list and dashboard already went through `OnlineNumbers()` and were not affected.

## Test plan

- [ ] `make test` passes (all existing + 3 new `IsOnline` unit tests)
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] Manual: trigger `*#0` on a device, confirm the web UI shows the line as offline while the device reboots and reconnects in pairing mode