### PR TITLE
refactor(server): use stdlib helpers in IsPrivateAddr

### DIFF
--- a/server/internal/httputil/clientip.go
+++ b/server/internal/httputil/clientip.go
@@ -32,43 +32,15 @@ func ClientIP(r *http.Request) string {
 	return host
 }
 
-// privateNets is built once at init from the canonical CIDRs we treat
-// as "LAN-only" for display purposes: RFC1918 plus loopback (v4 and v6),
-// link-local (v4 and v6), and IPv6 ULA. Non-private ranges (public,
-// CGNAT 100.64/10) are explicitly NOT included.
-var privateNets []*net.IPNet
-
-func init() {
-	for _, cidr := range []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"::1/128",
-		"fe80::/10",
-		"fc00::/7",
-	} {
-		_, n, err := net.ParseCIDR(cidr)
-		if err != nil {
-			panic("httputil: bad private CIDR " + cidr + ": " + err.Error())
-		}
-		privateNets = append(privateNets, n)
-	}
-}
-
-// IsPrivateAddr reports whether ip parses as an IP address inside one of
-// the private ranges enumerated above. Empty or unparseable input returns
-// false.
+// IsPrivateAddr reports whether ip parses as an address we treat as
+// "LAN-only" for display purposes: RFC1918 / RFC4193 (IsPrivate), loopback
+// (IsLoopback), or link-local unicast (IsLinkLocalUnicast). Non-private
+// ranges (public, CGNAT 100.64/10) are excluded by all three predicates.
+// Empty or unparseable input returns false.
 func IsPrivateAddr(ip string) bool {
 	parsed := net.ParseIP(ip)
 	if parsed == nil {
 		return false
 	}
-	for _, n := range privateNets {
-		if n.Contains(parsed) {
-			return true
-		}
-	}
-	return false
+	return parsed.IsPrivate() || parsed.IsLoopback() || parsed.IsLinkLocalUnicast()
 }


### PR DESCRIPTION
## Summary

`httputil.IsPrivateAddr` parsed eight CIDRs at init and walked them on every call. The three stdlib predicates `net.IP.IsPrivate` (RFC1918 + RFC4193), `IsLoopback`, and `IsLinkLocalUnicast` together cover the same set of ranges, so the predicate collapses to a one-liner.

Behavior is unchanged: every case in `TestIsPrivateAddr` (RFC1918 boundaries, loopback `127/8`, link-local `169.254/16`, ULA `fc00::/7`, public, CGNAT, IPv6 loopback / link-local, garbage input) continues to pass.

Net delta: -34 / +6 lines. Removes the init-time CIDR parse (and its panic-on-typo guard) and the `privateNets` package var.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/httputil/`
- [x] `go test ./...` (autodeploy `TestLoadConfigOptionalTokenFileUnreadable` failure is pre-existing and unrelated: `chmod 000` does not block root)
- [x] `golangci-lint run ./...` clean