### PR TITLE
fix(server): report local connection count in device metric

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -143,7 +143,7 @@ func run(ctx context.Context) error {
 	// relay (signaling_errors_total). Live-state gauges sample the hub and
 	// tracker at scrape time so we never persist counts elsewhere.
 	mreg := metrics.New(version.Version, version.Commit)
-	mreg.RegisterDevicesGauge(func() float64 { return float64(len(hub.OnlineNumbers())) })
+	mreg.RegisterDevicesGauge(func() float64 { return float64(hub.LocalConnectionCount()) })
 	mreg.RegisterCallsGauge(func() float64 { return float64(len(tracker.Active())) })
 
 	// Dashboard pub/sub: hub.Register/Unregister and tracker.OnCall* notify

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -605,6 +605,16 @@ func (h *Hub) IsOnline(number string) bool {
 	return h.Get(number) != nil
 }
 
+func (h *Hub) LocalConnectionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	n := len(h.conns)
+	if _, ok := h.conns["unpaired"]; ok {
+		n--
+	}
+	return n
+}
+
 func (h *Hub) OnlineNumbers() []string {
 	h.mu.RLock()
 	ds := h.state


### PR DESCRIPTION
## Summary

- The `digits_signald_active_devices_current` gauge was calling `hub.OnlineNumbers()` which, with Redis cluster state enabled, queries all pods via Redis SCAN. Every replica reported the same cluster-wide total, making the "Devices per replica" Grafana panel show identical bars.
- Adds `Hub.LocalConnectionCount()` that counts only the local `h.conns` map (this pod's WebSocket connections).
- Uses `LocalConnectionCount()` for the Prometheus gauge so each pod reports its own connection count.

## Test plan

- [x] Unit tests pass (`make test`)
- [x] Lint clean (`golangci-lint run ./...`)
- [ ] After deploy, verify "Devices per replica" panel in Grafana shows different values per pod (based on which pod each device connected to)