### PR TITLE
docs: document release-mode default and BUILD_LOCAL escape hatch for image builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,10 @@ make firmware-local   # builds on host (requires arm-none-eabi-gcc + Pico SDK)
 
 Pi OS image and SD card flash (from repo root):
 ```
-make image            # build V1 (Codec Zero HAT) image via Docker
-make image-dev        # V1 image with SSH enabled
-make image-v2         # build V2 (carrier board) image
-make image-v2-dev     # V2 image with SSH enabled
+make image            # build V1 (Codec Zero HAT) image: release-mode by default
+make image-dev        # V1 image with SSH enabled (BUILD_LOCAL=1, cross-compiles from working tree)
+make image-v2         # build V2 (carrier board) image: release-mode by default
+make image-v2-dev     # V2 image with SSH enabled (BUILD_LOCAL=1)
 
 make flash            # flash newest image to auto-detected SD (override SD=/dev/sdX)
 make flash-v1         # flash newest V1 image
@@ -73,6 +73,8 @@ make flash-v2         # flash newest V2 image
 make image-flash      # build V1 dev image AND flash in one shot
 make image-v2-flash   # build V2 dev image AND flash
 ```
+
+The plain `make image` / `make image-v2` targets default to release mode: the Docker builder downloads pre-built `pi/v*` binaries and the latest `fw/v*` firmware from GitHub Releases, so a `GITHUB_TOKEN` env var with read-access to `justinlindh/digits` is required. Pin a specific Pi release with `RELEASE_TAG=pi/v1.21.0 make image` and a specific firmware with `FIRMWARE_TAG=fw/v0.9.0 make image`. Use `BUILD_LOCAL=1 make image` (or the `*-dev` targets, which set it for you) to cross-compile from the working tree instead, no token needed.
 
 The flash targets refuse to write to anything that isn't a block device. Override SD detection with `make flash-v2 SD=/dev/sdX`. `make help` lists every target with a one-line description.
 


### PR DESCRIPTION
## Summary

Cross-PR drift caught by daily holistic review.

#415 flipped `make image` / `make image-v2` from "cross-compile via Docker" to "download pre-built `pi/v*` binaries and `fw/v*` firmware from GitHub Releases by default," and moved the local cross-compile path behind `BUILD_LOCAL=1`. The CLAUDE.md quickstart still described the pre-#415 behavior, so a contributor running `make image` from these notes hits the new `GITHUB_TOKEN` requirement with no heads-up.

## Changes

- `CLAUDE.md`: Pi OS image section now calls out the release-mode default, the `GITHUB_TOKEN` need, `RELEASE_TAG` / `FIRMWARE_TAG` pinning, and the `BUILD_LOCAL=1` escape hatch. Dev targets are annotated to note they imply `BUILD_LOCAL=1`, matching what `Makefile` actually does post-#415.

## Motivated by

- #415 (image release-mode default)

## Test plan

- [ ] `make image-dev` (BUILD_LOCAL via the dev target) still works locally without a token
- [ ] `RELEASE_TAG=pi/vX.Y.Z make image` fetches the named release