### PR TITLE
fix(server): admin-gate phone endpoints, fix unpaired filter, rate-limit /ws

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -590,10 +591,10 @@ func (h *Hub) LastSeenAt(number string) *time.Time {
 }
 
 // IsOnline returns true if number has an active hub connection and is not in
-// pairing mode. Unpaired devices connect under the sentinel "unpaired" number
+// pairing mode. Unpaired devices connect under the "unpaired:<hwID>" prefix
 // and must not be presented as online in the UI.
 func (h *Hub) IsOnline(number string) bool {
-	if number == "unpaired" {
+	if strings.HasPrefix(number, "unpaired:") {
 		return false
 	}
 	h.mu.RLock()
@@ -608,9 +609,11 @@ func (h *Hub) IsOnline(number string) bool {
 func (h *Hub) LocalConnectionCount() int {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	n := len(h.conns)
-	if _, ok := h.conns["unpaired"]; ok {
-		n--
+	n := 0
+	for key := range h.conns {
+		if !strings.HasPrefix(key, "unpaired:") {
+			n++
+		}
 	}
 	return n
 }
@@ -626,7 +629,7 @@ func (h *Hub) OnlineNumbers() []string {
 	defer h.mu.RUnlock()
 	nums := make([]string, 0, len(h.conns))
 	for n := range h.conns {
-		if n == "unpaired" {
+		if strings.HasPrefix(n, "unpaired:") {
 			continue
 		}
 		nums = append(nums, n)

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -35,11 +35,9 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 func TestIsOnlineReturnsFalseForUnpaired(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}
-	_ = hub.Register("unpaired", conn)
-	// A device in pairing mode is connected under "unpaired" but must not
-	// report as online for UI purposes.
-	if hub.IsOnline("unpaired") {
-		t.Fatal("IsOnline should return false for the unpaired sentinel number")
+	_ = hub.Register("unpaired:test-hw-xyz", conn)
+	if hub.IsOnline("unpaired:test-hw-xyz") {
+		t.Fatal("IsOnline should return false for unpaired devices")
 	}
 }
 

--- a/server/internal/signaling/state_redis.go
+++ b/server/internal/signaling/state_redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -85,7 +86,7 @@ func (s *DeviceState) OnlineNumbers(ctx context.Context) []string {
 	for iter.Next(ctx) {
 		key := iter.Val()
 		number := key[prefixLen:]
-		if number == "unpaired" {
+		if strings.HasPrefix(number, "unpaired:") {
 			continue
 		}
 		numbers = append(numbers, number)

--- a/server/internal/signaling/state_redis_test.go
+++ b/server/internal/signaling/state_redis_test.go
@@ -63,7 +63,7 @@ func TestDeviceStateOnlineNumbers(t *testing.T) {
 
 	ds.SetOnline(ctx, "5551111", DevicePresence{PodID: "p", HardwareID: "h1"})
 	ds.SetOnline(ctx, "5552222", DevicePresence{PodID: "p", HardwareID: "h2"})
-	ds.SetOnline(ctx, "unpaired", DevicePresence{PodID: "p", HardwareID: "h3"})
+	ds.SetOnline(ctx, "unpaired:test-hw-abc", DevicePresence{PodID: "p", HardwareID: "h3"})
 
 	numbers := ds.OnlineNumbers(ctx)
 
@@ -75,8 +75,8 @@ func TestDeviceStateOnlineNumbers(t *testing.T) {
 	if !got["5551111"] || !got["5552222"] {
 		t.Fatalf("expected both numbers, got %v", numbers)
 	}
-	if got["unpaired"] {
-		t.Fatal("unpaired should be excluded from OnlineNumbers")
+	if got["unpaired:test-hw-abc"] {
+		t.Fatal("unpaired device should be excluded from OnlineNumbers")
 	}
 }
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -242,6 +242,7 @@ type Handler struct {
 	googleLoginLimiter *ratelimit.Limiter // GET  /auth/google/login
 	pairingLimiter     *ratelimit.Limiter // POST /phones/pair
 	inviteLimiter      *ratelimit.Limiter // POST /settings/household/invite
+	wsLimiter          *ratelimit.Limiter // GET  /ws (WebSocket upgrade)
 	// Updates
 	Releases *updates.GitHubReleases
 	// Metrics is the optional Prometheus registry. When set, a request
@@ -449,6 +450,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		googleLoginLimiter:       ratelimit.New(10, time.Minute),
 		pairingLimiter:           ratelimit.New(5, time.Minute),
 		inviteLimiter:            ratelimit.New(5, time.Minute),
+		wsLimiter:                ratelimit.New(30, time.Minute),
 		metrics:                  deps.Metrics,
 	}, nil
 }
@@ -482,7 +484,7 @@ func (h *Handler) Router() http.Handler {
 	mux.HandleFunc("POST /invite/{token}/accept", h.handleInviteAcceptPost)
 	mux.HandleFunc("GET /api/version", h.handleAPIVersion)
 	mux.HandleFunc("GET /internal/stats", h.handleInternalStats)
-	mux.HandleFunc("GET /ws", h.handleWS)
+	mux.Handle("GET /ws", h.wsLimiter.Middleware(http.HandlerFunc(h.handleWS)))
 
 	// Update release index endpoint (unauthenticated — phones fetch this)
 	if h.Releases != nil {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -30,18 +30,18 @@ func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, n
 // requireLineOwnershipAdmin is requireLineOwnership with an additional admin
 // role check. Used for destructive phone endpoints (delete, factory reset,
 // restart, update, pair, add line).
-func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Request, number string) *line.Line {
+func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Request, number string) (*line.Line, *household.Household) {
 	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
-		return nil
+		return nil, nil
 	}
 	user := auth.UserFromContext(r.Context())
 	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
 	if err != nil || role != "admin" {
 		http.Error(w, "forbidden", http.StatusForbidden)
-		return nil
+		return nil, nil
 	}
-	return ln
+	return ln, hh
 }
 
 // requireLineOwnershipWithHousehold is requireLineOwnership plus the matched

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -27,6 +27,23 @@ func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, n
 	return ln
 }
 
+// requireLineOwnershipAdmin is requireLineOwnership with an additional admin
+// role check. Used for destructive phone endpoints (delete, factory reset,
+// restart, update, pair, add line).
+func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Request, number string) *line.Line {
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
+	if ln == nil {
+		return nil
+	}
+	user := auth.UserFromContext(r.Context())
+	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
+	if err != nil || role != "admin" {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return nil
+	}
+	return ln
+}
+
 // requireLineOwnershipWithHousehold is requireLineOwnership plus the matched
 // household value, for callers that need the household state (e.g., DND)
 // without an extra DB round-trip. On any failure it writes 404 and returns

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -10,7 +10,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -528,7 +527,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings, househ
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnershipAdmin(w, r, number) == nil {
+	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -581,7 +580,7 @@ func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnershipAdmin(w, r, number) == nil {
+	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
 		return
 	}
 
@@ -595,7 +594,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnershipAdmin(w, r, number) == nil {
+	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -656,14 +655,8 @@ func (h *Handler) respondPhoneCommandResult(w http.ResponseWriter, r *http.Reque
 
 func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
+	ln, hh := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
-		return
-	}
-	user := auth.UserFromContext(r.Context())
-	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
-	if err != nil || role != "admin" {
-		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 	if err := h.lineStore.Delete(r.Context(), ln.ID); err != nil {

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/device"
 	"github.com/justinlindh/digits/server/internal/household"
 	"github.com/justinlindh/digits/server/internal/line"
@@ -127,6 +128,10 @@ func (h *Handler) handlePhonesGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
+		return
+	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -134,11 +139,7 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
 
-	hh := h.activeHousehold(r)
-	var householdID string
-	if hh != nil {
-		householdID = hh.ID
-	}
+	householdID := hh.ID
 
 	if err := line.ValidateNumber(number); err != nil {
 		data := h.buildLinesData(r, hh, err.Error())
@@ -165,6 +166,10 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
+	_, hh, ok := h.requireHouseholdAdmin(w, r)
+	if !ok {
+		return
+	}
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -172,8 +177,6 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	code := strings.TrimSpace(r.FormValue("code"))
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
 	name := strings.TrimSpace(r.FormValue("name"))
-
-	hh := h.activeHousehold(r)
 
 	if err := line.ValidateNumber(number); err != nil {
 		data := h.buildLinesData(r, hh, "")
@@ -189,16 +192,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var householdID string
-	if hh != nil {
-		householdID = hh.ID
-	}
-	if householdID == "" {
-		data := h.buildLinesData(r, hh, "")
-		data.PairError = "no household found: please complete onboarding first"
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
-		return
-	}
+	householdID := hh.ID
 
 	token, hwID, err := h.pairingStore.ClaimDevice(r.Context(), code, number, name, householdID)
 	if err != nil {
@@ -534,7 +528,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings, househ
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	if h.requireLineOwnershipAdmin(w, r, number) == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -587,7 +581,7 @@ func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	if h.requireLineOwnershipAdmin(w, r, number) == nil {
 		return
 	}
 
@@ -601,7 +595,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	if h.requireLineOwnershipAdmin(w, r, number) == nil {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -664,6 +658,12 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
 	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
+		return
+	}
+	user := auth.UserFromContext(r.Context())
+	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
+	if err != nil || role != "admin" {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 	if err := h.lineStore.Delete(r.Context(), ln.ID); err != nil {


### PR DESCRIPTION
## Summary

- **#490**: Destructive phone endpoints (add line, pair, update, factory reset, restart, delete) now require admin role. New `requireLineOwnershipAdmin` helper combines line ownership check with admin role verification. Read paths stay member-accessible.
- **#491**: `OnlineNumbers`, `LocalConnectionCount`, and `IsOnline` now filter on `strings.HasPrefix(n, "unpaired:")` instead of exact-matching the obsolete `"unpaired"` literal. Fixes inflated Prometheus gauge and admin stats from transient unpaired hardware IDs. Redis filter and test updated to match.
- **#492**: `/ws` upgrade handler wrapped in a per-IP rate limiter (30/min) using the existing `ratelimit.Limiter` + `httputil.ClientIP` path.

Closes #490, #491, #492.

## Test plan

- [x] `go build ./...` compiles
- [x] `make test` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [ ] Integration tests (CI)
- [ ] Manual: non-admin cannot factory reset, delete, restart, or update a phone
- [ ] Manual: admin can still perform all operations
- [ ] Manual: `/internal/stats.online_lines` does not count unpaired devices