### PR TITLE
refactor(server): extract phone-command send/log/respond helper

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -552,16 +552,7 @@ func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 		TargetPiVersion: targetPi,
 		TargetFWVersion: targetFW,
 	}
-
-	var sendErr string
-	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.Warn("update trigger failed", "number", number, "err", err)
-		sendErr = err.Error()
-	} else {
-		slog.Info("update trigger sent", "number", number, "target_pi", targetPi, "target_fw", targetFW)
-	}
-
-	h.respondPhoneCommandResult(w, r, number, sendErr)
+	h.sendPhoneCommandAndRespond(w, r, number, msg, "update trigger", "target_pi", targetPi, "target_fw", targetFW)
 }
 
 func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request) {
@@ -591,16 +582,7 @@ func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 	msg := &signaling.Message{
 		Type: signaling.TypeRingTest,
 	}
-
-	var sendErr string
-	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.Warn("ring test trigger failed", "number", number, "err", err)
-		sendErr = err.Error()
-	} else {
-		slog.Info("ring test triggered", "number", number)
-	}
-
-	h.respondPhoneCommandResult(w, r, number, sendErr)
+	h.sendPhoneCommandAndRespond(w, r, number, msg, "ring test")
 }
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
@@ -614,16 +596,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 	msg := &signaling.Message{
 		Type: signaling.TypeFactoryReset,
 	}
-
-	var sendErr string
-	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.Warn("factory reset trigger failed", "number", number, "err", err)
-		sendErr = err.Error()
-	} else {
-		slog.Info("factory reset triggered", "number", number)
-	}
-
-	h.respondPhoneCommandResult(w, r, number, sendErr)
+	h.sendPhoneCommandAndRespond(w, r, number, msg, "factory reset")
 }
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
@@ -648,15 +621,22 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 		Type:        signaling.TypeRestart,
 		RestartMode: mode,
 	}
+	h.sendPhoneCommandAndRespond(w, r, number, msg, "restart command", "mode", mode)
+}
 
+// sendPhoneCommandAndRespond pushes msg to the device, logs the outcome
+// (warn on hub send failure, info on success), and writes the standard
+// phone-command response. opName names the operation for the log
+// messages; extraInfo is forwarded to both the warn and info logs as
+// command-specific context (restart mode, update targets, etc.).
+func (h *Handler) sendPhoneCommandAndRespond(w http.ResponseWriter, r *http.Request, number string, msg *signaling.Message, opName string, extraInfo ...any) {
 	var sendErr string
 	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.Warn("restart command failed", "number", number, "mode", mode, "err", err)
+		slog.Warn(opName+" failed", append([]any{"number", number, "err", err}, extraInfo...)...)
 		sendErr = err.Error()
 	} else {
-		slog.Info("restart command sent", "number", number, "mode", mode)
+		slog.Info(opName+" sent", append([]any{"number", number}, extraInfo...)...)
 	}
-
 	h.respondPhoneCommandResult(w, r, number, sendErr)
 }
 


### PR DESCRIPTION
## Summary

`handlePhoneUpdate`, `handlePhoneRingTest`, `handlePhoneFactoryReset`, and `handlePhoneRestart` each repeated the same eight-line tail: send the `*signaling.Message` via `h.hub.SendTo`, log a `Warn` on failure with the err string captured, log an `Info` on success, then call `respondPhoneCommandResult` with the captured error string. Four near-identical blocks of bookkeeping for what is conceptually one operation.

Pull that pattern out into a `sendPhoneCommandAndRespond` helper alongside the existing `respondPhoneCommandResult`. `opName` names the operation for both log messages; the variadic `extraInfo` is forwarded to both the `Warn` and `Info` logs, so command-specific context (restart mode, update targets) lives at the call site rather than spread across four duplicated blocks.

Net: -33 / +13.

### Drive-by behavior change

`handlePhoneUpdate`'s previous failure log was `"number"` and `"err"` only; with the helper it now also carries `target_pi` and `target_fw`, matching the success log. This is the only call site whose output changes, and it changes by gaining context, which is a small win for the operator log.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/web/...`
- [x] `go test ./...` (only pre-existing unrelated `TestLoadConfigOptionalTokenFileUnreadable` failure unaffected by this change)
