### PR TITLE
fix(server): security hardening across signaling, pairing, and auth

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -179,7 +179,7 @@ func run(ctx context.Context) error {
 		if cfg.TURNSecret == "" {
 			return errors.New("SIGNALD_TURN_SECRET must be set when TURN is enabled")
 		}
-		relay.TURNGen = turn.NewCredentialGenerator(cfg.TURNSecret, 24*time.Hour)
+		relay.TURNGen = turn.NewCredentialGenerator(cfg.TURNSecret, 2*time.Hour)
 		relay.TURNDomain = cfg.TURNDomain
 		slog.Info("TURN credential generation enabled", "domain", cfg.TURNDomain)
 	}

--- a/server/docker-compose.prod.yml
+++ b/server/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
     restart: unless-stopped
     environment:
       SIGNALD_ADDR: ":8080"
-      DATABASE_URL: "postgres://${DB_USER:-digits}:${DB_PASSWORD:-changeme}@user-db:5432/digits?sslmode=disable"
+      DATABASE_URL: "postgres://${DB_USER:-digits}:${DB_PASSWORD}@user-db:5432/digits?sslmode=disable"
       SMTP_HOST: "${SMTP_HOST:-}"
       SMTP_PORT: "${SMTP_PORT:-587}"
       SMTP_USER: "${SMTP_USER:-}"
@@ -45,7 +45,7 @@ services:
     environment:
       POSTGRES_DB: digits
       POSTGRES_USER: digits
-      POSTGRES_PASSWORD: "${DB_PASSWORD:-digits}"
+      POSTGRES_PASSWORD: "${DB_PASSWORD}"
     volumes:
       - user_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -135,7 +135,7 @@ func (s *Store) AuthStatus(ctx context.Context, hardwareID, token string) (paire
 // BoundLineNumber returns the line number assigned to the paired device with
 // the given hardware ID. Returns ("", nil) if the device has no bound line.
 func (s *Store) BoundLineNumber(ctx context.Context, hardwareID string) (string, error) {
-	var number sql.NullString
+	var number string
 	err := s.db.QueryRowContext(ctx, `
 		SELECT l.number FROM devices d
 		JOIN lines l ON l.id = d.line_id
@@ -147,6 +147,6 @@ func (s *Store) BoundLineNumber(ctx context.Context, hardwareID string) (string,
 	if err != nil {
 		return "", fmt.Errorf("bound line number: %w", err)
 	}
-	return number.String, nil
+	return number, nil
 }
 

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -132,3 +132,21 @@ func (s *Store) AuthStatus(ctx context.Context, hardwareID, token string) (paire
 	return true, valid, nil
 }
 
+// BoundLineNumber returns the line number assigned to the paired device with
+// the given hardware ID. Returns ("", nil) if the device has no bound line.
+func (s *Store) BoundLineNumber(ctx context.Context, hardwareID string) (string, error) {
+	var number sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		SELECT l.number FROM devices d
+		JOIN lines l ON l.id = d.line_id
+		WHERE d.hardware_id = $1 AND d.paired_at IS NOT NULL
+	`, hardwareID).Scan(&number)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("bound line number: %w", err)
+	}
+	return number.String, nil
+}
+

--- a/server/internal/httputil/clientip.go
+++ b/server/internal/httputil/clientip.go
@@ -11,25 +11,22 @@ import (
 
 // ClientIP returns the resolved client IP for an inbound HTTP request.
 //
-// Preference order:
-//  1. The first entry of X-Forwarded-For, trimmed.
-//  2. Host portion of r.RemoteAddr (port stripped).
-//  3. r.RemoteAddr verbatim if SplitHostPort cannot parse it.
-//
-// Assumption: a single trusted reverse proxy (nginx-proxy-manager) is the
-// only writer of X-Forwarded-For. Behind that assumption the leftmost
-// XFF entry is the original client. If the deployment grows additional
-// proxies, this function must be revisited.
+// X-Forwarded-For is only trusted when RemoteAddr is a private or loopback
+// address, meaning the request arrived through a local reverse proxy. Direct
+// connections from untrusted networks use RemoteAddr so an attacker cannot
+// rotate XFF to bypass rate limiters.
 func ClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		parts := strings.SplitN(xff, ",", 2)
-		return strings.TrimSpace(parts[0])
-	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		return r.RemoteAddr
+		remoteHost = r.RemoteAddr
 	}
