### PR TITLE
docs: explain Redis cluster state added in #440

### DIFF
--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -8,7 +8,7 @@ If you do happen to have a k8s cluster lying around and want to deploy digits th
 - ClusterIP Service (with optional metrics port)
 - Ingress resource for external access
 - CNPG PostgreSQL Cluster (userdb) with S3-compatible backups
-- Optional Redis Sentinel StatefulSet for multi-replica signaling
+- Optional Redis Sentinel StatefulSet for multi-replica signaling and shared cluster state
 - OpenTelemetry tracing, Pyroscope profiling, and Prometheus ServiceMonitor
 
 ## Install
@@ -89,7 +89,7 @@ When enabled, the deployment exposes Prometheus metrics on a dedicated port and 
 
 Single-replica is the default. To run more than one signald pod, enable the
 bundled 3-node Redis Sentinel StatefulSet so cross-pod calls reach the right
-device:
+device and pods share state:
 
 ```yaml
 signald:
@@ -101,11 +101,21 @@ redis:
   sentinelMasterName: digits
 ```
 
-When `redis.enabled` is false, signaling is local-only and replica counts
-above 1 will silently drop calls whose target is on a different pod. With
-`redis.enabled: true`, the chart wires `REDIS_URL` (the comma-separated list
-of sentinel addresses) and `REDIS_SENTINEL_MASTER` into signald automatically;
-the daemon switches to failover-aware client mode based on those env vars.
+When `redis.enabled: true`, the chart wires `REDIS_URL` (the comma-separated
+list of sentinel addresses) and `REDIS_SENTINEL_MASTER` into signald
+automatically; the daemon switches to failover-aware client mode based on
+those env vars. Redis then carries:
+
+- cross-pod signaling pub/sub (calls whose target is on another pod);
+- device presence (which pod owns each connected device);
+- active-call and conference state (so any pod can answer "is this number
+  busy?" or list live calls);
+- dashboard SSE events (so `/api/dashboard/stream` re-renders on any pod).
+
+When `redis.enabled` is false, all of the above is local-only. Replica
+counts above 1 then silently break: calls whose target is on another pod
+get dropped, devices on other pods appear offline here, and dashboard
+counters reflect just the local pod.
 
 To bring your own Redis instead of the bundled StatefulSet, leave
 `redis.enabled: false` and inject `REDIS_URL` (and, for sentinel mode,

--- a/server/README.md
+++ b/server/README.md
@@ -140,14 +140,29 @@ around what is and is not collected.
 
 ### Multi-replica signaling
 
-| Variable    | Description                                                    |
-|-------------|----------------------------------------------------------------|
-| `REDIS_URL` | Redis connection URL (`redis://host:port` or `rediss://...`). When set, signald uses Redis pub/sub as a cross-pod broadcast channel so calls whose target is on a different pod still reach the device. Empty disables Redis (single-instance mode). |
+| Variable                | Description                                                    |
+|-------------------------|----------------------------------------------------------------|
+| `REDIS_URL`             | Redis connection URL (`redis://host:port` or `rediss://...`), or a comma-separated list of Sentinel addresses for failover mode. When set, signald enables both cross-pod signaling (pub/sub) and shared cluster state (device presence, active calls and conferences, dashboard SSE events). Empty disables Redis (single-instance mode). |
+| `REDIS_SENTINEL_MASTER` | Sentinel master name. When set together with a comma-separated `REDIS_URL`, the client switches to failover-aware mode. Leave empty for a direct connection. |
 
 Without `REDIS_URL`, behavior is identical to the single-instance default
 and Redis is not a runtime dependency. With it, every pod publishes to a
-shared `digits:signal` channel when a local lookup misses, and subscribing
-pods deliver to their local connections.
+shared `digits:signal` channel when a local lookup misses, subscribing pods
+deliver to their local connections, and the following cluster state moves
+into Redis so multi-pod queries see a consistent view:
+
+- **Device presence:** a pod records the device-to-pod mapping for each
+  connected device, and other pods read it to route calls to the owning pod.
+- **Active calls and conferences:** the call tracker writes per-call and
+  per-conference records (with a 30-minute safety-net TTL) so any pod can
+  answer "is this number busy?" or "what calls are live?".
+- **Dashboard events:** the SSE broadcaster fans out across pods via Redis
+  pub/sub so `/api/dashboard/stream` re-renders counters regardless of which
+  pod the SSE client connected to.
+
+Running multiple replicas without Redis silently breaks all of these:
+calls land on the wrong pod, devices appear offline to other pods, and
+dashboard counters reflect only the local pod's events.
 
 ### Tracing and Profiling
 


### PR DESCRIPTION
## Motivated by

- #437: rewrote the Helm chart README around the new `redis.enabled` Sentinel toggle. Failure mode listed: "silently drop calls whose target is on a different pod."
- #440: merged about an hour after #437. It expanded Redis from "just signaling pub/sub" to also carry shared cluster state: device presence, active calls and conferences, and dashboard SSE event fan-out. The READMEs were not updated to match.
- #430: introduced `REDIS_SENTINEL_MASTER` into the chart, but the env-var table in `server/README.md` still only listed `REDIS_URL`.

## What

Two README updates, no code changes.

**`charts/digits/README.md`**

- Chart summary bullet now reads "...for multi-replica signaling and shared cluster state."
- Multi-replica section enumerates what Redis actually carries (signaling pub/sub, device presence, call/conference state, dashboard SSE) and what breaks when you run multi-replica without it.

**`server/README.md`**

- `REDIS_URL` description expanded to mention failover/sentinel mode and the cluster state surface.
- New `REDIS_SENTINEL_MASTER` row in the env-var table.
- Section body lists the four state surfaces and what running multi-replica without Redis actually breaks.

## Test plan

- [x] No code changes; CI build/test/lint unaffected.
- [x] Both files render cleanly as Markdown locally.
- [x] No em dashes in the diff (per repo style rules).
