### PR TITLE
feat(server): graceful WebSocket drain on SIGTERM

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -297,17 +297,31 @@ func run(ctx context.Context) error {
 		}
 		return fmt.Errorf("metrics listen: %w", err)
 	case <-ctx.Done():
-		slog.Info("shutdown signal received, draining")
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		slog.Info("shutdown signal received, draining connections")
+
+		// 25s budget leaves 5s headroom before k8s SIGKILL at 30s.
+		drainCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 		defer cancel()
+
+		// 1. Stop accepting new WebSocket upgrades (returns 503).
+		hub.StartDraining()
+
+		// 2. Shut down HTTP server (waits for non-hijacked requests).
+		if err := srv.Shutdown(drainCtx); err != nil {
+			slog.Warn("http shutdown", "err", err)
+		}
+
+		// 3. Close remaining WebSocket connections gracefully (close frame 1001).
+		hub.DrainAndClose(drainCtx)
+
+		// 4. Shut down metrics listener.
 		if metricsSrv != nil {
-			if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			if err := metricsSrv.Shutdown(drainCtx); err != nil {
 				slog.Warn("metrics shutdown", "err", err)
 			}
 		}
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			return fmt.Errorf("http shutdown: %w", err)
-		}
+
+		slog.Info("shutdown complete")
 		return nil
 	}
 }

