### PR TITLE
feat(server): multi-handset UX for lines

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -125,6 +126,7 @@ type stores struct {
 	house *household.Store
 	link  *household.LinkStore
 	line  *line.Store
+	db    *sql.DB
 }
 
 func main() {
@@ -151,6 +153,7 @@ func main() {
 		house: household.NewStore(database.DB),
 		link:  household.NewLinkStore(database.DB),
 		line:  line.NewStore(database),
+		db:    database.DB,
 	}
 
 	primaryUser, primaryHH, err := ensureUser(ctx, s, primary, *minimal)
@@ -162,6 +165,13 @@ func main() {
 		printSummary(*baseURL, []string{primary.Email}, primary.Email)
 		return
 	}
+
+	// Seed device rows with names for the primary household's lines.
+	// The Kitchen line (248-0001) gets two handsets to exercise multi-device UI.
+	ensureDeviceWithName(ctx, s.db, s.line, "2480001", "Kitchen", "dev-hw-kitchen")
+	ensureDeviceWithName(ctx, s.db, s.line, "2480001", "Hallway", "dev-hw-hallway")
+	ensureDeviceWithName(ctx, s.db, s.line, "2480002", "Living room", "dev-hw-living")
+	ensureDeviceWithName(ctx, s.db, s.line, "2480003", "Garage", "dev-hw-garage")
 
 	// Add a second member to the primary household
 	secondUser, err := upsertUser(ctx, s.auth, secondMember.Email, secondMember.DisplayName)
@@ -348,6 +358,37 @@ func printSummary(baseURL string, emails []string, primaryEmail string) {
 	)
 	fmt.Println()
 	fmt.Println("The server must be running with DEV_MODE=true for the dev-session endpoint to work.")
+}
+
+// ensureDeviceWithName creates a paired device row for the given line number
+// if one with that hardware_id does not already exist. Idempotent.
+func ensureDeviceWithName(ctx context.Context, db *sql.DB, lineStore *line.Store, lineNumber, deviceName, hardwareID string) {
+	ln, err := lineStore.GetByNumber(ctx, lineNumber)
+	if err != nil {
+		log.Printf("ensureDevice: line %s not found: %v", lineNumber, err)
+		return
+	}
+	var exists bool
+	_ = db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM devices WHERE hardware_id = $1)`,
+		hardwareID,
+	).Scan(&exists)
+	if exists {
+		// Update name if it changed
+		_, _ = db.ExecContext(ctx,
+			`UPDATE devices SET name = $1 WHERE hardware_id = $2`,
+			deviceName, hardwareID,
+		)
+		return
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO devices (line_id, hardware_id, name, paired_at, device_token)
+		 VALUES ($1, $2, $3, NOW(), 'devseed-token-' || $2)`,
+		ln.ID, hardwareID, deviceName,
+	)
+	if err != nil {
+		log.Printf("ensureDevice: insert device %s on line %s: %v", hardwareID, lineNumber, err)
+	}
 }
 
 func envOr(key, fallback string) string {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -411,6 +411,26 @@ BEGIN
         INSERT INTO schema_version (version) VALUES (26);
     END IF;
 END $$;`,
+		// v27: per-device name column. Previously line.name served double duty
+		// as both the line label and the handset label. With multiple handsets
+		// per line, each device needs its own name. Backfill copies the line
+		// name to the first paired device on each line.
+		`DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM schema_version WHERE version = 27) THEN
+
+        ALTER TABLE devices ADD COLUMN IF NOT EXISTS name TEXT NOT NULL DEFAULT '';
+
+        UPDATE devices d
+        SET name = l.name
+        FROM lines l
+        WHERE d.line_id = l.id
+          AND d.paired_at IS NOT NULL
+          AND d.name = '';
+
+        INSERT INTO schema_version (version) VALUES (27);
+    END IF;
+END $$;`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -17,6 +17,7 @@ import (
 type Device struct {
 	ID                   int64
 	LineID               *int64
+	Name                 string
 	HardwareID           string
 	DeviceID             string
 	DeviceToken          *string
@@ -43,7 +44,7 @@ func NewStore(database *db.Database) *Store {
 // ListByLine returns all devices associated with a given line.
 func (s *Store) ListByLine(ctx context.Context, lineID int64) ([]Device, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, line_id, hardware_id, device_id, device_token,
+		SELECT id, line_id, name, hardware_id, device_id, device_token,
 			pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at
 		FROM devices
 		WHERE line_id = $1
@@ -58,7 +59,7 @@ func (s *Store) ListByLine(ctx context.Context, lineID int64) ([]Device, error) 
 	for rows.Next() {
 		var d Device
 		if err := rows.Scan(
-			&d.ID, &d.LineID, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
+			&d.ID, &d.LineID, &d.Name, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
 			&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan device: %w", err)
@@ -130,6 +131,18 @@ func (s *Store) AuthStatus(ctx context.Context, hardwareID, token string) (paire
 	candidate := HashToken(token)
 	valid := subtle.ConstantTimeCompare([]byte(candidate), []byte(storedHash.String)) == 1
 	return true, valid, nil
+}
+
+// UpdateName sets the display name for a device.
+func (s *Store) UpdateName(ctx context.Context, deviceID int64, name string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE devices SET name = $1 WHERE id = $2`,
+		name, deviceID,
+	)
+	if err != nil {
+		return fmt.Errorf("update device name: %w", err)
+	}
+	return nil
 }
 
 // BoundLineNumber returns the line number assigned to the paired device with

--- a/server/internal/pairing/e2e_pairing_test.go
+++ b/server/internal/pairing/e2e_pairing_test.go
@@ -76,7 +76,7 @@ func TestE2EPairingFlow(t *testing.T) {
 	}
 
 	// Step 3: Claim phone (parent enters code in dashboard)
-	token, hwID, err := pairingStore.ClaimDevice(context.Background(), code, "5559876", "Kitchen Phone", hh.ID)
+	token, hwID, err := pairingStore.ClaimDevice(context.Background(), code, "5559876", "Kitchen Phone", "Kitchen Phone", hh.ID)
 	if err != nil {
 		t.Fatalf("ClaimDevice: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestE2EPairingFlow(t *testing.T) {
 	}
 
 	// Step 5: Reuse same code — should fail
-	_, _, err = pairingStore.ClaimDevice(context.Background(), code, "5559877", "Reuse Attempt", hh.ID)
+	_, _, err = pairingStore.ClaimDevice(context.Background(), code, "5559877", "Reuse Attempt", "Reuse Attempt", hh.ID)
 	if !errors.Is(err, ErrInvalidCode) {
 		t.Fatalf("expected ErrInvalidCode on code reuse, got: %v", err)
 	}
@@ -109,13 +109,13 @@ func TestE2EPairingFlow(t *testing.T) {
 	}
 
 	// Step 7: Try to claim with duplicate number — should fail
-	_, _, err = pairingStore.ClaimDevice(context.Background(), code2, "5559876", "Dupe Number", hh.ID)
+	_, _, err = pairingStore.ClaimDevice(context.Background(), code2, "5559876", "Dupe Number", "Dupe Number", hh.ID)
 	if !errors.Is(err, ErrNumberTaken) {
 		t.Fatalf("expected ErrNumberTaken for duplicate number, got: %v", err)
 	}
 
 	// Step 8: Claim second phone with unique number — should succeed
-	_, _, err = pairingStore.ClaimDevice(context.Background(), code2, "5559877", "Living Room Phone", hh.ID)
+	_, _, err = pairingStore.ClaimDevice(context.Background(), code2, "5559877", "Living Room Phone", "Living Room Phone", hh.ID)
 	if err != nil {
 		t.Fatalf("ClaimDevice (second phone): %v", err)
 	}

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -68,11 +68,11 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 	return newCode, nil
 }
 
-// ClaimDevice pairs a device using a pairing code, creating the line and
+// ClaimDevice pairs a device using a pairing code, creating a new line and
 // assigning the device in a single transaction. If any step fails the whole
 // operation rolls back, leaving the device claimable with a fresh code.
 // Returns (deviceToken, hardwareID, error).
