### PR TITLE
refactor(server): drop device.Store pairing-code shadow API

### DIFF
--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -146,47 +146,6 @@ func (s *Store) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-// SetPairingCode sets the pairing code and its expiry on a device.
-func (s *Store) SetPairingCode(ctx context.Context, id int64, code string, expiresAt time.Time) error {
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE devices
-		SET pairing_code = $2, pairing_code_expires_at = $3
-		WHERE id = $1
-	`, id, code, expiresAt)
-	if err != nil {
-		return fmt.Errorf("set pairing code: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("set pairing code rows affected: %w", err)
-	}
-	if n == 0 {
-		return ErrNotFound
-	}
-	return nil
-}
-
-// CompletePairing marks a device as paired by setting paired_at to now and
-// clearing the pairing code fields.
-func (s *Store) CompletePairing(ctx context.Context, id int64) error {
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE devices
-		SET paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
-		WHERE id = $1
-	`, id)
-	if err != nil {
-		return fmt.Errorf("complete pairing: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("complete pairing rows affected: %w", err)
-	}
-	if n == 0 {
-		return ErrNotFound
-	}
-	return nil
-}
-
 // Unpair invalidates the device's paired_at and device_token so the next
 // register-without-token from this hardware ID will be issued a fresh
 // pairing code instead of being rejected. Used by the Phone -> Server
@@ -215,28 +174,6 @@ func (s *Store) TouchLastSeen(ctx context.Context, hardwareID string) error {
 		return fmt.Errorf("touch last seen: %w", err)
 	}
 	return nil
-}
-
-// GetByPairingCode returns the device with the given pairing code, provided
-// the code has not yet expired. Returns ErrNotFound if no matching device exists.
-func (s *Store) GetByPairingCode(ctx context.Context, code string) (*Device, error) {
-	d := &Device{}
-	err := s.db.QueryRowContext(ctx, `
-		SELECT `+deviceColumns+`
-		FROM devices
-		WHERE pairing_code = $1
-		  AND pairing_code_expires_at > NOW()
-	`, code).Scan(
-		&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
-		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get device by pairing code: %w", err)
-	}
-	return d, nil
 }
 
 // HashToken returns the SHA-256 hex hash of a plaintext device token.

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -219,59 +219,6 @@ func TestTouchLastSeen_UnknownHardware(t *testing.T) {
 	}
 }
 
-func TestPairingCode(t *testing.T) {
-	s, database := testStore(t)
-	hhID := createTestHousehold(t, database, "Pairing Household")
-	lineID := createTestLine(t, database, "5556667777", hhID)
-
-	dev, err := s.Create(context.Background(), lineID, "hw-pair-001")
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	expiresAt := time.Now().Add(10 * time.Minute)
-	if err := s.SetPairingCode(context.Background(), dev.ID, "SECRET123", expiresAt); err != nil {
-		t.Fatalf("SetPairingCode: %v", err)
-	}
-
-	got, err := s.GetByPairingCode(context.Background(), "SECRET123")
-	if err != nil {
-		t.Fatalf("GetByPairingCode: %v", err)
-	}
-	if got.ID != dev.ID {
-		t.Errorf("GetByPairingCode.ID = %d, want %d", got.ID, dev.ID)
-	}
-
-	// Expired code should not be found
-	pastExpiry := time.Now().Add(-1 * time.Minute)
-	if err := s.SetPairingCode(context.Background(), dev.ID, "EXPIRED", pastExpiry); err != nil {
-		t.Fatalf("SetPairingCode (expired): %v", err)
-	}
-	_, err = s.GetByPairingCode(context.Background(), "EXPIRED")
-	if err != ErrNotFound {
-		t.Errorf("expected ErrNotFound for expired pairing code, got %v", err)
-	}
-
-	// CompletePairing clears the code
-	if err := s.SetPairingCode(context.Background(), dev.ID, "COMPLETE", time.Now().Add(10*time.Minute)); err != nil {
-		t.Fatalf("SetPairingCode (complete): %v", err)
-	}
-	if err := s.CompletePairing(context.Background(), dev.ID); err != nil {
-		t.Fatalf("CompletePairing: %v", err)
-	}
-
-	completed, err := s.GetByID(context.Background(), dev.ID)
-	if err != nil {
-		t.Fatalf("GetByID after CompletePairing: %v", err)
-	}
-	if completed.PairingCode != nil {
-		t.Errorf("expected PairingCode to be nil after CompletePairing, got %q", *completed.PairingCode)
-	}
-	if completed.PairedAt == nil {
-		t.Error("expected PairedAt to be set after CompletePairing")
-	}
-}
-
 func TestValidateToken_Correct(t *testing.T) {
 	s, database := testStore(t)
 	hhID := createTestHousehold(t, database, "Token Household")


### PR DESCRIPTION
`device.Store` carries three pairing-code methods that nothing in production ever calls: `SetPairingCode`, `CompletePairing`, and `GetByPairingCode`. Production pairing goes through `pairing.Store` (`GenerateCode`, `ClaimDevice`, `IsPaired`, `RegenerateCode`, `CleanupExpired`), which writes the same `devices` table directly with raw SQL.

The only thing keeping these methods alive was `TestPairingCode` in `store_test.go`, which exercised them in isolation. The real pairing behavior they were standing in for is already covered by `pairing/pairing_test.go` (10 tests).

Drop the three methods and the test that exists only to call them, so the device package presents one pairing-related write surface (`Unpair`) and pairing claim/issue lives entirely behind `pairing.Store`. Two files; 116 lines deleted; nothing added.