### PR TITLE
feat(server): add pg_stat_statements support to CNPG cluster template

### DIFF
--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -37,9 +37,18 @@ spec:
         compression: gzip
     retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
   {{- end }}
+  {{- if .Values.cnpg.userdb.sharedPreloadLibraries }}
+  postgresql:
+    shared_preload_libraries:
+      {{- toYaml .Values.cnpg.userdb.sharedPreloadLibraries | nindent 6 }}
+  {{- end }}
   {{- if .Values.observability.enabled }}
   monitoring:
     enablePodMonitor: true
+    {{- if .Values.cnpg.userdb.customQueriesConfigMap }}
+    customQueriesConfigMap:
+      {{- toYaml .Values.cnpg.userdb.customQueriesConfigMap | nindent 6 }}
+    {{- end }}
   {{- end }}
   resources:
     requests:

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -42,6 +42,8 @@ cnpg:
     storageClass: ""
     database: digits
     owner: digits
+    sharedPreloadLibraries: []
+    customQueriesConfigMap: []
   backup:
     enabled: false
     retentionPolicy: "14d"


### PR DESCRIPTION
## Summary

- Adds `cnpg.userdb.sharedPreloadLibraries` to the Helm chart (renders into the CNPG Cluster spec's `postgresql.shared_preload_libraries`)
- Adds `cnpg.userdb.customQueriesConfigMap` to wire custom monitoring queries into the CNPG exporter
- Both default to empty (no-op for existing deployments)

Enables deploying pg_stat_statements and custom Prometheus metrics purely through values without patching live cluster CRs.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders postgresql and monitoring sections correctly when values are set
- [x] Empty defaults produce no change to existing cluster spec