### PR TITLE
refactor(server): drop dead household.GetMembers and Member type

### DIFF
--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -19,14 +19,6 @@ type Household struct {
 	CreatedAt          time.Time
 }
 
-// Member represents a user's membership in a household.
-type Member struct {
-	UserID      string
-	HouseholdID string
-	Role        string
-	CreatedAt   time.Time
-}
-
 // Store provides household persistence backed by Postgres.
 type Store struct {
 	db *sql.DB
@@ -131,27 +123,6 @@ func (s *Store) AddMember(ctx context.Context, userID, householdID, role string)
 		return fmt.Errorf("add member: %w", err)
 	}
 	return nil
-}
-
-// GetMembers returns all members of a household.
-func (s *Store) GetMembers(ctx context.Context, householdID string) ([]Member, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT user_id, household_id, role FROM household_members WHERE household_id = $1`,
-		householdID,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-	var members []Member
-	for rows.Next() {
-		var m Member
-		if err := rows.Scan(&m.UserID, &m.HouseholdID, &m.Role); err != nil {
-			return nil, err
-		}
-		members = append(members, m)
-	}
-	return members, rows.Err()
 }
 
 // MemberWithUser includes user profile data alongside membership info.

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -293,24 +293,24 @@ func TestRemoveMember(t *testing.T) {
 		t.Fatalf("AddMember: %v", err)
 	}
 
-	members, err := s.GetMembers(context.Background(), hh.ID)
+	count, err := s.MemberCount(context.Background(), hh.ID)
 	if err != nil {
-		t.Fatalf("GetMembers: %v", err)
+		t.Fatalf("MemberCount: %v", err)
 	}
-	if len(members) != 2 {
-		t.Fatalf("expected 2 members, got %d", len(members))
+	if count != 2 {
+		t.Fatalf("expected 2 members, got %d", count)
 	}
 
 	if err := s.RemoveMember(context.Background(), memberID, hh.ID); err != nil {
 		t.Fatalf("RemoveMember: %v", err)
 	}
 
-	members, err = s.GetMembers(context.Background(), hh.ID)
+	count, err = s.MemberCount(context.Background(), hh.ID)
 	if err != nil {
-		t.Fatalf("GetMembers after remove: %v", err)
+		t.Fatalf("MemberCount after remove: %v", err)
 	}
-	if len(members) != 1 {
-		t.Fatalf("expected 1 member after remove, got %d", len(members))
+	if count != 1 {
+		t.Fatalf("expected 1 member after remove, got %d", count)
 	}
 }
 


### PR DESCRIPTION
`GetMembers` and the bare `Member` struct are referenced only by `TestRemoveMember` in the same package. Production code uses `GetMembersWithUsers` (which returns `MemberWithUser`, joining the `users` table) and `MemberCount`. Two list APIs returning two struct shapes for the same table invites a future caller to pick the wrong one and skip the user-profile join.

Switched `TestRemoveMember` to `MemberCount`, which is what the assertion actually checks (count went from 2 to 1), and dropped `GetMembers` plus the `Member` struct.

Net diff: 29 production lines deleted, the test now reads more directly.