-	return host
+	if IsPrivateAddr(remoteHost) {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.SplitN(xff, ",", 2)
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	return remoteHost
 }
 
 // IsPrivateAddr reports whether ip parses as an address we treat as

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -55,6 +55,7 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 		VALUES (NULL, $1, $2, $3)
 		ON CONFLICT (hardware_id) DO UPDATE
 		SET pairing_code = $2, pairing_code_expires_at = $3
+		WHERE devices.paired_at IS NULL
 	`, hardwareID, newCode, expiresAt)
 	if err != nil {
 		return "", fmt.Errorf("upsert pairing code: %w", err)

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -10,6 +10,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/lib/pq"
+
+	"github.com/justinlindh/digits/server/internal/dbutil"
 	"github.com/justinlindh/digits/server/internal/device"
 )
 
@@ -17,7 +20,7 @@ const (
 	// CodeLength is the number of digits in a pairing code.
 	CodeLength = 6
 	// CodeTTL is how long a pairing code remains valid.
-	CodeTTL = 10 * time.Minute
+	CodeTTL = 3 * time.Minute
 )
 
 var (
@@ -36,24 +39,10 @@ func NewStore(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
-// GenerateCode returns a 6-digit pairing code for the given hardware ID.
-// If a valid (non-expired, unpaired) code already exists, it is reused.
+// GenerateCode creates a fresh 6-digit pairing code for the given hardware ID,
+// replacing any previously issued code. A new code is generated on every call
+// so that a leaked code becomes invalid as soon as the device reconnects.
 func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, error) {
-	// Check for existing valid code
-	var code sql.NullString
-	err := s.db.QueryRowContext(ctx, `
-		SELECT pairing_code FROM devices
-		WHERE hardware_id = $1
-		  AND pairing_code IS NOT NULL
-		  AND pairing_code_expires_at > NOW()
-		  AND paired_at IS NULL
-	`, hardwareID).Scan(&code)
-
-	if err == nil && code.Valid {
-		return code.String, nil
-	}
-
-	// Generate a new code
 	newCode, err := randomCode(CodeLength)
 	if err != nil {
 		return "", fmt.Errorf("generate code: %w", err)
@@ -61,8 +50,6 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 
 	expiresAt := time.Now().Add(CodeTTL)
 
-	// Upsert: insert device row if it doesn't exist, or update the pairing code.
-	// New devices get line_id=NULL until pairing completes and a line is created.
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO devices (line_id, hardware_id, pairing_code, pairing_code_expires_at)
 		VALUES (NULL, $1, $2, $3)
@@ -76,72 +63,69 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 	return newCode, nil
 }
 
-// ClaimDevice pairs a device using a pairing code, creating or looking up the
-// line and assigning the device to it.
+// ClaimDevice pairs a device using a pairing code, creating the line and
+// assigning the device in a single transaction. If any step fails the whole
+// operation rolls back, leaving the device claimable with a fresh code.
 // Returns (deviceToken, hardwareID, error).
 func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, householdID string) (string, string, error) {
-	// Check line number uniqueness
-	var count int
-	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM lines WHERE number = $1`,
-		lineNumber,
-	).Scan(&count)
-	if err != nil {
-		return "", "", fmt.Errorf("check number uniqueness: %w", err)
-	}
-	if count > 0 {
-		return "", "", ErrNumberTaken
-	}
-
-	// Find the device with this pairing code
-	var deviceID int64
-	var hardwareID sql.NullString
-	err = s.db.QueryRowContext(ctx, `
-		SELECT id, hardware_id FROM devices
-		WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
-	`, code).Scan(&deviceID, &hardwareID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", "", ErrInvalidCode
-	}
-	if err != nil {
-		return "", "", fmt.Errorf("lookup pairing code: %w", err)
-	}
-
-	// Create the line
-	var lineID int64
-	err = s.db.QueryRowContext(ctx, `
-		INSERT INTO lines (number, name, household_id)
-		VALUES ($1, $2, $3)
-		RETURNING id
-	`, lineNumber, lineName, householdID).Scan(&lineID)
-	if err != nil {
-		return "", "", fmt.Errorf("create line: %w", err)
-	}
-
 	token, err := randomHex(32)
 	if err != nil {
 		return "", "", fmt.Errorf("generate device token: %w", err)
 	}
 	tokenHash := device.HashToken(token)
 
