### PR TITLE
feat(server): log version and commit at startup

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -51,6 +51,7 @@ func main() {
 // through slog instead of bypassing it via log.Fatal.
 func run(ctx context.Context) error {
 	cfg := config.Load()
+	slog.Info("starting signald", "version", version.Version, "commit", version.Commit)
 	if cfg.DatabaseURL == "" {
 		return errors.New("DATABASE_URL must be set")
 	}


### PR DESCRIPTION
## Summary

Adds a startup log line with version and commit hash for easier debugging when tailing pod logs.

## Test plan

- [x] Compiles