### PR TITLE
feat(image): pull pre-built binaries from GitHub Releases for production images

### DIFF
--- a/.github/workflows/pi-release.yml
+++ b/.github/workflows/pi-release.yml
@@ -48,7 +48,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.26.1"
-          cache-dependency-path: pi/digitsd/go.sum
+          cache-dependency-path: |
+            pi/digitsd/go.sum
+            pi/digits-setup/go.sum
+            pi/digits-recovery/go.sum
+            pi/digits-panic-check/go.sum
 
       - name: Install aarch64 cross-compiler and libraries
         run: |

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ stage-firmware: firmware ## Build firmware and stage it at tools/build/firmware.
 # ── Pi SD Card Image ─────────────────────────────────────────────────────────
 #
 # Default (make image / make image-v2): downloads pre-built binaries and
-# firmware from the latest GitHub release. No local Go or ARM toolchain needed.
+# firmware from the latest GitHub release. Requires Go (for `make embed`).
 # To build from local source instead: BUILD_LOCAL=1 make image
+# (run `git fetch --tags` first so version stamps are accurate).
 #
 # Dev targets (make image-dev / make image-v2-dev) imply BUILD_LOCAL=1 and
 # stage firmware from the local build before invoking the container.

--- a/Makefile
+++ b/Makefile
@@ -48,18 +48,25 @@ stage-firmware: firmware ## Build firmware and stage it at tools/build/firmware.
 	@echo "==> staged firmware $(DIGITS_FW_VERSION) -> tools/build/firmware.elf"
 
 # ── Pi SD Card Image ─────────────────────────────────────────────────────────
+#
+# Default (make image / make image-v2): downloads pre-built binaries and
+# firmware from the latest GitHub release. No local Go or ARM toolchain needed.
+# To build from local source instead: BUILD_LOCAL=1 make image
+#
+# Dev targets (make image-dev / make image-v2-dev) imply BUILD_LOCAL=1 and
+# stage firmware from the local build before invoking the container.
 
-image: stage-firmware ## Build Pi SD card image for V1/prototype hardware (Codec Zero HAT)
+image: ## Build Pi SD card image for V1/prototype hardware (release artifacts by default)
 	./pi/image/build-docker.sh
 
-image-dev: stage-firmware ## Build V1/prototype image with SSH enabled (Docker)
-	./pi/image/build-docker.sh --dev
+image-dev: stage-firmware ## Build V1/prototype image with SSH enabled (local build)
+	BUILD_LOCAL=1 ./pi/image/build-docker.sh --dev
 
-image-v2: stage-firmware ## Build Pi SD card image for V2 carrier board (onboard codec)
+image-v2: ## Build Pi SD card image for V2 carrier board (release artifacts by default)
 	./pi/image/build-docker.sh --pcb
 