-	// Update device: set line_id, device_token (hashed), mark as paired, clear pairing code
-	res, err := s.db.ExecContext(ctx, `
-		UPDATE devices
-		SET line_id = $2, device_token = $3,
-		    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
-		WHERE id = $1 AND paired_at IS NULL
-	`, deviceID, lineID, tokenHash)
-	if err != nil {
-		return "", "", fmt.Errorf("claim device: %w", err)
+	var hardwareID string
+	if err := dbutil.WithTx(ctx, s.db, func(tx *sql.Tx) error {
+		// Lock the device row to prevent concurrent claims.
+		var deviceID int64
+		var hwID sql.NullString
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, hardware_id FROM devices
+			WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
+			FOR UPDATE
+		`, code).Scan(&deviceID, &hwID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrInvalidCode
+		}
+		if err != nil {
+			return fmt.Errorf("lookup pairing code: %w", err)
+		}
+		hardwareID = hwID.String
+
+		// Insert the line. The unique constraint on number rejects collisions
+		// without a separate SELECT + INSERT race window.
+		var lineID int64
+		err = tx.QueryRowContext(ctx, `
+			INSERT INTO lines (number, name, household_id)
+			VALUES ($1, $2, $3)
+			RETURNING id
+		`, lineNumber, lineName, householdID).Scan(&lineID)
+		if err != nil {
+			if isUniqueViolation(err) {
+				return ErrNumberTaken
+			}
+			return fmt.Errorf("create line: %w", err)
+		}
+
+		// Bind device to the line, mark paired, clear the pairing code.
+		res, err := tx.ExecContext(ctx, `
+			UPDATE devices
+			SET line_id = $2, device_token = $3,
+			    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
+			WHERE id = $1 AND paired_at IS NULL
+		`, deviceID, lineID, tokenHash)
+		if err != nil {
+			return fmt.Errorf("claim device: %w", err)
+		}
+		rows, _ := res.RowsAffected()
+		if rows == 0 {
+			return ErrInvalidCode
+		}
+		return nil
+	}); err != nil {
+		return "", "", err
 	}
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return "", "", fmt.Errorf("claim device rows: %w", err)
-	}
-	if rows == 0 {
-		return "", "", ErrInvalidCode
-	}
-	return token, hardwareID.String, nil
+	return token, hardwareID, nil
 }
 
 // IsPaired returns whether the device with the given hardware ID has been paired.
@@ -173,6 +157,11 @@ func (s *Store) CleanupExpired(ctx context.Context) (int64, error) {
 		return 0, fmt.Errorf("cleanup expired codes: %w", err)
 	}
 	return res.RowsAffected()
+}
+
+func isUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && pqErr.Code == "23505"
 }
 
 func randomHex(n int) (string, error) {

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -59,7 +59,7 @@ func TestGenerateCode_Returns6Digits(t *testing.T) {
 	}
 }
 
-func TestGenerateCode_ReusesBeforeExpiry(t *testing.T) {
+func TestGenerateCode_RotatesOnEveryCall(t *testing.T) {
 	s := setupStore(t)
 	code1, err := s.GenerateCode(context.Background(), "test-hw-002")
 	if err != nil {
@@ -69,8 +69,8 @@ func TestGenerateCode_ReusesBeforeExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateCode 2: %v", err)
 	}
-	if code1 != code2 {
-		t.Errorf("expected same code before expiry, got %q and %q", code1, code2)
+	if code1 == code2 {
+		t.Errorf("expected rotated code on second call, got same %q both times", code1)
 	}
 }
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -102,7 +102,7 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeConferenceMerge:
 		r.handleConferenceMerge(ctx, from, msg)
 	case TypeDTMF:
-		r.forward(msg)
+		r.handleDTMF(ctx, from, msg)
 	case TypeRequestICE:
 		r.handleRequestICE(from)
 	case TypeDeviceInfo:
@@ -182,6 +182,32 @@ func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 	})
 }
 
+// inCallOrConference returns true if from and to are in an active 2-party
+// call or are co-members of the same conference. When the tracker is nil
+// (tests), all traffic is allowed.
+func (r *Relay) inCallOrConference(from, to string) bool {
+	if r.Tracker == nil {
+		return true
+	}
+	if r.Tracker.InCall(from, to) {
+		return true
+	}
+	ct := r.Tracker.Conferences()
+	if conf := ct.ConferenceByPhone(from); conf != nil {
+		return ct.ConferenceContains(conf.ID, from, to)
+	}
+	return false
+}
+
+func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
+	if !r.inCallOrConference(from, msg.To) {
+		slog.Warn("dtmf without active call", "from", from, "to", msg.To)
+		r.observeError("invalid_message")
+		return
+	}
+	r.forward(msg)
+}
+
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
 	if r.Tracker != nil && !r.Tracker.InCall(from, msg.To) {
 		slog.Warn("ice_restart without active call", "from", from, "to", msg.To)
@@ -227,8 +253,9 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 	if r.Tracker != nil {
 		peers = r.Tracker.AllPeersOf(from)
 	}
-	if len(peers) == 0 && msg.To != "" {
-		peers = []string{msg.To}
+	if len(peers) == 0 {
+		slog.Debug("hangup from phone not in any active call", "from", from)
+		return
 	}
 	for _, peer := range peers {
 		if r.Tracker != nil {
@@ -254,6 +281,11 @@ func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
 			return
 		}
 	}
+	if !r.inCallOrConference(from, msg.To) {
+		slog.Warn("sdp without active call", "from", from, "to", msg.To)
+		r.observeError("invalid_message")
+		return
+	}
 	r.forward(msg)
 }
 
@@ -270,6 +302,11 @@ func (r *Relay) handleICE(ctx context.Context, from string, msg *Message) {
 			})
 			return
 		}
+	}
+	if !r.inCallOrConference(from, msg.To) {
+		slog.Warn("ice without active call", "from", from, "to", msg.To)
+		r.observeError("invalid_message")
+		return
 	}
 	r.forward(msg)
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -209,9 +209,8 @@ func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
-	if r.Tracker != nil && !r.Tracker.InCall(from, msg.To) {
+	if !r.inCallOrConference(from, msg.To) {
 		slog.Warn("ice_restart without active call", "from", from, "to", msg.To)
-		// invalid_message: ICE restart received outside a call.
 		r.observeError("invalid_message")
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
 		return
@@ -220,6 +219,11 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 }
 
 func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
+	if !r.inCallOrConference(from, msg.To) {
+		slog.Warn("answer without active call", "from", from, "to", msg.To)
+		r.observeError("invalid_message")
+		return
+	}
 	if r.Tracker != nil {
 		if err := r.Tracker.OnCallAnswered(ctx, msg.To, from); err != nil {
 			slog.Error("failed to track call answer", "err", err)

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -603,7 +603,7 @@ func (h *Handler) Router() http.Handler {
 	mux.Handle("/", protectedHandler)
 
 	// Wrap with root-domain redirect before security headers.
-	wrapped := rootDomainRedirect(h.cfg.BaseURL, securityHeadersMiddleware(mux))
+	wrapped := rootDomainRedirect(h.cfg.BaseURL, csrfOriginCheck(h.cfg.BaseURL, securityHeadersMiddleware(h.cfg.BaseURL, mux)))
 	// Metrics middleware sits outside redirect/security headers so it
 	// sees the actual response code and duration including any redirect
 	// header work above. RouteOf bucket is computed from the request
@@ -646,15 +646,45 @@ func isGateExempt(path string, extra ...string) bool {
 	return false
 }
 
-func securityHeadersMiddleware(next http.Handler) http.Handler {
+func securityHeadersMiddleware(baseURL string, next http.Handler) http.Handler {
+	connectSrc := "'self' wss:"
+	if baseURL != "" {
+		wssOrigin := strings.Replace(baseURL, "https://", "wss://", 1)
+		wssOrigin = strings.Replace(wssOrigin, "http://", "ws://", 1)
+		connectSrc = "'self' " + wssOrigin
+	}
+	csp := fmt.Sprintf("default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src %s; frame-ancestors 'none'", connectSrc)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' wss:; frame-ancestors 'none'")
+		w.Header().Set("Content-Security-Policy", csp)
 		if r.TLS != nil {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// csrfOriginCheck rejects state-changing requests (POST/PUT/DELETE/PATCH)
+// whose Origin header does not match the configured base URL. GET/HEAD/OPTIONS
+// are safe methods and pass through. Requests with no Origin header are allowed
+// because non-browser clients (CLI tools, the Pi daemon) legitimately omit it.
+func csrfOriginCheck(baseURL string, next http.Handler) http.Handler {
+	if baseURL == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+			return
+		}
+		origin := r.Header.Get("Origin")
+		if origin != "" && origin != baseURL {
+			http.Error(w, "origin not allowed", http.StatusForbidden)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -12,7 +13,8 @@ import (
 )
 
 func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
-	if h.cfg.AdminSecret == "" || r.Header.Get("X-Admin-Secret") != h.cfg.AdminSecret {
+	if h.cfg.AdminSecret == "" ||
+		subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Admin-Secret")), []byte(h.cfg.AdminSecret)) != 1 {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -286,6 +286,28 @@ func (h *Handler) activeHousehold(r *http.Request) *household.Household {
 	return active
 }
 
+// requireHouseholdAdmin checks that the requesting user holds the "admin" role
+// in the active household. Returns (user, household, true) on success. On
+// failure it writes an appropriate redirect or 403 and returns (nil, nil, false).
+func (h *Handler) requireHouseholdAdmin(w http.ResponseWriter, r *http.Request) (*auth.User, *household.Household, bool) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
+		return nil, nil, false
+	}
+	hh := h.activeHousehold(r)
+	if hh == nil {
+		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+		return nil, nil, false
+	}
+	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
+	if err != nil || role != "admin" {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return nil, nil, false
+	}
+	return user, hh, true
+}
+
 // chromeData holds the fields every protected page-data struct shares for
 // rendering the layout chrome (sidebar, nav, DND chip, version pill). The
 // HouseholdName/HouseholdDND/CallHistoryEnabled methods read through the

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -83,14 +83,8 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	myHousehold := h.activeHousehold(r)
-	if myHousehold == nil {
-		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+	user, myHousehold, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 
@@ -177,15 +171,18 @@ func (h *Handler) handleLinksRevokePost(w http.ResponseWriter, r *http.Request) 
 		http.NotFound(w, r)
 		return
 	}
-	owned := false
+	isAdmin := false
 	for _, hh := range households {
 		if hh.ID == link.HouseholdAID || (link.HouseholdBID != nil && hh.ID == *link.HouseholdBID) {
-			owned = true
-			break
+			role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
+			if err == nil && role == "admin" {
+				isAdmin = true
+				break
+			}
 		}
 	}
-	if !owned {
-		http.NotFound(w, r)
+	if !isAdmin {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -62,14 +62,8 @@ func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -88,9 +82,8 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Request) {
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
@@ -107,9 +100,8 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"
@@ -139,9 +131,8 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request) {
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -201,14 +192,8 @@ func (h *Handler) handleSettingsAppearance(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/onboard", http.StatusSeeOther)
+	user, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -260,14 +245,8 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	inviteID := r.PathValue("id")
@@ -283,14 +262,8 @@ func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http
 }
 
 func (h *Handler) handleHouseholdMemberRemovePost(w http.ResponseWriter, r *http.Request) {
-	user := auth.UserFromContext(r.Context())
-	if user == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	hh := h.activeHousehold(r)
-	if hh == nil {
-		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	user, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
 		return
 	}
 	targetUserID := r.PathValue("id")

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1124,12 +1124,12 @@ func TestWSRegister_PairedDevice_CorrectToken(t *testing.T) {
 	srv := httptest.NewServer(h.Router())
 	defer srv.Close()
 
-	hwID, _, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
 
 	ws := dialWS(t, srv)
 	sendMsg(t, ws, signaling.Message{
 		Type:        signaling.TypeRegister,
-		Number:      "1001",
+		Number:      number,
 		HardwareID:  hwID,
 		DeviceToken: token,
 	})

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -56,7 +56,10 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check pairing and token status
+	// Check pairing and token status. For paired devices, the server-side
+	// bound line number is authoritative: a device cannot register as a
+	// line it is not paired to.
+	isPaired := false
 	if h.pairingStore != nil {
 		paired, tokenValid, err := h.deviceStore.AuthStatus(r.Context(), msg.HardwareID, msg.DeviceToken)
 		if err != nil {
@@ -74,7 +77,10 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 					PairingCode: code,
 				}))
 			}
-			// Continue to register so the device can receive the TypePaired message
+			// Unpaired devices register under their hardware ID (not a line
+			// number) so they can receive the TypePaired message via
+			// SendToHardware without displacing a real line's connection.
+			msg.Number = "unpaired:" + msg.HardwareID
 		} else if msg.DeviceToken == "" {
 			slog.Warn("ws register without device_token", "hardware_id", msg.HardwareID)
 			wsReject(ws, "device_token required")
@@ -83,6 +89,27 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 			slog.Warn("ws invalid device_token", "hardware_id", msg.HardwareID)
 			wsReject(ws, "invalid device_token")
 			return
+		} else {
+			isPaired = true
+			boundNumber, err := h.deviceStore.BoundLineNumber(r.Context(), msg.HardwareID)
+			if err != nil {
+				slog.Error("bound line lookup failed", "hardware_id", msg.HardwareID, "err", err)
+				wsReject(ws, "internal error")
+				return
+			}
+			if boundNumber == "" {
+				slog.Warn("paired device has no bound line", "hardware_id", msg.HardwareID)
+				wsReject(ws, "device has no assigned line")
+				return
+			}
+			if boundNumber != msg.Number {
+				slog.Warn("ws register number mismatch",
+					"hardware_id", msg.HardwareID,
+					"claimed", msg.Number,
+					"bound", boundNumber)
+				wsReject(ws, "number does not match paired line")
+				return
+			}
 		}
 	}
 
@@ -102,7 +129,9 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		wsReject(ws, "server shutting down")
 		return
 	}
-	h.relay.OnRegistered(r.Context(), msg.Number)
+	if isPaired {
+		h.relay.OnRegistered(r.Context(), msg.Number)
+	}
 	number := msg.Number
 
 	// Configure pong handler to extend read deadline on each pong


### PR DESCRIPTION
## Summary

Addresses 13 server-side security issues filed today (#471-#483):

**Critical**
- **#471**: Paired devices can no longer register as an arbitrary line number. The server validates `msg.Number` against the device's bound line via a new `BoundLineNumber` query. Unpaired devices register under `unpaired:<hardwareID>` so they cannot displace real line connections.
- **#472/#479/#480**: Pairing codes now rotate on every device reconnect (no reuse), TTL shortened from 10min to 3min, and `ClaimDevice` runs in a single transaction with `FOR UPDATE` + unique-constraint-based collision detection.

**High**
- **#473**: Relay gates SDP, ICE, DTMF on `inCallOrConference()`. Hangup fallback to `msg.To` removed: hangups from devices not in any call are dropped.
- **#474**: `ClientIP` only trusts `X-Forwarded-For` when `RemoteAddr` is a private address.
- **#475/#482**: Destructive household endpoints (rename, invite, remove member, DND, call history, timezone, link invite, link revoke) require admin role via new `requireHouseholdAdmin` helper.
- **#476**: CSRF Origin-check middleware rejects cross-origin state-changing requests.
- **#477**: Admin secret comparison uses `subtle.ConstantTimeCompare`.

**Medium**
- **#478**: TURN credential TTL reduced from 24h to 2h.
- **#481**: CSP `connect-src` pinned to configured wss origin instead of `wss:`.
- **#483**: Docker Compose prod file drops default DB passwords; missing `.env.prod` now fails loudly.

**Skipped (low severity, firmware/Pi side)**
- #484 (session TOCTOU, negligible timing edge), #485 (firmware atomic, no runtime impact today), #487 (digitsd UART, bounded by non-blocking send)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `make test` passes (all unit tests)
- [x] `golangci-lint run ./...` reports 0 issues
- [ ] Integration tests with Postgres (CI)
- [ ] Manual: pair a new device, verify code rotates on reconnect
- [ ] Manual: non-admin member cannot rename household or remove members
- [ ] Manual: WebSocket connects from the app, CSP blocks external wss