### PR TITLE
refactor(server): drop dead Tracker.Recent helper

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -372,17 +372,6 @@ func scanCallRows(rows *sql.Rows) ([]Call, error) {
 	return calls, rows.Err()
 }
 
-func (t *Tracker) Recent(ctx context.Context, limit int) ([]Call, error) {
-	rows, err := t.db.DB.QueryContext(ctx,
-		`SELECT `+callColumns+` FROM calls ORDER BY started_at DESC LIMIT $1`, limit,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	return scanCallRows(rows)
-}
-
 // MarkForceEnded records which user force-ended a call. Returns nil error
 // even if no rows matched (idempotent against racing peer hangups).
 func (t *Tracker) MarkForceEnded(ctx context.Context, callID int64, userID string) error {

--- a/server/internal/calls/tracker_test.go
+++ b/server/internal/calls/tracker_test.go
@@ -54,9 +54,9 @@ func TestCallLifecycle(t *testing.T) {
 	}
 
 	// Check history
-	calls, err := tr.Recent(context.Background(), 10)
+	calls, err := tr.RecentForPhones(context.Background(), []string{"3140001", "3140002"}, 10)
 	if err != nil {
-		t.Fatalf("Recent: %v", err)
+		t.Fatalf("RecentForPhones: %v", err)
 	}
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(calls))

--- a/server/internal/web/e2e_test.go
+++ b/server/internal/web/e2e_test.go
@@ -106,9 +106,9 @@ func TestE2EFullCallFlow(t *testing.T) {
 	}
 
 	// Verify call in tracker history
-	recentCalls, err := tracker.Recent(context.Background(), 10)
+	recentCalls, err := tracker.RecentForPhones(context.Background(), []string{"3140001", "3140002"}, 10)
 	if err != nil {
-		t.Fatalf("Recent: %v", err)
+		t.Fatalf("RecentForPhones: %v", err)
 	}
 	if len(recentCalls) == 0 {
 		t.Fatal("expected at least 1 call in history")


### PR DESCRIPTION
`Tracker.Recent` returns every call in the database with no household scoping. Its only callers are two integration tests that assert "the call we just placed shows up in history". Production reads go through `RecentForPhones`, which filters to the requesting household's own line numbers so a request can't surface another household's calls.

Switched both tests to `RecentForPhones` with the phones the test just placed (same code path the dashboard uses), then deleted the unscoped helper so a future caller can't pick it up by mistake.

Net diff: 11 lines deleted from production code, 2 trivial test updates.