### PR TITLE
feat(server): add What's New changelog modal

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -219,6 +219,7 @@ type Handler struct {
 	tmplConferenceLivePanel  *template.Template
 	tmplConferenceLiveDetail *template.Template
 	tmplDashboardAMStatus    *template.Template
+	tmplChangelog            *template.Template
 	cfg                      HandlerConfig
 	// Auth
 	authStore    *auth.Store
@@ -306,6 +307,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	parsePage := func(page string) (*template.Template, error) {
 		return template.New("").Funcs(funcMap).ParseFS(templateFS,
 			"templates/_partials.html",
+			"templates/_changelog.html",
 			"templates/layout-v2.html",
 			"templates/layout-dialup.html",
 			"templates/layout-answering-machine.html",
@@ -389,6 +391,13 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if _, err := tmplConferenceLiveDetail.ParseFS(templateFS, "templates/_conference-live-panel.html"); err != nil {
 		return nil, fmt.Errorf("parse conference-live-panel partial into detail: %w", err)
 	}
+	tmplChangelog, err := template.New("changelog").Funcs(funcMap).ParseFS(templateFS,
+		"templates/_partials.html",
+		"templates/_changelog.html",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parse changelog: %w", err)
+	}
 
 	u := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
@@ -425,6 +434,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		tmplConferenceLivePanel:  tmplConferenceLivePanel,
 		tmplConferenceLiveDetail: tmplConferenceLiveDetail,
 		tmplDashboardAMStatus:    tmplDashboardAMStatus,
+		tmplChangelog:            tmplChangelog,
 		cfg:                      cfg,
 		authStore:                deps.AuthStore,
 		authHandlers:             deps.AuthHandlers,
@@ -539,6 +549,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /settings/household/invite/{id}/cancel", h.handleHouseholdInviteCancelPost)
 	protected.HandleFunc("POST /settings/household/members/{id}/remove", h.handleHouseholdMemberRemovePost)
 	protected.HandleFunc("POST /settings/household/switch", h.handleHouseholdSwitchPost)
+	protected.HandleFunc("GET /changelog", h.handleChangelog)
 	protected.HandleFunc("GET /links", h.handleLinksGet)
 	protected.HandleFunc("POST /links/invite", h.handleLinksInvitePost)
 	protected.HandleFunc("POST /links/accept", h.handleLinksAcceptPost)

--- a/server/internal/web/handler_changelog.go
+++ b/server/internal/web/handler_changelog.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/justinlindh/digits/server/internal/updates"
+)
+
+type changelogRelease struct {
+	Version    string
+	Notes      string
+	Date       string
+	PhoneCount int
+	TotalCount int
+}
+
+type changelogData struct {
+	Software []changelogRelease
+	Firmware []changelogRelease
+}
+
+func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
+	hh := h.activeHousehold(r)
+	var lines []string
+	if hh != nil && h.lineStore != nil {
+		ll, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
+		if err == nil {
+			for _, l := range ll {
+				lines = append(lines, l.Number)
+			}
+		}
+	}
+
+	var idx *updates.ReleaseIndex
+	if h.Releases != nil {
+		idx = h.Releases.ReleaseIndex()
+	}
+
+	var data changelogData
+	if idx != nil {
+		data.Software = buildChangelogSection(idx, updates.ComponentPi, lines, h)
+		data.Firmware = buildChangelogSection(idx, updates.ComponentFirmware, lines, h)
+	}
+
+	renderWith(w, h.tmplChangelog, "changelog-content", data)
+}
+
+func buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []string, h *Handler) []changelogRelease {
+	releases := idx.SortedReleases(component)
+	total := len(lines)
+	out := make([]changelogRelease, 0, len(releases))
+
+	versionCounts := make(map[string]int)
+	for _, number := range lines {
+		info := h.hub.DeviceInfo(number)
+		if info == nil {
+			continue
+		}
+		var ver string
+		if component == updates.ComponentPi {
+			ver = info.PiVersion
+		} else {
+			ver = info.FirmwareVersion
+		}
+		if ver != "" {
+			versionCounts[ver]++
+		}
+	}
+
+	for _, r := range releases {
+		out = append(out, changelogRelease{
+			Version:    r.Version,
+			Notes:      r.Notes,
+			Date:       r.Date,
+			PhoneCount: versionCounts[r.Version],
+			TotalCount: total,
+		})
+	}
+	return out
+}

