### PR TITLE
fix(server): switch Redis monitoring to PodMonitor and fix replicaof

### DIFF
--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -192,7 +192,7 @@ spec:
 ---
 {{- if .Values.observability.enabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ include "digits.fullname" . }}-redis
   labels:
@@ -203,7 +203,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
       app.kubernetes.io/instance: {{ .Release.Name }}
-  endpoints:
+  podMetricsEndpoints:
     - port: metrics
       path: /metrics
       interval: 30s


### PR DESCRIPTION
## Summary

- Switch Redis monitoring from ServiceMonitor to PodMonitor (ServiceMonitor endpoints weren't being discovered by Prometheus)
- Fix duplicate command key in redis container (replicaof logic was silently overwritten)
- Add exec to redis-server and redis-sentinel commands for clean signal handling
- Add redis-exporter sidecar for Prometheus metrics

## Test plan

- [x] `helm lint` passes
- [ ] Redis metrics appear in Prometheus after deploy