### PR TITLE
feat(server): add Helm chart for k8s deployment

### DIFF
--- a/charts/digits/.helmignore
+++ b/charts/digits/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.swp
+*.bak
+*.tmp

--- a/charts/digits/Chart.yaml
+++ b/charts/digits/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: digits
+description: Signaling server and admin dashboard for the digits private phone network.
+type: application
+version: 0.1.0
+appVersion: "1.56.1"

--- a/charts/digits/templates/_helpers.tpl
+++ b/charts/digits/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "digits.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "digits.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "digits.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ include "digits.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Signald labels.
+*/}}
+{{- define "digits.signald.labels" -}}
+app.kubernetes.io/name: signald
+{{ include "digits.labels" . }}
+{{- end }}
+
+{{/*
+Signald selector labels.
+*/}}
+{{- define "digits.signald.selectorLabels" -}}
+app.kubernetes.io/name: signald
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Admind labels.
+*/}}
+{{- define "digits.admind.labels" -}}
+app.kubernetes.io/name: admind
+{{ include "digits.labels" . }}
+{{- end }}
+
+{{/*
+Admind selector labels.
+*/}}
+{{- define "digits.admind.selectorLabels" -}}
+app.kubernetes.io/name: admind
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Signald image.
+*/}}
+{{- define "digits.signald.image" -}}
+{{ .Values.signald.image.repository }}:{{ .Values.signald.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Admind image.
+*/}}
+{{- define "digits.admind.image" -}}
+{{ .Values.admind.image.repository }}:{{ .Values.admind.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{- end }}

--- a/charts/digits/templates/cluster-admindb.yaml
+++ b/charts/digits/templates/cluster-admindb.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "digits.fullname" . }}-admindb
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-admindb
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.admindb.instances }}
+  imageName: {{ .Values.cnpg.imageName }}
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: {{ .Values.cnpg.admindb.size }}
+    {{- if .Values.cnpg.admindb.storageClass }}
+    storageClass: {{ .Values.cnpg.admindb.storageClass }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.cnpg.admindb.database }}
+      owner: {{ .Values.cnpg.admindb.owner }}
+  {{- if .Values.cnpg.backup.enabled }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.cnpg.backup.destinationPath }}/{{ include "digits.fullname" . }}-admindb
+      endpointURL: {{ .Values.cnpg.backup.endpointURL }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3AccessKeyIDKey }}
+        secretAccessKey:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3SecretAccessKeyKey }}
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
+  {{- end }}
+  {{- if .Values.observability.enabled }}
+  monitoring:
+    enablePodMonitor: true
+  {{- end }}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+{{- end }}

--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "digits.fullname" . }}-userdb
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-userdb
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.userdb.instances }}
+  imageName: {{ .Values.cnpg.imageName }}
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: {{ .Values.cnpg.userdb.size }}
+    {{- if .Values.cnpg.userdb.storageClass }}
+    storageClass: {{ .Values.cnpg.userdb.storageClass }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.cnpg.userdb.database }}
+      owner: {{ .Values.cnpg.userdb.owner }}
+  {{- if .Values.cnpg.backup.enabled }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.cnpg.backup.destinationPath }}/{{ include "digits.fullname" . }}-userdb
+      endpointURL: {{ .Values.cnpg.backup.endpointURL }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3AccessKeyIDKey }}
+        secretAccessKey:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: {{ .Values.cnpg.backup.s3SecretAccessKeyKey }}
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
+  {{- end }}
+  {{- if .Values.observability.enabled }}
+  monitoring:
+    enablePodMonitor: true
+  {{- end }}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+{{- end }}

