### PR TITLE
feat(server): add enableSuperuserAccess and postInitApplicationSQL to CNPG cluster

### DIFF
--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -10,6 +10,7 @@ spec:
   instances: {{ .Values.cnpg.userdb.instances }}
   imageName: {{ .Values.cnpg.imageName }}
   primaryUpdateStrategy: unsupervised
+  enableSuperuserAccess: {{ .Values.cnpg.enableSuperuserAccess }}
   storage:
     size: {{ .Values.cnpg.userdb.size }}
     {{- if .Values.cnpg.userdb.storageClass }}
@@ -22,6 +23,10 @@ spec:
       {{- if .Values.cnpg.userdb.postInitSQL }}
       postInitSQL:
         {{- toYaml .Values.cnpg.userdb.postInitSQL | nindent 8 }}
+      {{- end }}
+      {{- if .Values.cnpg.userdb.postInitApplicationSQL }}
+      postInitApplicationSQL:
+        {{- toYaml .Values.cnpg.userdb.postInitApplicationSQL | nindent 8 }}
       {{- end }}
   {{- if .Values.cnpg.backup.enabled }}
   backup:

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -36,6 +36,7 @@ redis:
 cnpg:
   enabled: false
   imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+  enableSuperuserAccess: false
   userdb:
     instances: 2
     size: 10Gi
@@ -45,6 +46,7 @@ cnpg:
     sharedPreloadLibraries: []
     customQueriesConfigMap: []
     postInitSQL: []
+    postInitApplicationSQL: []
   backup:
     enabled: false
     retentionPolicy: "14d"


### PR DESCRIPTION
## Summary

- Adds `cnpg.enableSuperuserAccess` to the Helm chart (renders into the CNPG Cluster spec)
- Adds `cnpg.userdb.postInitApplicationSQL` for running SQL against the app database at bootstrap
- Together these allow declaring pg_stat_statements as part of the cluster spec so the extension is always present from first boot

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders enableSuperuserAccess and postInitApplicationSQL correctly
- [x] Empty defaults produce no change to existing cluster spec