-func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, householdID string) (string, string, error) {
+func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, deviceName, householdID string) (string, string, error) {
 	token, err := randomHex(32)
 	if err != nil {
 		return "", "", fmt.Errorf("generate device token: %w", err)
@@ -115,12 +115,74 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, hou
 		// Bind device to the line, mark paired, clear the pairing code.
 		res, err := tx.ExecContext(ctx, `
 			UPDATE devices
-			SET line_id = $2, device_token = $3,
+			SET line_id = $2, device_token = $3, name = $4,
 			    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
 			WHERE id = $1 AND paired_at IS NULL
-		`, deviceID, lineID, tokenHash)
+		`, deviceID, lineID, tokenHash, deviceName)
 		if err != nil {
 			return fmt.Errorf("claim device: %w", err)
+		}
+		rows, _ := res.RowsAffected()
+		if rows == 0 {
+			return ErrInvalidCode
+		}
+		return nil
+	}); err != nil {
+		return "", "", err
+	}
+	return token, hardwareID, nil
+}
+
+// ClaimDeviceToLine pairs a device to an existing line using a pairing code.
+// Unlike ClaimDevice, no new line is created. The line must exist and belong
+// to the given household. Returns (deviceToken, hardwareID, error).
+func (s *Store) ClaimDeviceToLine(ctx context.Context, code string, lineID int64, deviceName, householdID string) (string, string, error) {
+	token, err := randomHex(32)
+	if err != nil {
+		return "", "", fmt.Errorf("generate device token: %w", err)
+	}
+	tokenHash := device.HashToken(token)
+
+	var hardwareID string
+	if err := dbutil.WithTx(ctx, s.db, func(tx *sql.Tx) error {
+		var deviceRowID int64
+		var hwID sql.NullString
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, hardware_id FROM devices
+			WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
+			FOR UPDATE
+		`, code).Scan(&deviceRowID, &hwID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrInvalidCode
+		}
+		if err != nil {
+			return fmt.Errorf("lookup pairing code: %w", err)
+		}
+		hardwareID = hwID.String
+
+		// Verify the line exists and belongs to this household.
+		var ownerHH string
+		err = tx.QueryRowContext(ctx,
+			`SELECT household_id FROM lines WHERE id = $1`, lineID,
+		).Scan(&ownerHH)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("line not found")
+		}
+		if err != nil {
+			return fmt.Errorf("verify line ownership: %w", err)
+		}
+		if ownerHH != householdID {
+			return fmt.Errorf("line does not belong to this household")
+		}
+
+		res, err := tx.ExecContext(ctx, `
+			UPDATE devices
+			SET line_id = $2, device_token = $3, name = $4,
+			    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
+			WHERE id = $1 AND paired_at IS NULL
+		`, deviceRowID, lineID, tokenHash, deviceName)
+		if err != nil {
+			return fmt.Errorf("claim device to line: %w", err)
 		}
 		rows, _ := res.RowsAffected()
 		if rows == 0 {

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -68,6 +68,45 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 	return newCode, nil
 }
 
+// lookupPairingCode locks the device row for the given code within a
+// transaction and returns (deviceID, hardwareID). Returns ErrInvalidCode
+// when the code is missing, expired, or already claimed.
+func lookupPairingCode(ctx context.Context, tx *sql.Tx, code string) (int64, string, error) {
+	var deviceID int64
+	var hwID sql.NullString
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, hardware_id FROM devices
+		WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
+		FOR UPDATE
+	`, code).Scan(&deviceID, &hwID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, "", ErrInvalidCode
+	}
+	if err != nil {
+		return 0, "", fmt.Errorf("lookup pairing code: %w", err)
+	}
+	return deviceID, hwID.String, nil
+}
+
+// bindDeviceToLine marks a device as paired and assigns it to a line within
+// a transaction. Clears the pairing code and sets the device token.
+func bindDeviceToLine(ctx context.Context, tx *sql.Tx, deviceID, lineID int64, tokenHash, deviceName string) error {
+	res, err := tx.ExecContext(ctx, `
+		UPDATE devices
+		SET line_id = $2, device_token = $3, name = $4,
+		    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
+		WHERE id = $1 AND paired_at IS NULL
+	`, deviceID, lineID, tokenHash, deviceName)
+	if err != nil {
+		return fmt.Errorf("bind device to line: %w", err)
+	}
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return ErrInvalidCode
+	}
+	return nil
+}
+
 // ClaimDevice pairs a device using a pairing code, creating a new line and
 // assigning the device in a single transaction. If any step fails the whole
 // operation rolls back, leaving the device claimable with a fresh code.
@@ -81,24 +120,12 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, dev
 
 	var hardwareID string
 	if err := dbutil.WithTx(ctx, s.db, func(tx *sql.Tx) error {
-		// Lock the device row to prevent concurrent claims.
-		var deviceID int64
-		var hwID sql.NullString
-		err := tx.QueryRowContext(ctx, `
-			SELECT id, hardware_id FROM devices
-			WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
-			FOR UPDATE
-		`, code).Scan(&deviceID, &hwID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrInvalidCode
-		}
+		deviceID, hwID, err := lookupPairingCode(ctx, tx, code)
 		if err != nil {
-			return fmt.Errorf("lookup pairing code: %w", err)
+			return err
 		}
-		hardwareID = hwID.String
+		hardwareID = hwID
 
-		// Insert the line. The unique constraint on number rejects collisions
-		// without a separate SELECT + INSERT race window.
 		var lineID int64
 		err = tx.QueryRowContext(ctx, `
 			INSERT INTO lines (number, name, household_id)
@@ -112,21 +139,7 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, dev
 			return fmt.Errorf("create line: %w", err)
 		}
 
-		// Bind device to the line, mark paired, clear the pairing code.
-		res, err := tx.ExecContext(ctx, `
-			UPDATE devices
-			SET line_id = $2, device_token = $3, name = $4,
-			    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
-			WHERE id = $1 AND paired_at IS NULL
-		`, deviceID, lineID, tokenHash, deviceName)
-		if err != nil {
-			return fmt.Errorf("claim device: %w", err)
-		}
-		rows, _ := res.RowsAffected()
-		if rows == 0 {
-			return ErrInvalidCode
-		}
-		return nil
+		return bindDeviceToLine(ctx, tx, deviceID, lineID, tokenHash, deviceName)
 	}); err != nil {
 		return "", "", err
 	}
