### PR TITLE
feat(server): add postInitSQL to CNPG cluster template

### DIFF
--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -19,6 +19,10 @@ spec:
     initdb:
       database: {{ .Values.cnpg.userdb.database }}
       owner: {{ .Values.cnpg.userdb.owner }}
+      {{- if .Values.cnpg.userdb.postInitSQL }}
+      postInitSQL:
+        {{- toYaml .Values.cnpg.userdb.postInitSQL | nindent 8 }}
+      {{- end }}
   {{- if .Values.cnpg.backup.enabled }}
   backup:
     barmanObjectStore:

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -44,6 +44,7 @@ cnpg:
     owner: digits
     sharedPreloadLibraries: []
     customQueriesConfigMap: []
+    postInitSQL: []
   backup:
     enabled: false
     retentionPolicy: "14d"


### PR DESCRIPTION
## Summary

Adds `cnpg.userdb.postInitSQL` to the Helm chart values. Renders into the CNPG Cluster's `bootstrap.initdb.postInitSQL` field so extensions like pg_stat_statements are created automatically on cluster bootstrap.

## Test plan

- [x] `helm lint` passes
- [x] Empty default produces no change