### PR TITLE
feat(server): add Redis Sentinel support for HA pub/sub

### DIFF
--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -55,7 +55,7 @@ spec:
             {{- end }}
             {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: "{{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless:26379,{{ include "digits.fullname" . }}-redis-1.{{ include "digits.fullname" . }}-redis-headless:26379,{{ include "digits.fullname" . }}-redis-2.{{ include "digits.fullname" . }}-redis-headless:26379"
+              value: "{{ range $i := until (int .Values.redis.replicas) }}{{ if $i }},{{ end }}{{ include "digits.fullname" $ }}-redis-{{ $i }}.{{ include "digits.fullname" $ }}-redis-headless:26379{{ end }}"
             - name: REDIS_SENTINEL_MASTER
               value: {{ .Values.redis.sentinelMasterName | quote }}
             {{- end }}

--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -53,9 +53,11 @@ spec:
                   name: {{ include "digits.fullname" . }}-userdb-app
                   key: uri
             {{- end }}
-            {{- if .Values.redis.url }}
+            {{- if .Values.redis.enabled }}
             - name: REDIS_URL
-              value: {{ .Values.redis.url | quote }}
+              value: "{{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless:26379,{{ include "digits.fullname" . }}-redis-1.{{ include "digits.fullname" . }}-redis-headless:26379,{{ include "digits.fullname" . }}-redis-2.{{ include "digits.fullname" . }}-redis-headless:26379"
+            - name: REDIS_SENTINEL_MASTER
+              value: {{ .Values.redis.sentinelMasterName | quote }}
             {{- end }}
             {{- if .Values.observability.enabled }}
             {{- include "digits.observability.env" (dict "serviceName" "signald" "ctx" .) | nindent 12 }}

--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -1,0 +1,160 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "digits.fullname" . }}-redis-config
+  labels:
+    {{- include "digits.labels" . | nindent 4 }}
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    port 6379
+    appendonly no
+    save ""
+    maxmemory 64mb
+    maxmemory-policy allkeys-lru
+  sentinel.conf: |
+    sentinel monitor {{ .Values.redis.sentinelMasterName }} {{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless 6379 2
+    sentinel down-after-milliseconds {{ .Values.redis.sentinelMasterName }} 5000
+    sentinel failover-timeout {{ .Values.redis.sentinelMasterName }} 10000
+    sentinel parallel-syncs {{ .Values.redis.sentinelMasterName }} 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "digits.fullname" . }}-redis-headless
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: redis
+      port: 6379
+    - name: sentinel
+      port: 26379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "digits.fullname" . }}-redis-sentinel
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: sentinel
+      port: 26379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "digits.fullname" . }}-redis
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "digits.fullname" . }}-redis-headless
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/part-of: {{ include "digits.name" . }}
+    spec:
+      automountServiceAccountToken: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+                topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          command: ["redis-server", "/etc/redis/redis.conf"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis
+            - name: data
+              mountPath: /data
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 3
+            periodSeconds: 5
+        - name: sentinel
+          image: redis:7-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: sentinel
+              containerPort: 26379
+          command:
+            - sh
+            - -c
+            - |
+              cp /etc/redis/sentinel.conf /tmp/sentinel.conf
+              redis-sentinel /tmp/sentinel.conf
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "digits.fullname" . }}-redis-config
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -102,12 +102,22 @@ spec:
           ports:
             - name: redis
               containerPort: 6379