@@ -145,22 +158,12 @@ func (s *Store) ClaimDeviceToLine(ctx context.Context, code string, lineID int64
 
 	var hardwareID string
 	if err := dbutil.WithTx(ctx, s.db, func(tx *sql.Tx) error {
-		var deviceRowID int64
-		var hwID sql.NullString
-		err := tx.QueryRowContext(ctx, `
-			SELECT id, hardware_id FROM devices
-			WHERE pairing_code = $1 AND pairing_code_expires_at > NOW() AND paired_at IS NULL
-			FOR UPDATE
-		`, code).Scan(&deviceRowID, &hwID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrInvalidCode
-		}
+		deviceID, hwID, err := lookupPairingCode(ctx, tx, code)
 		if err != nil {
-			return fmt.Errorf("lookup pairing code: %w", err)
+			return err
 		}
-		hardwareID = hwID.String
+		hardwareID = hwID
 
-		// Verify the line exists and belongs to this household.
 		var ownerHH string
 		err = tx.QueryRowContext(ctx,
 			`SELECT household_id FROM lines WHERE id = $1`, lineID,
@@ -175,20 +178,7 @@ func (s *Store) ClaimDeviceToLine(ctx context.Context, code string, lineID int64
 			return fmt.Errorf("line does not belong to this household")
 		}
 
-		res, err := tx.ExecContext(ctx, `
-			UPDATE devices
-			SET line_id = $2, device_token = $3, name = $4,
-			    paired_at = NOW(), pairing_code = NULL, pairing_code_expires_at = NULL
-			WHERE id = $1 AND paired_at IS NULL
-		`, deviceRowID, lineID, tokenHash, deviceName)
-		if err != nil {
-			return fmt.Errorf("claim device to line: %w", err)
-		}
-		rows, _ := res.RowsAffected()
-		if rows == 0 {
-			return ErrInvalidCode
-		}
-		return nil
+		return bindDeviceToLine(ctx, tx, deviceID, lineID, tokenHash, deviceName)
 	}); err != nil {
 		return "", "", err
 	}

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -82,7 +82,7 @@ func TestClaimDevice_Success(t *testing.T) {
 		t.Fatalf("GenerateCode: %v", err)
 	}
 
-	token, _, err := s.ClaimDevice(context.Background(), code, "5550100", "Kitchen Phone", hhID)
+	token, _, err := s.ClaimDevice(context.Background(), code, "5550100", "Kitchen Phone", "Kitchen Phone", hhID)
 	if err != nil {
 		t.Fatalf("ClaimDevice: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestClaimDevice_Success(t *testing.T) {
 func TestClaimDevice_FailOnInvalidCode(t *testing.T) {
 	s := setupStore(t)
 	hhID := seedHousehold(t, s)
-	_, _, err := s.ClaimDevice(context.Background(), "999999", "5550101", "Bad Phone", hhID)
+	_, _, err := s.ClaimDevice(context.Background(), "999999", "5550101", "Bad Phone", "Bad Phone", hhID)
 	if err != ErrInvalidCode {
 		t.Errorf("expected ErrInvalidCode, got %v", err)
 	}
@@ -122,7 +122,7 @@ func TestClaimDevice_FailOnExpiredCode(t *testing.T) {
 		t.Fatalf("expire code: %v", err)
 	}
 
-	_, _, err = s.ClaimDevice(context.Background(), code, "5550102", "Expired Phone", seedHousehold(t, s))
+	_, _, err = s.ClaimDevice(context.Background(), code, "5550102", "Expired Phone", "Expired Phone", seedHousehold(t, s))
 	if err != ErrInvalidCode {
 		t.Errorf("expected ErrInvalidCode for expired code, got %v", err)
 	}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -122,9 +122,7 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 	switch env.TargetType {
 	case "number":
 		h.mu.RLock()
-		conns := h.conns[env.Target]
-		h.mu.RUnlock()
-		for _, conn := range conns {
+		for _, conn := range h.conns[env.Target] {
 			select {
 			case conn.Send <- data:
 				slog.Debug("redis: delivered to local connection", "pod", env.PodID, "delivered", true)
@@ -132,6 +130,7 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 				slog.Debug("redis: local send buffer full", "pod", env.PodID)
 			}
 		}
+		h.mu.RUnlock()
 
 	case "hardware":
 		h.mu.RLock()
@@ -308,12 +307,13 @@ func (h *Hub) Register(number string, conn *Conn) error {
 		h.hwConns[conn.HardwareID] = conn
 	}
 
+	devCount := len(h.conns[number])
 	d := h.dashEvents
 	ds := h.state
 	h.mu.Unlock()
 
 	slog.Debug("hub registered", "number", number, "hardware_id", conn.HardwareID,
-		"devices_on_line", len(h.conns[number]))
+		"devices_on_line", devCount)
 
 	if d != nil {
 		d.Notify()
@@ -413,9 +413,8 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 	h.mu.RLock()
 	conns := h.conns[number]
 	bridge := h.redis
-	h.mu.RUnlock()
-
 	if len(conns) == 0 {
+		h.mu.RUnlock()
 		if bridge != nil {
 			bridge.Publish(context.Background(), &Envelope{
 				TargetType: "number",
@@ -426,7 +425,6 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 		}
 		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
 	}
-
 	for _, conn := range conns {
 		select {
 		case conn.Send <- data:
@@ -435,6 +433,7 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 				"number", number, "hardware_id", conn.HardwareID)
 		}
 	}
+	h.mu.RUnlock()
 	return nil
 }
 
@@ -566,29 +565,6 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 	}
 }
 
-// DeviceInfoAll returns version info for every connected device on a line,
-// keyed by hardware ID. Returns nil if no devices are online.
-func (h *Hub) DeviceInfoAll(number string) map[string]*DeviceInfoSnapshot {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	conns := h.conns[number]
-	if len(conns) == 0 {
-		return nil
-	}
-	out := make(map[string]*DeviceInfoSnapshot, len(conns))
-	for _, c := range conns {
-		out[c.HardwareID] = &DeviceInfoSnapshot{
-			HardwareID:      c.HardwareID,
-			PiVersion:       c.PiVersion,
-			PiCommit:        c.PiCommit,
-			FirmwareVersion: c.FirmwareVersion,
-			FirmwareCommit:  c.FirmwareCommit,
-			RemoteAddr:      c.RemoteAddr,
-		}
-	}
-	return out
-}
-
 // SetUpdateStatus stores the latest update status for a phone.
 func (h *Hub) SetUpdateStatus(number, status, detail string) {
 	h.mu.Lock()
@@ -638,28 +614,15 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit, localAd
 		localAddr = ""
 	}
 	h.mu.Lock()
-	// Find the specific conn. With multiple devices per line, iterate to
-	// find the one that sent this message. The caller (relay) routes by
-	// line number; we match using the hwConns index when possible, but
-	// fall back to the first conn on the number for backward compat.
-	var conn *Conn
+	// Legacy fallback: when the caller doesn't know the hardware ID,
+	// update the first (or only) device on this number. Multi-device
+	// callers should use UpdateDeviceInfoByHardware instead.
 	conns := h.conns[number]
-	if len(conns) == 1 {
-		conn = conns[0]
-	} else {
-		// Multi-device: the relay sets msg.HardwareID but
-		// UpdateDeviceInfo receives it as the number. Use hwConns.
-		for _, c := range conns {
-			if c.Number == number {
-				conn = c
-				break
-			}
-		}
-	}
-	if conn == nil {
+	if len(conns) == 0 {
 		h.mu.Unlock()
 		return false
 	}
+	conn := conns[0]
 	conn.PiVersion = piVer
 	conn.PiCommit = piCommit
 	conn.FirmwareVersion = fwVer
@@ -724,16 +687,6 @@ func (h *Hub) TouchLastSeen(number string) {
 	if ds != nil {
 		ds.TouchLastSeen(context.Background(), number)
 	}
-}
-
-// TouchLastSeenByHardware updates the in-memory last-seen timestamp for
-// a specific device by hardware ID.
-func (h *Hub) TouchLastSeenByHardware(hardwareID string) {
-	h.mu.Lock()
-	if conn, ok := h.hwConns[hardwareID]; ok {
-		conn.LastSeen = time.Now()
-	}
-	h.mu.Unlock()
 }
 
 // LastSeenAt returns the most recent last-seen timestamp across all

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -54,7 +54,7 @@ type dashNotifier interface {
 
 type Hub struct {
 	mu           sync.RWMutex
-	conns        map[string]*Conn                 // phone number -> connection
+	conns        map[string][]*Conn               // phone number -> connections (multiple devices per line)
 	hwConns      map[string]*Conn                 // hardware ID -> connection
 	updateStatus map[string]*UpdateStatusSnapshot // phone number -> last update status
 	dashEvents   dashNotifier
@@ -65,7 +65,7 @@ type Hub struct {
 
 func NewHub() *Hub {
 	return &Hub{
-		conns:        make(map[string]*Conn),
+		conns:        make(map[string][]*Conn),
 		hwConns:      make(map[string]*Conn),
 		updateStatus: make(map[string]*UpdateStatusSnapshot),
 	}
@@ -121,15 +121,16 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 
 	switch env.TargetType {
 	case "number":
-		conn := h.Get(env.Target)
-		if conn == nil {
-			return
-		}
-		select {
-		case conn.Send <- data:
-			slog.Debug("redis: delivered to local connection", "pod", env.PodID, "delivered", true)
-		default:
-			slog.Debug("redis: local send buffer full", "pod", env.PodID)
+		h.mu.RLock()
+		conns := h.conns[env.Target]
+		h.mu.RUnlock()
+		for _, conn := range conns {
+			select {
+			case conn.Send <- data:
+				slog.Debug("redis: delivered to local connection", "pod", env.PodID, "delivered", true)
+			default:
+				slog.Debug("redis: local send buffer full", "pod", env.PodID)
+			}
 		}
 
 	case "hardware":
@@ -148,10 +149,12 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 
 	case "broadcast":
 		h.mu.RLock()
-		for _, conn := range h.conns {
-			select {
-			case conn.Send <- data:
-			default:
+		for _, conns := range h.conns {
+			for _, conn := range conns {
+				select {
+				case conn.Send <- data:
+				default:
+				}
 			}
 		}
 		h.mu.RUnlock()
@@ -181,11 +184,11 @@ func (h *Hub) IsDraining() bool {
 // logs aggregate counts only (no per-device data).
 func (h *Hub) DrainAndClose(ctx context.Context) {
 	h.mu.RLock()
-	n := len(h.conns)
-	snapshot := make([]*Conn, 0, n)
-	for _, c := range h.conns {
-		snapshot = append(snapshot, c)
+	var snapshot []*Conn
+	for _, conns := range h.conns {
+		snapshot = append(snapshot, conns...)
 	}
+	n := len(snapshot)
 	h.mu.RUnlock()
 
 	if n == 0 {
@@ -216,7 +219,7 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 			return
 		case <-ticker.C:
 			h.mu.RLock()
-			remaining := len(h.conns)
+			remaining := h.totalConns()
 			h.mu.RUnlock()
 			if remaining == 0 {
 				slog.Info("drain: all connections closed gracefully")
@@ -226,13 +229,22 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 	}
 }
 
+// totalConns returns the total number of connections. Must be called with
+// at least a read lock held.
+func (h *Hub) totalConns() int {
+	n := 0
+	for _, conns := range h.conns {
+		n += len(conns)
+	}
+	return n
+}
+
 // forceCloseAll hard-closes every remaining WebSocket connection.
 func (h *Hub) forceCloseAll() {
 	h.mu.RLock()
-	remaining := len(h.conns)
-	conns := make([]*Conn, 0, remaining)
-	for _, c := range h.conns {
-		conns = append(conns, c)
+	var conns []*Conn
+	for _, cs := range h.conns {
+		conns = append(conns, cs...)
 	}
 	h.mu.RUnlock()
 
@@ -241,7 +253,7 @@ func (h *Hub) forceCloseAll() {
 			_ = c.WS.Close()
 		}
 	}
-	slog.Info("drain: force-closed remaining connections", "connections", remaining)
+	slog.Info("drain: force-closed remaining connections", "connections", len(conns))
 }
 
 // SetDashboardEvents registers an optional broadcaster that is signalled
@@ -253,36 +265,55 @@ func (h *Hub) SetDashboardEvents(b dashNotifier) {
 	h.mu.Unlock()
 }
 
+// Register adds a connection for the given number. Multiple devices on the
+// same line each get their own connection (POTS extension model). If a
+// connection with the same HardwareID is already registered on this number,
+// the old one is closed and replaced.
 func (h *Hub) Register(number string, conn *Conn) error {
 	h.mu.Lock()
 	if h.draining {
 		h.mu.Unlock()
 		return ErrDraining
 	}
-	_, replacing := h.conns[number]
-	if replacing {
-		old := h.conns[number]
-		if old.WS != nil {
-			_ = old.WS.Close()
-		}
-		select {
-		case _, ok := <-old.Send:
-			if ok {
+
+	conn.Number = number
+
+	// If the same hardware_id already has a connection on this number,
+	// close the old one (device reconnect).
+	existing := h.conns[number]
+	replaced := false
+	for i, old := range existing {
+		if old.HardwareID != "" && old.HardwareID == conn.HardwareID {
+			if old.WS != nil {
+				_ = old.WS.Close()
+			}
+			select {
+			case _, ok := <-old.Send:
+				if ok {
+					close(old.Send)
+				}
+			default:
 				close(old.Send)
 			}
-		default:
-			close(old.Send)
+			existing[i] = conn
+			replaced = true
+			break
 		}
 	}
-	conn.Number = number
-	h.conns[number] = conn
+	if !replaced {
+		h.conns[number] = append(existing, conn)
+	}
+
 	if conn.HardwareID != "" {
 		h.hwConns[conn.HardwareID] = conn
 	}
+
 	d := h.dashEvents
 	ds := h.state
 	h.mu.Unlock()
-	slog.Debug("hub registered", "number", number)
+
+	slog.Debug("hub registered", "number", number, "hardware_id", conn.HardwareID,
+		"devices_on_line", len(h.conns[number]))
 
 	if d != nil {
 		d.Notify()
@@ -301,64 +332,110 @@ func (h *Hub) Register(number string, conn *Conn) error {
 	return nil
 }
 
+// Unregister removes the specific connection from the hub. Only the exact
+// conn pointer is removed; other devices on the same line are not affected.
 func (h *Hub) Unregister(number string, conn *Conn) {
 	h.mu.Lock()
 	var changed bool
-	if existing, ok := h.conns[number]; ok && existing == conn {
-		close(conn.Send)
-		delete(h.conns, number)
-		if conn.HardwareID != "" {
-			delete(h.hwConns, conn.HardwareID)
+	conns := h.conns[number]
+	for i, c := range conns {
+		if c == conn {
+			close(conn.Send)
+			h.conns[number] = append(conns[:i], conns[i+1:]...)
+			if len(h.conns[number]) == 0 {
+				delete(h.conns, number)
+			}
+			if conn.HardwareID != "" {
+				delete(h.hwConns, conn.HardwareID)
+			}
+			changed = true
+			break
 		}
-		changed = true
 	}
+	remaining := len(h.conns[number])
 	d := h.dashEvents
 	ds := h.state
 	h.mu.Unlock()
 
 	if changed {
-		slog.Debug("hub unregistered", "number", number)
+		slog.Debug("hub unregistered", "number", number, "remaining", remaining)
 		if d != nil {
 			d.Notify()
 		}
-		if ds != nil {
+		if ds != nil && remaining == 0 {
 			ds.SetOffline(context.Background(), number)
 		}
 	}
 }
 
+// Get returns the first active connection for a number, or nil if none.
+// Used for connectivity checks (is anyone online on this line?).
 func (h *Hub) Get(number string) *Conn {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.conns[number]
-}
-
-func (h *Hub) SendTo(number string, msg *Message) error {
-	err := sendToConn(h.Get(number), msg, "phone", number)
-	if err == nil {
+	conns := h.conns[number]
+	if len(conns) == 0 {
 		return nil
 	}
+	return conns[0]
+}
 
-	// Only fall through to Redis when the device is not connected locally.
-	// Buffer-full means the connection exists on this pod but is
-	// backpressured; other pods won't have it either.
-	if !errors.Is(err, ErrNotConnected) {
+// GetAll returns all active connections for a number. Returns nil if none.
+func (h *Hub) GetAll(number string) []*Conn {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	conns := h.conns[number]
+	if len(conns) == 0 {
+		return nil
+	}
+	out := make([]*Conn, len(conns))
+	copy(out, conns)
+	return out
+}
+
+// ConnectionCount returns the number of active connections for a line.
+func (h *Hub) ConnectionCount(number string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.conns[number])
+}
+
+// SendTo marshals msg and sends it to every device on the given line number.
+// This is the POTS extension model: a ring reaches all phones on the line.
+// Returns ErrNotConnected only when no devices are connected locally AND
+// Redis cannot deliver.
+func (h *Hub) SendTo(number string, msg *Message) error {
+	data, err := msg.Marshal()
+	if err != nil {
 		return err
 	}
 
 	h.mu.RLock()
+	conns := h.conns[number]
 	bridge := h.redis
 	h.mu.RUnlock()
-	if bridge != nil {
-		bridge.Publish(context.Background(), &Envelope{
-			TargetType: "number",
-			Target:     number,
-			Message:    msg,
-		})
-		return nil
+
+	if len(conns) == 0 {
+		if bridge != nil {
+			bridge.Publish(context.Background(), &Envelope{
+				TargetType: "number",
+				Target:     number,
+				Message:    msg,
+			})
+			return nil
+		}
+		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
 	}
 
-	return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
+	for _, conn := range conns {
+		select {
+		case conn.Send <- data:
+		default:
+			slog.Warn("SendTo: send buffer full, skipping device",
+				"number", number, "hardware_id", conn.HardwareID)
+		}
+	}
+	return nil
 }
 
 func (h *Hub) SendToHardware(hardwareID string, msg *Message) error {
@@ -400,11 +477,13 @@ func (h *Hub) Broadcast(msg *Message) {
 	}
 	h.mu.RLock()
 	bridge := h.redis
-	for number, conn := range h.conns {
-		select {
-		case conn.Send <- data:
-		default:
-			slog.Warn("broadcast: send buffer full, skipping", "number", number)
+	for number, conns := range h.conns {
+		for _, conn := range conns {
+			select {
+			case conn.Send <- data:
+			default:
+				slog.Warn("broadcast: send buffer full, skipping", "number", number)
+			}
 		}
 	}
 	h.mu.RUnlock()
@@ -446,6 +525,7 @@ type UpdateStatusSnapshot struct {
 
 // DeviceInfoSnapshot holds a point-in-time copy of device version info.
 type DeviceInfoSnapshot struct {
+	HardwareID      string
 	PiVersion       string
 	PiCommit        string
 	FirmwareVersion string
@@ -460,7 +540,8 @@ type DeviceInfoSnapshot struct {
 	RemoteAddr string `json:"-"`
 }
 
-// DeviceInfo returns version info for a connected phone. Returns nil if offline.
+// DeviceInfo returns version info for the first connected device on a line.
+// Returns nil if no device is online. For per-device info use DeviceInfoAll.
 func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 	h.mu.RLock()
 	ds := h.state
@@ -470,17 +551,42 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	conn, ok := h.conns[number]
-	if !ok {
+	conns := h.conns[number]
+	if len(conns) == 0 {
 		return nil
 	}
+	c := conns[0]
 	return &DeviceInfoSnapshot{
-		PiVersion:       conn.PiVersion,
-		PiCommit:        conn.PiCommit,
-		FirmwareVersion: conn.FirmwareVersion,
-		FirmwareCommit:  conn.FirmwareCommit,
-		RemoteAddr:      conn.RemoteAddr,
+		HardwareID:      c.HardwareID,
+		PiVersion:       c.PiVersion,
+		PiCommit:        c.PiCommit,
+		FirmwareVersion: c.FirmwareVersion,
+		FirmwareCommit:  c.FirmwareCommit,
+		RemoteAddr:      c.RemoteAddr,
 	}
+}
+
+// DeviceInfoAll returns version info for every connected device on a line,
+// keyed by hardware ID. Returns nil if no devices are online.
+func (h *Hub) DeviceInfoAll(number string) map[string]*DeviceInfoSnapshot {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	conns := h.conns[number]
+	if len(conns) == 0 {
+		return nil
+	}
+	out := make(map[string]*DeviceInfoSnapshot, len(conns))
+	for _, c := range conns {
+		out[c.HardwareID] = &DeviceInfoSnapshot{
+			HardwareID:      c.HardwareID,
+			PiVersion:       c.PiVersion,
+			PiCommit:        c.PiCommit,
+			FirmwareVersion: c.FirmwareVersion,
+			FirmwareCommit:  c.FirmwareCommit,
+			RemoteAddr:      c.RemoteAddr,
+		}
+	}
+	return out
 }
 
 // SetUpdateStatus stores the latest update status for a phone.
@@ -523,7 +629,7 @@ func (h *Hub) ClearUpdateStatus(number string) {
 }
 
 // UpdateDeviceInfo sets version info and the device-reported LAN address for
-// a connected phone under the write lock. localAddr is filtered through
+// a specific device identified by hardware ID. localAddr is filtered through
 // httputil.IsPrivateAddr; non-private values (or unparseable input) are
 // stored as "" so a compromised client cannot push a public IP into the
 // owner UI.
@@ -532,8 +638,25 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit, localAd
 		localAddr = ""
 	}
 	h.mu.Lock()
-	conn, ok := h.conns[number]
-	if !ok {
+	// Find the specific conn. With multiple devices per line, iterate to
+	// find the one that sent this message. The caller (relay) routes by
+	// line number; we match using the hwConns index when possible, but
+	// fall back to the first conn on the number for backward compat.
+	var conn *Conn
+	conns := h.conns[number]
+	if len(conns) == 1 {
+		conn = conns[0]
+	} else {
+		// Multi-device: the relay sets msg.HardwareID but
+		// UpdateDeviceInfo receives it as the number. Use hwConns.
+		for _, c := range conns {
+			if c.Number == number {
+				conn = c
+				break
+			}
+		}
+	}
+	if conn == nil {
 		h.mu.Unlock()
 		return false
 	}
@@ -556,11 +679,45 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit, localAd
 	return true
 }
 
-// TouchLastSeen updates the in-memory last-seen timestamp for a connected phone.
-func (h *Hub) TouchLastSeen(number string) {
+// UpdateDeviceInfoByHardware sets version info for a specific device by
+// hardware ID. Used when the caller knows which device sent the message.
+func (h *Hub) UpdateDeviceInfoByHardware(hardwareID, piVer, piCommit, fwVer, fwCommit, localAddr string) bool {
+	if !httputil.IsPrivateAddr(localAddr) {
+		localAddr = ""
+	}
 	h.mu.Lock()
-	if conn, ok := h.conns[number]; ok {
-		conn.LastSeen = time.Now()
+	conn, ok := h.hwConns[hardwareID]
+	if !ok {
+		h.mu.Unlock()
+		return false
+	}
+	conn.PiVersion = piVer
+	conn.PiCommit = piCommit
+	conn.FirmwareVersion = fwVer
+	conn.FirmwareCommit = fwCommit
+	conn.RemoteAddr = localAddr
+	number := conn.Number
+	ds := h.state
+	h.mu.Unlock()
+	if ds != nil {
+		ds.UpdateDeviceInfo(context.Background(), number, DevicePresence{
+			PiVersion:       piVer,
+			PiCommit:        piCommit,
+			FirmwareVersion: fwVer,
+			FirmwareCommit:  fwCommit,
+			RemoteAddr:      localAddr,
+		})
+	}
+	return true
+}
+
+// TouchLastSeen updates the in-memory last-seen timestamp for all devices
+// on the given number.
+func (h *Hub) TouchLastSeen(number string) {
+	now := time.Now()
+	h.mu.Lock()
+	for _, conn := range h.conns[number] {
+		conn.LastSeen = now
 	}
 	ds := h.state
 	h.mu.Unlock()
@@ -569,7 +726,18 @@ func (h *Hub) TouchLastSeen(number string) {
 	}
 }
 
-// LastSeenAt returns the last-seen timestamp for a connected phone, or nil if offline.
+// TouchLastSeenByHardware updates the in-memory last-seen timestamp for
+// a specific device by hardware ID.
+func (h *Hub) TouchLastSeenByHardware(hardwareID string) {
+	h.mu.Lock()
+	if conn, ok := h.hwConns[hardwareID]; ok {
+		conn.LastSeen = time.Now()
+	}
+	h.mu.Unlock()
+}
+
+// LastSeenAt returns the most recent last-seen timestamp across all
+// connected devices on a line, or nil if no device is online.
 func (h *Hub) LastSeenAt(number string) *time.Time {
 	h.mu.RLock()
 	ds := h.state
@@ -579,20 +747,20 @@ func (h *Hub) LastSeenAt(number string) *time.Time {
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	conn, ok := h.conns[number]
-	if !ok {
+	var latest time.Time
+	for _, conn := range h.conns[number] {
+		if conn.LastSeen.After(latest) {
+			latest = conn.LastSeen
+		}
+	}
+	if latest.IsZero() {
 		return nil
 	}
-	if conn.LastSeen.IsZero() {
-		return nil
-	}
-	t := conn.LastSeen
-	return &t
+	return &latest
 }
 
-// IsOnline returns true if number has an active hub connection and is not in
-// pairing mode. Unpaired devices connect under the "unpaired:<hwID>" prefix
-// and must not be presented as online in the UI.
+// IsOnline returns true if the number has at least one active hub connection
+// and is not an unpaired sentinel key.
 func (h *Hub) IsOnline(number string) bool {
 	if strings.HasPrefix(number, "unpaired:") {
 		return false
@@ -610,10 +778,11 @@ func (h *Hub) LocalConnectionCount() int {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	n := 0
-	for key := range h.conns {
-		if !strings.HasPrefix(key, "unpaired:") {
-			n++
+	for key, conns := range h.conns {
+		if strings.HasPrefix(key, "unpaired:") {
+			continue
 		}
+		n += len(conns)
 	}
 	return n
 }
@@ -628,8 +797,8 @@ func (h *Hub) OnlineNumbers() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	nums := make([]string, 0, len(h.conns))
-	for n := range h.conns {
-		if strings.HasPrefix(n, "unpaired:") {
+	for n, conns := range h.conns {
+		if strings.HasPrefix(n, "unpaired:") || len(conns) == 0 {
 			continue
 		}
 		nums = append(nums, n)

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -540,7 +540,7 @@ type DeviceInfoSnapshot struct {
 }
 
 // DeviceInfo returns version info for the first connected device on a line.
-// Returns nil if no device is online. For per-device info use DeviceInfoAll.
+// Returns nil if no device is online.
 func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 	h.mu.RLock()
 	ds := h.state

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -12,7 +12,7 @@ func TestUnregisterOnlyRemovesMatchingConnection(t *testing.T) {
 	oldConn := &Conn{Send: make(chan []byte, 1)}
 	newConn := &Conn{Send: make(chan []byte, 1)}
 
-	hub.conns[number] = newConn
+	hub.conns[number] = []*Conn{newConn}
 
 	hub.Unregister(number, oldConn)
 	if got := hub.Get(number); got != newConn {
@@ -24,7 +24,7 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 	hub := NewHub()
 	number := "3140001"
 	conn := &Conn{Send: make(chan []byte, 1)}
-	hub.conns[number] = conn
+	hub.conns[number] = []*Conn{conn}
 
 	hub.Unregister(number, conn)
 	if got := hub.Get(number); got != nil {
@@ -76,11 +76,12 @@ func TestHubGetReturnsConnForOnline(t *testing.T) {
 func TestRegisterHandlesAlreadyClosedSendChannel(t *testing.T) {
 	hub := NewHub()
 	number := "3140001"
-	oldConn := &Conn{Send: make(chan []byte)}
+	oldConn := &Conn{Send: make(chan []byte), HardwareID: "hw-001"}
 	close(oldConn.Send)
-	hub.conns[number] = oldConn
+	hub.conns[number] = []*Conn{oldConn}
+	hub.hwConns["hw-001"] = oldConn
 
-	newConn := &Conn{Send: make(chan []byte, 1)}
+	newConn := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-001"}
 	_ = hub.Register(number, newConn)
 
 	if got := hub.Get(number); got != newConn {
@@ -119,10 +120,10 @@ func TestDeviceInfoNilWhenOffline(t *testing.T) {
 
 func TestRegisterOverwritesRemoteAddrOnReconnect(t *testing.T) {
 	hub := NewHub()
-	first := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.42"}
+	first := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-003", RemoteAddr: "192.168.1.42"}
 	_ = hub.Register("3140003", first)
 
-	second := &Conn{Send: make(chan []byte, 1), RemoteAddr: "192.168.1.99"}
+	second := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-003", RemoteAddr: "192.168.1.99"}
 	_ = hub.Register("3140003", second)
 
 	info := hub.DeviceInfo("3140003")

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -235,20 +235,11 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 	}
 	r.forward(msg)
 
-	// POTS extension model: when one device answers, cancel ringing on all
-	// other devices sharing the same line number. The answering device is
-	// identified by msg.HardwareID (set by the WS handler).
 	if msg.HardwareID != "" {
+		cancelMsg := &Message{Type: TypeHangup, From: msg.To}
 		for _, conn := range r.Hub.GetAll(from) {
 			if conn.HardwareID != msg.HardwareID {
-				cancelMsg := &Message{Type: TypeHangup, From: msg.To}
-				data, err := cancelMsg.Marshal()
-				if err == nil {
-					select {
-					case conn.Send <- data:
-					default:
-					}
-				}
+				_ = r.Hub.SendToHardware(conn.HardwareID, cancelMsg)
 			}
 		}
 	}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -106,8 +106,15 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeRequestICE:
 		r.handleRequestICE(from)
 	case TypeDeviceInfo:
-		if r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr) {
+		updated := false
+		if msg.HardwareID != "" {
+			updated = r.Hub.UpdateDeviceInfoByHardware(msg.HardwareID, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr)
+		} else {
+			updated = r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr)
+		}
+		if updated {
 			slog.Info("device_info", "number", from,
+				"hardware_id", msg.HardwareID,
 				"pi_version", msg.PiVersion,
 				"fw_version", msg.FirmwareVersion,
 				"local_addr", msg.LocalAddr)
@@ -135,10 +142,7 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
-	target := r.Hub.Get(msg.To)
-	if target == nil {
-		// peer_unreachable: caller asked for a phone that isn't connected.
-		// Counted as an aggregate; no caller, callee, or call ID is recorded.
+	if r.Hub.ConnectionCount(msg.To) == 0 {
 		r.observeError("peer_unreachable")
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "phone not connected"})
 		return
@@ -230,6 +234,24 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 		}
 	}
 	r.forward(msg)
+
+	// POTS extension model: when one device answers, cancel ringing on all
+	// other devices sharing the same line number. The answering device is
+	// identified by msg.HardwareID (set by the WS handler).
+	if msg.HardwareID != "" {
+		for _, conn := range r.Hub.GetAll(from) {
+			if conn.HardwareID != msg.HardwareID {
+				cancelMsg := &Message{Type: TypeHangup, From: msg.To}
+				data, err := cancelMsg.Marshal()
+				if err == nil {
+					select {
+					case conn.Send <- data:
+					default:
+					}
+				}
+			}
+		}
+	}
 }
 
 func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -228,13 +228,9 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 		r.observeError("invalid_message")
 		return
 	}
-	if r.Tracker != nil {
-		if err := r.Tracker.OnCallAnswered(ctx, msg.To, from); err != nil {
-			slog.Error("failed to track call answer", "err", err)
-		}
-	}
-	r.forward(msg)
 
+	// Cancel ringing on sibling devices BEFORE forwarding the answer so
+	// a near-simultaneous second answer doesn't reach the caller.
 	if msg.HardwareID != "" {
 		cancelMsg := &Message{Type: TypeHangup, From: msg.To}
 		for _, conn := range r.Hub.GetAll(from) {
@@ -243,6 +239,13 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 			}
 		}
 	}
+
+	if r.Tracker != nil {
+		if err := r.Tracker.OnCallAnswered(ctx, msg.To, from); err != nil {
+			slog.Error("failed to track call answer", "err", err)
+		}
+	}
+	r.forward(msg)
 }
 
 func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
@@ -384,14 +387,17 @@ func (r *Relay) OnRegistered(ctx context.Context, number string) {
 }
 
 // OnDisconnect cleans up any active calls or conference membership for a
-// phone that disconnected.
+// phone that disconnected. With multiple devices per line, only tear down
+// the call when the last device on that line disconnects. OnDisconnect
+// runs before Unregister (LIFO defer order in handler_ws.go), so the
+// departing conn is still counted; >1 means siblings remain.
 func (r *Relay) OnDisconnect(ctx context.Context, number string) {
 	if r.Tracker == nil {
 		return
 	}
-	// If the phone was in a conference, end the conference cleanly: persist
-	// the end, notify remaining members. This runs BEFORE ClearByNumber so
-	// the conference cleanup happens through the structured path.
+	if r.Hub.ConnectionCount(number) > 1 {
+		return
+	}
 	if conf := r.Tracker.Conferences().ConferenceByPhone(number); conf != nil {
 		r.endConference(ctx, conf.ID, "disconnect")
 	}

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -124,7 +124,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate code A: %v", err)
 	}
-	if _, _, err := pairingStore.ClaimDevice(context.Background(), codeA, phoneNumA, "Phone A", hhA.ID); err != nil {
+	if _, _, err := pairingStore.ClaimDevice(context.Background(), codeA, phoneNumA, "Phone A", "Phone A", hhA.ID); err != nil {
 		t.Fatalf("claim phone A: %v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestCallsPageScopedToHousehold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate code B: %v", err)
 	}
-	if _, _, err := pairingStore.ClaimDevice(context.Background(), codeB, phoneNumB, "Phone B", hhB.ID); err != nil {
+	if _, _, err := pairingStore.ClaimDevice(context.Background(), codeB, phoneNumB, "Phone B", "Phone B", hhB.ID); err != nil {
 		t.Fatalf("claim phone B: %v", err)
 	}
 
@@ -250,7 +250,7 @@ func TestCallsPageRenders3WayConference(t *testing.T) {
 		if err != nil {
 			t.Fatalf("generate code %d: %v", i, err)
 		}
-		if _, _, err := pairingStore.ClaimDevice(context.Background(), code, num, "Phone "+num, hh.ID); err != nil {
+		if _, _, err := pairingStore.ClaimDevice(context.Background(), code, num, "Phone "+num, "Phone "+num, hh.ID); err != nil {
 			t.Fatalf("claim phone %d: %v", i, err)
 		}
 	}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -16,6 +17,10 @@ import (
 	"github.com/justinlindh/digits/server/internal/signaling"
 	"github.com/justinlindh/digits/server/internal/updates"
 )
+
+func parseInt64(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
+}
 
 const maxLineNameRunes = 50
 
@@ -53,6 +58,8 @@ type lineRow struct {
 	OnCallElapsed       string // "mm:ss" for the Dashboard room-card callout
 	OnCallID            int64  // 0 when not on a call; otherwise the active call id
 	DeviceInfo          *signaling.DeviceInfoSnapshot
+	Devices             []device.Device
+	OnlineDeviceCount   int
 	FirmwareUpdateNotes []updates.Release
 	PiUpdateNotes       []updates.Release
 }
@@ -96,6 +103,17 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 	for i, l := range lines {
 		info := h.hub.DeviceInfo(l.Number)
 		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
+		row.OnlineDeviceCount = h.hub.ConnectionCount(l.Number)
+
+		if h.deviceStore != nil {
+			devs, err := h.deviceStore.ListByLine(r.Context(), l.ID)
+			if err != nil {
+				slog.Error("list devices for line", "line_id", l.ID, "err", err)
+			} else {
+				row.Devices = devs
+			}
+		}
+
 		if idx != nil && info != nil {
 			if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
 				row.FirmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, info.FirmwareVersion, latestFw)
@@ -174,15 +192,9 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	code := strings.TrimSpace(r.FormValue("code"))
-	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
-	name := strings.TrimSpace(r.FormValue("name"))
-
-	if err := line.ValidateNumber(number); err != nil {
-		data := h.buildLinesData(r, hh, "")
-		data.PairError = "invalid phone number: " + err.Error()
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
-		return
-	}
+	deviceName := strings.TrimSpace(r.FormValue("name"))
+	pairMode := strings.TrimSpace(r.FormValue("pair_mode"))
+	existingLineID := strings.TrimSpace(r.FormValue("existing_line_id"))
 
 	if h.pairingStore == nil {
 		data := h.buildLinesData(r, hh, "")
@@ -193,7 +205,42 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 
 	householdID := hh.ID
 
-	token, hwID, err := h.pairingStore.ClaimDevice(r.Context(), code, number, name, householdID)
+	var (
+		token  string
+		hwID   string
+		number string
+		err    error
+	)
+
+	if pairMode == "existing" && existingLineID != "" {
+		// Add device to an existing line (POTS extension)
+		lineID, parseErr := parseInt64(existingLineID)
+		if parseErr != nil {
+			data := h.buildLinesData(r, hh, "")
+			data.PairError = "invalid line selection"
+			renderWith(w, h.tmplPhones, layoutFor(r), data)
+			return
+		}
+		token, hwID, err = h.pairingStore.ClaimDeviceToLine(r.Context(), code, lineID, deviceName, householdID)
+		if err == nil {
+			ln, lnErr := h.lineStore.GetByID(r.Context(), lineID)
+			if lnErr == nil {
+				number = ln.Number
+			}
+		}
+	} else {
+		// Create a new line and pair the device
+		number = line.StripNumber(strings.TrimSpace(r.FormValue("number")))
+		if verr := line.ValidateNumber(number); verr != nil {
+			data := h.buildLinesData(r, hh, "")
+			data.PairError = "invalid phone number: " + verr.Error()
+			renderWith(w, h.tmplPhones, layoutFor(r), data)
+			return
+		}
+		lineName := deviceName
+		token, hwID, err = h.pairingStore.ClaimDevice(r.Context(), code, number, lineName, deviceName, householdID)
+	}
+
 	if err != nil {
 		data := h.buildLinesData(r, hh, "")
 		data.PairError = err.Error()
@@ -201,7 +248,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if hwID != "" {
+	if hwID != "" && number != "" {
 		if err := h.hub.SendToHardware(hwID, &signaling.Message{
 			Type:        signaling.TypePaired,
 			DeviceToken: token,
@@ -212,7 +259,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	v := url.Values{}
-	v.Set("paired", name)
+	v.Set("paired", deviceName)
 	http.Redirect(w, r, "/phones?"+v.Encode(), http.StatusSeeOther)
 }
 

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -18,10 +18,6 @@ import (
 	"github.com/justinlindh/digits/server/internal/updates"
 )
 
-func parseInt64(s string) (int64, error) {
-	return strconv.ParseInt(s, 10, 64)
-}
-
 const maxLineNameRunes = 50
 
 func validateLineName(raw string) (string, error) {
@@ -214,7 +210,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 
 	if pairMode == "existing" && existingLineID != "" {
 		// Add device to an existing line (POTS extension)
-		lineID, parseErr := parseInt64(existingLineID)
+		lineID, parseErr := strconv.ParseInt(existingLineID, 10, 64)
 		if parseErr != nil {
 			data := h.buildLinesData(r, hh, "")
 			data.PairError = "invalid line selection"

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -77,7 +77,7 @@ func TestPhonesPage_HandsetNameField(t *testing.T) {
 	body := w.Body.String()
 	for _, want := range []string{
 		"Handset name",
-		"Kitchen · Grandma&#39;s bedroom · Garage",
+		"Kitchen · Bedroom · Garage",
 		"Most families name handsets by where they live",
 	} {
 		if !strings.Contains(body, want) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -457,7 +457,7 @@ func setupPairedDevice(t *testing.T, database *db.Database, pairingStore *pairin
 	}
 
 	// Claim the device (pairs it, sets hashed token)
-	token, _, err = pairingStore.ClaimDevice(context.Background(), code, number, "Test Phone", hh.ID)
+	token, _, err = pairingStore.ClaimDevice(context.Background(), code, number, "Test Phone", "Test Phone", hh.ID)
 	if err != nil {
 		t.Fatalf("claim device: %v", err)
 	}

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -210,6 +210,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 			}
 			continue
 		}
+		msg.HardwareID = conn.HardwareID
 		h.relay.HandleMessage(r.Context(), number, msg)
 	}
 }

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -154,7 +154,7 @@ func newLHEnv(t *testing.T) lhSetup {
 	if err != nil {
 		t.Fatalf("generate code A: %v", err)
 	}
-	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeA, numA, "Phone A", hhA.ID); err != nil {
+	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeA, numA, "Phone A", "Phone A", hhA.ID); err != nil {
 		t.Fatalf("claim phone A: %v", err)
 	}
 
@@ -162,7 +162,7 @@ func newLHEnv(t *testing.T) lhSetup {
 	if err != nil {
 		t.Fatalf("generate code B: %v", err)
 	}
-	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeB, numB, "Phone B", hhB.ID); err != nil {
+	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeB, numB, "Phone B", "Phone B", hhB.ID); err != nil {
 		t.Fatalf("claim phone B: %v", err)
 	}
 
@@ -170,7 +170,7 @@ func newLHEnv(t *testing.T) lhSetup {
 	if err != nil {
 		t.Fatalf("generate code C: %v", err)
 	}
-	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeC, numC, "Phone C", hhC.ID); err != nil {
+	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), codeC, numC, "Phone C", "Phone C", hhC.ID); err != nil {
 		t.Fatalf("claim phone C: %v", err)
 	}
 

--- a/server/internal/web/spec_compliance_test.go
+++ b/server/internal/web/spec_compliance_test.go
@@ -125,7 +125,7 @@ func TestSpecLines(t *testing.T) {
 	// Field label, placeholder, helper (Spec: the core pair-flow nudge).
 	for _, want := range []string{
 		"Handset name",
-		"Kitchen · Grandma&#39;s bedroom · Garage", // html/template escapes the apostrophe
+		"Kitchen · Bedroom · Garage",
 		"Most families name handsets by where they live",
 	} {
 		if !strings.Contains(body, want) {

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -58,8 +58,18 @@
           </div>
           {{if .Devices}}
           <div class="kv__row">
-            <dt class="kv__key">Devices</dt>
-            <dd class="kv__val">{{len .Devices}} paired</dd>
+            <dt class="kv__key">Handsets</dt>
+            <dd class="kv__val">
+              {{if gt (len .Devices) 1}}
+              <div style="display: flex; flex-direction: column; gap: 2px;">
+                {{range .Devices}}
+                <span>{{if .Name}}{{.Name}}{{else}}Unnamed{{end}}</span>
+                {{end}}
+              </div>
+              {{else}}
+              {{len .Devices}} paired
+              {{end}}
+            </dd>
           </div>
           {{end}}
         </dl>

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -38,6 +38,7 @@
         <!-- Entry form fields -->
         <form method="POST" action="/phones/pair" id="pair-form" class="stack-md" style="min-width: 0;">
           <input type="hidden" name="code" id="pair-code-hidden" value="">
+          <input type="hidden" name="pair_mode" id="pair-mode-hidden" value="new">
 
           <div class="field">
             <label for="pair-code-manual" class="field__label">Pairing code</label>
@@ -53,17 +54,41 @@
             <p class="field__hint">Or tap the keypad.</p>
           </div>
 
+          {{if .Lines}}
           <div class="field">
-            <label for="line-number-input" class="field__label">Line number</label>
-            <input type="text"
-                   name="number"
-                   id="line-number-input"
-                   placeholder="314-0001"
-                   pattern="\d{3}-?\d{4}"
-                   maxlength="8"
-                   required
-                   class="field__input field__input--mono">
-            <p id="number-hint" class="field__hint field__hint--err hidden">Line number is already in use.</p>
+            <span class="field__label">Line</span>
+            <div class="pair-mode-tabs" style="display: flex; gap: 0; margin-bottom: 8px;">
+              <button type="button" class="btn btn--sm pair-mode-tab is-active" data-mode="new" onclick="setPairMode('new')">New line</button>
+              <button type="button" class="btn btn--sm pair-mode-tab" data-mode="existing" onclick="setPairMode('existing')">Add extension</button>
+            </div>
+          </div>
+          {{end}}
+
+          <div id="new-line-fields">
+            <div class="field">
+              <label for="line-number-input" class="field__label">Line number</label>
+              <input type="text"
+                     name="number"
+                     id="line-number-input"
+                     placeholder="314-0001"
+                     pattern="\d{3}-?\d{4}"
+                     maxlength="8"
+                     class="field__input field__input--mono">
+              <p id="number-hint" class="field__hint field__hint--err hidden">Line number is already in use.</p>
+            </div>
+          </div>
+
+          <div id="existing-line-fields" class="hidden">
+            <div class="field">
+              <label for="existing-line-select" class="field__label">Add to line</label>
+              <select name="existing_line_id" id="existing-line-select" class="field__input">
+                <option value="">Choose a line...</option>
+                {{range .Lines}}
+                <option value="{{.Line.ID}}">{{fmtPhone .Line.Number}} - {{.Line.Name}}</option>
+                {{end}}
+              </select>
+              <p class="field__hint" style="font-size: 11.5px; margin-top: 4px;">Like plugging another phone into the same wall jack. All handsets on the line ring together.</p>
+            </div>
           </div>
 
           <div class="field">
@@ -71,7 +96,7 @@
             <input type="text"
                    id="line-name-input"
                    name="name"
-                   placeholder="Kitchen · Grandma&#39;s bedroom · Garage"
+                   placeholder="Kitchen · Bedroom · Garage"
                    required
                    maxlength="50"
                    class="field__input">
@@ -213,10 +238,41 @@
     numberInput.classList.remove('is-invalid');
     numberHint.classList.add('hidden');
   }
+  var pairModeHidden = document.getElementById('pair-mode-hidden');
+  var newLineFields = document.getElementById('new-line-fields');
+  var existingLineFields = document.getElementById('existing-line-fields');
+  var existingLineSelect = document.getElementById('existing-line-select');
+  var pairMode = 'new';
+
+  window.setPairMode = function(mode) {
+    pairMode = mode;
+    pairModeHidden.value = mode;
+    var tabs = document.querySelectorAll('.pair-mode-tab');
+    tabs.forEach(function(t) { t.classList.toggle('is-active', t.dataset.mode === mode); });
+    if (mode === 'existing') {
+      newLineFields.classList.add('hidden');
+      existingLineFields.classList.remove('hidden');
+      numberInput.removeAttribute('required');
+    } else {
+      newLineFields.classList.remove('hidden');
+      existingLineFields.classList.add('hidden');
+    }
+    updateSubmit();
+  };
+
   function updateSubmit() {
-    var numDigits = numberInput.value.replace(/\D/g, '');
     var hasName = nameInput.value.trim().length > 0;
-    submitBtn.disabled = code.length !== 6 || numDigits.length !== 7 || !hasName || numberInput.validity.customError;
+    if (pairMode === 'existing') {
+      var hasLine = existingLineSelect && existingLineSelect.value !== '';
+      submitBtn.disabled = code.length !== 6 || !hasLine || !hasName;
+    } else {
+      var numDigits = numberInput.value.replace(/\D/g, '');
+      submitBtn.disabled = code.length !== 6 || numDigits.length !== 7 || !hasName || numberInput.validity.customError;
+    }
+  }
+
+  if (existingLineSelect) {
+    existingLineSelect.addEventListener('change', updateSubmit);
   }
   function checkNumber() {
     var digits = numberInput.value.replace(/\D/g, '');
@@ -255,7 +311,7 @@
 <div id="phones-table" class="panel">
   <header class="panel__head">
     <h2 class="panel__title">Your lines</h2>
-    <span class="panel__title-sub">{{len .Lines}} total</span>
+    <span class="panel__title-sub">{{len .Lines}} line{{if ne (len .Lines) 1}}s{{end}}</span>
   </header>
   {{if .Lines}}
   <!-- Desktop table -->
@@ -264,7 +320,7 @@
       <thead>
         <tr>
           <th>Number</th>
-          <th>Label</th>
+          <th>Handsets</th>
           <th>Status</th>
           <th>Pi</th>
           <th>Firmware</th>
@@ -282,7 +338,16 @@
             {{end}}
           </td>
           <td>
-            <a href="/phones/{{.Line.Number}}">{{.Line.Name}}</a>
+            {{if gt (len .Devices) 1}}
+              <a href="/phones/{{.Line.Number}}" style="font-weight: 500;">{{.Line.Name}}</a>
+              <div style="margin-top: 4px; padding-left: 12px; border-left: 2px solid var(--rule-soft);">
+                {{range .Devices}}
+                <div style="font-size: 12px; color: var(--ink-muted); line-height: 1.6;">{{if .Name}}{{.Name}}{{else}}Unnamed{{end}}</div>
+                {{end}}
+              </div>
+            {{else}}
+              <a href="/phones/{{.Line.Number}}">{{.Line.Name}}</a>
+            {{end}}
             {{if .Line.Settings.SilentMode}}
             <span class="phone-silent" aria-label="Silent mode on" title="Silent mode on">
               <span class="phone-silent__dot" aria-hidden="true"></span>
@@ -292,7 +357,11 @@
           </td>
           <td>
             {{if .Online}}
-              <span class="chip chip--on"><span class="chip__dot"></span>online</span>
+              {{if gt (len .Devices) 1}}
+                <span class="chip chip--on"><span class="chip__dot"></span>{{.OnlineDeviceCount}}/{{len .Devices}} online</span>
+              {{else}}
+                <span class="chip chip--on"><span class="chip__dot"></span>online</span>
+              {{end}}
             {{else}}
               <span class="chip"><span class="chip__dot"></span>offline</span>
             {{end}}
@@ -365,9 +434,13 @@
     <li>
       <a class="lines__row" href="/phones/{{.Line.Number}}">
         <span class="lines__dot{{if .Online}} lines__dot--on{{end}}"></span>
-        <span class="lines__name">{{.Line.Name}}{{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}</span>
+        <span class="lines__name">
+          {{.Line.Name}}
+          {{if gt (len .Devices) 1}}<span class="muted" style="font-size: 11px; font-weight: normal;"> ({{len .Devices}} handsets)</span>{{end}}
+          {{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}
+        </span>
         <span class="lines__num">{{fmtPhone .Line.Number}}{{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}<span class="lines__ip num muted" style="display: block; font-size: 11px;">{{.DeviceInfo.RemoteAddr}}</span>{{end}}</span>
-        <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}online{{else}}offline{{end}}</span>
+        <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}{{if gt (len .Devices) 1}}{{.OnlineDeviceCount}}/{{len .Devices}}{{else}}online{{end}}{{else}}offline{{end}}</span>
       </a>
       {{if or .FirmwareUpdateNotes .PiUpdateNotes}}
         <details class="update-details update-details--mobile">

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -334,7 +334,7 @@ func seedUnrelatedUser(t *testing.T, env callsTestEnv, label string) *auth.User 
 	if err != nil {
 		t.Fatalf("seedUnrelatedUser %s: GenerateCode: %v", label, err)
 	}
-	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), code, num, "Phone "+label, hh.ID); err != nil {
+	if _, _, err := env.pairingStore.ClaimDevice(context.Background(), code, num, "Phone "+label, "Phone "+label, hh.ID); err != nil {
 		t.Fatalf("seedUnrelatedUser %s: ClaimDevice: %v", label, err)
 	}
 	return u


### PR DESCRIPTION
## Summary

Implements #212. Splits the identity model so a **line** is a phone number and a **handset** is a physical device. Multiple handsets can share one line -- the POTS extension model, where plugging a second phone into a wall jack means both ring on incoming calls.

- **DB migration (v27):** adds `devices.name` column; backfills from `lines.name`
- **Hub multi-connection:** `conns` map stores `[]*Conn` per line number. `Register` appends; `SendTo` broadcasts to all devices on a line. `Unregister` removes only the specific conn
- **Ring-all + first-answer-wins:** incoming calls ring every device on the callee line. When one device answers, the relay sends `TypeHangup` to cancel ringing on the others
- **Pair flow:** "New line" / "Add extension" toggle. Extension mode shows a dropdown of existing lines instead of a number field
- **Lines table:** multi-device lines show nested handset names and "N/M online" status
- **Detail page:** handsets section lists all devices by name
- **Devseed:** Kitchen line (248-0001) gets two devices to exercise the UI

### Technical limitations

- **Extension pickup (joining an active call):** not implemented. In 90s POTS you could pick up an extension mid-call; here only the first answerer gets the WebRTC session. The others get a hangup.
- **Per-device firmware display on the lines table:** shows the first connected device's version. The detail page shows all.
- **Redis cluster state:** `DeviceState` (cross-pod presence via Redis) is not yet multi-device aware. Single-instance mode (no Redis) works correctly. Production currently runs single-instance.
- **Unpairing individual handsets** from a multi-device line is out of scope (per #212).

## Screenshots

### Lines table with multi-handset Kitchen line (1/2 online)
![lines table](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-212-lines-table.png)

### Line detail showing both handsets
![detail page](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-212-detail-page.png)

### "Add extension" pair mode with line dropdown
![add extension](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-212-add-extension.png)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all pass (hub_test.go updated for `[]*Conn`)
- [x] `golangci-lint run ./...` zero issues
- [x] Dev server: lines page shows nested handsets, status badge, pair toggle
- [x] Dev server: detail page shows handset list
- [x] Dev server: "Add extension" mode shows line dropdown
- [ ] E2E tests (Playwright) -- need to update for new pair form fields
- [ ] Integration tests against real DB (ClaimDeviceToLine path)

Closes #212