### PR TITLE
refactor(server): consolidate line row scanning behind a single helper

### DIFF
--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -35,17 +35,36 @@ func scanSettings(raw []byte) (Settings, error) {
 
 const lineColumns = `id, number, name, household_id, settings, created_at, updated_at`
 
-func scanLineRow(rows *sql.Rows) (Line, error) {
+// rowScanner abstracts *sql.Row and *sql.Rows so the same field list and
+// settings decode can serve both single-row and multi-row queries.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanLine reads a single row from the lines table using lineColumns and
+// returns the materialized Line. sql.ErrNoRows is returned unwrapped so
+// callers can map it to ErrNotFound with errors.Is.
+func scanLine(s rowScanner) (Line, error) {
 	var l Line
 	var settingsRaw []byte
-	if err := rows.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {
-		return Line{}, fmt.Errorf("scan line: %w", err)
+	if err := s.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {
+		return Line{}, err
 	}
 	settings, err := scanSettings(settingsRaw)
 	if err != nil {
 		return Line{}, err
 	}
 	l.Settings = settings
+	return l, nil
+}
+
+// scanLineRow is the multi-row variant used by List* iterators.
+// sql.Rows.Scan never reports ErrNoRows, so wrapping unconditionally is safe.
+func scanLineRow(rows *sql.Rows) (Line, error) {
+	l, err := scanLine(rows)
+	if err != nil {
+		return Line{}, fmt.Errorf("scan line: %w", err)
+	}
 	return l, nil
 }
 
@@ -94,63 +113,49 @@ func NewStore(database *db.Database) *Store {
 
 // Add inserts a new line for the given household and returns it.
 func (s *Store) Add(ctx context.Context, number, name, householdID string) (*Line, error) {
-	l := &Line{}
-	var settingsRaw []byte
-	err := s.db.QueryRowContext(ctx,
+	row := s.db.QueryRowContext(ctx,
 		`INSERT INTO lines (number, name, household_id)
 		 VALUES ($1, $2, $3)
-		 RETURNING id, number, name, household_id, settings, created_at, updated_at`,
+		 RETURNING `+lineColumns,
 		number, name, householdID,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
+	)
+	l, err := scanLine(row)
 	if err != nil {
 		return nil, fmt.Errorf("add line: %w", err)
 	}
-	if l.Settings, err = scanSettings(settingsRaw); err != nil {
-		return nil, err
-	}
-	return l, nil
+	return &l, nil
 }
 
 // GetByID retrieves a line by its integer ID.
 func (s *Store) GetByID(ctx context.Context, id int64) (*Line, error) {
-	l := &Line{}
-	var settingsRaw []byte
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, number, name, household_id, settings, created_at, updated_at
-		 FROM lines WHERE id = $1`,
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+lineColumns+` FROM lines WHERE id = $1`,
 		id,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
+	)
+	l, err := scanLine(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get line by id %d: %w", id, err)
 	}
-	if l.Settings, err = scanSettings(settingsRaw); err != nil {
-		return nil, err
-	}
-	return l, nil
+	return &l, nil
 }
 
 // GetByNumber retrieves a line by its phone number.
 func (s *Store) GetByNumber(ctx context.Context, number string) (*Line, error) {
-	l := &Line{}
-	var settingsRaw []byte
-	err := s.db.QueryRowContext(ctx,
-		`SELECT id, number, name, household_id, settings, created_at, updated_at
-		 FROM lines WHERE number = $1`,
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+lineColumns+` FROM lines WHERE number = $1`,
 		number,
-	).Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt)
+	)
+	l, err := scanLine(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get line by number %s: %w", number, err)
 	}
-	if l.Settings, err = scanSettings(settingsRaw); err != nil {
-		return nil, err
-	}
-	return l, nil
+	return &l, nil
 }
 
 // EffectiveSettingsByNumber returns the line's settings plus the household's


### PR DESCRIPTION
## Summary

`Add`, `GetByID`, and `GetByNumber` in `server/internal/line/store.go` each repeated:

1. Declare `*Line` and a `[]byte settingsRaw`.
2. Call `Scan` with the same seven-column receiver list.
3. Run `scanSettings` on the JSONB blob and assign onto `l.Settings`.

The literal `SELECT` list inside two of those methods had also drifted from the existing `lineColumns` constant that the multi-row `List*` helpers use, so adding a column today touches four spots: the constant, plus each single-row caller.

This PR introduces a small `rowScanner` interface (just `Scan(...)`) so one `scanLine` helper can serve both `*sql.Row` and `*sql.Rows`. `Add` / `GetByID` / `GetByNumber` now reference `lineColumns` directly and call `scanLine`, and `scanLineRow` becomes a thin wrapper around the same helper. The single-row paths drop about six lines of boilerplate each, the column list lives in one place, and the multi-row variant gains a one-line comment about why it can wrap unconditionally (`sql.Rows.Scan` never returns `ErrNoRows`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/line/...` (the existing unit tests cover Add/GetByID/GetByNumber/List variants)
- [x] `go test ./...` (only pre-existing unrelated failure on `TestLoadConfigOptionalTokenFileUnreadable`, which depends on the test process not running as root)
