### PR TITLE
fix(server): remove duplicate command key in Redis Sentinel template

### DIFF
--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -38,6 +38,8 @@ spec:
       port: 6379
     - name: sentinel
       port: 26379
+    - name: metrics
+      port: 9121
 ---
 apiVersion: v1
 kind: Service
@@ -161,6 +163,24 @@ spec:
               memory: 32Mi
             limits:
               memory: 64Mi
+        - name: exporter
+          image: oliver006/redis_exporter:v1.67.0-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - name: metrics
+              containerPort: 9121
+          args:
+            - --redis.addr=redis://localhost:6379
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
       volumes:
         - name: config
           configMap:
@@ -169,4 +189,30 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+---
+{{- if .Values.observability.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "digits.fullname" . }}-redis
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: instance
+        - action: replace
+          targetLabel: job
+          replacement: digits-redis
+{{- end }}
 {{- end }}

--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -112,8 +112,7 @@ spec:
               if [ "$(hostname)" != "{{ include "digits.fullname" . }}-redis-0" ]; then
                 echo "replicaof {{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless.{{ .Release.Namespace }}.svc.cluster.local 6379" >> /tmp/redis.conf
               fi
-              redis-server /tmp/redis.conf
-          command: ["redis-server", "/etc/redis/redis.conf"]
+              exec redis-server /tmp/redis.conf
           volumeMounts:
             - name: config
               mountPath: /etc/redis
@@ -150,7 +149,7 @@ spec:
             - -c
             - |
               cp /etc/redis/sentinel.conf /tmp/sentinel.conf
-              redis-sentinel /tmp/sentinel.conf
+              exec redis-sentinel /tmp/sentinel.conf
           volumeMounts:
             - name: config
               mountPath: /etc/redis


### PR DESCRIPTION
## Summary

The redis container in the Sentinel StatefulSet had two `command:` keys. YAML uses last-wins semantics for duplicate keys, so the shell script that conditionally adds `replicaof` for non-zero ordinals was silently overwritten by the simpler `command: ["redis-server", ...]`. This meant replicas started as standalone masters, making sentinel failover non-functional.

Also adds `exec` to both redis-server and redis-sentinel commands so the shell doesn't linger as PID 1 (cleaner signal propagation on shutdown).

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders the correct shell script command (no duplicate)