--- a/server/internal/signaling/conference_integration_test.go
+++ b/server/internal/signaling/conference_integration_test.go
@@ -84,9 +84,9 @@ func TestConferenceLifecycle_Integration(t *testing.T) {
 	aConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	bConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	cConn := &signaling.Conn{Send: make(chan []byte, 50)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Step 1: Directly prime both active calls via the tracker (bypassing the
 	// relay's busy-check, which would block A's second call since A is already
@@ -235,9 +235,9 @@ func TestHangupDuringADDCalling_Integration(t *testing.T) {
 	aConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	bConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	cConn := &signaling.Conn{Send: make(chan []byte, 50)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Prime both active 2-party calls: A-B (held) and A-C (active, adding).
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550002"); err != nil {
@@ -312,9 +312,9 @@ func TestDisconnectNonHostConferenceParticipant_Integration(t *testing.T) {
 	aConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	bConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	cConn := &signaling.Conn{Send: make(chan []byte, 50)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Set up an active conference: A hosts, B and C are members.
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550002"); err != nil {
@@ -399,9 +399,9 @@ func TestKickMember_SendsConferenceEndToKickedAndRemaining_Integration(t *testin
 	aConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	bConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	cConn := &signaling.Conn{Send: make(chan []byte, 50)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Set up an active conference: A hosts, B and C are members.
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550002"); err != nil {
@@ -457,9 +457,9 @@ func TestDisconnectConferenceParticipant_Integration(t *testing.T) {
 	aConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	bConn := &signaling.Conn{Send: make(chan []byte, 50)}
 	cConn := &signaling.Conn{Send: make(chan []byte, 50)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Set up an active conference: A hosts, B and C are members.
 	if _, err := tr.OnCallInitiated(context.Background(), "5550001", "5550002"); err != nil {

--- a/server/internal/signaling/conference_test.go
+++ b/server/internal/signaling/conference_test.go
@@ -41,9 +41,9 @@ func TestHandleConferenceMerge_Success(t *testing.T) {
 	connA := &Conn{Send: make(chan []byte, 20)}
 	connB := &Conn{Send: make(chan []byte, 20)}
 	connC := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550001", connA)
-	hub.Register("5550002", connB)
-	hub.Register("5550003", connC)
+	_ = hub.Register("5550001", connA)
+	_ = hub.Register("5550002", connB)
+	_ = hub.Register("5550003", connC)
 
 	// Pre-condition: A has active calls to both B and C.
 	tr.onCallInitiated("5550001", "5550002")
@@ -105,8 +105,8 @@ func TestHandleConferenceMerge_RejectsMissingCalls(t *testing.T) {
 
 	connA := &Conn{Send: make(chan []byte, 20)}
 	connB := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550001", connA)
-	hub.Register("5550002", connB)
+	_ = hub.Register("5550001", connA)
+	_ = hub.Register("5550002", connB)
 
 	// A has only A-B, not A-C.
 	tr.onCallInitiated("5550001", "5550002")
@@ -138,8 +138,8 @@ func TestHandleSDP_AllowsConferencePeer(t *testing.T) {
 
 	bConn := &Conn{Send: make(chan []byte, 20)}
 	cConn := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	r := &Relay{Tracker: tr, Hub: hub, CallAuthorizer: &mockCallAuthorizer{denyAll: true}}
 
@@ -175,9 +175,9 @@ func TestHandleHangup_InConferenceEndsViaLeave(t *testing.T) {
 	aConn := &Conn{Send: make(chan []byte, 20)}
 	bConn := &Conn{Send: make(chan []byte, 20)}
 	cConn := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	r := &Relay{Tracker: tr, Hub: hub, CallAuthorizer: &mockCallAuthorizer{}}
 
@@ -217,9 +217,9 @@ func TestHandleHangup_HostEndsConference(t *testing.T) {
 	aConn := &Conn{Send: make(chan []byte, 20)}
 	bConn := &Conn{Send: make(chan []byte, 20)}
 	cConn := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	r := &Relay{Tracker: tr, Hub: hub, CallAuthorizer: &mockCallAuthorizer{}}
 
@@ -255,11 +255,11 @@ func TestHandleConferenceMerge_RejectsIfMemberAlreadyInConference(t *testing.T) 
 	connB := &Conn{Send: make(chan []byte, 20)}
 	connC := &Conn{Send: make(chan []byte, 20)}
 	connD := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550010", connA1)
-	hub.Register("5550001", connA2)
-	hub.Register("5550002", connB)
-	hub.Register("5550003", connC)
-	hub.Register("5550004", connD)
+	_ = hub.Register("5550010", connA1)
+	_ = hub.Register("5550001", connA2)
+	_ = hub.Register("5550002", connB)
+	_ = hub.Register("5550003", connC)
+	_ = hub.Register("5550004", connD)
 
 	// A1 has merged with B and C previously (conference exists).
 	tr.onCallInitiated("5550010", "5550002")

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -194,13 +194,14 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 	slog.Info("drain: sending close frames", "connections", n)
 
 	// Send 1001 Going Away close frame to each connection.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(5 * time.Second)
+	}
+	slog.Info("drain: sending close frames", "connections", n, "remaining", time.Until(deadline).Round(time.Millisecond))
 	closeMsg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down")
 	for _, c := range snapshot {
 		if c.WS != nil {
-			deadline, ok := ctx.Deadline()
-			if !ok {
-				deadline = time.Now().Add(5 * time.Second)
-			}
 			_ = c.WS.WriteControl(websocket.CloseMessage, closeMsg, deadline)
 		}
 	}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -19,6 +19,10 @@ import (
 // logging.
 var ErrNotConnected = errors.New("not connected")
 
+// ErrDraining is returned by Register when the hub is draining (shutdown in
+// progress). The WebSocket handler should reject new upgrade requests.
+var ErrDraining = errors.New("hub is draining")
+
 type Conn struct {
 	WS         *websocket.Conn
 	Number     string
@@ -54,6 +58,7 @@ type Hub struct {
 	updateStatus map[string]*UpdateStatusSnapshot // phone number -> last update status
 	dashEvents   dashNotifier
 	redis        redisPubSub // nil = single-instance mode (no Redis)
+	draining     bool        // set by StartDraining; blocks new Register calls
 }
 
 func NewHub() *Hub {
@@ -153,6 +158,91 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 	}
 }
 
+// StartDraining marks the hub as draining. New Register calls will return
+// ErrDraining and the WebSocket handler should reject upgrade requests.
+func (h *Hub) StartDraining() {
+	h.mu.Lock()
+	h.draining = true
+	h.mu.Unlock()
+	slog.Info("hub draining started")
+}
+
+// IsDraining reports whether the hub is in drain mode.
+func (h *Hub) IsDraining() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.draining
+}
+
+// DrainAndClose sends a WebSocket close frame (1001 Going Away) to every
+// connected device and waits for connections to disconnect. If the context
+// deadline is reached, remaining connections are force-closed. The method
+// logs aggregate counts only (no per-device data).
+func (h *Hub) DrainAndClose(ctx context.Context) {
+	h.mu.RLock()
+	n := len(h.conns)
+	snapshot := make([]*Conn, 0, n)
+	for _, c := range h.conns {
+		snapshot = append(snapshot, c)
+	}
+	h.mu.RUnlock()
+
+	if n == 0 {
+		slog.Info("drain: no connections to close")
+		return
+	}
+	slog.Info("drain: sending close frames", "connections", n)
+
+	// Send 1001 Going Away close frame to each connection.
+	closeMsg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down")
+	for _, c := range snapshot {
+		if c.WS != nil {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				deadline = time.Now().Add(5 * time.Second)
+			}
+			_ = c.WS.WriteControl(websocket.CloseMessage, closeMsg, deadline)
+		}
+	}
+
+	// Poll until all connections are gone or the context expires.
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			h.forceCloseAll()
+			return
+		case <-ticker.C:
+			h.mu.RLock()
+			remaining := len(h.conns)
+			h.mu.RUnlock()
+			if remaining == 0 {
+				slog.Info("drain: all connections closed gracefully")
+				return
+			}
+		}
+	}
+}
+
+// forceCloseAll hard-closes every remaining WebSocket connection.
+func (h *Hub) forceCloseAll() {
+	h.mu.RLock()
+	remaining := len(h.conns)
+	conns := make([]*Conn, 0, remaining)
+	for _, c := range h.conns {
+		conns = append(conns, c)
+	}
+	h.mu.RUnlock()
+
+	for _, c := range conns {
+		if c.WS != nil {
+			_ = c.WS.Close()
+		}
+	}
+	slog.Info("drain: force-closed remaining connections", "connections", remaining)
+}
+
 // SetDashboardEvents registers an optional broadcaster that is signalled
 // whenever the set of online lines changes. Wakes dashboard SSE subscribers.
 // Safe to call once at startup; subsequent calls overwrite.
@@ -162,8 +252,12 @@ func (h *Hub) SetDashboardEvents(b dashNotifier) {
 	h.mu.Unlock()
 }
 
-func (h *Hub) Register(number string, conn *Conn) {
+func (h *Hub) Register(number string, conn *Conn) error {
 	h.mu.Lock()
+	if h.draining {
+		h.mu.Unlock()
+		return ErrDraining
+	}
 	// Close existing connection for this number if any
 	if old, ok := h.conns[number]; ok {
 		if old.WS != nil {
@@ -191,6 +285,7 @@ func (h *Hub) Register(number string, conn *Conn) {
 	if d != nil {
 		d.Notify()
 	}
+	return nil
 }
 
 func (h *Hub) Unregister(number string, conn *Conn) {

--- a/server/internal/signaling/hub_dashevents_test.go
+++ b/server/internal/signaling/hub_dashevents_test.go
@@ -25,7 +25,7 @@ func TestHub_DashEvents_NotifiesOnRegisterAndUnregister(t *testing.T) {
 	h.SetDashboardEvents(n)
 
 	conn := &Conn{Send: make(chan []byte, 1)}
-	h.Register("+15550001", conn)
+	_ = h.Register("+15550001", conn)
 	if got := n.Count(); got != 1 {
 		t.Fatalf("Register: got %d notifications want 1", got)
 	}
@@ -46,6 +46,6 @@ func TestHub_DashEvents_NilSafe(t *testing.T) {
 	h := NewHub()
 	// No SetDashboardEvents call: Register and Unregister must not panic.
 	conn := &Conn{Send: make(chan []byte, 1)}
-	h.Register("+15550002", conn)
+	_ = h.Register("+15550002", conn)
 	h.Unregister("+15550002", conn)
 }

--- a/server/internal/signaling/hub_drain_test.go
+++ b/server/internal/signaling/hub_drain_test.go
@@ -1,0 +1,172 @@
+package signaling
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestStartDrainingBlocksNewRegistrations(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{Send: make(chan []byte, 1)}
+	_ = hub.Register("3140001", conn)
+
+	hub.StartDraining()
+
+	if !hub.IsDraining() {
+		t.Fatal("expected IsDraining to return true after StartDraining")
+	}
+
+	newConn := &Conn{Send: make(chan []byte, 1)}
+	err := hub.Register("3140002", newConn)
+	if err != ErrDraining {
+		t.Fatalf("expected ErrDraining, got %v", err)
+	}
+
+	// Original connection should still be present.
+	if hub.Get("3140001") == nil {
+		t.Fatal("expected original connection to remain")
+	}
+	// Rejected connection should not be in the hub.
+	if hub.Get("3140002") != nil {
+		t.Fatal("expected rejected connection to not be registered")
+	}
+}
+
+func TestIsDrainingDefaultsFalse(t *testing.T) {
+	hub := NewHub()
+	if hub.IsDraining() {
+		t.Fatal("new hub should not be draining")
+	}
+}
+
+func TestDrainAndCloseNoConnections(t *testing.T) {
+	hub := NewHub()
+	hub.StartDraining()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Should return immediately without error.
+	hub.DrainAndClose(ctx)
+}
+
+func TestDrainAndCloseSendsCloseFrame(t *testing.T) {
+	hub := NewHub()
+
+	// Channel signalled when the server-side read pump exits and unregisters.
+	unregistered := make(chan struct{})
+
+	// Start a test WebSocket server that registers with the hub.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		conn := &Conn{
+			WS:   ws,
+			Send: make(chan []byte, 32),
+		}
+		_ = hub.Register("3140001", conn)
+
+		// Read pump: exits on close frame or error.
+		for {
+			_, _, err := ws.ReadMessage()
+			if err != nil {
+				break
+			}
+		}
+		hub.Unregister("3140001", conn)
+		close(unregistered)
+	}))
+	defer srv.Close()
+
+	// Connect a WebSocket client.
+	wsURL := "ws" + srv.URL[len("http"):]
+	clientWS, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = clientWS.Close() }()
+
+	// Wait for the server to register the connection.
+	deadline := time.Now().Add(2 * time.Second)
+	for hub.Get("3140001") == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for connection to register")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	hub.StartDraining()
+
+	// Track whether the client receives a close frame.
+	closeCh := make(chan int, 1)
+	clientWS.SetCloseHandler(func(code int, _ string) error {
+		closeCh <- code
+		// Respond with a close frame so the server side detects the close.
+		msg := websocket.FormatCloseMessage(code, "")
+		_ = clientWS.WriteControl(websocket.CloseMessage, msg, time.Now().Add(time.Second))
+		return nil
+	})
+
+	drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// DrainAndClose in background so we can read the close frame on the client.
+	done := make(chan struct{})
+	go func() {
+		hub.DrainAndClose(drainCtx)
+		close(done)
+	}()
+
+	// Client must read to receive the close frame.
+	_, _, _ = clientWS.ReadMessage()
+
+	select {
+	case code := <-closeCh:
+		if code != websocket.CloseGoingAway {
+			t.Errorf("expected close code %d (Going Away), got %d", websocket.CloseGoingAway, code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for close frame")
+	}
+
+	// Wait for server-side unregister so DrainAndClose can observe zero conns.
+	select {
+	case <-unregistered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server-side unregister did not happen")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("DrainAndClose did not return")
+	}
+}
+
+func TestDrainAndCloseForceClosesOnDeadline(t *testing.T) {
+	hub := NewHub()
+
+	// Register a connection with no real WebSocket (Send-only fake).
+	conn := &Conn{Send: make(chan []byte, 1)}
+	_ = hub.Register("3140001", conn)
+
+	hub.StartDraining()
+
+	// Use a very short deadline so forceCloseAll triggers quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	hub.DrainAndClose(ctx)
+
+	// The fake connection has no WS, so force-close is a no-op on the socket,
+	// but DrainAndClose should still return without hanging.
+}

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -35,7 +35,7 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 func TestIsOnlineReturnsFalseForUnpaired(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("unpaired", conn)
+	_ = hub.Register("unpaired", conn)
 	// A device in pairing mode is connected under "unpaired" but must not
 	// report as online for UI purposes.
 	if hub.IsOnline("unpaired") {
@@ -46,7 +46,7 @@ func TestIsOnlineReturnsFalseForUnpaired(t *testing.T) {
 func TestIsOnlineReturnsTrueForPairedConnected(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 	if !hub.IsOnline("3140001") {
 		t.Fatal("IsOnline should return true for a paired, connected device")
 	}
@@ -69,7 +69,7 @@ func TestHubGetReturnsNilForOffline(t *testing.T) {
 func TestHubGetReturnsConnForOnline(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 	if hub.Get("3140001") == nil {
 		t.Fatal("expected connection for registered number")
 	}
@@ -83,7 +83,7 @@ func TestRegisterHandlesAlreadyClosedSendChannel(t *testing.T) {
 	hub.conns[number] = oldConn
 
 	newConn := &Conn{Send: make(chan []byte, 1)}
-	hub.Register(number, newConn)
+	_ = hub.Register(number, newConn)
 
 	if got := hub.Get(number); got != newConn {
 		t.Fatalf("expected new connection to be registered")
@@ -98,7 +98,7 @@ func TestDeviceInfoIncludesRemoteAddr(t *testing.T) {
 		FirmwareVersion: "0.4.0",
 		RemoteAddr:      "192.168.1.42",
 	}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	info := hub.DeviceInfo("3140001")
 	if info == nil {
@@ -122,10 +122,10 @@ func TestDeviceInfoNilWhenOffline(t *testing.T) {
 func TestRegisterOverwritesRemoteAddrOnReconnect(t *testing.T) {
 	hub := NewHub()
 	first := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.42"}
-	hub.Register("3140003", first)
+	_ = hub.Register("3140003", first)
 
 	second := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.99"}
-	hub.Register("3140003", second)
+	_ = hub.Register("3140003", second)
 
 	info := hub.DeviceInfo("3140003")
 	if info == nil {
@@ -141,8 +141,8 @@ func TestBroadcastSendsToAllConnected(t *testing.T) {
 
 	c1 := &Conn{Send: make(chan []byte, 10)}
 	c2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", c1)
-	hub.Register("3140002", c2)
+	_ = hub.Register("3140001", c1)
+	_ = hub.Register("3140002", c2)
 
 	msg := &Message{
 		Type:            TypeReleaseAvailable,
@@ -184,8 +184,8 @@ func TestBroadcastSkipsFullBuffers(t *testing.T) {
 
 	full := &Conn{Send: make(chan []byte)} // unbuffered, will be full
 	ok := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", full)
-	hub.Register("3140002", ok)
+	_ = hub.Register("3140001", full)
+	_ = hub.Register("3140002", ok)
 
 	msg := &Message{Type: TypeReleaseAvailable, LatestPiVersion: "2.0.0"}
 	hub.Broadcast(msg)

--- a/server/internal/signaling/redis_integration_test.go
+++ b/server/internal/signaling/redis_integration_test.go
@@ -54,7 +54,7 @@ func TestRedisBridgeEndToEnd(t *testing.T) {
 
 	// Register a connection on pod B.
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hubB.Register("3140001", conn)
+	_ = hubB.Register("3140001", conn)
 
 	// Send from pod A (target is not on pod A, so it publishes to Redis).
 	err = hubA.SendTo("3140001", &Message{Type: TypeRing, From: "3140002"})
@@ -105,7 +105,7 @@ func TestRedisBridgeSelfMessagesSkipped(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	// Send to a number NOT on this hub. The hub publishes to Redis, but
 	// the subscriber should skip the message because it originated here.
@@ -160,7 +160,7 @@ func TestRedisBridgeBroadcastCrossPod(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hubB.Register("3140001", conn)
+	_ = hubB.Register("3140001", conn)
 
 	hubA.Broadcast(&Message{Type: TypeReleaseAvailable, LatestPiVersion: "9.9.9"})
 

--- a/server/internal/signaling/redis_test.go
+++ b/server/internal/signaling/redis_test.go
@@ -118,7 +118,7 @@ func TestSendToLocalFastPathSkipsRedis(t *testing.T) {
 	hub.redis = fake
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	err := hub.SendTo("3140001", &Message{Type: TypeRing, From: "3140002"})
 	if err != nil {
@@ -170,7 +170,7 @@ func TestSendToHardwareLocalSkipsRedis(t *testing.T) {
 	hub.redis = fake
 
 	conn := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-abc"}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	err := hub.SendToHardware("hw-abc", &Message{Type: TypePaired})
 	if err != nil {
@@ -189,7 +189,7 @@ func TestBroadcastPublishesToRedis(t *testing.T) {
 	hub.redis = fake
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	hub.Broadcast(&Message{Type: TypeReleaseAvailable, LatestPiVersion: "3.0.0"})
 
@@ -213,7 +213,7 @@ func TestBroadcastPublishesToRedis(t *testing.T) {
 func TestDeliverFromRedisToLocalConnection(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	hub.deliverFromRedis(&Envelope{
 		PodID:      "other-pod",
@@ -250,7 +250,7 @@ func TestDeliverFromRedisSkipsMissingTarget(t *testing.T) {
 func TestDeliverFromRedisHardware(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-abc"}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	hub.deliverFromRedis(&Envelope{
 		PodID:      "other-pod",
@@ -277,8 +277,8 @@ func TestDeliverFromRedisBroadcast(t *testing.T) {
 	hub := NewHub()
 	c1 := &Conn{Send: make(chan []byte, 10)}
 	c2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", c1)
-	hub.Register("3140002", c2)
+	_ = hub.Register("3140001", c1)
+	_ = hub.Register("3140002", c2)
 
 	hub.deliverFromRedis(&Envelope{
 		PodID:      "other-pod",
@@ -336,7 +336,7 @@ func TestRunDeliversFromSubscription(t *testing.T) {
 	hub.redis = fake
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -48,7 +48,7 @@ func TestOnRegisteredPushesSilentMode(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, store)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	relay.OnRegistered(context.Background(), "3140001")
 
@@ -86,7 +86,7 @@ func TestOnRegisteredPushesAutoUpdate(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, store)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140003", conn)
+	_ = hub.Register("3140003", conn)
 
 	relay.OnRegistered(context.Background(), "3140003")
 
@@ -125,7 +125,7 @@ func TestOnRegisteredPushesSilentModeFalseByDefault(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, store)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140002", conn)
+	_ = hub.Register("3140002", conn)
 
 	relay.OnRegistered(context.Background(), "3140002")
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -213,8 +213,8 @@ func TestRelayCallFlow(t *testing.T) {
 	// Register two mock connections
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	// Phone 1 calls Phone 2
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -240,7 +240,7 @@ func TestRelayCallToOfflinePhone(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, nil)
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
+	_ = hub.Register("3140001", conn1)
 
 	// Call offline phone
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140099"})
@@ -272,8 +272,8 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	// Test 1: Phone 1 calls Phone 2 → ring delivered (authorized)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -316,7 +316,7 @@ func TestRelayCallAuthorizationIntegration(t *testing.T) {
 
 	// Test 3: Phone 3 comes online, Phone 1 calls Phone 3 → not_authorized
 	conn3 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140003", conn3)
+	_ = hub.Register("3140003", conn3)
 
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140003"})
 
@@ -355,8 +355,8 @@ func TestRelayCallDeniedOnAuthorizerError(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
 
@@ -391,9 +391,9 @@ func TestRelayBusySignal(t *testing.T) {
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
 	conn3 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
-	hub.Register("3140003", conn3)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
+	_ = hub.Register("3140003", conn3)
 
 	// Phone 1 calls Phone 2 (establishes active call)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -457,9 +457,9 @@ func TestRelayAddDialRejectedForNonHost(t *testing.T) {
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
 	conn3 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
-	hub.Register("3140003", conn3)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
+	_ = hub.Register("3140003", conn3)
 
 	// Phone 1 calls Phone 2 -- Phone 2 is now the CALLEE.
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -498,8 +498,8 @@ func TestRelayHangupWithoutToResolvesPeer(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	// Phone 1 calls Phone 2
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -545,8 +545,8 @@ func TestRegression_HangupBeforeAnswer_StopsRing(t *testing.T) {
 
 	d1 := &Conn{Send: make(chan []byte, 20)}
 	d3 := &Conn{Send: make(chan []byte, 20)}
-	hub.Register("5550001", d1)
-	hub.Register("5550003", d3)
+	_ = hub.Register("5550001", d1)
+	_ = hub.Register("5550003", d3)
 
 	// D1 calls D3
 	relay.HandleMessage(context.Background(), "5550001", &Message{Type: TypeCall, To: "5550003"})
@@ -582,8 +582,8 @@ func TestRelayICERestartForwarded(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	// Establish an active call first
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -623,8 +623,8 @@ func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	// Phone 1 sends ICE restart without an active call
 	relay.HandleMessage(context.Background(), "3140001", &Message{
@@ -668,9 +668,9 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
 	conn3 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
-	hub.Register("3140003", conn3)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
+	_ = hub.Register("3140003", conn3)
 
 	// Establish a call: Phone 1 → Phone 2
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
@@ -695,7 +695,7 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 
 	// Phone 3 can now call Phone 2 (once reconnected)
 	newConn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140002", newConn2)
+	_ = hub.Register("3140002", newConn2)
 	relay.HandleMessage(context.Background(), "3140003", &Message{Type: TypeCall, To: "3140002"})
 
 	select {
@@ -713,8 +713,8 @@ func TestHubOnlineNumbers(t *testing.T) {
 	hub := NewHub()
 	conn1 := &Conn{Send: make(chan []byte, 1)}
 	conn2 := &Conn{Send: make(chan []byte, 1)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	nums := hub.OnlineNumbers()
 	if len(nums) != 2 {
@@ -733,9 +733,9 @@ func TestHandleHangup_EndsAllActivePeers(t *testing.T) {
 	aConn := &Conn{Send: make(chan []byte, 10)}
 	bConn := &Conn{Send: make(chan []byte, 10)}
 	cConn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("5550001", aConn)
-	hub.Register("5550002", bConn)
-	hub.Register("5550003", cConn)
+	_ = hub.Register("5550001", aConn)
+	_ = hub.Register("5550002", bConn)
+	_ = hub.Register("5550003", cConn)
 
 	// Prime two active 2-party calls: A-B (held) and A-C (active).
 	tracker.onCallInitiated("5550001", "5550002")
@@ -818,7 +818,7 @@ func TestRelayRestartMessageNotPanics(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, nil)
 
 	conn := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn)
+	_ = hub.Register("3140001", conn)
 
 	// Restart messages are server->device, not relayed through HandleMessage.
 	// But verify it doesn't crash if one passes through.
@@ -894,8 +894,8 @@ func TestRelayForceHangupSendsToBothPeers(t *testing.T) {
 	hub := NewHub()
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("555-1111", conn1)
-	hub.Register("555-2222", conn2)
+	_ = hub.Register("555-1111", conn1)
+	_ = hub.Register("555-2222", conn2)
 
 	r := &Relay{Hub: hub}
 	r.ForceHangup(context.Background(), "555-1111", "555-2222")
@@ -926,7 +926,7 @@ func TestRelayForceHangupTolerantOfOnePeerOffline(t *testing.T) {
 	hub := NewHub()
 	// 555-1111 is NOT registered (offline); only 555-2222 is online.
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("555-2222", conn2)
+	_ = hub.Register("555-2222", conn2)
 
 	r := &Relay{Hub: hub}
 
@@ -1064,7 +1064,7 @@ func TestRelayObservesPeerUnreachableOnOfflineCall(t *testing.T) {
 	relay.Errors = obs
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
+	_ = hub.Register("3140001", conn1)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140099"})
 
 	if len(obs.seen) != 1 || obs.seen[0] != "peer_unreachable" {
@@ -1081,8 +1081,8 @@ func TestRelayObservesAuthFailedWhenAuthorizerDenies(t *testing.T) {
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
-	hub.Register("3140002", conn2)
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
 
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
 
@@ -1098,7 +1098,7 @@ func TestRelayObservesInvalidMessageOnICERestartWithoutCall(t *testing.T) {
 	relay.Errors = obs
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
+	_ = hub.Register("3140001", conn1)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeICERestart, To: "3140002"})
 
 	if len(obs.seen) != 1 || obs.seen[0] != "invalid_message" {
@@ -1111,7 +1111,7 @@ func TestRelayNilObserverIsSafe(t *testing.T) {
 	relay := NewRelay(hub, nil, nil, nil)
 	// Errors is nil; the relay must not panic when it tries to observe.
 	conn1 := &Conn{Send: make(chan []byte, 10)}
-	hub.Register("3140001", conn1)
+	_ = hub.Register("3140001", conn1)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140099"})
 	// No assertion: the test passes if it didn't panic.
 }

--- a/server/internal/web/dashboard_sse_integration_test.go
+++ b/server/internal/web/dashboard_sse_integration_test.go
@@ -107,7 +107,7 @@ func TestDashboardStream_HubRegisterTriggersFrame(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 1)}
-	h.hub.Register(number, conn)
+	_ = h.hub.Register(number, conn)
 	t.Cleanup(func() { h.hub.Unregister(number, conn) })
 
 	ev, _, err := readSSEFrame(t, ctx, sr)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -482,7 +482,7 @@ func TestPhoneRestartOnline(t *testing.T) {
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	form := url.Values{"mode": {"service"}}
 	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
@@ -561,7 +561,7 @@ func TestPhoneRestartInvalidMode(t *testing.T) {
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	form := url.Values{"mode": {"explode"}}
 	req := httptest.NewRequest("POST", "/phones/3140001/restart", strings.NewReader(form.Encode()))
@@ -586,7 +586,7 @@ func TestPhoneRingTestOnline(t *testing.T) {
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	req := httptest.NewRequest("POST", "/phones/3140001/ring-test", nil)
 	req.Header.Set("Accept", "application/json")
@@ -652,7 +652,7 @@ func TestPhoneOnlineStatus(t *testing.T) {
 	}
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	req = httptest.NewRequest("GET", "/phones/3140001/online", nil)
 	req.Header.Set("Accept", "application/json")
@@ -938,7 +938,7 @@ func TestPhoneSilentModePushesToConnectedDevice(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	if w := postSilentMode(t, h, cookie, "on", false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
@@ -967,7 +967,7 @@ func TestPhoneSilentModeNoOpSkipsPush(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	// Line defaults to silent_mode=false on insert. Saving false again must be a no-op.
 	if w := postSilentMode(t, h, cookie, "off", false); w.Code != http.StatusSeeOther {
@@ -1009,7 +1009,7 @@ func TestPhoneVoiceStylePushesToConnectedDevice(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	if w := postVoiceStyle(t, h, cookie, "modern", false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
@@ -1038,7 +1038,7 @@ func TestPhoneVoiceStyleNoOpSkipsPush(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register("3140001", conn)
+	_ = h.hub.Register("3140001", conn)
 
 	// Line defaults to copper on insert — saving copper again must be a no-op.
 	if w := postVoiceStyle(t, h, cookie, "copper", false); w.Code != http.StatusSeeOther {
@@ -1645,7 +1645,7 @@ func seedPairedHandsetForTest(t *testing.T, h *Handler, database *db.Database, h
 	})
 
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register(number, conn)
+	_ = h.hub.Register(number, conn)
 	h.hub.UpdateDeviceInfo(number, "", "", fwVersion, "", "")
 }
 

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -21,6 +21,11 @@ func wsReject(ws *websocket.Conn, errMsg string) {
 }
 
 func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
+	if h.hub.IsDraining() {
+		http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+		return
+	}
+
 	ws, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("websocket upgrade failed", "err", err)
@@ -93,7 +98,10 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		Send:       make(chan []byte, 32),
 		LastSeen:   time.Now(),
 	}
-	h.hub.Register(msg.Number, conn)
+	if err := h.hub.Register(msg.Number, conn); err != nil {
+		wsReject(ws, "server shutting down")
+		return
+	}
 	h.relay.OnRegistered(r.Context(), msg.Number)
 	number := msg.Number
 
@@ -272,7 +280,10 @@ func (h *Handler) handleDevSeedFirmware(w http.ResponseWriter, r *http.Request) 
 		for range conn.Send {
 		}
 	}()
-	h.hub.Register(number, conn)
+	if err := h.hub.Register(number, conn); err != nil {
+		http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+		return
+	}
 	h.hub.UpdateDeviceInfo(number, pi, "", fw, "", "")
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprintf(w, `{"ok":true,"number":%q,"fw":%q,"pi":%q}`, number, fw, pi)

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -232,7 +232,7 @@ func setupLineWithConn(t *testing.T, h *Handler, database *db.Database, hh *hous
 		t.Fatalf("add line %s: %v", number, err)
 	}
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
-	h.hub.Register(number, conn)
+	_ = h.hub.Register(number, conn)
 	t.Cleanup(func() {
 		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
 	})


### PR DESCRIPTION
## Summary

On SIGTERM, signald now performs a 3-phase graceful shutdown instead of hard-closing:

1. `hub.StartDraining()`: blocks new WebSocket upgrades (returns 503)
2. `srv.Shutdown()`: stops accepting HTTP, waits for non-hijacked requests
3. `hub.DrainAndClose()`: sends close frames (1001 Going Away) to all connected phones, waits for them to disconnect, force-closes stragglers after deadline

Drain timeout is 25s (5s headroom before k8s SIGKILL at 30s default).

## Why

With 2 signald replicas, rolling updates kill one pod. Phones reconnect to the surviving pod via the Redis pub/sub bridge. Without graceful drain, the dying pod hard-closes WebSockets mid-signaling. With this change, phones get a proper close frame and reconnect cleanly.

## Changes

- `hub.go`: `Register()` now returns error (`ErrDraining` when draining). Added `StartDraining()`, `IsDraining()`, `DrainAndClose(ctx)`.
- `handler_ws.go`: checks `IsDraining()` before upgrading, returns 503.
- `main.go`: SIGTERM handler with 3-phase drain sequence.
- 5 new drain tests + 13 files updated for `Register()` error return.

## Test plan

- [x] `make test` passes
- [x] `golangci-lint run ./...` clean
- [ ] Deploy with 2 replicas, trigger rolling update, verify phones reconnect without call drops