### PR TITLE
docs: drop dead admind references missed by #438

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A single phone unit is split into two cooperating processors:
 | **Pico H** (firmware) | Low-level telephony, timing-sensitive I/O, UART protocol to Pi |
 | **Pi Zero 2 W** (digitsd) | Go daemon for VoIP, signaling, WebRTC media, Opus codec, call control |
 | **Codec Zero** (DA7212) | Audio pHAT with mic input (3.5mm TRS), speaker output (screw terminal) |
-| **Signaling Server** (Go) | WebSocket relay for SDP/ICE, PostgreSQL persistence, web app + admin |
+| **Signaling Server** (Go) | WebSocket relay for SDP/ICE, PostgreSQL persistence, web app |
 
 See [Architecture deep-dive](docs/architecture/overview.md) for the full call path, data model, and NAT traversal.
 
@@ -48,7 +48,7 @@ See [Architecture deep-dive](docs/architecture/overview.md) for the full call pa
 ```text
 firmware/   Pico H firmware (C/CMake + Pico SDK)
 pi/         Pi Zero userland -- digitsd VoIP daemon, setup tools, image builder
-server/     Go signaling server (WebSocket relay, web app, admin panel)
+server/     Go signaling server (WebSocket relay, web app)
 docs/       Hardware build guides, architecture, self-hosting
 scripts/    Build and flash helpers
 ```

--- a/docs/architecture/updates-and-recovery.md
+++ b/docs/architecture/updates-and-recovery.md
@@ -50,7 +50,7 @@ A factory reset restores the device to its out-of-box state: rootfs is repopulat
 
 Two paths:
 
-- **Web UI:** The "Factory Reset" button on the phone detail page in the signald admin panel.
+- **Web UI:** The "Factory Reset" button on the phone detail page in the signald web app (`/phones/<number>`).
 - **Service code:** Dial `*#00000#` on the phone keypad.
 
 ### What Happens

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 
   # Ephemeral Postgres for local integration tests. Mirrors the CI service in
   # .github/workflows/server-integration.yml: one Postgres 16 container hosting
-  # both digits_test and digits_admin_test, bound to host 5432.
+  # digits_test, bound to host 5432.
   #
   # Start:  docker compose --profile test up -d test-db
   # Stop:   docker compose --profile test down

--- a/server/docker/Caddyfile.production
+++ b/server/docker/Caddyfile.production
@@ -12,14 +12,6 @@
         reverse_proxy signald:8080
     }
 
-    # Admin dashboard
-    @admin {
-        path /admin /admin/*
-    }
-    handle @admin {
-        reverse_proxy admind:9090
-    }
-
     # All other requests
     handle {
         reverse_proxy signald:8080


### PR DESCRIPTION
## Motivated by

- #423: removed the admind service.
- #438: cleaned up the leftover `/admin` metrics bucket and self-hosting docs, but missed the references below.

## What

Drop the remaining admind / admin-panel references across the repo.

| File | Was | Now |
| --- | --- | --- |
| `server/docker/Caddyfile.production` | `@admin { path /admin /admin/* } handle @admin { reverse_proxy admind:9090 }` | block deleted; /admin falls through to signald |
| `README.md` (×2) | "web app + admin", "admin panel" | "web app" |
| `docs/architecture/updates-and-recovery.md` | "the signald admin panel" | "the signald web app (`/phones/{number}`)" |
| `server/docker-compose.yml` | comment: hosts both `digits_test` and `digits_admin_test` | hosts `digits_test` (the only DB that exists) |

The Caddyfile entry is the one with real impact: `docs/hosting/self-hosting.md` recommends `cp docker/Caddyfile.production docker/Caddyfile`, so any production install following the docs would 502 on `/admin` because `admind:9090` no longer exists. After this change, `/admin` falls through to the catch-all `signald:8080` block (which returns whatever signald returns for an unknown path).

The other three are doc-only.

## Test plan

- [x] `grep -rn 'admind\|admin panel\|digits_admin_test'` repo-wide returns only intended hits (`server/.gitignore: /admind`, which is fine).
- [x] No Go code touched; CI build/test/lint unaffected.
