### PR TITLE
refactor(server): use errors.Is for sql.ErrNoRows and fix handler hygiene

### DIFF
--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -95,7 +95,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 		&link.InvitedBy, &link.AcceptedBy, &link.CreatedAt, &link.AcceptedAt,
 		&link.RevokedAt, &link.RevokedBy,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, errors.New("invite code not found or already used")
 	}
 	if err != nil {
@@ -187,7 +187,7 @@ func (s *LinkStore) RevokeLink(ctx context.Context, linkID, revokedByUserID stri
 		WHERE id = $3 AND status != 'revoked'
 		RETURNING id
 	`, time.Now(), revokedByUserID, linkID).Scan(&id)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return errors.New("link not found or already revoked")
 	}
 	if err != nil {
@@ -207,7 +207,7 @@ func (s *LinkStore) GetByID(ctx context.Context, id string) (*HouseholdLink, err
 		&link.InvitedBy, &link.AcceptedBy, &link.CreatedAt, &link.AcceptedAt,
 		&link.RevokedAt, &link.RevokedBy,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, errors.New("link not found")
 	}
 	if err != nil {

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -3,6 +3,7 @@ package household
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -59,7 +60,7 @@ func (s *Store) GetByID(ctx context.Context, id string) (*Household, error) {
 		`SELECT id, name, call_history_enabled, do_not_disturb, timezone, created_at FROM households WHERE id = $1`,
 		id,
 	).Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.DoNotDisturb, &h.Timezone, &h.CreatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("household not found")
 	}
 	if err != nil {
@@ -101,7 +102,7 @@ func (s *Store) GetRole(ctx context.Context, userID, householdID string) (string
 		`SELECT role FROM household_members WHERE user_id = $1 AND household_id = $2`,
 		userID, householdID,
 	).Scan(&role)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", fmt.Errorf("user is not a member of this household")
 	}
 	if err != nil {

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -120,7 +120,7 @@ func (s *Store) GetByID(ctx context.Context, id int64) (*Line, error) {
 		 FROM lines WHERE id = $1`,
 		id,
 	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
 	if err != nil {
@@ -141,7 +141,7 @@ func (s *Store) GetByNumber(ctx context.Context, number string) (*Line, error) {
 		 FROM lines WHERE number = $1`,
 		number,
 	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
 	if err != nil {
@@ -166,7 +166,7 @@ func (s *Store) EffectiveSettingsByNumber(ctx context.Context, number string) (S
 		 WHERE l.number = $1`,
 		number,
 	).Scan(&settingsRaw, &householdDND)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return Settings{}, false, ErrNotFound
 	}
 	if err != nil {
@@ -329,7 +329,7 @@ func (s *Store) GetHouseholdIDByNumber(ctx context.Context, number string) (stri
 	err := s.db.QueryRowContext(ctx,
 		`SELECT household_id FROM lines WHERE number = $1`, number,
 	).Scan(&householdID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", ErrNotFound
 	}
 	if err != nil {

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -100,7 +100,7 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, hou
 		SELECT id, hardware_id FROM devices
 		WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
 	`, code).Scan(&deviceID, &hardwareID)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", "", ErrInvalidCode
 	}
 	if err != nil {
@@ -150,7 +150,7 @@ func (s *Store) IsPaired(ctx context.Context, hardwareID string) (bool, error) {
 	err := s.db.QueryRowContext(ctx, `
 		SELECT paired_at FROM devices WHERE hardware_id = $1
 	`, hardwareID).Scan(&pairedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
 	if err != nil {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -337,7 +337,9 @@ func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chro
 func jsonError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": msg}); err != nil {
+		slog.Error("jsonError: encode failed", "err", err)
+	}
 }
 
 func renderWith(w http.ResponseWriter, t *template.Template, name string, data any) {

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -3,6 +3,7 @@ package web
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -96,7 +97,7 @@ func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) 
 	link, err := h.linkStore.CreateInvite(r.Context(), myHousehold.ID, user.ID)
 	if err != nil {
 		slog.Error("create invite failed", "err", err)
-		http.Redirect(w, r, "/links?error="+err.Error(), http.StatusSeeOther)
+		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
 
@@ -128,7 +129,7 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 	link, err := h.linkStore.AcceptInvite(r.Context(), code, user.ID, myHousehold.ID)
 	if err != nil {
 		slog.Error("accept invite failed", "err", err)
-		http.Redirect(w, r, "/links?error="+err.Error(), http.StatusSeeOther)
+		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
 
@@ -192,7 +193,7 @@ func (h *Handler) handleLinksRevokePost(w http.ResponseWriter, r *http.Request) 
 
 	if err := h.linkStore.RevokeLink(r.Context(), id, user.ID); err != nil {
 		slog.Error("revoke link failed", "link_id", id, "err", err)
-		http.Redirect(w, r, "/links?error="+err.Error(), http.StatusSeeOther)
+		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
 


### PR DESCRIPTION
## Code review grade: 78 → 82 / 100

### What was graded

The `server/` folder was audited for idiomatic Go, code cleanliness, stale code, project layout, and test coverage. The codebase is well-organized with a clean standard layout, proper raw-SQL patterns, good context propagation, and solid test coverage across packages. Three concrete fixable issues were identified and addressed here.

### Findings (pre-fix)

**1. Non-idiomatic `sql.ErrNoRows` comparison (11 occurrences, 4 files)**

Several store files compared `err == sql.ErrNoRows` directly. The idiomatic form since Go 1.13 is `errors.Is(err, sql.ErrNoRows)`, which correctly handles wrapped errors and matches the pattern already used in `auth/store.go`, `device/store.go`, `calls/tracker.go`, and `household/invite.go`. The inconsistency was spread across `household/store.go`, `household/link.go`, `line/store.go`, and `pairing/pairing.go`.

**2. `//nolint:errcheck` in `jsonError` (`internal/web/handler_helpers.go`)**

The `jsonError` helper silenced its encoding error with a nolint comment while every other `json.NewEncoder(w).Encode` call in the same package used `slog.Error`. One-line inconsistency, straightforward to align.

**3. Raw `err.Error()` appended to redirect URLs (`internal/web/handler_links.go`)**

Three redirect paths in the links handlers concatenated `err.Error()` directly into the URL query string without escaping. Error strings from the store can contain `&`, `=`, `:`, spaces, or other URL metacharacters that break query parsing. For example, a DB-level error like `"accept invite: pq: connection reset"` would produce a malformed URL. Fixed with `url.QueryEscape`.

### What was skipped (with reasons)

- `handler_settings.go` redirect patterns: those use only hardcoded, already-safe string literals (`"invalid+email"`, `"last+member"`, etc.) -- no dynamic content, no fix needed.
- `link.Status == "pending"` magic string: pre-existing throughout the codebase, defining a constant is YAGNI at this scale.
- Rate limit magic numbers in `NewHandler`: pre-existing, out of scope.

### Files changed

| File | Change |
|---|---|
| `internal/household/store.go` | Add `"errors"` import; 2x `errors.Is` |
| `internal/household/link.go` | 3x `errors.Is` |
| `internal/line/store.go` | 4x `errors.Is` |
| `internal/pairing/pairing.go` | 2x `errors.Is` |
| `internal/web/handler_helpers.go` | Replace `//nolint:errcheck` with proper error log |
| `internal/web/handler_links.go` | Add `"net/url"`; 3x `url.QueryEscape` |

### Test results

All unit tests that were passing before these changes continue to pass. The single pre-existing failure (`TestLoadConfigOptionalTokenFileUnreadable` in `internal/autodeploy`) is unrelated to this change and fails in this environment due to file-permission constraints (running as root).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7LXD8Y4C93YWu5NSR4sXY)_