### PR TITLE
fix(firmware,pi,digitsd): boot state bugs (panic-check, hook init, pairing tone)

### DIFF
--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -428,6 +428,9 @@ void phone_fsm_init(void) {
     s_state = PHONE_STATE_IDLE;
     clear_dialing_buffer();
     set_state(PHONE_STATE_IDLE);
+    if (hook_is_off_hook()) {
+        uart_proto_send("HOOK:OFF");
+    }
 }
 
 void phone_fsm_update(void) {

--- a/pi/digits-panic-check/main.go
+++ b/pi/digits-panic-check/main.go
@@ -55,6 +55,12 @@ func defaultConfig() config {
 	}
 }
 
+// lineResult is a line (or error) produced by the background scanner goroutine.
+type lineResult struct {
+	line string
+	err  error
+}
+
 // run executes the panic check. Returns true if recovery was triggered.
 func run(cfg config) (bool, error) {
 	port, err := cfg.openSerial(cfg.serialDev, cfg.baud)
@@ -65,6 +71,42 @@ func run(cfg config) (bool, error) {
 	}
 	defer port.Close()
 
+	// A single background scanner feeds every read in this function, so no
+	// goroutine silently consumes data that a later read needs.
+	lineCh := make(chan lineResult, keydumpTotalLines+1)
+	go func() {
+		sc := bufio.NewScanner(port)
+		for sc.Scan() {
+			lineCh <- lineResult{line: sc.Text()}
+		}
+		if err := sc.Err(); err != nil {
+			lineCh <- lineResult{err: err}
+		}
+		close(lineCh)
+	}()
+
+	// Wait for the Pico to be ready. It may still be booting when this
+	// service runs at sysinit.
+	ready := false
+	for attempt := 1; attempt <= 5; attempt++ {
+		if _, err := port.Write([]byte("PING\n")); err != nil {
+			log.Printf("PING write failed: %v (attempt %d)", err, attempt)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		lines, err := collectLines(lineCh, 1, 1*time.Second)
+		if err == nil && len(lines) > 0 && lines[0] == "PONG" {
+			ready = true
+			break
+		}
+		log.Printf("PING: no PONG (attempt %d/5)", attempt)
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !ready {
+		log.Printf("Pico not responding after 5 PING attempts (continuing normal boot)")
+		return false, nil
+	}
+
 	// Send KEYDUMP command.
 	if _, err := port.Write([]byte("KEYDUMP\n")); err != nil {
 		log.Printf("cannot write KEYDUMP: %v (continuing normal boot)", err)
@@ -72,7 +114,7 @@ func run(cfg config) (bool, error) {
 	}
 
 	// Read response lines with a timeout.
-	lines, err := readLines(port, keydumpTotalLines, keydumpTimeout)
+	lines, err := collectLines(lineCh, keydumpTotalLines, keydumpTimeout)
 	if err != nil {
 		log.Printf("KEYDUMP read failed: %v (continuing normal boot)", err)
 		return false, nil
@@ -110,27 +152,8 @@ func run(cfg config) (bool, error) {
 	return true, nil
 }
 
-// readLines reads up to count newline-delimited lines from r within the
-// given timeout. Returns whatever lines were collected if the timeout fires
-// before all lines arrive.
-func readLines(r io.Reader, count int, timeout time.Duration) ([]string, error) {
-	type result struct {
-		line string
-		err  error
-	}
-
-	ch := make(chan result, count)
-	go func() {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			ch <- result{line: scanner.Text()}
-		}
-		if err := scanner.Err(); err != nil {
-			ch <- result{err: err}
-		}
-		close(ch)
-	}()
-
+// collectLines drains up to count lines from ch within the given timeout.
+func collectLines(ch <-chan lineResult, count int, timeout time.Duration) ([]string, error) {
 	var lines []string
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -150,6 +173,24 @@ func readLines(r io.Reader, count int, timeout time.Duration) ([]string, error) 
 		}
 	}
 	return lines, nil
+}
+
+// readLines reads up to count newline-delimited lines from r within the
+// given timeout. Returns whatever lines were collected if the timeout fires
+// before all lines arrive.
+func readLines(r io.Reader, count int, timeout time.Duration) ([]string, error) {
+	ch := make(chan lineResult, count)
+	go func() {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			ch <- lineResult{line: sc.Text()}
+		}
+		if err := sc.Err(); err != nil {
+			ch <- lineResult{err: err}
+		}
+		close(ch)
+	}()
+	return collectLines(ch, count, timeout)
 }
 
 // parseStarHeld checks the KEYDUMP output for the * key (row 3, col 0).

--- a/pi/digits-panic-check/main_test.go
+++ b/pi/digits-panic-check/main_test.go
@@ -218,7 +218,7 @@ func TestRun_StarHeld(t *testing.T) {
 	tmpDir := t.TempDir()
 	flagPath := filepath.Join(tmpDir, "recovery-mode")
 
-	response := keydumpResponse([4][3]int{
+	response := "PONG\n" + keydumpResponse([4][3]int{
 		{1, 1, 1},
 		{1, 1, 1},
 		{1, 1, 1},
@@ -265,7 +265,7 @@ func TestRun_StarHeld(t *testing.T) {
 }
 
 func TestRun_NoKeyHeld(t *testing.T) {
-	response := keydumpResponse([4][3]int{
+	response := "PONG\n" + keydumpResponse([4][3]int{
 		{1, 1, 1},
 		{1, 1, 1},
 		{1, 1, 1},
@@ -372,7 +372,7 @@ func TestRun_WriteFails(t *testing.T) {
 
 func TestRun_MalformedResponse(t *testing.T) {
 	mock := &mockSerial{
-		rx: bytes.NewBufferString("garbage line 1\ngarbage line 2\ngarbage 3\ngarbage 4\ngarbage 5\ngarbage 6\n"),
+		rx: bytes.NewBufferString("PONG\ngarbage line 1\ngarbage line 2\ngarbage 3\ngarbage 4\ngarbage 5\ngarbage 6\n"),
 	}
 
 	cfg := config{
@@ -399,7 +399,7 @@ func TestRun_MalformedResponse(t *testing.T) {
 func TestRun_PartialResponse(t *testing.T) {
 	// Only 3 lines instead of 6.
 	mock := &mockSerial{
-		rx: bytes.NewBufferString("ROWS: R0/GP27=1\nCOLS: C0/GP24=1\nSCAN R0/GP27=LOW: C0=1\n"),
+		rx: bytes.NewBufferString("PONG\nROWS: R0/GP27=1\nCOLS: C0/GP24=1\nSCAN R0/GP27=LOW: C0=1\n"),
 	}
 
 	cfg := config{
@@ -429,6 +429,7 @@ func TestRun_V1FourColumns(t *testing.T) {
 	flagPath := filepath.Join(tmpDir, "recovery-mode")
 
 	var b strings.Builder
+	b.WriteString("PONG\n")
 	b.WriteString("ROWS: R0/GP2=1 R1/GP3=1 R2/GP4=1 R3/GP5=1\n")
 	b.WriteString("COLS: C0/GP6=1 C1/GP7=1 C2/GP8=1 C3/GP9=1\n")
 	b.WriteString("SCAN R0/GP2=LOW: C0=1 C1=1 C2=1 C3=1\n")

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -3043,12 +3043,11 @@ func main() {
 					cb.pairingCode = ""
 					sp.StateSet("PAIRED")
 					mixer.StopAll()
-					mixer.PlayOnce("tone_dial")
-					// Restart to reconnect with the assigned phone number
+					sp.SendFire("TONE:DIAL")
 					slog.Info("signal: restarting to register", "number", msg.Number)
 					go func() {
-						time.Sleep(2 * time.Second) // let dial tone play briefly
-						os.Exit(0)                  // systemd will restart us
+						time.Sleep(1 * time.Second)
+						os.Exit(0) // systemd restarts; Pico tone survives
 					}()
 				}
 


### PR DESCRIPTION
## Summary

Three connected boot-state bugs:

- **Panic-check fails at boot**: the Pico isn't ready when `digits-panic-check` runs at sysinit. Added PING/PONG retry loop (5 attempts, 500ms spacing) before KEYDUMP so it waits for the Pico. Refactored serial reading to use a shared scanner goroutine to avoid data races between PING and KEYDUMP reads.
- **Firmware FSM ignores initial hook state**: if the handset is off-hook at power-on, no HOOK:OFF event fires because the FSM only reacts to state changes. Added `hook_is_off_hook()` check in `phone_fsm_init()` to emit HOOK:OFF over UART if the handset is already lifted.
- **Post-pairing dial tone dies on restart**: `mixer.PlayOnce("tone_dial")` dies when `os.Exit(0)` kills the process. Switched to `sp.SendFire("TONE:DIAL")` so the Pico plays the tone independently and it survives the digitsd restart.

## Test plan

- [ ] Hold `*` key on keypad during power-on: device enters recovery mode
- [ ] Power on with handset off-hook: digitsd log shows `RX line=HOOK:OFF` early, controller enters dial tone
- [ ] Pair device: Pico dial tone plays continuously through digitsd restart
- [ ] Normal boot (no keys held, handset on-hook): no regression, boots normally
- [ ] Panic-check logs: `PING: PONG` followed by `KEYDUMP` parsed successfully
- [ ] `go test -v` in `pi/digits-panic-check/`: 14/14 tests pass