### PR TITLE
feat(server): expose REDIS_URL in Helm chart for multi-replica signaling

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -35,6 +35,7 @@ jobs:
             --set ingress.signald.host=app.example.com \
             --set ingress.admind.host=admin.example.com \
             --set cnpg.enabled=true \
+            --set redis.url=redis://redis:6379 \
             --set observability.enabled=true \
             --set observability.otelEndpoint=otel:4317 \
             --set observability.serviceMonitor.enabled=true
@@ -55,6 +56,7 @@ jobs:
             --set cnpg.backup.destinationPath=s3://backups \
             --set cnpg.backup.endpointURL=http://minio:9000 \
             --set cnpg.backup.s3CredentialsSecret=minio-creds \
+            --set redis.url=redis://redis:6379 \
             --set observability.enabled=true \
             --set observability.otelEndpoint=otel:4317 \
             --set observability.pyroscopeEndpoint=http://pyroscope:4040 \

--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -98,6 +98,24 @@ observability:
 
 When enabled, the deployments expose Prometheus metrics on dedicated ports and the chart creates ServiceMonitor resources (requires prometheus-operator/kube-prometheus-stack).
 
+### Multi-replica signaling (Redis)
+
+Single-replica is the default. To run more than one signald pod, configure a
+Redis instance the pods can share so cross-pod calls reach the right device:
+
+```yaml
+signald:
+  replicas: 2
+
+redis:
+  url: "redis://redis.redis.svc.cluster.local:6379"
+```
+
+When `redis.url` is empty, signaling is local-only and replica counts above 1
+will silently drop calls whose target is on a different pod. For passwords or
+rotating credentials, leave `redis.url` empty and inject `REDIS_URL` via
+`signald.envFrom` referencing your own Secret.
+
 ### Image tags
 
 By default, image tags derive from `Chart.yaml`'s `appVersion` (prefixed with `v`). Override per-service:

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -53,6 +53,10 @@ spec:
                   name: {{ include "digits.fullname" . }}-userdb-app
                   key: uri
             {{- end }}
+            {{- if .Values.redis.url }}
+            - name: REDIS_URL
+              value: {{ .Values.redis.url | quote }}
+            {{- end }}
             {{- if .Values.observability.enabled }}
             {{- include "digits.observability.env" (dict "serviceName" "signald" "ctx" .) | nindent 12 }}
             {{- end }}

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -37,6 +37,14 @@ ingress:
   admind:
     host: ""
 
+# Redis pub/sub for multi-replica signaling. When set, signald uses Redis as
+# a shared broadcast channel so cross-pod calls reach the right device.
+# Leave empty for single-replica deployments. For passwords or rotating
+# credentials, leave url empty here and inject REDIS_URL via signald.envFrom
+# (an existing secret) instead.
+redis:
+  url: ""
+
 cnpg:
   enabled: false
   imageName: ghcr.io/cloudnative-pg/postgresql:16.4

--- a/server/README.md
+++ b/server/README.md
@@ -152,6 +152,17 @@ no per-user or per-call data, no caller/callee identifiers). See
 [`docs/metrics.md`](docs/metrics.md) for the full list and the rules
 around what is and is not collected.
 
+### Multi-replica signaling
+
+| Variable    | Description                                                    |
+|-------------|----------------------------------------------------------------|
+| `REDIS_URL` | Redis connection URL (`redis://host:port` or `rediss://...`). When set, signald uses Redis pub/sub as a cross-pod broadcast channel so calls whose target is on a different pod still reach the device. Empty disables Redis (single-instance mode). |
+
+Without `REDIS_URL`, behavior is identical to the single-instance default
+and Redis is not a runtime dependency. With it, every pod publishes to a
+shared `digits:signal` channel when a local lookup misses, and subscribing
+pods deliver to their local connections.
+
 ### Tracing and Profiling
 
 | Variable                       | Description                                |


### PR DESCRIPTION
## Summary

Cross-PR drift caught by daily holistic review of yesterday's merges.

#410 added the Helm chart and #416 added the Redis pub/sub bridge for multi-replica signaling, but the two never met: the chart has no `REDIS_URL` value, so a chart-driven deployment that bumps `signald.replicas` above 1 silently drops cross-pod calls.

This wires `REDIS_URL` through the Helm chart and documents it alongside the `OTEL_*` / `PYROSCOPE_*` env table introduced by #405.

## Changes

- `charts/digits/values.yaml`: new top-level `redis.url` value (empty default)
- `charts/digits/templates/deployment-signald.yaml`: emit `REDIS_URL` env when `redis.url` is set
- `charts/digits/README.md`: new "Multi-replica signaling (Redis)" section
- `server/README.md`: new `REDIS_URL` row under env vars
- `.github/workflows/helm-ci.yml`: extend all-features lint and template steps with `redis.url`

For passwords or rotating credentials, operators can keep `redis.url` empty and inject `REDIS_URL` via the existing `signald.envFrom` hook against their own Secret.

## Motivated by

- #410 (Helm chart) and #416 (Redis bridge) merged 2 hours apart yesterday
- #405 (env-var README precedent)

## Test plan

- [ ] Helm CI lint passes (defaults and all-features-enabled)
- [ ] Helm CI template passes (defaults and all-features-enabled)
- [ ] `helm template digits charts/digits/ --set redis.url=redis://r:6379 --set signald.replicas=2` shows `REDIS_URL` env on signald Deployment