### PR TITLE
docs: drop digits-setup binary references missed by #450

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2237,11 +2237,12 @@ func main() {
 		slog.Info("service code: *#SETUP# (*#73887#) -> awaiting confirmation")
 		confirm("confirm_wifi_setup", func() {
 			slog.Info("service code setup confirmed: removing wifi-configured flag, rebooting")
-			// /data/wifi-configured is owned by root (digits-setup writes it
-			// as root); /data itself is mode 755 root:root. digitsd runs as
-			// the 'digits' user, which lacks write access to /data and so
-			// cannot unlink the flag directly. The digits-updater sudoers
-			// entry grants NOPASSWD on rm -f for this exact path.
+			// /data/wifi-configured is owned by root (digitsd writes it as
+			// root from --mode=setup); /data itself is mode 755 root:root.
+			// digitsd in normal mode runs as the 'digits' user, which lacks
+			// write access to /data and so cannot unlink the flag directly.
+			// The digits-updater sudoers entry grants NOPASSWD on rm -f for
+			// this exact path.
 			out, err := exec.Command("sudo", "/usr/bin/rm", "-f", phone.WifiConfiguredFlag).CombinedOutput()
 			if err != nil {
 				slog.Warn("service code setup: remove wifi flag failed", "path", phone.WifiConfiguredFlag, "error", err, "output", strings.TrimSpace(string(out)))

--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -14,8 +14,9 @@
 # is downloaded automatically and cached in a Docker volume for reuse.
 #
 # Default: downloads pre-built binaries from the latest pi/v* GitHub release.
-# Requires a Go toolchain for `make embed` (cross-compiles digits-setup into
-# the rootfs overlay). Pin a specific release with RELEASE_TAG:
+# Requires a Go toolchain for `make embed` (stages the rootfs overlay, tones,
+# and mixer state into pi/digitsd/internal/assets/embed). Pin a specific
+# release with RELEASE_TAG:
 #
 #   RELEASE_TAG=pi/v1.21.0 ./pi/image/build-docker.sh --pcb
 #

--- a/pi/image/rootfs-overlay/etc/systemd/system/wpa_supplicant@wlan0.service.d/digits.conf
+++ b/pi/image/rootfs-overlay/etc/systemd/system/wpa_supplicant@wlan0.service.d/digits.conf
@@ -1,5 +1,5 @@
 # Override wpa_supplicant@wlan0.service to read credentials from /data
-# (the read-write partition written by digits-setup during provisioning).
+# (the read-write partition written by digitsd --mode=setup during provisioning).
 #
 # ExecStart= must be cleared before reassigning in a drop-in.
 [Service]

--- a/tools/README-image-builder.md
+++ b/tools/README-image-builder.md
@@ -56,18 +56,13 @@ You also need Go 1.22+ installed.
 ### Build Steps
 
 ```bash
-# 1. Cross-compile binaries
+# 1. Cross-compile the digitsd binary (also serves recovery and setup modes)
 mkdir -p tools/build
 
 cd pi/digitsd
 PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
   CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOOS=linux GOARCH=arm64 \
   go build -o ../../tools/build/digitsd ./cmd/digitsd/
-cd ../..
-
-cd pi/digits-setup
-CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-  go build -o ../../tools/build/digits-setup ./cmd/digits-setup/
 cd ../..
 
 # 2. Download Raspberry Pi OS Lite (Bookworm, 64-bit)


### PR DESCRIPTION
## What

Update four files that still attribute work to the deleted `digits-setup` binary, after #450 consolidated it into `digitsd --mode=setup` and deleted `pi/digits-setup/`.

- `tools/README-image-builder.md`: the manual-build instructions told readers to `cd pi/digits-setup` and `go build ./cmd/digits-setup/`. That directory no longer exists, so the command fails. Drop the dead step; the digitsd build above it covers normal, recovery, and setup modes from one binary.
- `pi/image/build-docker.sh`: header comment claimed `make embed` "cross-compiles digits-setup into the rootfs overlay". `make embed` actually stages the rootfs overlay, tones, and mixer state into `pi/digitsd/internal/assets/embed`; no binary is built at that step.
- `pi/digitsd/cmd/digitsd/main.go`: the `*#SETUP#` service-code handler comment said "digits-setup writes it as root". The writer is now `digitsd --mode=setup`; reword to describe the current mode-aware ownership story.
- `pi/image/rootfs-overlay/etc/systemd/system/wpa_supplicant@wlan0.service.d/digits.conf`: same `digits-setup` attribution, same fix.

## Why

This is cross-PR doc drift that single-PR review missed: #450 was a 69-file consolidation, the surrounding PRs in the phase sequence (#458, #463, #465) didn't touch these spots, and follow-up #460 only updated the deploy-phone skill. The README breakage is a hard error for anyone trying the manual build path; the comment ones are quietly wrong.

## Out of scope (intentionally not touched)

- `digits-setup.service` (systemd unit) is unchanged and still real, just running `digitsd --mode=setup`. References to the unit name from `digits-ap-check`, `verify.go`, and `docs/build/wiring.md` are still accurate.

## Test plan

- [ ] Manual-build instructions in `tools/README-image-builder.md` execute cleanly (single `cd pi/digitsd` step).
- [ ] No remaining `pi/digits-setup` or `cmd/digits-setup` path references via `rg "pi/digits-setup|cmd/digits-setup"`.