-image-v2-dev: stage-firmware ## Build V2 carrier board image with SSH enabled (Docker)
-	./pi/image/build-docker.sh --dev --pcb
+image-v2-dev: stage-firmware ## Build V2 carrier board image with SSH enabled (local build)
+	BUILD_LOCAL=1 ./pi/image/build-docker.sh --dev --pcb
 
 # Default flash glob: newest of any variant. flash-v1 / flash-v2 narrow it.
 # Override with IMAGE=<path> to flash a specific file regardless of glob.

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -48,6 +48,12 @@ module.exports = {
       assets: [
         { path: 'artifacts/digitsd-*-aarch64', label: 'digitsd (aarch64 Linux)' },
         { path: 'artifacts/digitsd-*-aarch64.sha256', label: 'digitsd SHA256 checksum' },
+        { path: 'artifacts/digits-setup-*-aarch64', label: 'digits-setup (aarch64 Linux)' },
+        { path: 'artifacts/digits-setup-*-aarch64.sha256', label: 'digits-setup SHA256 checksum' },
+        { path: 'artifacts/digits-recovery-*-aarch64', label: 'digits-recovery (aarch64 Linux)' },
+        { path: 'artifacts/digits-recovery-*-aarch64.sha256', label: 'digits-recovery SHA256 checksum' },
+        { path: 'artifacts/digits-panic-check-*-aarch64', label: 'digits-panic-check (aarch64 Linux)' },
+        { path: 'artifacts/digits-panic-check-*-aarch64.sha256', label: 'digits-panic-check SHA256 checksum' },
       ],
       successComment: false,
       failComment: false,

--- a/pi/image/Dockerfile
+++ b/pi/image/Dockerfile
@@ -58,6 +58,18 @@ RUN dpkg --add-architecture arm64 \
     && ldconfig \
     && rm -rf /tmp/opusfile-dev /tmp/opusfile-lib *.deb /var/lib/apt/lists/*
 
+# GitHub CLI - needed for release mode (RELEASE_TAG) to download
+# pre-built binaries from GitHub Releases.
+RUN mkdir -p /usr/share/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /digits
 
 COPY entrypoint.sh /entrypoint.sh

--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -14,7 +14,8 @@
 # is downloaded automatically and cached in a Docker volume for reuse.
 #
 # Default: downloads pre-built binaries from the latest pi/v* GitHub release.
-# No Go toolchain required. Pin a specific release with RELEASE_TAG:
+# Requires a Go toolchain for `make embed` (cross-compiles digits-setup into
+# the rootfs overlay). Pin a specific release with RELEASE_TAG:
 #
 #   RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
 #
@@ -83,10 +84,10 @@ DOCKER_ARGS=(
 [[ -n "${RELEASE_TAG:-}" ]]   && DOCKER_ARGS+=(-e "RELEASE_TAG=${RELEASE_TAG}")
 [[ -n "${FIRMWARE_TAG:-}" ]]  && DOCKER_ARGS+=(-e "FIRMWARE_TAG=${FIRMWARE_TAG}")
 
-# Release mode needs gh CLI auth inside the container. If a GITHUB_TOKEN is
-# present in the environment, forward it; otherwise gh will use the host's
-# stored credential via the mounted repo's config (no extra setup needed for
-# public releases).
+# Release mode needs gh CLI auth inside the container for GitHub API access.
+if [[ -z "${BUILD_LOCAL:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+    warn "No GITHUB_TOKEN set. Release mode requires a token to download artifacts. Set GITHUB_TOKEN or use BUILD_LOCAL=1."
+fi
 [[ -n "${GITHUB_TOKEN:-}" ]]  && DOCKER_ARGS+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
 
 # If this is a git worktree, .git is a file pointing to the main repo's

--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -13,11 +13,16 @@
 # If no base image is provided, a known-good Raspberry Pi OS Lite image
 # is downloaded automatically and cached in a Docker volume for reuse.
 #
-# Release mode: set RELEASE_TAG=pi/v<version> to download pre-built binaries
-# from GitHub Releases instead of compiling locally. Produces a clean image
-# from a tagged release without requiring the Go cross-compile toolchain.
+# Default: downloads pre-built binaries from the latest pi/v* GitHub release.
+# No Go toolchain required. Pin a specific release with RELEASE_TAG:
 #
 #   RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
+#
+# Local build mode: set BUILD_LOCAL=1 to cross-compile from the local working
+# tree instead of downloading release artifacts. Use this to test unreleased
+# code changes.
+#
+#   BUILD_LOCAL=1 ./pi/image/build-docker.sh --pcb
 #
 # Optionally pin the firmware release with FIRMWARE_TAG=fw/v<version>.
 # Without FIRMWARE_TAG, the latest fw/v* release is used.
@@ -50,10 +55,9 @@ for arg in "$@"; do
 done
 
 # Generate embedded assets on the host (avoids root-owned files from Docker).
-# In release mode, make embed still runs to populate rootfs overlay, tones,
-# and mixer state; the container then overwrites digits-setup (and the other
-# Go binaries) with the downloaded release artifacts before build-image.sh
-# uses them.
+# make embed populates rootfs overlay, tones, and mixer state regardless of
+# build mode. In release mode, the container overwrites the Go binaries with
+# downloaded release artifacts before build-image.sh uses them.
 info "Generating embedded assets..."
 make -C "$REPO_DIR/pi/digitsd" embed
 
@@ -74,7 +78,8 @@ DOCKER_ARGS=(
     -e "HOST_GID=$(id -g)"
 )
 
-# Pass release tags into the container when set.
+# Pass build mode and release tags into the container when set.
+[[ -n "${BUILD_LOCAL:-}" ]]   && DOCKER_ARGS+=(-e "BUILD_LOCAL=${BUILD_LOCAL}")
 [[ -n "${RELEASE_TAG:-}" ]]   && DOCKER_ARGS+=(-e "RELEASE_TAG=${RELEASE_TAG}")
 [[ -n "${FIRMWARE_TAG:-}" ]]  && DOCKER_ARGS+=(-e "FIRMWARE_TAG=${FIRMWARE_TAG}")
 

--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -13,6 +13,15 @@
 # If no base image is provided, a known-good Raspberry Pi OS Lite image
 # is downloaded automatically and cached in a Docker volume for reuse.
 #
+# Release mode: set RELEASE_TAG=pi/v<version> to download pre-built binaries
+# from GitHub Releases instead of compiling locally. Produces a clean image
+# from a tagged release without requiring the Go cross-compile toolchain.
+#
+#   RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
+#
+# Optionally pin the firmware release with FIRMWARE_TAG=fw/v<version>.
+# Without FIRMWARE_TAG, the latest fw/v* release is used.
+#
 # Output: digits-pi-YYYYMMDD.img.gz in the current directory.
 set -euo pipefail
 
@@ -40,7 +49,11 @@ for arg in "$@"; do
     esac
 done
 
-# Generate embedded assets on the host (avoids root-owned files from Docker)
+# Generate embedded assets on the host (avoids root-owned files from Docker).
+# In release mode, make embed still runs to populate rootfs overlay, tones,
+# and mixer state; the container then overwrites digits-setup (and the other
+# Go binaries) with the downloaded release artifacts before build-image.sh
+# uses them.
 info "Generating embedded assets..."
 make -C "$REPO_DIR/pi/digitsd" embed
 
@@ -60,6 +73,16 @@ DOCKER_ARGS=(
     -e "HOST_UID=$(id -u)"
     -e "HOST_GID=$(id -g)"
 )
+
+# Pass release tags into the container when set.
+[[ -n "${RELEASE_TAG:-}" ]]   && DOCKER_ARGS+=(-e "RELEASE_TAG=${RELEASE_TAG}")
+[[ -n "${FIRMWARE_TAG:-}" ]]  && DOCKER_ARGS+=(-e "FIRMWARE_TAG=${FIRMWARE_TAG}")
+
+# Release mode needs gh CLI auth inside the container. If a GITHUB_TOKEN is
+# present in the environment, forward it; otherwise gh will use the host's
+# stored credential via the mounted repo's config (no extra setup needed for
+# public releases).
+[[ -n "${GITHUB_TOKEN:-}" ]]  && DOCKER_ARGS+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
 
 # If this is a git worktree, .git is a file pointing to the main repo's
 # .git/worktrees/ directory. Mount the main repo's .git so the pointer

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 # entrypoint.sh -- Docker entrypoint for Digits Pi image builder
 #
-# Cross-compiles the Go binaries, then runs build-image.sh.
+# Provides two modes for sourcing Pi binaries:
+#
+#   Default (local build):
+#     Cross-compiles digitsd, digits-recovery, digits-panic-check from the
+#     mounted repo. Used for development and testing unreleased code.
+#
+#   Release mode (RELEASE_TAG=pi/v<version>):
+#     Downloads pre-built binaries from the specified GitHub release tag
+#     instead of compiling locally. Use this for producing clean production
+#     images from a tagged release.
+#
+#     Example: RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
+#
+#     The firmware is sourced from its own release (FIRMWARE_TAG=fw/v<version>).
+#     If FIRMWARE_TAG is not set, the latest fw/v* release is used.
+#
 # The repo must be mounted at /digits. If no base image is provided,
 # downloads a known-good Raspberry Pi OS Lite image to /cache.
 set -euo pipefail
@@ -79,56 +94,119 @@ if [[ ! -f /proc/sys/fs/binfmt_misc/qemu-aarch64 ]]; then
     [[ -f /proc/sys/fs/binfmt_misc/qemu-aarch64 ]] || die "Failed to register qemu-aarch64 binfmt. Is the container running with --privileged?"
 fi
 
-# Cross-compile digitsd
-info "Cross-compiling digitsd for aarch64..."
 mkdir -p /digits/tools/build
-cd /digits/pi/digitsd
 
-# Verify embedded assets exist (must be generated on host via 'make embed')
-if [[ ! -d internal/assets/embed ]]; then
-    die "Embed directory not found. Run 'make embed' in pi/digitsd/ before building the image."
+# ── binary sourcing: release mode vs local build ─────────────────────────────
+#
+# RELEASE_TAG=pi/v<version> downloads pre-built binaries from GitHub Releases.
+# Default (no RELEASE_TAG) cross-compiles from the local working tree.
+
+if [[ -n "${RELEASE_TAG:-}" ]]; then
+    # Release mode: download pre-built binaries from GitHub Releases.
+    info "Release mode: downloading Pi binaries from GitHub release ${RELEASE_TAG}..."
+
+    # Verify the tag exists before proceeding.
+    if ! gh release view "${RELEASE_TAG}" --repo justinlindh/digits &>/dev/null; then
+        die "GitHub release '${RELEASE_TAG}' not found. Check the tag and try again."
+    fi
+
+    # Resolve the version string from the tag (e.g. pi/v1.21.0 -> 1.21.0).
+    PI_VERSION="${RELEASE_TAG#pi/v}"
+    # Export for build-image.sh so it writes the correct asset-version marker.
+    export DIGITS_PI_VERSION="${PI_VERSION}"
+
+    info "  Downloading digitsd-${PI_VERSION}-aarch64..."
+    gh release download "${RELEASE_TAG}" \
+        --repo justinlindh/digits \
+        --pattern "digitsd-${PI_VERSION}-aarch64" \
+        --output /digits/tools/build/digitsd
+    chmod +x /digits/tools/build/digitsd
+
+    info "  Downloading digits-setup-${PI_VERSION}-aarch64..."
+    DIGITS_SETUP_EMBED=/digits/pi/digitsd/internal/assets/embed/rootfs/usr/local/bin/digits-setup
+    mkdir -p "$(dirname "$DIGITS_SETUP_EMBED")"
+    gh release download "${RELEASE_TAG}" \
+        --repo justinlindh/digits \
+        --pattern "digits-setup-${PI_VERSION}-aarch64" \
+        --output "$DIGITS_SETUP_EMBED"
+    chmod +x "$DIGITS_SETUP_EMBED"
+
+    info "  Downloading digits-recovery-${PI_VERSION}-aarch64..."
+    mkdir -p /digits/pi/digits-recovery/bin
+    gh release download "${RELEASE_TAG}" \
+        --repo justinlindh/digits \
+        --pattern "digits-recovery-${PI_VERSION}-aarch64" \
+        --output /digits/pi/digits-recovery/bin/digits-recovery
+    chmod +x /digits/pi/digits-recovery/bin/digits-recovery
+
+    info "  Downloading digits-panic-check-${PI_VERSION}-aarch64..."
+    gh release download "${RELEASE_TAG}" \
+        --repo justinlindh/digits \
+        --pattern "digits-panic-check-${PI_VERSION}-aarch64" \
+        --output /digits/tools/build/digits-panic-check
+    chmod +x /digits/tools/build/digits-panic-check
+
+    info "Pi binaries downloaded from ${RELEASE_TAG}."
+else
+    # Local build mode: cross-compile from the mounted repo.
+
+    # Cross-compile digitsd
+    info "Cross-compiling digitsd for aarch64..."
+    cd /digits/pi/digitsd
+
+    # Verify embedded assets exist (must be generated on host via 'make embed')
+    if [[ ! -d internal/assets/embed ]]; then
+        die "Embed directory not found. Run 'make embed' in pi/digitsd/ before building the image."
+    fi
+
+    export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
+    export CC=aarch64-linux-gnu-gcc
+    export CGO_ENABLED=1
+    export CGO_CFLAGS="-I/usr/aarch64-linux-gnu/include -I/usr/include"
+    export CGO_LDFLAGS="-L/usr/lib/aarch64-linux-gnu"
+
+    # Stamp pi_version / pi_commit so devices report a real version instead
+    # of "dev". Tags were refreshed host-side by make fetch-tags before this
+    # container ran; if no pi/v* tag exists, fall back to "dev".
+    DIGITSD_VERSION=$(git -C /digits describe --tags --dirty --match 'pi/v*' 2>/dev/null | sed 's|^pi/v||')
+    DIGITSD_VERSION=${DIGITSD_VERSION:-dev}
+    DIGITSD_COMMIT=$(git -C /digits rev-parse --short HEAD 2>/dev/null || echo unknown)
+    # Export for build-image.sh so it writes the correct asset-version marker.
+    export DIGITS_PI_VERSION="${DIGITSD_VERSION}"
+    info "Stamping digitsd: version=$DIGITSD_VERSION commit=$DIGITSD_COMMIT"
+    GOOS=linux GOARCH=arm64 go build \
+        -ldflags "-X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$DIGITSD_VERSION \
+                  -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$DIGITSD_COMMIT" \
+        -o /digits/tools/build/digitsd \
+        ./cmd/digitsd/
+
+    # digits-setup is cross-compiled by `make embed` on the host (see
+    # pi/digitsd/Makefile) and lands on the rootfs via build-image.sh's
+    # embed/rootfs/ rsync. Nothing to do here.
+
+    # Cross-compile digits-recovery (pure Go, no CGO needed). build-image.sh reads
+    # this from pi/digits-recovery/bin/ to match the local Makefile output path.
+    info "Cross-compiling digits-recovery for aarch64..."
+    cd /digits/pi/digits-recovery
+    mkdir -p bin
+    CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/digits-recovery .
+
+    # Cross-compile digits-panic-check (pure Go + golang.org/x/sys, no CGO).
+    info "Cross-compiling digits-panic-check for aarch64..."
+    cd /digits/pi/digits-panic-check
+    CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /digits/tools/build/digits-panic-check .
+
+    info "Binaries ready in tools/build/"
 fi
 
-export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
-export CC=aarch64-linux-gnu-gcc
-export CGO_ENABLED=1
-export CGO_CFLAGS="-I/usr/aarch64-linux-gnu/include -I/usr/include"
-export CGO_LDFLAGS="-L/usr/lib/aarch64-linux-gnu"
+# ── firmware: host-staged, release download, or error ────────────────────────
+#
+# An image without firmware is a regression we don't ship. Priority:
+#   1. Host-staged ELF (make stage-firmware, or release mode put it there).
+#   2. FIRMWARE_TAG env var: download from that specific fw/v* release.
+#   3. Auto-detect: download from the latest fw/v* release on GitHub.
+#   4. Die if none of the above succeed.
 
-# Stamp pi_version / pi_commit so devices report a real version instead
-# of "dev". Tags were refreshed host-side by make fetch-tags before this
-# container ran; if no pi/v* tag exists, fall back to "dev".
-DIGITSD_VERSION=$(git -C /digits describe --tags --dirty --match 'pi/v*' 2>/dev/null | sed 's|^pi/v||')
-DIGITSD_VERSION=${DIGITSD_VERSION:-dev}
-DIGITSD_COMMIT=$(git -C /digits rev-parse --short HEAD 2>/dev/null || echo unknown)
-info "Stamping digitsd: version=$DIGITSD_VERSION commit=$DIGITSD_COMMIT"
-GOOS=linux GOARCH=arm64 go build \
-    -ldflags "-X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=$DIGITSD_VERSION \
-              -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=$DIGITSD_COMMIT" \
-    -o /digits/tools/build/digitsd \
-    ./cmd/digitsd/
-
-# digits-setup is cross-compiled by `make embed` on the host (see
-# pi/digitsd/Makefile) and lands on the rootfs via build-image.sh's
-# embed/rootfs/ rsync. Nothing to do here.
-
-# Cross-compile digits-recovery (pure Go, no CGO needed). build-image.sh reads
-# this from pi/digits-recovery/bin/ to match the local Makefile output path.
-info "Cross-compiling digits-recovery for aarch64..."
-cd /digits/pi/digits-recovery
-mkdir -p bin
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/digits-recovery .
-
-# Cross-compile digits-panic-check (pure Go + golang.org/x/sys, no CGO).
-info "Cross-compiling digits-panic-check for aarch64..."
-cd /digits/pi/digits-panic-check
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /digits/tools/build/digits-panic-check .
-
-info "Binaries ready in tools/build/"
-
-# An image without firmware is a regression we don't ship: prefer the
-# host-staged ELF (make stage-firmware), fall back to GitHub release,
-# die if neither is available.
 FW_ELF=/digits/tools/build/firmware.elf
 FW_VER_FILE=/digits/tools/build/firmware.elf.version
 if [[ -f "$FW_ELF" ]]; then
@@ -138,25 +216,30 @@ if [[ -f "$FW_ELF" ]]; then
         info "Using host-staged Pico firmware (no version file)"
     fi
 else
-    info "Downloading latest Pico firmware from GitHub releases..."
-    FW_API_URL="https://api.github.com/repos/justinlindh/digits/releases"
-    FW_TAG=$(curl -sf "$FW_API_URL" | python3 -c "
-import json, sys
-for r in json.load(sys.stdin):
-    if r['tag_name'].startswith('fw/'):
-        print(r['tag_name']); break
-" 2>/dev/null || true)
-    if [[ -z "$FW_TAG" ]]; then
-        die "Could not determine latest fw/v* release tag from GitHub. Run 'make stage-firmware' first or check network."
+    if [[ -n "${FIRMWARE_TAG:-}" ]]; then
+        # Explicit firmware release tag supplied.
+        FW_TAG="${FIRMWARE_TAG}"
+        if ! gh release view "${FW_TAG}" --repo justinlindh/digits &>/dev/null; then
+            die "GitHub release '${FW_TAG}' not found. Check FIRMWARE_TAG and try again."
+        fi
+    else
+        # Auto-detect the latest fw/v* release.
+        info "Resolving latest Pico firmware release from GitHub..."
+        FW_TAG=$(gh release list --repo justinlindh/digits --limit 50 --json tagName \
+            --jq '[.[].tagName | select(startswith("fw/"))] | first' 2>/dev/null || true)
+        if [[ -z "$FW_TAG" ]]; then
+            die "Could not determine latest fw/v* release tag from GitHub. Run 'make stage-firmware' first or set FIRMWARE_TAG."
+        fi
     fi
+
     FW_VERSION="${FW_TAG#fw/v}"
-    FW_DOWNLOAD_URL="https://github.com/justinlindh/digits/releases/download/${FW_TAG}/firmware-${FW_VERSION}.elf"
-    info "  Downloading firmware ${FW_VERSION}..."
-    if ! curl -sfL -o "$FW_ELF" "$FW_DOWNLOAD_URL"; then
-        die "Failed to download firmware from $FW_DOWNLOAD_URL"
-    fi
+    info "Downloading Pico firmware ${FW_VERSION} from GitHub release ${FW_TAG}..."
+    gh release download "${FW_TAG}" \
+        --repo justinlindh/digits \
+        --pattern "firmware-${FW_VERSION}.elf" \
+        --output "$FW_ELF"
     printf '%s\n' "$FW_VERSION" > "$FW_VER_FILE"
-    info "  Firmware downloaded: tools/build/firmware.elf ($FW_VERSION)"
+    info "Firmware downloaded: tools/build/firmware.elf ($FW_VERSION)"
 fi
 [[ -f "$FW_ELF" ]] || die "Firmware ELF still missing at $FW_ELF after fetch"
 

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -119,7 +119,7 @@ if [[ -z "${BUILD_LOCAL:-}" ]]; then
         fi
     else
         info "Resolving latest Pi release from GitHub..."
-        PI_TAG=$(gh release list --repo justinlindh/digits --limit 20 --json tagName \
+        PI_TAG=$(gh release list --repo justinlindh/digits --limit 50 --json tagName \
             --jq '[.[].tagName | select(startswith("pi/"))] | first' 2>/dev/null || true)
         if [[ -z "$PI_TAG" ]]; then
             die "Could not determine latest pi/v* release tag from GitHub. Set RELEASE_TAG=pi/v<version> or BUILD_LOCAL=1."

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -3,19 +3,21 @@
 #
 # Provides two modes for sourcing Pi binaries:
 #
-#   Default (local build):
-#     Cross-compiles digitsd, digits-recovery, digits-panic-check from the
-#     mounted repo. Used for development and testing unreleased code.
-#
-#   Release mode (RELEASE_TAG=pi/v<version>):
-#     Downloads pre-built binaries from the specified GitHub release tag
-#     instead of compiling locally. Use this for producing clean production
-#     images from a tagged release.
+#   Default (release mode):
+#     Downloads pre-built binaries from the latest pi/v* GitHub release.
+#     Produces clean production images without requiring the Go cross-compile
+#     toolchain. Pin a specific release with RELEASE_TAG=pi/v<version>.
 #
 #     Example: RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
 #
 #     The firmware is sourced from its own release (FIRMWARE_TAG=fw/v<version>).
 #     If FIRMWARE_TAG is not set, the latest fw/v* release is used.
+#
+#   Local build mode (BUILD_LOCAL=1):
+#     Cross-compiles digitsd, digits-recovery, digits-panic-check from the
+#     mounted repo. Use this to test unreleased code changes.
+#
+#     Example: BUILD_LOCAL=1 ./pi/image/build-docker.sh --pcb
 #
 # The repo must be mounted at /digits. If no base image is provided,
 # downloads a known-good Raspberry Pi OS Lite image to /cache.
@@ -96,27 +98,42 @@ fi
 
 mkdir -p /digits/tools/build
 
-# ── binary sourcing: release mode vs local build ─────────────────────────────
+# ── binary sourcing: release mode (default) vs local build ───────────────────
 #
-# RELEASE_TAG=pi/v<version> downloads pre-built binaries from GitHub Releases.
-# Default (no RELEASE_TAG) cross-compiles from the local working tree.
+# Default: download pre-built binaries from the latest pi/v* GitHub release.
+# Pin a specific tag with RELEASE_TAG=pi/v<version>.
+# Set BUILD_LOCAL=1 to cross-compile from the local working tree instead.
 
-if [[ -n "${RELEASE_TAG:-}" ]]; then
+if [[ -z "${BUILD_LOCAL:-}" ]]; then
     # Release mode: download pre-built binaries from GitHub Releases.
-    info "Release mode: downloading Pi binaries from GitHub release ${RELEASE_TAG}..."
 
-    # Verify the tag exists before proceeding.
-    if ! gh release view "${RELEASE_TAG}" --repo justinlindh/digits &>/dev/null; then
-        die "GitHub release '${RELEASE_TAG}' not found. Check the tag and try again."
+    # Resolve the release tag: use RELEASE_TAG if set, otherwise auto-detect
+    # the latest pi/v* release from GitHub.
+    if [[ -n "${RELEASE_TAG:-}" ]]; then
+        PI_TAG="${RELEASE_TAG}"
+        info "Release mode: downloading Pi binaries from GitHub release ${PI_TAG}..."
+
+        # Verify the tag exists before proceeding.
+        if ! gh release view "${PI_TAG}" --repo justinlindh/digits &>/dev/null; then
+            die "GitHub release '${PI_TAG}' not found. Check RELEASE_TAG and try again."
+        fi
+    else
+        info "Resolving latest Pi release from GitHub..."
+        PI_TAG=$(gh release list --repo justinlindh/digits --limit 20 --json tagName \
+            --jq '[.[].tagName | select(startswith("pi/"))] | first' 2>/dev/null || true)
+        if [[ -z "$PI_TAG" ]]; then
+            die "Could not determine latest pi/v* release tag from GitHub. Set RELEASE_TAG=pi/v<version> or BUILD_LOCAL=1."
+        fi
+        info "Release mode: downloading Pi binaries from latest release ${PI_TAG}..."
     fi
 
     # Resolve the version string from the tag (e.g. pi/v1.21.0 -> 1.21.0).
-    PI_VERSION="${RELEASE_TAG#pi/v}"
+    PI_VERSION="${PI_TAG#pi/v}"
     # Export for build-image.sh so it writes the correct asset-version marker.
     export DIGITS_PI_VERSION="${PI_VERSION}"
 
     info "  Downloading digitsd-${PI_VERSION}-aarch64..."
-    gh release download "${RELEASE_TAG}" \
+    gh release download "${PI_TAG}" \
         --repo justinlindh/digits \
         --pattern "digitsd-${PI_VERSION}-aarch64" \
         --output /digits/tools/build/digitsd
@@ -125,7 +142,7 @@ if [[ -n "${RELEASE_TAG:-}" ]]; then
     info "  Downloading digits-setup-${PI_VERSION}-aarch64..."
     DIGITS_SETUP_EMBED=/digits/pi/digitsd/internal/assets/embed/rootfs/usr/local/bin/digits-setup
     mkdir -p "$(dirname "$DIGITS_SETUP_EMBED")"
-    gh release download "${RELEASE_TAG}" \
+    gh release download "${PI_TAG}" \
         --repo justinlindh/digits \
         --pattern "digits-setup-${PI_VERSION}-aarch64" \
         --output "$DIGITS_SETUP_EMBED"
@@ -133,20 +150,20 @@ if [[ -n "${RELEASE_TAG:-}" ]]; then
 
     info "  Downloading digits-recovery-${PI_VERSION}-aarch64..."
     mkdir -p /digits/pi/digits-recovery/bin
-    gh release download "${RELEASE_TAG}" \
+    gh release download "${PI_TAG}" \
         --repo justinlindh/digits \
         --pattern "digits-recovery-${PI_VERSION}-aarch64" \
         --output /digits/pi/digits-recovery/bin/digits-recovery
     chmod +x /digits/pi/digits-recovery/bin/digits-recovery
 
     info "  Downloading digits-panic-check-${PI_VERSION}-aarch64..."
-    gh release download "${RELEASE_TAG}" \
+    gh release download "${PI_TAG}" \
         --repo justinlindh/digits \
         --pattern "digits-panic-check-${PI_VERSION}-aarch64" \
         --output /digits/tools/build/digits-panic-check
     chmod +x /digits/tools/build/digits-panic-check
 
-    info "Pi binaries downloaded from ${RELEASE_TAG}."
+    info "Pi binaries downloaded from ${PI_TAG}."
 else
     # Local build mode: cross-compile from the mounted repo.
 

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -741,7 +741,11 @@ fi
 # OTA digitsd updates land with a different version string and a fresh hash,
 # so the runtime extractor takes over from there.
 info "Pre-writing asset-version marker..."
-ASSET_MARKER=$(python3 "$ASSET_MARKER_TOOL" "$EMBED_DIR" dev)
+# DIGITS_PI_VERSION is set by entrypoint.sh to the version string stamped into
+# digitsd (release version in release mode, git-describe result in local mode,
+# "dev" if no pi/v* tag exists). Using the real version here lets digitsd skip
+# the first-boot asset extraction when its internal marker already matches.
+ASSET_MARKER=$(python3 "$ASSET_MARKER_TOOL" "$EMBED_DIR" "${DIGITS_PI_VERSION:-dev}")
 echo "$ASSET_MARKER" > "${DATA_MNT}/digits/asset-version"
 chown 999:992 "${DATA_MNT}/digits/asset-version"
 chmod 644 "${DATA_MNT}/digits/asset-version"

--- a/tools/build-pi.sh
+++ b/tools/build-pi.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# tools/build-pi.sh — Cross-compile digitsd for aarch64
+# tools/build-pi.sh - Cross-compile Pi binaries for aarch64
 # Usage: tools/build-pi.sh <version>
-# Outputs: artifacts/digitsd-aarch64, artifacts/digitsd-aarch64.sha256
+# Outputs (in artifacts/):
+#   digitsd-<version>-aarch64            (and .sha256)
+#   digits-setup-<version>-aarch64       (and .sha256)
+#   digits-recovery-<version>-aarch64    (and .sha256)
+#   digits-panic-check-<version>-aarch64 (and .sha256)
 set -euo pipefail
 
 VERSION="${1:?Usage: build-pi.sh <version>}"
@@ -13,26 +17,60 @@ mkdir -p "$OUT_DIR"
 
 GIT_COMMIT="$(git -C "$REPO_DIR" rev-parse --short HEAD)"
 
-echo "=== Building digitsd aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
+sha_file() {
+    sha256sum "$1" | awk '{print $1}' > "$1.sha256"
+    echo "Built: $1"
+    echo "SHA256: $(cat "$1.sha256")"
+}
 
-ARTIFACT="digitsd-${VERSION}-aarch64"
+# digitsd (CGO, requires cross-compiler)
+
+echo "=== Building digitsd aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
 
 cd "${REPO_DIR}/pi/digitsd"
 
 # Populate the embed tree so the //go:embed directive sees actual files
 # rather than just the committed .gitkeep. Without this, the binary ships
 # with an effectively empty assets FS and digitsd's asset extractor becomes
-# a no-op, leaving stale files on disk after every OTA update.
+# a no-op, leaving stale files on disk after every OTA update. This also
+# cross-compiles digits-setup into the embed tree.
 make embed
 
 export PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig"
 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 go build \
     -ldflags "-X github.com/justinlindh/digits/pi/digitsd/internal/version.Version=${VERSION} \
               -X github.com/justinlindh/digits/pi/digitsd/internal/version.Commit=${GIT_COMMIT}" \
-    -o "${OUT_DIR}/${ARTIFACT}" \
+    -o "${OUT_DIR}/digitsd-${VERSION}-aarch64" \
     ./cmd/digitsd/
+sha_file "${OUT_DIR}/digitsd-${VERSION}-aarch64"
 
-sha256sum "${OUT_DIR}/${ARTIFACT}" | awk '{print $1}' > "${OUT_DIR}/${ARTIFACT}.sha256"
+# digits-setup (pure Go)
 
-echo "Built: ${OUT_DIR}/${ARTIFACT}"
-echo "SHA256: $(cat "${OUT_DIR}/${ARTIFACT}.sha256")"
+echo "=== Building digits-setup aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
+
+cd "${REPO_DIR}/pi/digits-setup"
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+    -trimpath -ldflags="-s -w" \
+    -o "${OUT_DIR}/digits-setup-${VERSION}-aarch64" \
+    ./cmd/digits-setup
+sha_file "${OUT_DIR}/digits-setup-${VERSION}-aarch64"
+
+# digits-recovery (pure Go)
+
+echo "=== Building digits-recovery aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
+
+cd "${REPO_DIR}/pi/digits-recovery"
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+    -o "${OUT_DIR}/digits-recovery-${VERSION}-aarch64" \
+    .
+sha_file "${OUT_DIR}/digits-recovery-${VERSION}-aarch64"
+
+# digits-panic-check (pure Go)
+
+echo "=== Building digits-panic-check aarch64 v${VERSION} (commit ${GIT_COMMIT}) ==="
+
+cd "${REPO_DIR}/pi/digits-panic-check"
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
+    -o "${OUT_DIR}/digits-panic-check-${VERSION}-aarch64" \
+    .
+sha_file "${OUT_DIR}/digits-panic-check-${VERSION}-aarch64"


### PR DESCRIPTION
## Summary

- Adds `RELEASE_TAG=pi/v<version>` mode to the image builder: when set, the Docker container downloads pre-built binaries from the specified GitHub release instead of cross-compiling from the local tree
- Extends `tools/build-pi.sh` and `pi/.releaserc.cjs` to also publish `digits-setup`, `digits-recovery`, and `digits-panic-check` as release artifacts (previously only `digitsd` was published)
- Installs `gh` CLI into the builder Docker image for release downloads
- Fixes the asset-version marker to use the real version string on release builds instead of always writing `dev`

## Usage

```bash
# Build a clean production V2 image from the latest tagged release:
RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb

# Pin the firmware release too:
RELEASE_TAG=pi/v1.21.0 FIRMWARE_TAG=fw/v1.8.0 ./pi/image/build-docker.sh --pcb

# Default (no RELEASE_TAG): local cross-compile, same as before
./pi/image/build-docker.sh --pcb
```

## How it works

1. `build-docker.sh` runs `make embed` (populates rootfs overlay, tones, mixer state, and locally compiles digits-setup as a placeholder)
2. Container starts; if `RELEASE_TAG` is set, `entrypoint.sh` downloads all four Go binaries from the GitHub release and places them at the same paths the local build would have produced
3. The downloaded `digits-setup` overwrites the locally-compiled placeholder in the embed tree
4. `build-image.sh` proceeds unchanged; it picks up the released binaries from their expected locations
5. The asset-version marker is stamped with the actual release version so digitsd skips first-boot extraction

## Test plan

- [ ] Local build path: `./pi/image/build-docker.sh --pcb` still works (no `RELEASE_TAG`)
- [ ] Release build: `RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb` downloads binaries and builds image
- [ ] After next `pi/v*` release, all four binaries appear as assets on the GitHub release
- [ ] CI `pi-release.yml` passes with updated `build-pi.sh`