### PR TITLE
fix(server): remove dead Tailwind CSS build step from Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,11 +4,6 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-# Build Tailwind CSS for admin (webapp uses hand-rolled CSS, no Tailwind)
-RUN set -e; \
-    TWCSS=/tmp/tailwindcss; \
-    curl -fsSL https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.2/tailwindcss-linux-x64 -o $TWCSS && chmod +x $TWCSS; \
-    $TWCSS --input internal/admin/static/input.css --output internal/admin/static/tailwind.css --content 'internal/admin/templates/*.html' --minify
 
 ARG VERSION=dev
 ARG COMMIT=unknown


### PR DESCRIPTION
## Summary

The admind removal (#423) deleted `internal/admin/static/` but left the Dockerfile step that builds Tailwind from `input.css`. This breaks every server release since #423 merged.

## Test plan

- [ ] Server Release workflow succeeds (image builds)