### PR TITLE
refactor(server): consolidate active-household lookup in web handlers

### DIFF
--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -242,35 +242,47 @@ func (h *Handler) householdNumbers(r *http.Request) map[string]bool {
 	return nums
 }
 
-// activeHousehold returns the household the user is currently viewing. Reads
-// active_household_id from the session; falls back to the first household
-// when unset or when the user is no longer a member.
-func (h *Handler) activeHousehold(r *http.Request) *household.Household {
+// resolveActiveHousehold returns the user's full household list along with
+// the entry currently selected as active. The active entry is the one whose
+// ID matches the session cookie's active_household_id; on any miss (cookie
+// absent, ID unset, ID not in the list) it falls back to households[0].
+// Returns (nil, nil) when the request has no authenticated user, the
+// household store is unset, GetForUser fails, or the user has no
+// households.
+func (h *Handler) resolveActiveHousehold(r *http.Request) (*household.Household, []*household.Household) {
 	if h.householdStore == nil {
-		return nil
+		return nil, nil
 	}
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		return nil
+		return nil, nil
 	}
 	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
 	if err != nil || len(households) == 0 {
-		return nil
+		return nil, nil
 	}
-
-	cookie, err := r.Cookie(auth.CookieName)
-	if err == nil && h.authStore != nil {
+	active := households[0]
+	cookie, cookieErr := r.Cookie(auth.CookieName)
+	if cookieErr == nil && h.authStore != nil {
 		activeID := h.authStore.ActiveHouseholdID(r.Context(), cookie.Value)
 		if activeID != "" {
 			for _, hh := range households {
 				if hh.ID == activeID {
-					return hh
+					active = hh
+					break
 				}
 			}
 		}
 	}
+	return active, households
+}
 
-	return households[0]
+// activeHousehold returns the household the user is currently viewing. Reads
+// active_household_id from the session; falls back to the first household
+// when unset or when the user is no longer a member.
+func (h *Handler) activeHousehold(r *http.Request) *household.Household {
+	active, _ := h.resolveActiveHousehold(r)
+	return active
 }
 
 // chromeData holds the fields every protected page-data struct shares for
@@ -316,28 +328,8 @@ func newChromeData(page string, user *auth.User, hh *household.Household) chrome
 }
 
 func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chromeData {
-	user := auth.UserFromContext(r.Context())
-	if user == nil || h.householdStore == nil {
-		return newChromeData(page, user, nil)
-	}
-	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
-	if err != nil || len(households) == 0 {
-		return newChromeData(page, user, nil)
-	}
-	active := households[0]
-	cookie, cookieErr := r.Cookie(auth.CookieName)
-	if cookieErr == nil && h.authStore != nil {
-		activeID := h.authStore.ActiveHouseholdID(r.Context(), cookie.Value)
-		if activeID != "" {
-			for _, hh := range households {
-				if hh.ID == activeID {
-					active = hh
-					break
-				}
-			}
-		}
-	}
-	cd := newChromeData(page, user, active)
+	active, households := h.resolveActiveHousehold(r)
+	cd := newChromeData(page, auth.UserFromContext(r.Context()), active)
 	cd.Households = households
 	return cd
 }


### PR DESCRIPTION
## Summary

`activeHousehold` and `newChromeDataWithHouseholds` in `internal/web/handler_helpers.go` each open-coded the same GetForUser-then-resolve-cookie dance to pick the household the user is currently viewing. Extract the shared logic into `resolveActiveHousehold`, which returns both the active entry and the full list, and rewrite the two callers as thin wrappers over it.

No behavior change. The cookie lookup, the fallback to `households[0]`, and the `(nil, nil)` anonymous-user response are preserved exactly. The chrome-data path drops a duplicated copy of the same loop.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/web/`
- [x] `go test ./...` (autodeploy `TestLoadConfigOptionalTokenFileUnreadable` failure is pre-existing and unrelated: `chmod 000` does not block root)
- [x] `golangci-lint run ./...` clean