### PR TITLE
feat(server): add Helm chart for k8s deployment

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -1,0 +1,61 @@
+name: Helm CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+  pull_request:
+    paths:
+      - "charts/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint-and-template:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: azure/setup-helm@v4
+
+      - name: Lint (defaults)
+        run: helm lint charts/digits/
+
+      - name: Lint (all features enabled)
+        run: |
+          helm lint charts/digits/ \
+            --set ingress.enabled=true \
+            --set ingress.signald.host=app.example.com \
+            --set ingress.admind.host=admin.example.com \
+            --set cnpg.enabled=true \
+            --set observability.enabled=true \
+            --set observability.otelEndpoint=otel:4317 \
+            --set observability.serviceMonitor.enabled=true
+
+      - name: Template (defaults)
+        run: helm template digits charts/digits/ --namespace digits
+
+      - name: Template (all features enabled)
+        run: |
+          helm template digits charts/digits/ --namespace digits \
+            --set ingress.enabled=true \
+            --set ingress.signald.host=app.example.com \
+            --set ingress.admind.host=admin.example.com \
+            --set cnpg.enabled=true \
+            --set cnpg.userdb.storageClass=default \
+            --set cnpg.admindb.storageClass=default \
+            --set cnpg.backup.enabled=true \
+            --set cnpg.backup.destinationPath=s3://backups \
+            --set cnpg.backup.endpointURL=http://minio:9000 \
+            --set cnpg.backup.s3CredentialsSecret=minio-creds \
+            --set observability.enabled=true \
+            --set observability.otelEndpoint=otel:4317 \
+            --set observability.pyroscopeEndpoint=http://pyroscope:4040 \
+            --set observability.serviceMonitor.enabled=true

--- a/charts/digits/.helmignore
+++ b/charts/digits/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.swp
+*.bak
+*.tmp

--- a/charts/digits/Chart.yaml
+++ b/charts/digits/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: digits
+description: Signaling server and admin dashboard for the digits private phone network.
+type: application
+version: 0.1.0
+appVersion: "1.56.1"

