### PR TITLE
refactor(server): drop unused RunOutput from autodeploy Runner

### DIFF
--- a/server/internal/autodeploy/deploy.go
+++ b/server/internal/autodeploy/deploy.go
@@ -141,7 +141,7 @@ func (d *Deployer) Run(ctx context.Context) (Result, error) {
 	// require a manual --retry. Instead, exit cleanly and retry next tick.
 	for _, svc := range d.Cfg.Services {
 		img := fmt.Sprintf("ghcr.io/%s/%s:v%s", d.Cfg.Repo, svc, version)
-		if _, err := d.Runner.Run(ctx, RunSpec{
+		if err := d.Runner.Run(ctx, RunSpec{
 			Name: "docker", Args: []string{"manifest", "inspect", img},
 		}); err != nil {
 			d.log().Info("images not yet pushed for tag, will retry",
@@ -213,7 +213,7 @@ func (d *Deployer) deployVersion(ctx context.Context, version string, healthTime
 	// Skip docker login for public images: docker pull works unauthenticated
 	// and `login --password-stdin` with an empty token errors anyway.
 	if d.Cfg.GHCRToken != "" {
-		if _, err := d.Runner.Run(ctx, RunSpec{
+		if err := d.Runner.Run(ctx, RunSpec{
 			Name:  "docker",
 			Args:  []string{"login", "ghcr.io", "-u", d.Cfg.GHCRUsername, "--password-stdin"},
 			Stdin: []byte(d.Cfg.GHCRToken),
@@ -231,7 +231,7 @@ func (d *Deployer) deployVersion(ctx context.Context, version string, healthTime
 
 	pullArgs := append(append([]string{}, composeArgs...), "pull")
 	pullArgs = append(pullArgs, d.Cfg.Services...)
-	if _, err := d.Runner.Run(ctx, RunSpec{
+	if err := d.Runner.Run(ctx, RunSpec{
 		Name: "docker", Args: pullArgs, Dir: d.Cfg.ComposeDir, Env: env,
 	}); err != nil {
 		return &stepError{Step: StepPull, Err: err}
@@ -239,7 +239,7 @@ func (d *Deployer) deployVersion(ctx context.Context, version string, healthTime
 
 	upArgs := append(append([]string{}, composeArgs...), "up", "-d", "--wait")
 	upArgs = append(upArgs, d.Cfg.Services...)
-	if _, err := d.Runner.Run(ctx, RunSpec{
+	if err := d.Runner.Run(ctx, RunSpec{
 		Name: "docker", Args: upArgs, Dir: d.Cfg.ComposeDir, Env: env,
 	}); err != nil {
 		return &stepError{Step: StepUp, Err: err}

--- a/server/internal/autodeploy/deploy_test.go
+++ b/server/internal/autodeploy/deploy_test.go
@@ -22,19 +22,19 @@ type mockRunner struct {
 	errs  map[string]error // keyed by "Name" or "Name arg0"
 }
 
-func (m *mockRunner) Run(ctx context.Context, spec RunSpec) (RunOutput, error) {
+func (m *mockRunner) Run(ctx context.Context, spec RunSpec) error {
 	m.calls = append(m.calls, spec)
 	if m.errs != nil {
 		if e, ok := m.errs[spec.Name]; ok {
-			return RunOutput{}, e
+			return e
 		}
 		if len(spec.Args) > 0 {
 			if e, ok := m.errs[spec.Name+" "+spec.Args[0]]; ok {
-				return RunOutput{}, e
+				return e
 			}
 		}
 	}
-	return RunOutput{}, nil
+	return nil
 }
 
 type sentEmail struct {

--- a/server/internal/autodeploy/runner.go
+++ b/server/internal/autodeploy/runner.go
@@ -16,20 +16,15 @@ type RunSpec struct {
 	Stdin []byte
 }
 
-type RunOutput struct {
-	Stdout []byte
-	Stderr []byte
-}
-
 type Runner interface {
-	Run(ctx context.Context, spec RunSpec) (RunOutput, error)
+	Run(ctx context.Context, spec RunSpec) error
 }
 
 type ExecRunner struct{}
 
 func NewExecRunner() *ExecRunner { return &ExecRunner{} }
 
-func (ExecRunner) Run(ctx context.Context, spec RunSpec) (RunOutput, error) {
+func (ExecRunner) Run(ctx context.Context, spec RunSpec) error {
 	cmd := exec.CommandContext(ctx, spec.Name, spec.Args...)
 	cmd.Dir = spec.Dir
 	if len(spec.Env) > 0 {
@@ -38,13 +33,10 @@ func (ExecRunner) Run(ctx context.Context, spec RunSpec) (RunOutput, error) {
 	if len(spec.Stdin) > 0 {
 		cmd.Stdin = bytes.NewReader(spec.Stdin)
 	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	err := cmd.Run()
-	out := RunOutput{Stdout: stdout.Bytes(), Stderr: stderr.Bytes()}
-	if err != nil {
-		return out, fmt.Errorf("%s %v: %w (stderr=%q)", spec.Name, spec.Args, err, stderr.String())
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s %v: %w (stderr=%q)", spec.Name, spec.Args, err, stderr.String())
 	}
-	return out, nil
+	return nil
 }

--- a/server/internal/autodeploy/runner_test.go
+++ b/server/internal/autodeploy/runner_test.go
@@ -8,22 +8,20 @@ import (
 
 func TestExecRunner(t *testing.T) {
 	r := NewExecRunner()
-	out, err := r.Run(context.Background(), RunSpec{
-		Name: "echo",
-		Args: []string{"hello"},
-	})
-	if err != nil {
+	if err := r.Run(context.Background(), RunSpec{
+		Name: "true",
+	}); err != nil {
 		t.Fatal(err)
-	}
-	if !strings.Contains(string(out.Stdout), "hello") {
-		t.Errorf("stdout=%q", string(out.Stdout))
 	}
 }
 
 func TestExecRunnerNonZeroExit(t *testing.T) {
 	r := NewExecRunner()
-	_, err := r.Run(context.Background(), RunSpec{Name: "false"})
+	err := r.Run(context.Background(), RunSpec{Name: "sh", Args: []string{"-c", "echo nope >&2; exit 1"}})
 	if err == nil {
 		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("expected stderr in error, got %q", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

`Runner.Run` returned a `(RunOutput, error)` where `RunOutput` carried both stdout and stderr, but every production caller in `deploy.go` discarded the value with `_`. The only consumer was a single `TestExecRunner` assertion against `echo`'s stdout. `ExecRunner` already folds stderr into the formatted error string (`(stderr=%q)`), which is the only place stderr was actually useful.

This PR collapses the interface to `Run(ctx, RunSpec) error`, drops the `RunOutput` struct and the orphan stdout buffer in `ExecRunner`, and updates the mock and tests. `TestExecRunnerNonZeroExit` gains an explicit assertion that the formatted error contains the stderr text, so the `(stderr=%q)` path keeps test coverage.

Net delta: -10 lines, four files. No behavior change in production: the four `if _, err := d.Runner.Run(...)` sites become `if err := d.Runner.Run(...)`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autodeploy/` (only pre-existing `TestLoadConfigOptionalTokenFileUnreadable` failure remains, unrelated: `chmod 000` does not block root)
- [x] `go test -run TestExecRunner -v ./internal/autodeploy/` passes both subtests
- [x] `golangci-lint run ./...` clean