### PR TITLE
refactor(server): drop dead /admin route bucket left over from admind

### DIFF
--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -43,7 +43,6 @@ docker compose logs --follow
 
 Once running:
 - **User app** → `https://your-domain.com`
-- **Admin panel** → `https://your-domain.com/admin`
 
 ---
 
@@ -164,7 +163,7 @@ If your server uses a self-signed cert (dev only), add `-insecure` to skip TLS v
 
 ### Pairing Flow
 
-1. In the admin panel (`/admin`), create a household and add a line.
+1. In the user app, complete onboarding to create a household, then add a line on `/phones`.
 2. The system generates a pairing code.
 3. On the Pi, the pairing code is exchanged automatically on first connect -- no screen needed.
 4. Once paired, the phone registers itself and is ready to dial.

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -350,10 +350,6 @@ func RouteOf(path string) string {
 	case path == "/connecting":
 		return "/connecting"
 
-	// Admin routes.
-	case path == "/admin" || path == "/admin/" || strings.HasPrefix(path, "/admin/"):
-		return "/admin"
-
 	default:
 		return "other"
 	}

--- a/server/internal/metrics/metrics_test.go
+++ b/server/internal/metrics/metrics_test.go
@@ -32,9 +32,6 @@ func TestRouteOfBucketsKnownPaths(t *testing.T) {
 		{"/conference/live/8b6e2bb8-19fa-4f0a-8af9-f60094f0a7d5", "/conference/live/{uuid}"},
 		{"/internal/stats", "/internal/stats"},
 		{"/internal/metrics", "/internal/metrics"},
-		{"/admin", "/admin"},
-		{"/admin/users", "/admin"},
-		{"/admin/login", "/admin"},
 		// Random/unknown paths must NOT echo segments back as labels: that
 		// is the leakage path we explicitly guard against.
 		{"/some/secret/that/should/not/appear", "other"},


### PR DESCRIPTION
## Summary

Cross-PR cleanup caught by today's holistic review. PR #423 removed the `admind` service (binary, container, CNPG cluster, Helm resources, and most docs), but a few references to its admin panel survived:

- `server/internal/metrics/metrics.go` kept an `/admin` route bucket in `RouteOf`. Since signald never registers `/admin` handlers, any path landing in that branch would already be a 404, so the bucket can no longer fire on real traffic.
- `server/internal/metrics/metrics_test.go` had matching cases that locked in the dead bucket.
- `docs/hosting/self-hosting.md` still listed an "Admin panel → /admin" link in the post-install summary and pointed the pairing flow at the admin panel for household and line creation, neither of which exist anymore.

## Changes

- Remove the `/admin` case from `RouteOf` and its three test rows.
- Drop the post-install admin-panel bullet in self-hosting.md.
- Rewrite the pairing-flow step 1 to point at the actual user-app surfaces (onboarding for household creation, then `/phones` to add a line).

## Test plan

- [x] `go build ./...` in `server/`
- [x] `go test ./internal/metrics/...` passes
- [x] `go vet ./internal/metrics/...` clean
- [x] No remaining `/admin` references in `server/`, `docs/hosting/`, or `charts/digits/`

Motivated by merged PR #423.