### PR TITLE
chore(server): drop unused HTTP client tracing transport

### DIFF
--- a/server/internal/tracing/tracing.go
+++ b/server/internal/tracing/tracing.go
@@ -13,8 +13,6 @@
 //     template strings; unknown paths collapse to "other". The default
 //     otelhttp span name (the raw URL.Path) is replaced by the bucketed
 //     route so a span name itself never echoes user data.
-//   - HTTP client spans: same approach for outbound requests; request URL
-//     is reduced to host plus a static path label set by the caller.
 //   - Database client spans: query category (SELECT, INSERT, UPDATE, etc.)
 //     plus a static table name when the driver-supplied operation lookup
 //     can attribute one. SQL text and bound parameters never reach a span
@@ -378,69 +376,4 @@ func isNoiseRoute(path string) bool {
 		return true
 	}
 	return false
-}
-
-// HTTPClientTransport wraps base with a tracing transport that injects
-// W3C traceparent on outbound requests and produces one client span per
-// request. The span carries:
-//
-//   - http.method
-//   - http.status_code (set after the request returns)
-//   - server.address: the destination host (already a configured
-//     service hostname for our internal calls; never a user-derived
-//     value)
-//
-// We deliberately do NOT use otelhttp.NewTransport. That wrapper records
-// url.full and url.path as raw strings, which for any per-call outbound
-// (today: none; tomorrow: who knows) would echo path components into a
-// span attribute. The strip-and-bucket pattern is enforced at the
-// transport rather than every call site so a future caller cannot
-// regress the privacy boundary by forgetting an option.
-func HTTPClientTransport(base http.RoundTripper) http.RoundTripper {
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	return &tracingTransport{
-		base:   base,
-		tracer: otel.Tracer("github.com/justinlindh/digits/server/internal/tracing"),
-	}
-}
-
-// tracingTransport implements http.RoundTripper. It is intentionally
-// minimal; the OTel SDK does the heavy lifting via tracer.Start and the
-// global propagator.
-type tracingTransport struct {
-	base   http.RoundTripper
-	tracer trace.Tracer
-}
-
-// RoundTrip starts a client span, injects traceparent into the request
-// headers, dispatches via the wrapped transport, and records the status.
-func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	propagator := otel.GetTextMapPropagator()
-
-	ctx, span := t.tracer.Start(req.Context(), "HTTP "+req.Method,
-		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			attribute.String("http.method", req.Method),
-			attribute.String("server.address", req.URL.Host),
-		),
-	)
-	defer span.End()
-
-	// Clone the request so traceparent header injection does not mutate
-	// a caller-owned *http.Request. Headers cloned by req.Clone are deep
-	// copies, so adding traceparent here doesn't leak into a retry's
-	// header set.
-	req = req.Clone(ctx)
-	propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
-
-	resp, err := t.base.RoundTrip(req)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	}
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
-	return resp, nil
 }

--- a/server/internal/tracing/tracing_test.go
+++ b/server/internal/tracing/tracing_test.go
@@ -232,45 +232,6 @@ func TestHTTPServerMiddlewareFiltersNoiseRoutes(t *testing.T) {
 	}
 }
 
-// TestHTTPClientTransportInjectsTraceparent confirms outbound requests
-// carry the W3C traceparent header when wrapped via HTTPClientTransport.
-// Without this, any cross-service hop would produce two disconnected
-// traces in Tempo instead of a parent-child pair.
-func TestHTTPClientTransportInjectsTraceparent(t *testing.T) {
-	withRecording(t)
-
-	var seenHeader string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		seenHeader = r.Header.Get("Traceparent")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	client := &http.Client{Transport: HTTPClientTransport(http.DefaultTransport)}
-
-	// A traceparent header is only injected when there is an active span.
-	// Start a span around the request so otelhttp has a context to lift.
-	tracer := otel.Tracer("test")
-	ctx, span := tracer.Start(context.Background(), "outer")
-	defer span.End()
-	req, err := http.NewRequestWithContext(ctx, "GET", srv.URL, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = resp.Body.Close()
-	if seenHeader == "" {
-		t.Fatal("server did not see Traceparent header from wrapped client")
-	}
-	// Per the W3C Trace Context spec, the value is "version-traceid-spanid-flags".
-	if !strings.HasPrefix(seenHeader, "00-") {
-		t.Errorf("Traceparent has unexpected version: %q", seenHeader)
-	}
-}
-
 // TestHTTPServerMiddlewareNeverEchoesNumber is the belt-and-suspenders
 // guard test that mirrors metrics.TestRouteOfNeverEchoesNumber. If a
 // future maintainer adds a route case that lets a phone number through,


### PR DESCRIPTION
## Summary

`tracing.HTTPClientTransport`, the `tracingTransport` struct, and its `RoundTrip` implementation were scaffolded as a privacy-respecting wrapper around outbound HTTP calls. The package comment itself admits there are zero production callers (`today: none; tomorrow: who knows`), and a code search confirms it: nothing wires the transport in. The only reference is the test that exercises the transport directly.

## Shape of the change

- Delete `HTTPClientTransport`, `tracingTransport`, and `tracingTransport.RoundTrip` from `server/internal/tracing/tracing.go`.
- Delete `TestHTTPClientTransportInjectsTraceparent` from `server/internal/tracing/tracing_test.go`.
- Drop the corresponding bullet from the package doc's "what is collected" list.

The privacy posture for inbound traces is unchanged: `HTTPServerMiddleware` and the noise-route filter stay exactly as they were. When a future caller actually needs traced outbound HTTP, the wrapper can come back with whatever shape that use case requires, instead of one that was guessed in advance.

## Test plan

- [x] `go build ./...` (server)
- [x] `go test ./...` (server, autodeploy failure is pre-existing on main)
- [x] `golangci-lint run ./...`