### PR TITLE
refactor(server): hoist Marshal call in Hub.deliverFromRedis

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -112,16 +112,16 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 	if env.Message == nil {
 		return
 	}
+	data, err := env.Message.Marshal()
+	if err != nil {
+		slog.Debug("redis: marshal for local delivery failed", "err", err)
+		return
+	}
 
 	switch env.TargetType {
 	case "number":
 		conn := h.Get(env.Target)
 		if conn == nil {
-			return
-		}
-		data, err := env.Message.Marshal()
-		if err != nil {
-			slog.Debug("redis: marshal for local delivery failed", "err", err)
 			return
 		}
 		select {
@@ -138,11 +138,6 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 		if conn == nil {
 			return
 		}
-		data, err := env.Message.Marshal()
-		if err != nil {
-			slog.Debug("redis: marshal for local delivery failed", "err", err)
-			return
-		}
 		select {
 		case conn.Send <- data:
 			slog.Debug("redis: delivered to local hardware connection", "pod", env.PodID, "delivered", true)
@@ -151,11 +146,6 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 		}
 
 	case "broadcast":
-		data, err := env.Message.Marshal()
-		if err != nil {
-			slog.Debug("redis: marshal for local broadcast failed", "err", err)
-			return
-		}
 		h.mu.RLock()
 		for _, conn := range h.conns {
 			select {


### PR DESCRIPTION
## Summary

`Hub.deliverFromRedis` switched on `TargetType` and inside each of the three cases it ran the same `env.Message.Marshal()` call with the same `"redis: marshal for local delivery failed"` debug-log fallback. Marshal does not depend on the target type, so doing it once at the top of the function and reusing `data` across cases removes the duplication and leaves a single place to revisit if the marshal step ever needs to change.

Net result: 5 lines added, 15 removed; behavior is unchanged.

## Test plan

- [x] `go build ./...` (server)
- [x] `go test ./internal/signaling/...`
