### PR TITLE
feat(firmware): phase-aware FSM LED, remove imperative LED management

### DIFF
--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -14,12 +14,23 @@
 #include "tone.h"
 #include "uart_proto.h"
 
-// fsm_led_set wraps led_set_mode: skips FSM-driven LED changes when
-// the Pi has locked the LED (e.g. recovery/setup modes).
+// fsm_led_set resolves the LED pattern from (phase, fsm_state). When the Pi
+// has locked the LED (e.g. CONNECTING during WiFi verify), FSM changes are
+// skipped. When the FSM requests OFF (idle/on-hook), the phase determines
+// the idle pattern so each mode gets the right ambient indicator.
 static void fsm_led_set(led_mode_t mode) {
-    if (!led_is_locked()) {
-        led_set_mode(mode);
+    if (led_is_locked()) {
+        return;
     }
+    if (mode == LED_MODE_OFF) {
+        switch (phase_read()) {
+        case PHASE_UNPAIRED: led_set_mode(LED_MODE_SLOW_PULSE); return;
+        case PHASE_SETUP:    led_set_mode(LED_MODE_DOUBLE_PULSE); return;
+        case PHASE_RECOVERY: led_set_mode(LED_MODE_FAST_BLINK); return;
+        default: break;
+        }
+    }
+    led_set_mode(mode);
 }
 
 #include "hardware/watchdog.h"

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1644,7 +1644,7 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 func resetPicoHardware(sp *phone.SerialPort) {
 	slog.Info("pico: clearing residual hardware state on startup")
 	sp.Ring(false)
-	sp.LED("OFF")
+	sp.LED("UNLOCK")
 }
 
 // playPairingAnnouncement queues one full pairing-voice sequence on mixer:
@@ -2608,6 +2608,11 @@ func main() {
 				}
 			}
 
+			if event == "HOOK:ON" && !cb.paired.Load() && pairingAnnouncementCancel != nil {
+				pairingAnnouncementCancel()
+				pairingAnnouncementCancel = nil
+			}
+
 			// Unpaired phone: play pairing voice sequence instead of dial tone,
 			// then re-play it on a timer so a user who keeps the handset off
 			// the cradle can hear the code again without hanging up. The loop
@@ -2631,7 +2636,6 @@ func main() {
 				code := cb.pairingCode
 				receivedAt := cb.pairingCodeReceivedAt
 				slog.Info("phone: playing pairing code via voice", "code", code)
-				sp.LED("ON")
 				go func() {
 					for {
 						if cb.paired.Load() || code == "" {

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -173,9 +173,6 @@ func runRecoveryMode(web *subsystem.WebModule, serial *subsystem.SerialModule, a
 	var mixer *audio.Mixer
 	if serial != nil && serial.IsReady() {
 		sp = serial.Port()
-		sp.LED("LOCK")
-		time.Sleep(50 * time.Millisecond)
-		sp.LED("FAST_BLINK")
 		sp.StateSet("RECOVERY")
 	}
 	if audioMod != nil && audioMod.IsReady() {

--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -37,13 +37,8 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		slog.Warn("setup: failed to clear boot counter", "error", err)
 	}
 
-	// LED: signal setup mode if serial is available.
 	if serial != nil && serial.IsReady() {
-		sp := serial.Port()
-		sp.LED("LOCK")
-		time.Sleep(50 * time.Millisecond)
-		sp.LED("DOUBLE_PULSE")
-		sp.StateSet("SETUP")
+		serial.Port().StateSet("SETUP")
 	}
 
 	mux := web.Mux()
@@ -121,8 +116,8 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "verifying"}) //nolint:errcheck
 
-		// LED: fast blink during verification
 		if serial != nil && serial.IsReady() {
+			serial.Port().LED("LOCK")
 			serial.Port().LED("CONNECTING")
 		}
 
@@ -135,7 +130,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 					state.lastAttempt = &wifi.VerifyResult{Error: fmt.Sprintf("internal error: %v", r)}
 					state.mu.Unlock()
 					if serial != nil && serial.IsReady() {
-						serial.Port().LED("DOUBLE_PULSE")
+						serial.Port().LED("UNLOCK")
 					}
 				}
 			}()
@@ -161,6 +156,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 			if result.Connected && result.Error == "" {
 				slog.Info("setup: WiFi configured, rebooting")
 				if serial != nil && serial.IsReady() {
+					serial.Port().LED("UNLOCK")
 					serial.Port().LED("ON")
 				}
 				if audio != nil && audio.IsReady() {
@@ -169,9 +165,8 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 				}
 				doReboot()
 			} else {
-				// Restore LED to setup pattern
 				if serial != nil && serial.IsReady() {
-					serial.Port().LED("DOUBLE_PULSE")
+					serial.Port().LED("UNLOCK")
 				}
 			}
 		}()


### PR DESCRIPTION
## Summary

- Firmware FSM consults the persisted phase byte when choosing idle LED pattern: UNPAIRED shows SLOW_PULSE, SETUP shows DOUBLE_PULSE, RECOVERY shows FAST_BLINK, PAIRED shows OFF
- Removes imperative LED:LOCK/LED:pattern management from digitsd setup and recovery mode entry
- Setup only uses LOCK during WiFi verification (CONNECTING pattern the firmware can't determine)
- resetPicoHardware sends UNLOCK instead of OFF so it clears stale locks without overriding the phase-based pattern
- Fixes pairing announcement goroutine leak on HOOK:ON while unpaired
- Removes explicit sp.LED("ON") on unpaired HOOK:OFF (firmware FSM DIAL_TONE state handles it)

## Test plan

- [ ] Boot unpaired: LED shows SLOW_PULSE immediately (firmware boot) and continues after digitsd starts
- [ ] Pick up handset: LED goes solid ON (firmware FSM enters DIAL_TONE)
- [ ] Hang up: LED returns to SLOW_PULSE (firmware FSM enters IDLE, phase-aware)
- [ ] Setup mode: LED shows DOUBLE_PULSE without digitsd sending explicit commands
- [ ] Setup WiFi verify: LED switches to CONNECTING (LOCK), returns to DOUBLE_PULSE on failure (UNLOCK)
- [ ] Recovery mode: LED shows FAST_BLINK without digitsd sending explicit commands
- [ ] Paired idle: LED stays OFF (no regression)