### PR TITLE
docs: update deploy-phone skill for consolidated digitsd modes

### DIFF
--- a/.claude/skills/deploy-phone/SKILL.md
+++ b/.claude/skills/deploy-phone/SKILL.md
@@ -12,16 +12,46 @@ Build and deploy Pi binaries to phone devices over SSH. Handles the read-only ro
 | Binary | Build dir | Build command | Output path | Install destination | Service restart |
 |--------|-----------|---------------|-------------|---------------------|-----------------|
 | `digitsd` | `pi/digitsd/` | `make build` | `bin/digitsd` | `/usr/local/bin/digitsd` | `digitsd` |
-| `digits-recovery` | `pi/digits-recovery/` | `make build` | `bin/digits-recovery` | `/usr/local/bin/digits-recovery` | none |
-| `digits-setup` | `pi/digits-setup/` | `make build-pi` | `digits-setup-arm64` | `/usr/local/bin/digits-setup` | none |
 | diagnostic tools | `pi/digitsd/` | `GOOS=linux GOARCH=arm64 go build -o bin/<name> ./cmd/<name>` | `bin/<name>` | `/tmp/<name>` | none |
 
 Diagnostic tools: `alsatest`, `latbench`, `latclient`, `memprofile`, `pipetest`, `dmixlat`, `clocksync`. Deploy to `/tmp/` -- they are throwaway debugging utilities, not permanent system binaries.
 
+`digitsd` handles all modes via the `--mode` flag: `normal` (default), `recovery`, `setup`, and `gpclk0`. There is no separate `digits-setup` or `digits-recovery` binary.
+
 **Build notes:**
 - `digitsd` uses a Docker builder container. Docker must be running. The `make build` target runs the embed step automatically.
-- `digits-recovery` and `digits-setup` are simple cross-compiles, no Docker needed.
-- `digits-setup` output binary is named `digits-setup-arm64`, not `digits-setup`.
+
+## Recovery Partition
+
+The recovery partition (`/dev/mmcblk0p3`) is a self-contained rootfs that boots as PID 1 when the boot counter hits 3. It has its own binary at `/digits-recovery` (symlinked from `/sbin/init`). This is the same `digitsd` binary running in `--mode=recovery` (auto-detected via PID 1).
+
+**The recovery partition binary is separate from the rootfs `/usr/local/bin/digitsd`.** Deploying digitsd to the rootfs does NOT update recovery mode. You must deploy to both locations if the change affects recovery behavior.
+
+**Deploy sequence (from normal mode, device must NOT be in recovery):**
+
+```bash
+# 1. Copy binary to /tmp
+sshpass -p <password> scp <local-digitsd-binary> <user>@<ip>:/tmp/digitsd-recovery
+
+# 2. Mount recovery partition, replace binary, unmount
+sshpass -p <password> ssh <user>@<ip> 'sudo mkdir -p /mnt/recovery && sudo mount /dev/mmcblk0p3 /mnt/recovery && sudo cp /tmp/digitsd-recovery /mnt/recovery/digits-recovery && sudo chmod 755 /mnt/recovery/digits-recovery && sudo umount /mnt/recovery && rm /tmp/digitsd-recovery && echo DONE'
+```
+
+**To test recovery after deploy:**
+```bash
+sshpass -p <password> ssh <user>@<ip> 'sudo sh -c "echo 3 > /data/digits/boot-counter" && sudo reboot'
+```
+
+The device reboots into recovery mode. Connect to the `Digits-Recovery` WiFi AP and access the web UI at `http://192.168.4.1/`. The `/debug` endpoint shows serial events and audio state.
+
+**To return to normal mode from recovery:** POST to `http://192.168.4.1/try-again` (clears boot counter and reboots), or connect to the AP via nmcli and curl it:
+```bash
+nmcli device wifi connect "Digits-Recovery"
+curl -X POST http://192.168.4.1/try-again
+nmcli connection delete "Digits-Recovery"
+```
+
+**Tones on the recovery partition:** The recovery binary loads tones from the same `--tones` path, which on the device resolves to `/data/digits/tones/` (the data partition is mounted at `/data` in recovery). DTMF WAVs and voice clips must be present there.
 
 ## Deployable Config Files
 
@@ -57,7 +87,7 @@ sshpass -p <password> scp <local-binary> <user>@<ip>:/tmp/<binary-name>
 sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,rw / && sudo mv /tmp/<binary-name> <install-destination> && sudo chmod 755 <install-destination> && sudo systemctl restart <service> && sleep 2 && sudo mount -o remount,ro /'
 ```
 
-If no service restart is needed (e.g. digits-recovery, digits-setup), just remount ro directly after the install:
+If no service restart is needed (e.g. deploying to the recovery partition), just remount ro directly after the install:
 
 ```bash
 sshpass -p <password> ssh <user>@<ip> 'sudo mount -o remount,rw / && sudo mv /tmp/<binary-name> <install-destination> && sudo chmod 755 <install-destination> && sudo mount -o remount,ro /'
@@ -91,7 +121,6 @@ When deploying to all phones, run the deploy sequence for each phone listed in `
 
 ## Common Mistakes
 
-- **Forgetting `make build-pi`** for digits-setup -- `make build` produces a host binary, not ARM64.
 - **Leaving rootfs in rw** -- always verify `ro` after deploy. Check with `mount | grep "on / "`.
 - **Deploying diagnostic tools to /usr/local/bin** -- they belong in `/tmp/`, not on the permanent rootfs.
 - **Running `make build` without Docker** -- digitsd requires the Docker builder. Use `make build-local` only if you have a local cross-compile toolchain.


### PR DESCRIPTION
## Summary

- Remove `digits-recovery` and `digits-setup` rows from the binary table (both consolidated into `digitsd --mode` in #450)
- Add recovery partition deploy section with mount/copy/unmount sequence and testing instructions
- Drop stale build notes (`make build-pi`, `digits-setup-arm64` naming)
- Update "no restart needed" example to reference recovery partition instead of removed binaries

## Test plan

- [ ] Verify skill renders correctly in Claude Code
- [ ] Confirm recovery deploy sequence matches actual device layout