### PR TITLE
feat(server): add pod anti-affinity to signald deployment

### DIFF
--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -16,6 +16,15 @@ spec:
         app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
       automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "digits.signald.selectorLabels" . | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
## Summary

Prefer scheduling signald replicas on different nodes so a single node failure never takes down all replicas. Uses `preferredDuringSchedulingIgnoredDuringExecution` (soft preference) so pods still schedule if fewer nodes are available than replicas.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders the affinity block correctly