### PR TITLE
docs(server): update Helm README to match Sentinel-based redis values

### DIFF
--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -8,6 +8,7 @@ If you do happen to have a k8s cluster lying around and want to deploy digits th
 - ClusterIP Service (with optional metrics port)
 - Ingress resource for external access
 - CNPG PostgreSQL Cluster (userdb) with S3-compatible backups
+- Optional Redis Sentinel StatefulSet for multi-replica signaling
 - OpenTelemetry tracing, Pyroscope profiling, and Prometheus ServiceMonitor
 
 ## Install
@@ -84,23 +85,31 @@ observability:
 
 When enabled, the deployment exposes Prometheus metrics on a dedicated port and the chart creates a ServiceMonitor resource (requires prometheus-operator/kube-prometheus-stack).
 
-### Multi-replica signaling (Redis)
+### Multi-replica signaling (Redis Sentinel)
 
-Single-replica is the default. To run more than one signald pod, configure a
-Redis instance the pods can share so cross-pod calls reach the right device:
+Single-replica is the default. To run more than one signald pod, enable the
+bundled 3-node Redis Sentinel StatefulSet so cross-pod calls reach the right
+device:
 
 ```yaml
 signald:
   replicas: 2
 
 redis:
-  url: "redis://redis.redis.svc.cluster.local:6379"
+  enabled: true
+  replicas: 3
+  sentinelMasterName: digits
 ```
 
-When `redis.url` is empty, signaling is local-only and replica counts above 1
-will silently drop calls whose target is on a different pod. For passwords or
-rotating credentials, leave `redis.url` empty and inject `REDIS_URL` via
-`signald.envFrom` referencing your own Secret.
+When `redis.enabled` is false, signaling is local-only and replica counts
+above 1 will silently drop calls whose target is on a different pod. With
+`redis.enabled: true`, the chart wires `REDIS_URL` (the comma-separated list
+of sentinel addresses) and `REDIS_SENTINEL_MASTER` into signald automatically;
+the daemon switches to failover-aware client mode based on those env vars.
+
+To bring your own Redis instead of the bundled StatefulSet, leave
+`redis.enabled: false` and inject `REDIS_URL` (and, for sentinel mode,
+`REDIS_SENTINEL_MASTER`) via `signald.envFrom` referencing your own Secret.
 
 ### Image tags
 


### PR DESCRIPTION
## Summary

Cross-PR doc drift caught by today's holistic review. PRs #429, #430, and #436 replaced the chart's single `redis.url` string with a `redis.enabled` toggle that deploys a 3-node Redis Sentinel StatefulSet and wires `REDIS_URL` (comma-separated sentinel addresses) and `REDIS_SENTINEL_MASTER` into signald automatically. `values.yaml` was updated, but `charts/digits/README.md` still documented the removed `redis.url` field, so anyone following the README would set a key the templates ignore and end up with single-replica signaling silently.

## Changes

- Rewrite the "Multi-replica signaling" section around the actual schema (`enabled`, `replicas`, `sentinelMasterName`).
- Document how `REDIS_URL` and `REDIS_SENTINEL_MASTER` get populated automatically when `redis.enabled` is true.
- Explain the BYO-Redis path via `signald.envFrom` for users who don't want the bundled StatefulSet.
- Add Redis Sentinel to the chart summary near the top.

## Test plan

- [x] No remaining `redis.url` references in `charts/digits/`
- [x] Example values in README are valid keys present in `values.yaml`

Motivated by merged PRs: #429, #430, #436.