--- a/server/internal/web/handler_changelog.go
+++ b/server/internal/web/handler_changelog.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/justinlindh/digits/server/internal/updates"
@@ -28,6 +29,8 @@ func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
 			for _, l := range ll {
 				lines = append(lines, l.Number)
 			}
+		} else {
+			slog.Error("changelog: list lines failed", "household_id", hh.ID, "err", err)
 		}
 	}
 

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2211,3 +2211,73 @@ body.am .deck-kick-confirm .deck-confirm__go {
 .am-hh-option:hover { background: var(--bezel); }
 .am-hh-option.is-active { font-weight: 700; }
 
+/* What's New footer + dialog */
+.am-shell__foot {
+  padding: 12px 16px;
+  text-align: right;
+}
+.am-shell__whats-new {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--am-font);
+  font-size: 11px;
+  color: var(--am-muted);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.15s;
+}
+.am-shell__whats-new:hover { text-decoration-color: var(--am-muted); }
+
+.changelog-dialog {
+  border: 1px solid var(--am-rule);
+  border-radius: 4px;
+  padding: 0;
+  background: var(--am-bg);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  max-width: 520px;
+  width: 92vw;
+  max-height: 80vh;
+  color: var(--am-ink);
+  font-family: var(--am-font);
+}
+.changelog-dialog::backdrop { background: rgba(0,0,0,0.5); }
+.changelog-dialog__titlebar { display: none; }
+.changelog-dialog__body { padding: 20px; overflow-y: auto; max-height: 78vh; }
+.changelog-dialog__title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+  color: var(--am-ink);
+}
+
+.changelog__section-title {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--am-muted);
+  margin: 0 0 10px;
+}
+.changelog__section + .changelog__section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--am-rule);
+}
+.changelog__release + .changelog__release {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--am-rule);
+}
+.changelog__version {
+  font-family: var(--am-mono);
+  font-size: 12px;
+  font-weight: 600;
+}
+.changelog__date { font-size: 11px; color: var(--am-muted); }
+.changelog__adoption { font-size: 11px; color: var(--am-accent); margin-left: auto; }
+.changelog__notes { font-size: 12px; line-height: 1.5; color: var(--am-ink); }
+.changelog__notes p { margin: 0 0 6px; }
+.changelog__notes p:last-child { margin: 0; }
+.changelog__empty { color: var(--am-muted); font-style: italic; font-size: 12px; }
+

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2211,24 +2211,20 @@ body.am .deck-kick-confirm .deck-confirm__go {
 .am-hh-option:hover { background: var(--bezel); }
 .am-hh-option.is-active { font-weight: 700; }
 
-/* What's New footer + dialog */
-.am-shell__foot {
-  padding: 12px 16px;
-  text-align: right;
-}
-.am-shell__whats-new {
+/* What's New footer link + dialog */
+.page__foot-sep { color: var(--am-muted); }
+.page__foot-link {
   background: none;
   border: none;
   padding: 0;
-  font-family: var(--am-font);
-  font-size: 11px;
+  font: inherit;
   color: var(--am-muted);
   cursor: pointer;
   text-decoration: underline;
   text-decoration-color: transparent;
   transition: text-decoration-color 0.15s;
 }
-.am-shell__whats-new:hover { text-decoration-color: var(--am-muted); }
+.page__foot-link:hover { text-decoration-color: var(--am-muted); }
 
 .changelog-dialog {
   border: 1px solid var(--am-rule);

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2212,68 +2212,70 @@ body.am .deck-kick-confirm .deck-confirm__go {
 .am-hh-option.is-active { font-weight: 700; }
 
 /* What's New footer link + dialog */
-.page__foot-sep { color: var(--am-muted); }
+.page__foot-sep { color: var(--ink-muted); }
 .page__foot-link {
   background: none;
   border: none;
   padding: 0;
   font: inherit;
-  color: var(--am-muted);
+  color: var(--ink-muted);
   cursor: pointer;
   text-decoration: underline;
   text-decoration-color: transparent;
   transition: text-decoration-color 0.15s;
 }
-.page__foot-link:hover { text-decoration-color: var(--am-muted); }
+.page__foot-link:hover { text-decoration-color: var(--ink-muted); }
 
 .changelog-dialog {
-  border: 1px solid var(--am-rule);
-  border-radius: 4px;
+  border: 1px solid rgba(100,80,40,0.25);
+  border-radius: 10px;
   padding: 0;
-  background: var(--am-bg);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  background: linear-gradient(180deg, var(--case-light) 0%, var(--case) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,0.7),
+    0 8px 24px rgba(40,30,15,0.25);
   max-width: 520px;
   width: 92vw;
   max-height: 80vh;
-  color: var(--am-ink);
-  font-family: var(--am-font);
+  color: var(--ink);
+  font-family: var(--font-body);
 }
-.changelog-dialog::backdrop { background: rgba(0,0,0,0.5); }
+.changelog-dialog::backdrop { background: rgba(40,30,15,0.4); }
 .changelog-dialog__titlebar { display: none; }
 .changelog-dialog__body { padding: 20px; overflow-y: auto; max-height: 78vh; }
 .changelog-dialog__title {
   font-size: 16px;
   font-weight: 600;
   margin: 0 0 16px;
-  color: var(--am-ink);
+  color: var(--ink);
 }
 
 .changelog__section-title {
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--am-muted);
+  color: var(--ink-muted);
   margin: 0 0 10px;
 }
 .changelog__section + .changelog__section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid var(--am-rule);
+  border-top: 1px dashed rgba(100,80,40,0.25);
 }
 .changelog__release + .changelog__release {
   margin-top: 12px;
   padding-top: 12px;
-  border-top: 1px solid var(--am-rule);
+  border-top: 1px dashed rgba(100,80,40,0.25);
 }
 .changelog__version {
-  font-family: var(--am-mono);
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
 }
-.changelog__date { font-size: 11px; color: var(--am-muted); }
-.changelog__adoption { font-size: 11px; color: var(--am-accent); margin-left: auto; }
-.changelog__notes { font-size: 12px; line-height: 1.5; color: var(--am-ink); }
+.changelog__date { font-size: 11px; color: var(--ink-muted); }
+.changelog__adoption { font-size: 11px; color: var(--chip-blue); margin-left: auto; }
+.changelog__notes { font-size: 12px; line-height: 1.5; color: var(--ink-soft); }
 .changelog__notes p { margin: 0 0 6px; }
 .changelog__notes p:last-child { margin: 0; }
-.changelog__empty { color: var(--am-muted); font-style: italic; font-size: 12px; }
+.changelog__empty { color: var(--ink-muted); font-style: italic; font-size: 12px; }
 

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2318,6 +2318,95 @@ body.dialup .phone-silent__text {
   min-width: 88px;
 }
 
+/* What's New changelog dialog, dialup theme */
+.page__foot-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--dialup-blue);
+  cursor: pointer;
+  text-decoration: underline;
+}
+.page__foot-link:hover { color: var(--dialup-blue-dark); }
+
+.changelog-dialog {
+  padding: 0;
+  background: var(--dialup-chrome);
+  border-top: 2px solid var(--dialup-bevel-hi);
+  border-left: 2px solid var(--dialup-bevel-hi);
+  border-right: 2px solid var(--dialup-bevel-ll);
+  border-bottom: 2px solid var(--dialup-bevel-ll);
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.4);
+  max-width: 520px;
+  width: 92vw;
+  max-height: 80vh;
+  font-family: "Tahoma", "MS Sans Serif", Geneva, sans-serif;
+  color: var(--dialup-ink);
+}
+.changelog-dialog::backdrop { background: rgba(0, 0, 0, 0.4); }
+
+.changelog-dialog__titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(90deg, var(--dialup-blue-dark) 0%, var(--dialup-blue) 55%, var(--dialup-blue-light) 100%);
+  color: #ffffff;
+  padding: 3px 5px;
+  font-weight: bold;
+  font-size: 12px;
+  min-height: 22px;
+}
+.changelog-dialog__titlebar-title { text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3); }
+.changelog-dialog__titlebar-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  background: var(--dialup-chrome);
+  color: var(--dialup-ink);
+  border: none;
+  border-top: 1px solid var(--dialup-bevel-hi);
+  border-left: 1px solid var(--dialup-bevel-hi);
+  border-right: 1px solid var(--dialup-bevel-ll);
+  border-bottom: 1px solid var(--dialup-bevel-ll);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+}
+.changelog-dialog__body { padding: 14px 16px; overflow-y: auto; max-height: calc(80vh - 28px); }
+.changelog-dialog__title {
+  font-weight: bold;
+  font-size: 13px;
+  margin: 0 0 12px;
+  color: var(--dialup-ink);
+}
+
+.changelog__section-title {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: var(--dialup-ink);
+  margin: 0 0 8px;
+}
+.changelog__release + .changelog__release {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--dialup-bevel-lo);
+}
+.changelog__version {
+  font-family: monospace;
+  font-size: 12px;
+  font-weight: bold;
+}
+.changelog__date { font-size: 11px; color: gray; }
+.changelog__adoption { font-size: 11px; color: var(--dialup-blue-dark); margin-left: auto; }
+.changelog__notes { font-size: 12px; line-height: 1.5; }
+.changelog__notes p { margin: 0 0 6px; }
+.changelog__notes p:last-child { margin: 0; }
+.changelog__empty { color: gray; font-style: italic; font-size: 12px; }
+
 /* =========================================================================
    Call-live observation deck — dialup theme (MODEM CONNECTED)
    ========================================================================= */

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1602,6 +1602,100 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   margin-top: 4px;
 }
 
