### PR TITLE
feat(server): add PodDisruptionBudgets and topology spread for HA

### DIFF
--- a/charts/digits/templates/deployment-signald.yaml
+++ b/charts/digits/templates/deployment-signald.yaml
@@ -16,6 +16,15 @@ spec:
         app.kubernetes.io/part-of: {{ include "digits.name" . }}
     spec:
       automountServiceAccountToken: false
+      {{- if gt (int .Values.signald.replicas) 1 }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "digits.signald.selectorLabels" . | nindent 14 }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/digits/templates/pdb-redis.yaml
+++ b/charts/digits/templates/pdb-redis.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.redis.enabled (gt (int .Values.redis.replicas) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "digits.fullname" . }}-redis
+  labels:
+    app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+    {{- include "digits.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "digits.fullname" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/digits/templates/pdb-signald.yaml
+++ b/charts/digits/templates/pdb-signald.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.signald.replicas) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: signald
+  labels:
+    {{- include "digits.signald.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "digits.signald.selectorLabels" . | nindent 6 }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds PodDisruptionBudgets for signald and Redis Sentinel (maxUnavailable=1), preventing voluntary disruptions from killing all replicas simultaneously
- Adds `topologySpreadConstraints` to the signald Deployment (ScheduleAnyway, maxSkew=1) to actively balance pods across workers, supplementing the existing preferred anti-affinity
- Both PDBs and topology spread are gated on `replicas > 1`, so single-replica deployments are unaffected

## Context

Pre-drill preparation for chaos testing the cluster. Without PDBs, a `kubectl drain` or node maintenance could evict all signald pods at once. Without topology spread, the scheduler was placing 2 of 3 signald pods on the same worker.

## Test plan

- [ ] `helm template` renders PDBs and topology spread with multi-replica values
- [ ] `helm template` skips both with default single-replica values
- [ ] `helm lint` passes
- [ ] After merge and ArgoCD sync, verify `kubectl -n digits get pdb` shows both PDBs
- [ ] Verify signald pods are spread across all three workers