### PR TITLE
chore(server): drop unused pairing.Store.RegenerateCode

### DIFF
--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -175,30 +175,6 @@ func (s *Store) CleanupExpired(ctx context.Context) (int64, error) {
 	return res.RowsAffected()
 }
 
-// RegenerateCode forces a new pairing code for the given hardware ID,
-// replacing any existing (valid or expired) code.
-func (s *Store) RegenerateCode(ctx context.Context, hardwareID string) (string, error) {
-	code, err := randomCode(CodeLength)
-	if err != nil {
-		return "", fmt.Errorf("generate code: %w", err)
-	}
-	expiresAt := time.Now().Add(CodeTTL)
-
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE devices
-		SET pairing_code = $2, pairing_code_expires_at = $3
-		WHERE hardware_id = $1 AND paired_at IS NULL
-	`, hardwareID, code, expiresAt)
-	if err != nil {
-		return "", fmt.Errorf("regenerate code: %w", err)
-	}
-	rows, _ := res.RowsAffected()
-	if rows == 0 {
-		return s.GenerateCode(ctx, hardwareID)
-	}
-	return code, nil
-}
-
 func randomHex(n int) (string, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -192,42 +192,6 @@ func TestCleanupExpiredCodes(t *testing.T) {
 	}
 }
 
-func TestRegenerateCode(t *testing.T) {
-	s := setupStore(t)
-	hwID := "test-hw-regen-001"
-	t.Cleanup(func() {
-		_, _ = s.db.Exec("DELETE FROM devices WHERE hardware_id = $1", hwID)
-	})
-
-	// Generate initial code
-	code1, err := s.GenerateCode(context.Background(), hwID)
-	if err != nil {
-		t.Fatalf("GenerateCode: %v", err)
-	}
-
-	// Regenerate — must return a 6-digit code
-	code2, err := s.RegenerateCode(context.Background(), hwID)
-	if err != nil {
-		t.Fatalf("RegenerateCode: %v", err)
-	}
-
-	if len(code2) != CodeLength {
-		t.Errorf("expected %d-digit code, got %q (len %d)", CodeLength, code2, len(code2))
-	}
-
-	// Statistically very unlikely to be the same; treat equality as a failure
-	if code1 == code2 {
-		t.Logf("note: regenerated code happens to match original (%q); rerunning once", code1)
-		code3, err := s.RegenerateCode(context.Background(), hwID)
-		if err != nil {
-			t.Fatalf("RegenerateCode retry: %v", err)
-		}
-		if code1 == code3 {
-			t.Errorf("regenerated code matched original twice (%q) — likely a bug", code1)
-		}
-	}
-}
-
 func TestRandomCode(t *testing.T) {
 	code, err := randomCode(6)
 	if err != nil {


### PR DESCRIPTION
## Summary

`pairing.Store.RegenerateCode` forces a fresh pairing code into a device row, falling back to `GenerateCode` when no row exists yet. Pairing today actually runs through `GenerateCode` directly (it already handles both the insert and the rotate-on-existing-row paths via the upsert SQL), and nothing in the server, the cmd binaries, or the digitsd / pi side calls `RegenerateCode`. The only reference is its own integration test.

Verified with `golang.org/x/tools/cmd/deadcode` and a manual `rg RegenerateCode` across the repo.

## Shape of the change

- Delete `RegenerateCode` from `server/internal/pairing/pairing.go`.
- Delete `TestRegenerateCode` from `pairing_test.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet -tags integration ./...`
- [x] `go test ./...` (autodeploy failure is pre-existing on main)
- [x] `golangci-lint run ./...`