--- a/charts/digits/templates/deployment-admind.yaml
+++ b/charts/digits/templates/deployment-admind.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.admind.replicas }}
+  selector:
+    matchLabels:
+      {{- include "digits.admind.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "digits.admind.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: admind
+          image: {{ include "digits.admind.image" . }}
+          imagePullPolicy: {{ .Values.admind.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.admind.port }}
+            {{- if .Values.observability.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.observability.admindMetricsPort }}
+            {{- end }}
+          env:
+            - name: ADMIN_ADDR
+              value: ":{{ .Values.admind.port }}"
+            {{- if .Values.observability.enabled }}
+            - name: ADMIN_METRICS_ADDR
+              value: ":{{ .Values.observability.admindMetricsPort }}"
+            {{- end }}
+            {{- if .Values.cnpg.enabled }}
+            - name: ADMIN_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "digits.fullname" . }}-admindb-app
+                  key: uri
+            {{- end }}
+            {{- if .Values.observability.enabled }}
+            {{- if .Values.observability.otelEndpoint }}
+            - name: OTEL_SERVICE_NAME
+              value: "admind"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otelEndpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.observability.otelProtocol | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.observability.otelInsecure | quote }}
+            {{- if .Values.observability.otelResourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ .Values.observability.otelResourceAttributes | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.observability.pyroscopeEndpoint }}
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.admind.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.admind.envFrom }}
+          envFrom:
+            {{- toYaml .Values.admind.envFrom | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- with .Values.admind.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.signald.replicas }}
+  selector:
+    matchLabels:
+      {{- include "digits.signald.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "digits.signald.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: signald
+          image: {{ include "digits.signald.image" . }}
+          imagePullPolicy: {{ .Values.signald.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.signald.port }}
+            {{- if .Values.observability.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.observability.signaldMetricsPort }}
+            {{- end }}
+          env:
+            - name: SIGNALD_ADDR
+              value: ":{{ .Values.signald.port }}"
+            {{- if .Values.observability.enabled }}
+            - name: SIGNALD_METRICS_ADDR
+              value: ":{{ .Values.observability.signaldMetricsPort }}"
+            {{- end }}
+            {{- if .Values.cnpg.enabled }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "digits.fullname" . }}-userdb-app
+                  key: uri
+            {{- end }}
+            {{- if .Values.observability.enabled }}
+            {{- if .Values.observability.otelEndpoint }}
+            - name: OTEL_SERVICE_NAME
+              value: "signald"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.observability.otelEndpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.observability.otelProtocol | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.observability.otelInsecure | quote }}
+            {{- if .Values.observability.otelResourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ .Values.observability.otelResourceAttributes | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.observability.pyroscopeEndpoint }}
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: {{ .Values.observability.pyroscopeEndpoint | quote }}
+            {{- end }}
+            {{- end }}
+            {{- range $key, $value := .Values.signald.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- if .Values.signald.envFrom }}
+          envFrom:
+            {{- toYaml .Values.signald.envFrom | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          {{- with .Values.signald.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/digits/templates/ingress-admind.yaml
+++ b/charts/digits/templates/ingress-admind.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.admind.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: admind
+                port:
+                  number: 80
+{{- end }}

--- a/charts/digits/templates/ingress-signald.yaml
+++ b/charts/digits/templates/ingress-signald.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.signald.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: signald
+                port:
+                  number: 80
+{{- end }}

--- a/charts/digits/templates/service-admind.yaml
+++ b/charts/digits/templates/service-admind.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "digits.admind.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.admind.port }}
+      protocol: TCP
+    {{- if .Values.observability.enabled }}
+    - name: metrics
+      port: {{ .Values.observability.admindMetricsPort }}
+      targetPort: {{ .Values.observability.admindMetricsPort }}
+      protocol: TCP
+    {{- end }}

--- a/charts/digits/templates/service-signald.yaml
+++ b/charts/digits/templates/service-signald.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "digits.signald.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.signald.port }}
+      protocol: TCP
+    - name: api
+      port: {{ .Values.signald.port }}
+      targetPort: {{ .Values.signald.port }}
+      protocol: TCP
+    {{- if .Values.observability.enabled }}
+    - name: metrics
+      port: {{ .Values.observability.signaldMetricsPort }}
+      targetPort: {{ .Values.observability.signaldMetricsPort }}
+      protocol: TCP
+    {{- end }}

--- a/charts/digits/templates/servicemonitor-admind.yaml
+++ b/charts/digits/templates/servicemonitor-admind.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.observability.enabled .Values.observability.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: admind
+  labels:
+    {{- include "digits.admind.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "digits.admind.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.serviceMonitor.interval }}
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: instance
+        - action: replace
+          targetLabel: job
+          replacement: digits-admind
+{{- end }}

--- a/charts/digits/templates/servicemonitor-signald.yaml
+++ b/charts/digits/templates/servicemonitor-signald.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.observability.enabled .Values.observability.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "digits.signald.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.observability.serviceMonitor.interval }}
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: instance
+        - action: replace
+          targetLabel: job
+          replacement: digits-signald
+{{- end }}

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -1,0 +1,68 @@
+signald:
+  image:
+    repository: ghcr.io/justinlindh/digits/signald
+    tag: ""  # defaults to appVersion
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  env: {}
+  envFrom: []
+  # Container port for the HTTP/WebSocket listener.
+  port: 8080
+
+admind:
+  image:
+    repository: ghcr.io/justinlindh/digits/admind
+    tag: ""  # defaults to appVersion
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  env: {}
+  envFrom: []
+  # Container port for the admin HTTP listener.
+  port: 9090
+
+ingress:
+  enabled: false
+  className: ""
+  signald:
+    host: ""
+  admind:
+    host: ""
+
+cnpg:
+  enabled: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+  userdb:
+    instances: 2
+    size: 10Gi
+    storageClass: ""
+    database: digits
+    owner: digits
+  admindb:
+    instances: 2
+    size: 5Gi
+    storageClass: ""
+    database: digits_admin
+    owner: digits_admin
+  backup:
+    enabled: false
+    retentionPolicy: "14d"
+    destinationPath: ""
+    endpointURL: ""
+    s3CredentialsSecret: ""
+    s3AccessKeyIDKey: ACCESS_KEY_ID
+    s3SecretAccessKeyKey: ACCESS_SECRET_KEY
+
+observability:
+  enabled: false
+  otelEndpoint: ""
+  otelProtocol: "grpc"
+  otelInsecure: "true"
+  otelResourceAttributes: ""
+  pyroscopeEndpoint: ""
+  signaldMetricsPort: 9091
+  admindMetricsPort: 9092
+  serviceMonitor:
+    enabled: false
+    interval: 30s


### PR DESCRIPTION
## Summary

- Helm chart at `charts/digits/` for deploying signald + admind to Kubernetes
- CNPG, observability, and ingress are all opt-in (disabled by default)
- Default render: 2 Deployments + 2 Services (no infra dependencies)
- Full render (with all toggles): + 2 CNPG Clusters, 2 Ingresses, 2 ServiceMonitors

## Design

- `cnpg.enabled: false` (default): users pass `DATABASE_URL` / `ADMIN_DATABASE_URL` via env. When true, chart renders CNPG Cluster CRs and auto-wires env from generated Secrets.
- `observability.enabled: false` (default): skips OTel/Pyroscope env vars, metrics ports, ServiceMonitors. When true, all render.
- `ingress.enabled: false` (default): no Ingress. When true, renders per-service Ingresses with configurable hosts + className.

## Dogfooding plan

After merge, the homelab ArgoCD `digits` Application switches from `path: manifests/digits` to multi-source helm (chart from this repo + values from homelab-k8s). A matching `helm/digits-values.yaml` has been prepared in the homelab repo to reproduce the current deployment exactly.

## Test plan

- [x] `helm template digits charts/digits/` renders 4 resources (default values)
- [x] `helm template digits charts/digits/ -f <homelab-values>` renders 10 resources (full)
- [ ] Deploy via ArgoCD multi-source after merge