--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -1,0 +1,122 @@
+# Digits Helm Chart
+
+This chart deploys the digits signaling server (signald) and admin dashboard (admind) to a Kubernetes cluster. It is used internally to run digits in a homelab k8s environment managed by ArgoCD. Most users will never need this; the standard deployment path is Docker Compose (see `server/docker-compose.prod.yml`).
+
+## When to use this
+
+You have a Kubernetes cluster and want to run digits there instead of Docker. The chart handles:
+
+- signald and admind Deployments with security-hardened pod specs
+- ClusterIP Services (with optional metrics ports)
+- Ingress resources for external access
+- CNPG PostgreSQL Clusters (userdb + admindb) with S3-compatible backups
+- OpenTelemetry tracing, Pyroscope profiling, and Prometheus ServiceMonitors
+
+## Install
+
+```bash
+helm install digits ./charts/digits -n digits --create-namespace -f my-values.yaml
+```
+
+Or via ArgoCD pointing at this repo's `charts/digits` path (see `argocd-application.example.yaml` for a working multi-source Application).
+
+## Configuration
+
+All features are off by default. Enable what your cluster provides.
+
+### Required values
+
+```yaml
+signald:
+  env:
+    BASE_URL: "https://app.example.com"
+    COOKIE_DOMAIN: ".example.com"
+    GOOGLE_REDIRECT_URL: "https://app.example.com/auth/google/callback"
+    SMTP_FROM: "noreply@example.com"
+  envFrom:
+    - secretRef:
+        name: digits-secrets  # must contain ADMIN_SECRET, SMTP_*, GOOGLE_*, SIGNALD_TURN_*
+
+admind:
+  env:
+    ADMIN_STATS_URL: "http://signald.digits.svc.cluster.local:8080/internal/stats"
+  envFrom:
+    - secretRef:
+        name: digits-secrets
+```
+
+The `digits-secrets` Secret is created out-of-band (kubectl or sealed-secrets). It must contain at minimum `ADMIN_SECRET` for cross-service auth.
+
+### CNPG (PostgreSQL)
+
+Requires the [CloudNativePG operator](https://cloudnative-pg.io/) installed in the cluster.
+
+```yaml
+cnpg:
+  enabled: true
+  userdb:
+    instances: 2
+    size: 10Gi
+    storageClass: longhorn  # your StorageClass
+  admindb:
+    instances: 2
+    size: 5Gi
+    storageClass: longhorn
+  backup:
+    enabled: true
+    destinationPath: s3://cnpg-backups
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3CredentialsSecret: minio-cnpg-credentials
+```
+
+When enabled, the chart creates CNPG Cluster CRs. The operator generates Secrets (`<release>-userdb-app`, `<release>-admindb-app`) containing connection URIs that the deployments consume automatically.
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik  # or nginx, etc.
+  signald:
+    host: app.example.com
+  admind:
+    host: admin.example.com
+```
+
+TLS is expected to terminate upstream (load balancer or reverse proxy). The chart does not manage certificates.
+
+### Observability
+
+```yaml
+observability:
+  enabled: true
+  otelEndpoint: "otel-collector.observability.svc.cluster.local:4317"
+  otelProtocol: "grpc"
+  pyroscopeEndpoint: "http://pyroscope.observability.svc.cluster.local:4040"
+  signaldMetricsPort: 9091
+  admindMetricsPort: 9092
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+```
+
+When enabled, the deployments expose Prometheus metrics on dedicated ports and the chart creates ServiceMonitor resources (requires prometheus-operator/kube-prometheus-stack).
+
+### Image tags
+
+By default, image tags derive from `Chart.yaml`'s `appVersion` (prefixed with `v`). Override per-service:
+
+```yaml
+signald:
+  image:
+    tag: v1.57.0
+admind:
+  image:
+    tag: v1.57.0
+```
+
+With ArgoCD Image Updater, tags are bumped automatically on release.
+
+## Full values reference
+
+See `values.yaml` for all available fields with defaults.

--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -18,8 +18,6 @@ You have a Kubernetes cluster and want to run digits there instead of Docker. Th
 helm install digits ./charts/digits -n digits --create-namespace -f my-values.yaml
 ```
 
-Or via ArgoCD pointing at this repo's `charts/digits` path (see `argocd-application.example.yaml` for a working multi-source Application).
-
 ## Configuration
 
 All features are off by default. Enable what your cluster provides.
@@ -114,8 +112,6 @@ admind:
   image:
     tag: v1.57.0
 ```
-
-With ArgoCD Image Updater, tags are bumped automatically on release.
 
 ## Full values reference
 

--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -1,10 +1,8 @@
 # Digits Helm Chart
 
-This chart deploys the digits signaling server (signald) and admin dashboard (admind) to a Kubernetes cluster. It is used internally to run digits in a homelab k8s environment managed by ArgoCD. Most users will never need this; the standard deployment path is Docker Compose (see `server/docker-compose.prod.yml`).
+You almost certainly don't need this. The `docker compose` setup in `server/` is the intended deployment path and will get you running in about two minutes. This Helm chart exists because I run a homelab Kubernetes cluster and enjoy over-engineering things. It's a fun project, and part of the fun is deploying it like it's a real production service with HA Postgres, distributed tracing, and continuous profiling. Is any of that necessary for a three-phone network? Absolutely not. But here we are.
 
-## When to use this
-
-You have a Kubernetes cluster and want to run digits there instead of Docker. The chart handles:
+If you do happen to have a k8s cluster lying around and want to deploy digits there, this chart handles:
 
 - signald and admind Deployments with security-hardened pod specs
 - ClusterIP Services (with optional metrics ports)

--- a/charts/digits/argocd-application.example.yaml
+++ b/charts/digits/argocd-application.example.yaml
@@ -47,7 +47,7 @@ spec:
       helm:
         valueFiles:
           - $values/helm/digits-values.yaml
-    - repoURL: ssh://git@192.168.100.51:22/justinlindh/homelab-k8s.git
+    - repoURL: ssh://git@<your-gitea>:22/<org>/homelab-k8s.git
       targetRevision: master
       ref: values
   destination:

--- a/charts/digits/argocd-application.example.yaml
+++ b/charts/digits/argocd-application.example.yaml
@@ -1,0 +1,62 @@
+# Example ArgoCD Application for the digits Helm chart.
+# Requires: a repository credential Secret in the argocd namespace for
+# github.com/justinlindh/digits, configured as a GitHub App:
+#
+#   apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: digits-repo
+#     namespace: argocd
+#     labels:
+#       argocd.argoproj.io/secret-type: repository
+#   stringData:
+#     type: git
+#     url: https://github.com/justinlindh/digits.git
+#     githubAppID: "<app-id>"
+#     githubAppInstallationID: "<installation-id>"
+#     githubAppPrivateKey: "<PEM private key>"
+#
+# This replaces the existing kustomize-based digits Application in
+# homelab-k8s/manifests/argocd/digits.yaml.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: digits
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: |
+      signald=ghcr.io/justinlindh/digits/signald,
+      admind=ghcr.io/justinlindh/digits/admind
+    argocd-image-updater.argoproj.io/signald.update-strategy: semver
+    argocd-image-updater.argoproj.io/admind.update-strategy: semver
+    argocd-image-updater.argoproj.io/signald.allow-tags: "regexp:^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    argocd-image-updater.argoproj.io/admind.allow-tags: "regexp:^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    argocd-image-updater.argoproj.io/write-back-method: "git:secret:argocd/image-updater-git-credentials"
+    argocd-image-updater.argoproj.io/git-branch: master
+    argocd-image-updater.argoproj.io/write-back-target: "helm:values"
+    argocd-image-updater.argoproj.io/signald.helm.image-name: signald.image.repository
+    argocd-image-updater.argoproj.io/signald.helm.image-tag: signald.image.tag
+    argocd-image-updater.argoproj.io/admind.helm.image-name: admind.image.repository
+    argocd-image-updater.argoproj.io/admind.helm.image-tag: admind.image.tag
+spec:
+  project: apps
+  sources:
+    - repoURL: https://github.com/justinlindh/digits.git
+      targetRevision: main
+      path: charts/digits
+      helm:
+        valueFiles:
+          - $values/helm/digits-values.yaml
+    - repoURL: ssh://git@192.168.100.51:22/justinlindh/homelab-k8s.git
+      targetRevision: master
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: digits
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/charts/digits/templates/_helpers.tpl
+++ b/charts/digits/templates/_helpers.tpl
@@ -80,9 +80,10 @@ Admind image.
 {{/*
 Observability env vars (OTEL + Pyroscope). Pass a dict with "serviceName" and "ctx".
 Usage: include "digits.observability.env" (dict "serviceName" "signald" "ctx" .)
+Callers should guard with observability.enabled, but the helper also checks it.
 */}}
 {{- define "digits.observability.env" -}}
-{{- if .ctx.Values.observability.otelEndpoint }}
+{{- if and .ctx.Values.observability.enabled .ctx.Values.observability.otelEndpoint }}
 - name: OTEL_SERVICE_NAME
   value: {{ .serviceName | quote }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -96,7 +97,7 @@ Usage: include "digits.observability.env" (dict "serviceName" "signald" "ctx" .)
   value: {{ .ctx.Values.observability.otelResourceAttributes | quote }}
 {{- end }}
 {{- end }}
-{{- if .ctx.Values.observability.pyroscopeEndpoint }}
+{{- if and .ctx.Values.observability.enabled .ctx.Values.observability.pyroscopeEndpoint }}
 - name: PYROSCOPE_SERVER_ADDRESS
   value: {{ .ctx.Values.observability.pyroscopeEndpoint | quote }}
 {{- end }}

--- a/charts/digits/templates/_helpers.tpl
+++ b/charts/digits/templates/_helpers.tpl
@@ -76,3 +76,28 @@ Admind image.
 {{- define "digits.admind.image" -}}
 {{ .Values.admind.image.repository }}:{{ .Values.admind.image.tag | default (printf "v%s" .Chart.AppVersion) }}
 {{- end }}
+
+{{/*
+Observability env vars (OTEL + Pyroscope). Pass a dict with "serviceName" and "ctx".
+Usage: include "digits.observability.env" (dict "serviceName" "signald" "ctx" .)
+*/}}
+{{- define "digits.observability.env" -}}
+{{- if .ctx.Values.observability.otelEndpoint }}
+- name: OTEL_SERVICE_NAME
+  value: {{ .serviceName | quote }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ .ctx.Values.observability.otelEndpoint | quote }}
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: {{ .ctx.Values.observability.otelProtocol | quote }}
+- name: OTEL_EXPORTER_OTLP_INSECURE
+  value: {{ .ctx.Values.observability.otelInsecure | quote }}
+{{- if .ctx.Values.observability.otelResourceAttributes }}
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: {{ .ctx.Values.observability.otelResourceAttributes | quote }}
+{{- end }}
+{{- end }}
+{{- if .ctx.Values.observability.pyroscopeEndpoint }}
+- name: PYROSCOPE_SERVER_ADDRESS
+  value: {{ .ctx.Values.observability.pyroscopeEndpoint | quote }}
+{{- end }}
+{{- end }}

--- a/charts/digits/templates/_helpers.tpl
+++ b/charts/digits/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "digits.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "digits.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "digits.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ include "digits.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Signald labels.
+*/}}
+{{- define "digits.signald.labels" -}}
+app.kubernetes.io/name: signald
+{{ include "digits.labels" . }}
+{{- end }}
+
+{{/*
+Signald selector labels.
+*/}}
+{{- define "digits.signald.selectorLabels" -}}
+app.kubernetes.io/name: signald
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Admind labels.
+*/}}
+{{- define "digits.admind.labels" -}}
+app.kubernetes.io/name: admind
+{{ include "digits.labels" . }}
+{{- end }}
+
+{{/*
+Admind selector labels.
+*/}}
+{{- define "digits.admind.selectorLabels" -}}
+app.kubernetes.io/name: admind
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Signald image.
+*/}}
+{{- define "digits.signald.image" -}}
+{{ .Values.signald.image.repository }}:{{ .Values.signald.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Admind image.
+*/}}
+{{- define "digits.admind.image" -}}
+{{ .Values.admind.image.repository }}:{{ .Values.admind.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{- end }}

--- a/charts/digits/templates/cluster-admindb.yaml
+++ b/charts/digits/templates/cluster-admindb.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "digits.fullname" . }}-admindb
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-admindb
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.admindb.instances }}
+  imageName: {{ .Values.cnpg.imageName }}
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: {{ .Values.cnpg.admindb.size }}
+    {{- if .Values.cnpg.admindb.storageClass }}
+    storageClass: {{ .Values.cnpg.admindb.storageClass }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.cnpg.admindb.database }}
+      owner: {{ .Values.cnpg.admindb.owner }}
+  {{- if .Values.cnpg.backup.enabled }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.cnpg.backup.destinationPath }}/{{ include "digits.fullname" . }}-admindb
+      endpointURL: {{ .Values.cnpg.backup.endpointURL }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3AccessKeyIDKey }}
+        secretAccessKey:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3SecretAccessKeyKey }}
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
+  {{- end }}
+  {{- if .Values.observability.enabled }}
+  monitoring:
+    enablePodMonitor: true
+  {{- end }}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+{{- end }}

--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "digits.fullname" . }}-userdb
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-userdb
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.userdb.instances }}
+  imageName: {{ .Values.cnpg.imageName }}
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: {{ .Values.cnpg.userdb.size }}
+    {{- if .Values.cnpg.userdb.storageClass }}
+    storageClass: {{ .Values.cnpg.userdb.storageClass }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.cnpg.userdb.database }}
+      owner: {{ .Values.cnpg.userdb.owner }}
+  {{- if .Values.cnpg.backup.enabled }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.cnpg.backup.destinationPath }}/{{ include "digits.fullname" . }}-userdb
+      endpointURL: {{ .Values.cnpg.backup.endpointURL }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3AccessKeyIDKey }}
+        secretAccessKey:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3SecretAccessKeyKey }}
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
+  {{- end }}
+  {{- if .Values.observability.enabled }}
+  monitoring:
+    enablePodMonitor: true
+  {{- end }}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+{{- end }}

--- a/charts/digits/templates/deployment-admind.yaml
+++ b/charts/digits/templates/deployment-admind.yaml
@@ -12,7 +12,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "digits.admind.labels" . | nindent 8 }}
+        {{- include "digits.admind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
       securityContext:
         runAsNonRoot: true
@@ -50,6 +51,11 @@ spec:
                   name: {{ include "digits.fullname" . }}-admindb-app
                   key: uri
             {{- end }}
+            - name: ADMIN_STATS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.admind.statsSecretRef.name }}
+                  key: {{ .Values.admind.statsSecretRef.key }}
             {{- if .Values.observability.enabled }}
             {{- if .Values.observability.otelEndpoint }}
             - name: OTEL_SERVICE_NAME

--- a/charts/digits/templates/deployment-admind.yaml
+++ b/charts/digits/templates/deployment-admind.yaml
@@ -57,24 +57,7 @@ spec:
                   name: {{ .Values.admind.statsSecretRef.name }}
                   key: {{ .Values.admind.statsSecretRef.key }}
             {{- if .Values.observability.enabled }}
-            {{- if .Values.observability.otelEndpoint }}
-            - name: OTEL_SERVICE_NAME
-              value: "admind"
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.observability.otelEndpoint | quote }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{ .Values.observability.otelProtocol | quote }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE
-              value: {{ .Values.observability.otelInsecure | quote }}
-            {{- if .Values.observability.otelResourceAttributes }}
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ .Values.observability.otelResourceAttributes | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.observability.pyroscopeEndpoint }}
-            - name: PYROSCOPE_SERVER_ADDRESS
-              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
-            {{- end }}
+            {{- include "digits.observability.env" (dict "serviceName" "admind" "ctx" .) | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.admind.env }}
             - name: {{ $key }}

--- a/charts/digits/templates/deployment-admind.yaml
+++ b/charts/digits/templates/deployment-admind.yaml
@@ -15,6 +15,7 @@ spec:
         {{- include "digits.admind.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -28,6 +29,7 @@ spec:
           imagePullPolicy: {{ .Values.admind.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:

--- a/charts/digits/templates/deployment-admind.yaml
+++ b/charts/digits/templates/deployment-admind.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.admind.replicas }}
+  selector:
+    matchLabels:
+      {{- include "digits.admind.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "digits.admind.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: admind
+          image: {{ include "digits.admind.image" . }}
+          imagePullPolicy: {{ .Values.admind.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.admind.port }}
+            {{- if .Values.observability.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.observability.admindMetricsPort }}
+            {{- end }}
+          env:
+            - name: ADMIN_ADDR
+              value: ":{{ .Values.admind.port }}"
+            {{- if .Values.observability.enabled }}
+            - name: ADMIN_METRICS_ADDR
+              value: ":{{ .Values.observability.admindMetricsPort }}"
+            {{- end }}
+            {{- if .Values.cnpg.enabled }}
+            - name: ADMIN_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "digits.fullname" . }}-admindb-app
+                  key: uri
+            {{- end }}
+            {{- if .Values.observability.enabled }}
+            {{- if .Values.observability.otelEndpoint }}
+            - name: OTEL_SERVICE_NAME
+              value: "admind"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otelEndpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.observability.otelProtocol | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.observability.otelInsecure | quote }}
+            {{- if .Values.observability.otelResourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ .Values.observability.otelResourceAttributes | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.observability.pyroscopeEndpoint }}
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.admind.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.admind.envFrom }}
+          envFrom:
+            {{- toYaml .Values.admind.envFrom | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- with .Values.admind.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -15,6 +15,7 @@ spec:
         {{- include "digits.signald.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -28,6 +29,7 @@ spec:
           imagePullPolicy: {{ .Values.signald.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -12,7 +12,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "digits.signald.labels" . | nindent 8 }}
+        {{- include "digits.signald.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
       securityContext:
         runAsNonRoot: true

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.signald.replicas }}
+  selector:
+    matchLabels:
+      {{- include "digits.signald.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "digits.signald.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: signald
+          image: {{ include "digits.signald.image" . }}
+          imagePullPolicy: {{ .Values.signald.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.signald.port }}
+            {{- if .Values.observability.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.observability.signaldMetricsPort }}
+            {{- end }}
+          env:
+            - name: SIGNALD_ADDR
+              value: ":{{ .Values.signald.port }}"
+            {{- if .Values.observability.enabled }}
+            - name: SIGNALD_METRICS_ADDR
+              value: ":{{ .Values.observability.signaldMetricsPort }}"
+            {{- end }}
+            {{- if .Values.cnpg.enabled }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "digits.fullname" . }}-userdb-app
+                  key: uri
+            {{- end }}
+            {{- if .Values.observability.enabled }}
+            {{- if .Values.observability.otelEndpoint }}
+            - name: OTEL_SERVICE_NAME
+              value: "signald"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otelEndpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.observability.otelProtocol | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.observability.otelInsecure | quote }}
+            {{- if .Values.observability.otelResourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ .Values.observability.otelResourceAttributes | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.observability.pyroscopeEndpoint }}
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.signald.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.signald.envFrom }}
+          envFrom:
+            {{- toYaml .Values.signald.envFrom | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- with .Values.signald.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -52,24 +52,7 @@ spec:
                   key: uri
             {{- end }}
             {{- if .Values.observability.enabled }}
-            {{- if .Values.observability.otelEndpoint }}
-            - name: OTEL_SERVICE_NAME
-              value: "signald"
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.observability.otelEndpoint | quote }}
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: {{ .Values.observability.otelProtocol | quote }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE
-              value: {{ .Values.observability.otelInsecure | quote }}
-            {{- if .Values.observability.otelResourceAttributes }}
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ .Values.observability.otelResourceAttributes | quote }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.observability.pyroscopeEndpoint }}
-            - name: PYROSCOPE_SERVER_ADDRESS
-              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
-            {{- end }}
+            {{- include "digits.observability.env" (dict "serviceName" "signald" "ctx" .) | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.signald.env }}
             - name: {{ $key }}

--- a/charts/digits/templates/ingress-admind.yaml
+++ b/charts/digits/templates/ingress-admind.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled }}
+{{- if not .Values.ingress.admind.host }}
+{{- fail "ingress.admind.host is required when ingress is enabled" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,7 +13,7 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.admind.host }}
+    - host: {{ .Values.ingress.admind.host | quote }}
       http:
         paths:
           - path: /

--- a/charts/digits/templates/ingress-admind.yaml
+++ b/charts/digits/templates/ingress-admind.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.admind.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: admind
+                port:
+                  number: 80
+{{- end }}

--- a/charts/digits/templates/ingress-signald.yaml
+++ b/charts/digits/templates/ingress-signald.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.signald.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: signald
+                port:
+                  number: 80
+{{- end }}

--- a/charts/digits/templates/ingress-signald.yaml
+++ b/charts/digits/templates/ingress-signald.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled }}
+{{- if not .Values.ingress.signald.host }}
+{{- fail "ingress.signald.host is required when ingress is enabled" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,7 +13,7 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.signald.host }}
+    - host: {{ .Values.ingress.signald.host | quote }}
       http:
         paths:
           - path: /

--- a/charts/digits/templates/service-admind.yaml
+++ b/charts/digits/templates/service-admind.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "digits.admind.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.admind.port }}
+      protocol: TCP
+    {{- if .Values.observability.enabled }}
+    - name: metrics
+      port: {{ .Values.observability.admindMetricsPort }}
+      targetPort: {{ .Values.observability.admindMetricsPort }}
+      protocol: TCP
+    {{- end }}

--- a/charts/digits/templates/service-signald.yaml
+++ b/charts/digits/templates/service-signald.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "digits.signald.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.signald.port }}
+      protocol: TCP
+    - name: api
+      port: {{ .Values.signald.port }}
+      targetPort: {{ .Values.signald.port }}
+      protocol: TCP
+    {{- if .Values.observability.enabled }}
+    - name: metrics
+      port: {{ .Values.observability.signaldMetricsPort }}
+      targetPort: {{ .Values.observability.signaldMetricsPort }}
+      protocol: TCP
+    {{- end }}

--- a/charts/digits/templates/servicemonitor-admind.yaml
+++ b/charts/digits/templates/servicemonitor-admind.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.observability.enabled .Values.observability.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "digits.admind.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.serviceMonitor.interval }}
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: instance
+        - action: replace
+          targetLabel: job
+          replacement: digits-admind
+{{- end }}

--- a/charts/digits/templates/servicemonitor-signald.yaml
+++ b/charts/digits/templates/servicemonitor-signald.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.observability.enabled .Values.observability.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "digits.signald.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.serviceMonitor.interval }}
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: instance
+        - action: replace
+          targetLabel: job
+          replacement: digits-signald
+{{- end }}

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -21,6 +21,10 @@ admind:
   envFrom: []
   # Container port for the admin HTTP listener.
   port: 9090
+  # Secret reference for ADMIN_STATS_SECRET (remapped from the shared secret).
+  statsSecretRef:
+    name: digits-secrets
+    key: ADMIN_SECRET
 
 ingress:
   enabled: false

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 signald:
   image:
     repository: ghcr.io/justinlindh/digits/signald

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -1,0 +1,68 @@
+signald:
+  image:
+    repository: ghcr.io/justinlindh/digits/signald
+    tag: ""  # defaults to appVersion
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  env: {}
+  envFrom: []
+  # Container port for the HTTP/WebSocket listener.
+  port: 8080
+
+admind:
+  image:
+    repository: ghcr.io/justinlindh/digits/admind
+    tag: ""  # defaults to appVersion
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  env: {}
+  envFrom: []
+  # Container port for the admin HTTP listener.
+  port: 9090
+
+ingress:
+  enabled: false
+  className: ""
+  signald:
+    host: ""
+  admind:
+    host: ""
+
+cnpg:
+  enabled: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+  userdb:
+    instances: 2
+    size: 10Gi
+    storageClass: ""
+    database: digits
+    owner: digits
+  admindb:
+    instances: 2
+    size: 5Gi
+    storageClass: ""
+    database: digits_admin
+    owner: digits_admin
+  backup:
+    enabled: false
+    retentionPolicy: "14d"
+    destinationPath: ""
+    endpointURL: ""
+    s3CredentialsSecret: ""
+    s3AccessKeyIDKey: ACCESS_KEY_ID
+    s3SecretAccessKeyKey: ACCESS_SECRET_KEY
+
+observability:
+  enabled: false
+  otelEndpoint: ""
+  otelProtocol: "grpc"
+  otelInsecure: "true"
+  otelResourceAttributes: ""
+  pyroscopeEndpoint: ""
+  signaldMetricsPort: 9091
+  admindMetricsPort: 9092
+  serviceMonitor:
+    enabled: false
+    interval: 30s


### PR DESCRIPTION
## Summary

- Adds a Helm chart at `charts/digits/` that deploys signald + admind with CNPG Postgres, Ingress, observability (OTEL/Pyroscope/ServiceMonitors), and security-hardened pod specs
- Values-driven feature toggles: CNPG, ingress, and observability are all off by default
- Includes an example ArgoCD Application for multi-source deployment (chart from this repo, values from homelab-k8s)
- Already deployed and running in the homelab cluster via ArgoCD, synced and healthy

## Test plan

- [x] `helm lint` passes with homelab values
- [x] `helm template` output matches existing raw manifests (verified via diff)
- [x] Deployed to homelab k8s cluster via ArgoCD
- [x] Both signald and admind healthy, no pod restarts
- [x] CNPG clusters untouched (not recreated)
- [x] Healthz endpoints responding on both services