+/* What's New changelog dialog */
+.page__foot-sep { color: var(--ink-muted); }
+.page__foot-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--brass);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: text-decoration-color 0.15s;
+}
+.page__foot-link:hover { text-decoration-color: var(--brass); }
+
+.changelog-dialog {
+  border: 1px solid var(--rule);
+  border-radius: 12px;
+  padding: 0;
+  background: var(--paper);
+  box-shadow: 0 12px 32px rgba(42,31,24,0.18), 0 2px 6px rgba(42,31,24,0.08);
+  max-width: 560px;
+  width: 92vw;
+  max-height: 80vh;
+  color: var(--ink);
+}
+.changelog-dialog::backdrop { background: rgba(42,31,24,0.35); }
+.changelog-dialog__titlebar { display: none; }
+.changelog-dialog__body { padding: 24px 26px; overflow-y: auto; max-height: 78vh; }
+.changelog-dialog__title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 20px;
+  letter-spacing: -0.005em;
+  margin: 0 0 18px;
+  color: var(--ink);
+}
+.changelog-dialog__content { min-height: 60px; }
+
+.changelog__section + .changelog__section {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid var(--rule-soft);
+}
+.changelog__section-title {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin: 0 0 12px;
+}
+.changelog__release + .changelog__release {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule-soft);
+}
+.changelog__release-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.changelog__version {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.changelog__date {
+  font-size: 11px;
+  color: var(--ink-muted);
+}
+.changelog__adoption {
+  font-size: 11px;
+  color: var(--brass);
+  margin-left: auto;
+}
+.changelog__notes {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+.changelog__notes p { margin: 0 0 8px; }
+.changelog__notes p:last-child { margin: 0; }
+.changelog__notes ul { margin: 4px 0 8px; padding-left: 18px; }
+.changelog__notes li { margin: 2px 0; }
+.changelog__empty {
+  color: var(--ink-muted);
+  font-style: italic;
+  font-size: 13px;
+}
+
 /* =========================================================================
    Call-live observation deck — intercom theme
    ========================================================================= */
@@ -2060,6 +2154,10 @@ html[data-theme="dark"] .lines__dot--on {
    light-theme ink tone. On dark, go plain deep black. */
 html[data-theme="dark"] .confirm-dialog::backdrop { background: rgba(0,0,0,0.55); }
 html[data-theme="dark"] .confirm-dialog {
+  box-shadow: 0 14px 40px rgba(0,0,0,0.7), 0 2px 8px rgba(0,0,0,0.4);
+}
+html[data-theme="dark"] .changelog-dialog::backdrop { background: rgba(0,0,0,0.55); }
+html[data-theme="dark"] .changelog-dialog {
   box-shadow: 0 14px 40px rgba(0,0,0,0.7), 0 2px 8px rgba(0,0,0,0.4);
 }
 

--- a/server/internal/web/templates/_changelog.html
+++ b/server/internal/web/templates/_changelog.html
@@ -1,0 +1,63 @@
+{{define "changelog-dialog-markup"}}
+<dialog id="changelog-dialog" class="changelog-dialog">
+  <div class="changelog-dialog__titlebar" aria-hidden="true">
+    <span class="changelog-dialog__titlebar-title">What's new</span>
+    <button type="button" class="changelog-dialog__titlebar-x" onclick="this.closest('dialog').close()" aria-label="Close">&#x2715;</button>
+  </div>
+  <div class="changelog-dialog__body">
+    <h2 class="changelog-dialog__title">What's new</h2>
+    <div id="changelog-body" class="changelog-dialog__content">
+      <p class="changelog__empty">Loading...</p>
+    </div>
+  </div>
+</dialog>
+<script>
+(function () {
+  var d = document.getElementById('changelog-dialog');
+  if (!d) return;
+  d.addEventListener('click', function (e) {
+    if (e.target === d) d.close();
+  });
+})();
+</script>
+{{end}}
+
+{{define "changelog-content"}}
+<div class="changelog">
+  {{if .Software}}
+  <section class="changelog__section">
+    <h3 class="changelog__section-title">Software</h3>
+    {{range .Software}}
+    <article class="changelog__release">
+      <div class="changelog__release-head">
+        <span class="changelog__version">{{.Version}}</span>
+        {{if .Date}}<span class="changelog__date">{{.Date}}</span>{{end}}
+        {{if .TotalCount}}<span class="changelog__adoption">{{.PhoneCount}} of {{.TotalCount}} phones</span>{{end}}
+      </div>
+      {{if .Notes}}<div class="changelog__notes">{{renderNotes .Notes}}</div>{{else}}<p class="changelog__empty">Notes not available yet.</p>{{end}}
+    </article>
+    {{end}}
+  </section>
+  {{end}}
+
+  {{if .Firmware}}
+  <section class="changelog__section">
+    <h3 class="changelog__section-title">Firmware</h3>
+    {{range .Firmware}}
+    <article class="changelog__release">
+      <div class="changelog__release-head">
+        <span class="changelog__version">{{.Version}}</span>
+        {{if .Date}}<span class="changelog__date">{{.Date}}</span>{{end}}
+        {{if .TotalCount}}<span class="changelog__adoption">{{.PhoneCount}} of {{.TotalCount}} phones</span>{{end}}
+      </div>
+      {{if .Notes}}<div class="changelog__notes">{{renderNotes .Notes}}</div>{{else}}<p class="changelog__empty">Notes not available yet.</p>{{end}}
+    </article>
+    {{end}}
+  </section>
+  {{end}}
+
+  {{if and (not .Software) (not .Firmware)}}
+  <p class="changelog__empty">No releases available.</p>
+  {{end}}
+</div>
+{{end}}

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -27,7 +27,10 @@
 <footer class="page__foot">
   <span>Server</span>
   <span class="num">{{.Version}}</span>
+  <span class="page__foot-sep">&middot;</span>
+  <button type="button" class="page__foot-link" onclick="document.getElementById('changelog-dialog').showModal(); htmx.ajax('GET', '/changelog', '#changelog-body')">What's new</button>
 </footer>
+{{template "changelog-dialog-markup" .}}
 {{end}}
 {{end}}
 

--- a/server/internal/web/templates/_partials.html
+++ b/server/internal/web/templates/_partials.html
@@ -28,7 +28,7 @@
   <span>Server</span>
   <span class="num">{{.Version}}</span>
   <span class="page__foot-sep">&middot;</span>
-  <button type="button" class="page__foot-link" onclick="document.getElementById('changelog-dialog').showModal(); htmx.ajax('GET', '/changelog', '#changelog-body')">What's new</button>
+  <button type="button" class="page__foot-link" onclick="var d=document.getElementById('changelog-dialog'); d.showModal(); if(!d.dataset.loaded){htmx.ajax('GET','/changelog','#changelog-body'); d.dataset.loaded='1'}">What's new</button>
 </footer>
 {{template "changelog-dialog-markup" .}}
 {{end}}

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -63,12 +63,6 @@
 
   <main class="am-shell__main">
     {{block "content" .}}{{end}}
-    {{if .Version}}
-    <footer class="am-shell__foot">
-      <button type="button" class="am-shell__whats-new" onclick="var d=document.getElementById('changelog-dialog'); d.showModal(); if(!d.dataset.loaded){htmx.ajax('GET','/changelog','#changelog-body'); d.dataset.loaded='1'}">What's new</button>
-    </footer>
-    {{template "changelog-dialog-markup" .}}
-    {{end}}
   </main>
 </div>
 {{else}}

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -63,6 +63,12 @@
 
   <main class="am-shell__main">
     {{block "content" .}}{{end}}
+    {{if .Version}}
+    <footer class="am-shell__foot">
+      <button type="button" class="am-shell__whats-new" onclick="document.getElementById('changelog-dialog').showModal(); htmx.ajax('GET', '/changelog', '#changelog-body')">What's new</button>
+    </footer>
+    {{template "changelog-dialog-markup" .}}
+    {{end}}
   </main>
 </div>
 {{else}}

--- a/server/internal/web/templates/layout-answering-machine.html
+++ b/server/internal/web/templates/layout-answering-machine.html
@@ -65,7 +65,7 @@
     {{block "content" .}}{{end}}
     {{if .Version}}
     <footer class="am-shell__foot">
-      <button type="button" class="am-shell__whats-new" onclick="document.getElementById('changelog-dialog').showModal(); htmx.ajax('GET', '/changelog', '#changelog-body')">What's new</button>
+      <button type="button" class="am-shell__whats-new" onclick="var d=document.getElementById('changelog-dialog'); d.showModal(); if(!d.dataset.loaded){htmx.ajax('GET','/changelog','#changelog-body'); d.dataset.loaded='1'}">What's new</button>
     </footer>
     {{template "changelog-dialog-markup" .}}
     {{end}}


### PR DESCRIPTION
## Summary

- Add a "What's New" link in the page footer (next to the server version pill) that opens a `<dialog>` modal showing pi and firmware release history
- Each release entry shows per-version phone adoption counts ("2 of 3 phones") as a subtle upgrade nudge
- Modal content is lazy-loaded via htmx GET `/changelog` on open, cached after first open
- Two separate sections (Software, Firmware), each sorted newest-first
- Styled for all three themes: intercom (with dark mode), dialup (Win98 titlebar chrome), and answering-machine

## Screenshots

### Intercom theme
![Intercom theme](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-462-intercom.png)

### Dialup theme
![Dialup theme](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-462-dialup.png)

### Answering-machine theme
![Answering-machine theme](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-462-answering-machine.png)

## Test plan

- [ ] Build compiles (`go build ./...`)
- [ ] Lint clean (`golangci-lint run ./...`)
- [ ] Unit tests pass (`make test`)
- [ ] Intercom theme: "What's new" link visible in footer, dialog opens with release notes, adoption counts render, backdrop/X close works
- [ ] Intercom dark mode: dialog backdrop and shadow render correctly
- [ ] Dialup theme: Win98-style titlebar renders, close button works
- [ ] Answering-machine theme: "What's new" link appears in footer, dialog renders with AM styling
- [ ] With no GitHub releases configured: dialog shows "No releases available" fallback
- [ ] Re-opening dialog does not re-fetch (dataset.loaded gate)