-          command: ["redis-server", "/etc/redis/redis.conf"]
+          command:
+            - sh
+            - -c
+            - |
+              cp /etc/redis/redis.conf /tmp/redis.conf
+              if [ "$(hostname)" != "{{ include "digits.fullname" . }}-redis-0" ]; then
+                echo "replicaof {{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless 6379" >> /tmp/redis.conf
+              fi
+              redis-server /tmp/redis.conf
           volumeMounts:
             - name: config
               mountPath: /etc/redis
             - name: data
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
           {{- with .Values.redis.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -19,13 +19,19 @@ ingress:
   signald:
     host: ""
 
-# Redis pub/sub for multi-replica signaling. When set, signald uses Redis as
-# a shared broadcast channel so cross-pod calls reach the right device.
-# Leave empty for single-replica deployments. For passwords or rotating
-# credentials, leave url empty here and inject REDIS_URL via signald.envFrom
-# (an existing secret) instead.
+# Redis pub/sub for multi-replica signaling. When enabled, the chart deploys
+# a 3-node Redis Sentinel StatefulSet and configures signald to use failover.
+# For single-replica deployments, leave enabled: false.
 redis:
-  url: ""
+  enabled: false
+  replicas: 3
+  sentinelMasterName: digits
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
 
 cnpg:
   enabled: false

--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -48,17 +48,22 @@ var _ redisPubSub = (*RedisBridge)(nil)
 //
 //   - Standard: pass a redis:// or rediss:// URL.
 //   - Sentinel: pass a comma-separated list of sentinel addresses as the URL
-//     with the master name in REDIS_SENTINEL_MASTER (defaults to "mymaster").
+//     with the master name in REDIS_SENTINEL_MASTER.
 //     Format: "sentinel-0:26379,sentinel-1:26379,sentinel-2:26379"
 //
 // The mode is selected by the presence of REDIS_SENTINEL_MASTER in the
 // environment. When set, redisURL is treated as a comma-separated sentinel
 // address list. When unset, redisURL is parsed as a standard Redis URL.
+// In sentinel mode, connection is lazy; callers must Ping to verify
+// reachability.
 func NewRedisBridge(redisURL string) (*RedisBridge, error) {
 	var client redis.UniversalClient
 
 	if master := os.Getenv("REDIS_SENTINEL_MASTER"); master != "" {
 		addrs := strings.Split(redisURL, ",")
+		for i := range addrs {
+			addrs[i] = strings.TrimSpace(addrs[i])
+		}
 		client = redis.NewFailoverClient(&redis.FailoverOptions{
 			MasterName:    master,
 			SentinelAddrs: addrs,

--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"strings"
 	"sync/atomic"
 
 	"github.com/redis/go-redis/v9"
@@ -32,7 +33,7 @@ type redisPubSub interface {
 // RedisBridge wraps a Redis pub/sub connection for cross-pod signaling.
 // The zero value is not usable; create with NewRedisBridge.
 type RedisBridge struct {
-	client *redis.Client
+	client redis.UniversalClient
 	podID  string
 
 	published atomic.Int64
@@ -42,15 +43,34 @@ type RedisBridge struct {
 // compile-time check
 var _ redisPubSub = (*RedisBridge)(nil)
 
-// NewRedisBridge connects to Redis at the given URL and returns a bridge
-// ready for use. The URL should be a redis:// or rediss:// connection
-// string. Call Close when done.
+// NewRedisBridge connects to Redis and returns a bridge ready for use.
+// It supports two modes:
+//
+//   - Standard: pass a redis:// or rediss:// URL.
+//   - Sentinel: pass a comma-separated list of sentinel addresses as the URL
+//     with the master name in REDIS_SENTINEL_MASTER (defaults to "mymaster").
+//     Format: "sentinel-0:26379,sentinel-1:26379,sentinel-2:26379"
+//
+// The mode is selected by the presence of REDIS_SENTINEL_MASTER in the
+// environment. When set, redisURL is treated as a comma-separated sentinel
+// address list. When unset, redisURL is parsed as a standard Redis URL.
 func NewRedisBridge(redisURL string) (*RedisBridge, error) {
-	opts, err := redis.ParseURL(redisURL)
-	if err != nil {
-		return nil, err
+	var client redis.UniversalClient
+
+	if master := os.Getenv("REDIS_SENTINEL_MASTER"); master != "" {
+		addrs := strings.Split(redisURL, ",")
+		client = redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:    master,
+			SentinelAddrs: addrs,
+		})
+		slog.Info("redis: using sentinel failover", "master", master, "sentinels", addrs)
+	} else {
+		opts, err := redis.ParseURL(redisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = redis.NewClient(opts)
 	}
-	client := redis.NewClient(opts)
 
 	podID, _ := os.Hostname()
 	if podID == "" {


### PR DESCRIPTION
## Summary

- Redis bridge now supports Sentinel failover mode via `REDIS_SENTINEL_MASTER` env var
- Helm chart adds an optional 3-node Redis Sentinel StatefulSet with pod anti-affinity
- When `redis.enabled: true`, signald pods get sentinel addresses injected automatically
- Docker Compose and single-replica deploys are unaffected (no Redis or plain `REDIS_URL` still work)

## How it works

When `REDIS_SENTINEL_MASTER` is set, the bridge treats `REDIS_URL` as a comma-separated list of sentinel addresses and uses `redis.NewFailoverClient`. Sentinels elect a master, and if it dies, they promote a replica within 5 seconds. The go-redis failover client handles reconnection transparently.

The StatefulSet runs 3 pods (redis + sentinel sidecar each), spread across nodes via anti-affinity. Ephemeral storage only (pub/sub is fire-and-forget, no persistence needed).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/signaling/` passes (existing tests still work, they use the standard client path)
- [x] `golangci-lint run ./internal/signaling/` clean
- [x] `helm lint` passes with `redis.enabled=true`
- [x] `helm template` renders sentinel StatefulSet, services, and env vars correctly
- [ ] CI passes