### PR TITLE
refactor(server): fix duplicate drain log, blank lines, and stale log context

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -191,7 +191,6 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 		slog.Info("drain: no connections to close")
 		return
 	}
-	slog.Info("drain: sending close frames", "connections", n)
 
 	// Send 1001 Going Away close frame to each connection.
 	deadline, ok := ctx.Deadline()

--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -84,7 +84,6 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
 func (h *Handler) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 	hh := h.activeHousehold(r)
 	ld := h.buildLinesData(r, hh, "")
@@ -161,9 +160,10 @@ func (h *Handler) handleAPINumberAvailable(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]bool{"available": !exists}) //nolint:errcheck
+	if err := json.NewEncoder(w).Encode(map[string]bool{"available": !exists}); err != nil {
+		slog.Error("number available: json encode failed", "err", err)
+	}
 }
-
 
 func (h *Handler) handleAPIVersion(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -66,7 +66,7 @@ func (h *Handler) requireLineOwnershipWithHousehold(w http.ResponseWriter, r *ht
 func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[string]*line.Line, *household.Household, bool) {
 	households, err := h.householdStore.GetForUser(ctx, user.ID)
 	if err != nil {
-		slog.Error("link_health: list households failed", "user_id", user.ID, "err", err)
+		slog.Error("ownedLinesForUser: list households failed", "user_id", user.ID, "err", err)
 		return nil, nil, false
 	}
 	if len(households) == 0 {
@@ -76,7 +76,7 @@ func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[s
 	for _, hh := range households {
 		hhLines, err := h.lineStore.ListByHousehold(ctx, hh.ID)
 		if err != nil {
-			slog.Error("link_health: list lines failed", "household_id", hh.ID, "err", err)
+			slog.Error("ownedLinesForUser: list lines failed", "household_id", hh.ID, "err", err)
 			return nil, nil, false
 		}
 		for i := range hhLines {

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -185,7 +185,6 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
 func mustMarshal(msg *signaling.Message) []byte {
 	data, _ := msg.Marshal()
 	return data


### PR DESCRIPTION
## Server code quality pass

**Before grade: 84/100. After grade: 91/100.**

### What was graded

The `server/` folder was reviewed for idiomatic Go, dead/stale code, project layout, test coverage, and general cleanliness. The codebase is in good shape overall: standard project layout (`internal/`, `cmd/`), raw SQL throughout, solid interface-based dependency injection, good error propagation, and reasonable test coverage across packages. The issues found were all minor.

### Issues fixed

**Duplicate log line in `hub.go` `DrainAndClose`**

Two `slog.Info("drain: sending close frames", ...)` calls fired within a few lines of each other. The first logged before the deadline was computed and carried no useful context. The second (kept) includes the `"remaining"` field. Removed the first.

**Stray double blank lines**

`handler_api.go` had two places where two consecutive blank lines separated top-level function declarations. `handler_ws.go` had the same between `handleWS` and `mustMarshal`. Go style uses a single blank line between top-level declarations; extra blank lines add visual noise without conveying structure.

**Inconsistent `json.Encode` error handling in `handler_api.go`**

Every other `json.NewEncoder(w).Encode(...)` call in the file checks and logs the error. `handleAPINumberAvailable` used `//nolint:errcheck` instead. Made it consistent with the rest of the file.

**Stale log context prefix in `ownedLinesForUser`**

The function `ownedLinesForUser` was originally written for the link-health path and its log messages carried a `"link_health:"` prefix. The function is now called from `requireCallEndpointOwnership`, `requireConferenceOwnership`, and `requireConferenceHostOwnership` as well. Renamed the prefix to `"ownedLinesForUser:"` so log lines are attributable to the actual function regardless of call site.

### What was skipped (YAGNI)

- `Message` struct in `protocol.go` has many fields covering multiple message types. Splitting it into typed sub-messages is a protocol change, not a cleanup.
- `TestLoadConfigOptionalTokenFileUnreadable` in `internal/autodeploy` fails in this environment because tests run as root (root ignores file permissions). Pre-existing, not introduced here.
- `//nolint:errcheck` on `w.Write(body)` in `httputil.go` and `syscall.Flock` unlocks in `state.go` are correct: write failures on a response already in flight are unactionable, and unlock failures on close are similarly benign.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -short` passes (pre-existing `TestLoadConfigOptionalTokenFileUnreadable` root-user failure unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hd6nSefyW7sQLAVE8ibQNv)_