### PR TITLE
feat(server): POTS extension pickup for multi-handset lines

### DIFF
--- a/server/internal/signaling/conference_integration_test.go
+++ b/server/internal/signaling/conference_integration_test.go
@@ -335,7 +335,7 @@ func TestDisconnectNonHostConferenceParticipant_Integration(t *testing.T) {
 	}
 
 	// Simulate B (non-host) disconnecting by calling OnDisconnect directly.
-	r.OnDisconnect(context.Background(), "5550002")
+	r.OnDisconnect(context.Background(), "5550002", "")
 
 	// Conference DB row must be ended with reason 'disconnect'.
 	var dbState, dbReason string
@@ -480,7 +480,7 @@ func TestDisconnectConferenceParticipant_Integration(t *testing.T) {
 	}
 
 	// Simulate A disconnecting by calling OnDisconnect directly.
-	r.OnDisconnect(context.Background(), "5550001")
+	r.OnDisconnect(context.Background(), "5550001", "")
 
 	// Conference DB row must be ended with reason 'disconnect'.
 	var dbState, dbReason string

--- a/server/internal/signaling/extension_test.go
+++ b/server/internal/signaling/extension_test.go
@@ -1,0 +1,222 @@
+package signaling
+
+import (
+	"context"
+	"testing"
+)
+
+func TestExtensionPickup_HappyPath(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	phoneA := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-a"}
+	phoneB := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-b"}
+	phoneY := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-y"}
+	_ = hub.Register("3140001", phoneA)
+	_ = hub.Register("3140001", phoneB)
+	_ = hub.Register("3140002", phoneY)
+
+	// Establish a call: line 3140001 (device A) calls line 3140002
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+	drainN(t, phoneY.Send, 1) // ring
+
+	relay.HandleMessage(context.Background(), "3140002", &Message{Type: TypeAnswer, To: "3140001", HardwareID: "hw-y"})
+	drainN(t, phoneA.Send, 1) // answer forwarded
+	drainN(t, phoneB.Send, 1) // ring-cancel hangup from first-answer-wins
+
+	// Device B picks up the extension
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeExtensionPickup,
+		HardwareID: "hw-b",
+	})
+
+	// B should get ExtensionConnect (initiator)
+	bMsg := drainOne(t, phoneB.Send)
+	if bMsg.Type != TypeExtensionConnect {
+		t.Fatalf("expected ExtensionConnect for B, got %s", bMsg.Type)
+	}
+	if !bMsg.Initiator {
+		t.Error("B should be initiator")
+	}
+	if bMsg.Peer != "3140002" {
+		t.Errorf("B's peer should be 3140002, got %s", bMsg.Peer)
+	}
+
+	// Y should get ExtensionConnect (non-initiator)
+	yMsg := drainOne(t, phoneY.Send)
+	if yMsg.Type != TypeExtensionConnect {
+		t.Fatalf("expected ExtensionConnect for Y, got %s", yMsg.Type)
+	}
+	if yMsg.Initiator {
+		t.Error("Y should not be initiator")
+	}
+
+	// A should get ExtensionActive notification
+	aMsg := drainOne(t, phoneA.Send)
+	if aMsg.Type != TypeExtensionActive {
+		t.Fatalf("expected ExtensionActive for A, got %s", aMsg.Type)
+	}
+}
+
+func TestExtensionPickup_NoActiveCall(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	phoneB := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-b"}
+	_ = hub.Register("3140001", phoneB)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeExtensionPickup,
+		HardwareID: "hw-b",
+	})
+
+	msg := drainOne(t, phoneB.Send)
+	if msg.Type != TypeError {
+		t.Fatalf("expected error when no active call, got %s", msg.Type)
+	}
+}
+
+func TestExtensionPickup_NoHardwareID(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	phone := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", phone)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type: TypeExtensionPickup,
+	})
+
+	msg := drainOne(t, phone.Send)
+	if msg.Type != TypeError {
+		t.Fatalf("expected error without hardware_id, got %s", msg.Type)
+	}
+}
+
+func TestExtensionHangup_OnlyExtensionCleared(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	phoneA := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-a"}
+	phoneB := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-b"}
+	phoneY := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-y"}
+	_ = hub.Register("3140001", phoneA)
+	_ = hub.Register("3140001", phoneB)
+	_ = hub.Register("3140002", phoneY)
+
+	// Establish call and extension
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+	drainN(t, phoneY.Send, 1)
+	relay.HandleMessage(context.Background(), "3140002", &Message{Type: TypeAnswer, To: "3140001", HardwareID: "hw-y"})
+	drainCh(phoneA.Send)
+	drainCh(phoneB.Send)
+	drainCh(phoneY.Send)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeExtensionPickup,
+		HardwareID: "hw-b",
+	})
+	drainCh(phoneA.Send)
+	drainCh(phoneB.Send)
+	drainCh(phoneY.Send)
+
+	// Extension device B hangs up
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeHangup,
+		To:         "3140002",
+		HardwareID: "hw-b",
+	})
+
+	// The main call between A and Y should still be active
+	if !tracker.Busy("3140001") {
+		t.Fatal("main call should still be active after extension hangup")
+	}
+	if !tracker.Busy("3140002") {
+		t.Fatal("remote peer should still be active after extension hangup")
+	}
+}
+
+func TestMainCallEnd_ClearsExtensions(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	phoneA := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-a"}
+	phoneB := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-b"}
+	phoneY := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-y"}
+	_ = hub.Register("3140001", phoneA)
+	_ = hub.Register("3140001", phoneB)
+	_ = hub.Register("3140002", phoneY)
+
+	// Establish call and extension
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+	drainN(t, phoneY.Send, 1)
+	relay.HandleMessage(context.Background(), "3140002", &Message{Type: TypeAnswer, To: "3140001", HardwareID: "hw-y"})
+	drainCh(phoneA.Send)
+	drainCh(phoneB.Send)
+	drainCh(phoneY.Send)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeExtensionPickup,
+		HardwareID: "hw-b",
+	})
+	drainCh(phoneA.Send)
+	drainCh(phoneB.Send)
+	drainCh(phoneY.Send)
+
+	// Main caller (line 3140001) hangs up
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:       TypeHangup,
+		To:         "3140002",
+		HardwareID: "hw-a",
+	})
+
+	// Extension device B should receive a hangup
+	bMsg := drainOne(t, phoneB.Send)
+	if bMsg.Type != TypeHangup {
+		t.Fatalf("extension device should get hangup when main call ends, got %s", bMsg.Type)
+	}
+}
+
+// drainOne reads exactly one message from ch. Fails the test if none available.
+func drainOne(t *testing.T, ch <-chan []byte) *Message {
+	t.Helper()
+	select {
+	case data := <-ch:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse message: %v", err)
+		}
+		return msg
+	default:
+		t.Fatal("expected a message but channel was empty")
+		return nil
+	}
+}
+
+// drainN reads exactly n messages from ch. Fails if fewer are available.
+func drainN(t *testing.T, ch <-chan []byte, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-ch:
+		default:
+			t.Fatalf("expected %d messages but only got %d", n, i)
+		}
+	}
+}
+
+// drainCh empties a single channel without blocking.
+func drainCh(ch <-chan []byte) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -32,6 +32,13 @@ const (
 	TypeReleaseAvailable = "release_available" // Server → All: new release detected
 )
 
+// Extension pickup types (POTS extension model: pick up a second handset mid-call)
+const (
+	TypeExtensionPickup  = "extension_pickup"  // Phone → Server: device is picking up during active call on its line
+	TypeExtensionConnect = "extension_connect" // Server → Phone: establish peer connection for the extension
+	TypeExtensionActive  = "extension_active"  // Server → Phone: notify original device that an extension joined
+)
+
 // Conference message types (three-way calling)
 const (
 	TypeConferenceMerge    = "conference_merge"    // client -> server
@@ -155,8 +162,15 @@ type Message struct {
 	// Per-line settings updates (line_settings messages)
 	LineSettings *LineSettings `json:"line_settings,omitempty"`
 
+	// Extension pickup fields (POTS extension model).
+	// Extension is true when this SDP/ICE message belongs to an extension
+	// pickup connection rather than the primary call. The relay routes
+	// extension SDP/ICE to specific hardware IDs rather than broadcasting
+	// to all devices on the line.
+	Extension bool `json:"extension,omitempty"`
+
 	// Conference fields (party-line / three-way calling).
-	ConfID     string                 `json:"conf_id,omitempty"`
+	ConfID string `json:"conf_id,omitempty"`
 	HeldPeer   string                 `json:"held_peer,omitempty"`
 	ActivePeer string                 `json:"active_peer,omitempty"`
 	Peer       string                 `json:"peer,omitempty"`

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -170,7 +170,7 @@ type Message struct {
 	Extension bool `json:"extension,omitempty"`
 
 	// Conference fields (party-line / three-way calling).
-	ConfID string `json:"conf_id,omitempty"`
+	ConfID     string                 `json:"conf_id,omitempty"`
 	HeldPeer   string                 `json:"held_peer,omitempty"`
 	ActivePeer string                 `json:"active_peer,omitempty"`
 	Peer       string                 `json:"peer,omitempty"`

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -287,7 +287,17 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 			r.dropMemberFromConference(ctx, conf.ID, from, "hangup")
 			return
 		}
+		// NOTE: If a member previously left and a 2-party continuation call was
+		// created (dropMemberFromConference ended the conference and left the
+		// remaining two in the active-call map), the conference is already gone
+		// by the time the host hangs up. ConferenceByPhone(from) returns nil here,
+		// so we fall through to the normal 2-party hangup path below, which
+		// correctly calls OnCallEnded and forwards Hangup to the peer. No special
+		// handling needed.
 	}
+	// Resolve the set of peers to notify. In pre-merge ADD_* flows the host
+	// may have multiple active 2-party calls (A-B held and A-C active); a
+	// single hook-on ends both. For the normal 2-party case this is one peer.
 	var peers []string
 	if r.Tracker != nil {
 		peers = r.Tracker.AllPeersOf(from)
@@ -539,6 +549,11 @@ func (r *Relay) clearExtension(hardwareID string) {
 	}
 	r.extMu.Unlock()
 	if ok {
+		_ = r.Hub.SendTo(ext.PeerNumber, &Message{
+			Type:      TypeHangup,
+			From:      ext.LineNumber,
+			Extension: true,
+		})
 		slog.Info("extension cleared", "hardware_id", hardwareID, "line", ext.LineNumber, "peer", ext.PeerNumber)
 	}
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -49,6 +50,16 @@ type SignalingErrorObserver interface {
 	ObserveSignalingErrorCategory(category string)
 }
 
+// activeExtension tracks a device that picked up an extension phone during
+// an active call on its line. The extension device has its own WebRTC peer
+// connection to the remote party, running in parallel with the original
+// answering device's connection.
+type activeExtension struct {
+	HardwareID string // the picking-up device
+	LineNumber string // the line the extension is on
+	PeerNumber string // the remote party's line number
+}
+
 type Relay struct {
 	Hub            *Hub
 	Tracker        CallTracker
@@ -62,6 +73,9 @@ type Relay struct {
 	// unreachable, etc). nil disables instrumentation; production wires it
 	// in cmd/signald/main.go.
 	Errors SignalingErrorObserver
+
+	extMu      sync.Mutex
+	extensions map[string]*activeExtension // hardware_id -> extension state
 }
 
 // observeError is a nil-safe pass-through to the SignalingErrorObserver.
@@ -79,6 +93,7 @@ func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer, lineStor
 		Tracker:        tracker,
 		CallAuthorizer: authorizer,
 		LineStore:      lineStore,
+		extensions:     make(map[string]*activeExtension),
 	}
 }
 
@@ -101,6 +116,8 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 		r.handleHangup(ctx, from, msg)
 	case TypeConferenceMerge:
 		r.handleConferenceMerge(ctx, from, msg)
+	case TypeExtensionPickup:
+		r.handleExtensionPickup(ctx, from, msg)
 	case TypeDTMF:
 		r.handleDTMF(ctx, from, msg)
 	case TypeRequestICE:
@@ -249,6 +266,18 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
+	// If the hangup comes from an extension device, only tear down the
+	// extension connection -- the primary call continues.
+	if msg.HardwareID != "" {
+		r.extMu.Lock()
+		_, isExt := r.extensions[msg.HardwareID]
+		r.extMu.Unlock()
+		if isExt {
+			r.clearExtension(msg.HardwareID)
+			return
+		}
+	}
+
 	if r.Tracker != nil {
 		if conf := r.Tracker.Conferences().ConferenceByPhone(from); conf != nil {
 			if conf.Host == from {
@@ -258,17 +287,7 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 			r.dropMemberFromConference(ctx, conf.ID, from, "hangup")
 			return
 		}
-		// NOTE: If a member previously left and a 2-party continuation call was
-		// created (dropMemberFromConference ended the conference and left the
-		// remaining two in the active-call map), the conference is already gone
-		// by the time the host hangs up. ConferenceByPhone(from) returns nil here,
-		// so we fall through to the normal 2-party hangup path below, which
-		// correctly calls OnCallEnded and forwards Hangup to the peer. No special
-		// handling needed.
 	}
-	// Resolve the set of peers to notify. In pre-merge ADD_* flows the host
-	// may have multiple active 2-party calls (A-B held and A-C active); a
-	// single hook-on ends both. For the normal 2-party case this is one peer.
 	var peers []string
 	if r.Tracker != nil {
 		peers = r.Tracker.AllPeersOf(from)
@@ -285,9 +304,13 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 		}
 		_ = r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: from, To: peer})
 	}
+	r.clearExtensionsForCall(from)
 }
 
 func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
+	if msg.Extension && r.routeExtensionSignaling(from, msg) {
+		return
+	}
 	if msg.ConfID != "" {
 		id, err := uuid.Parse(msg.ConfID)
 		if err == nil && r.Tracker != nil && r.Tracker.Conferences().ConferenceContains(id, from, msg.To) {
@@ -310,6 +333,9 @@ func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleICE(ctx context.Context, from string, msg *Message) {
+	if msg.Extension && r.routeExtensionSignaling(from, msg) {
+		return
+	}
 	if msg.ConfID != "" {
 		id, err := uuid.Parse(msg.ConfID)
 		if err == nil && r.Tracker != nil && r.Tracker.Conferences().ConferenceContains(id, from, msg.To) {
@@ -391,7 +417,13 @@ func (r *Relay) OnRegistered(ctx context.Context, number string) {
 // the call when the last device on that line disconnects. OnDisconnect
 // runs before Unregister (LIFO defer order in handler_ws.go), so the
 // departing conn is still counted; >1 means siblings remain.
-func (r *Relay) OnDisconnect(ctx context.Context, number string) {
+func (r *Relay) OnDisconnect(ctx context.Context, number string, hardwareID string) {
+	// Clear any extension state for this specific device, regardless of
+	// whether other devices remain on the line.
+	if hardwareID != "" {
+		r.clearExtension(hardwareID)
+	}
+
 	if r.Tracker == nil {
 		return
 	}
@@ -402,6 +434,134 @@ func (r *Relay) OnDisconnect(ctx context.Context, number string) {
 		r.endConference(ctx, conf.ID, "disconnect")
 	}
 	r.Tracker.ClearByNumber(ctx, number)
+	r.clearExtensionsForCall(number)
+}
+
+// handleExtensionPickup is the POTS extension model: a second device on the
+// same line picks up during an active call. The server establishes a parallel
+// WebRTC connection between the picking-up device and the remote peer,
+// without disrupting the original answering device's connection.
+func (r *Relay) handleExtensionPickup(ctx context.Context, from string, msg *Message) {
+	if msg.HardwareID == "" {
+		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "hardware_id required for extension pickup"})
+		return
+	}
+
+	if r.Tracker == nil {
+		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call on this line"})
+		return
+	}
+
+	peer := r.Tracker.PeerOf(from)
+	if peer == "" {
+		if conf := r.Tracker.Conferences().ConferenceByPhone(from); conf != nil {
+			_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "extension pickup not supported during conferences"})
+			return
+		}
+		_ = r.Hub.SendToHardware(msg.HardwareID, &Message{Type: TypeError, Error: "no active call on this line"})
+		return
+	}
+
+	r.extMu.Lock()
+	if _, exists := r.extensions[msg.HardwareID]; exists {
+		r.extMu.Unlock()
+		return
+	}
+	r.extensions[msg.HardwareID] = &activeExtension{
+		HardwareID: msg.HardwareID,
+		LineNumber: from,
+		PeerNumber: peer,
+	}
+	r.extMu.Unlock()
+
+	slog.Info("extension pickup", "line", from, "hardware_id", msg.HardwareID, "peer", peer)
+
+	_ = r.Hub.SendToHardware(msg.HardwareID, &Message{
+		Type:      TypeExtensionConnect,
+		Peer:      peer,
+		Initiator: true,
+	})
+
+	_ = r.Hub.SendTo(peer, &Message{
+		Type:      TypeExtensionConnect,
+		Peer:      from,
+		Initiator: false,
+		Extension: true,
+	})
+
+	for _, conn := range r.Hub.GetAll(from) {
+		if conn.HardwareID != msg.HardwareID {
+			_ = r.Hub.SendToHardware(conn.HardwareID, &Message{
+				Type:       TypeExtensionActive,
+				HardwareID: msg.HardwareID,
+			})
+		}
+	}
+}
+
+// routeExtensionSignaling routes SDP/ICE messages for extension connections.
+// Extension signaling is identified by the Extension flag on the message.
+// Returns true if the message was handled.
+func (r *Relay) routeExtensionSignaling(from string, msg *Message) bool {
+	r.extMu.Lock()
+	ext := r.extensions[msg.HardwareID]
+	r.extMu.Unlock()
+
+	if ext != nil {
+		if msg.To == ext.PeerNumber {
+			_ = r.Hub.SendTo(ext.PeerNumber, msg)
+			return true
+		}
+	}
+
+	// The message might be from the remote peer going back to the extension device.
+	// Find which extension expects traffic from this sender.
+	r.extMu.Lock()
+	for _, e := range r.extensions {
+		if e.PeerNumber == from && e.LineNumber == msg.To {
+			r.extMu.Unlock()
+			_ = r.Hub.SendToHardware(e.HardwareID, msg)
+			return true
+		}
+	}
+	r.extMu.Unlock()
+	return false
+}
+
+// clearExtension removes a device from the active extension set and notifies
+// the remote peer that the extension has hung up. Called when the extension
+// device sends a hangup or disconnects.
+func (r *Relay) clearExtension(hardwareID string) {
+	r.extMu.Lock()
+	ext, ok := r.extensions[hardwareID]
+	if ok {
+		delete(r.extensions, hardwareID)
+	}
+	r.extMu.Unlock()
+	if ok {
+		slog.Info("extension cleared", "hardware_id", hardwareID, "line", ext.LineNumber, "peer", ext.PeerNumber)
+	}
+}
+
+// clearExtensionsForCall removes all extensions on a line, called when the
+// main call ends. Sends hangup to each extension device.
+func (r *Relay) clearExtensionsForCall(lineNumber string) {
+	r.extMu.Lock()
+	var toRemove []string
+	for hwID, ext := range r.extensions {
+		if ext.LineNumber == lineNumber {
+			toRemove = append(toRemove, hwID)
+		}
+	}
+	for _, hwID := range toRemove {
+		delete(r.extensions, hwID)
+	}
+	r.extMu.Unlock()
+
+	for _, hwID := range toRemove {
+		_ = r.Hub.SendToHardware(hwID, &Message{Type: TypeHangup, From: lineNumber})
+		slog.Info("extension cleared (call ended)", "hardware_id", hwID, "line", lineNumber)
+	}
 }
 
 func (r *Relay) forward(msg *Message) {

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -682,7 +682,7 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	}
 
 	// Simulate Phone 2 disconnecting (WebSocket drops)
-	relay.OnDisconnect(context.Background(), "3140002")
+	relay.OnDisconnect(context.Background(), "3140002", "")
 
 	// Phone 2 should no longer be busy
 	if tracker.Busy("3140002") {

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -173,7 +173,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read pump (blocks until disconnect)
 	defer h.hub.Unregister(number, conn)
-	defer h.relay.OnDisconnect(r.Context(), number)
+	defer h.relay.OnDisconnect(r.Context(), number, conn.HardwareID)
 	defer func() {
 		if msg.HardwareID != "" && h.deviceStore != nil {
 			if err := h.deviceStore.TouchLastSeen(r.Context(), msg.HardwareID); err != nil {


### PR DESCRIPTION
## Summary

Builds on #494 (multi-handset lines). Implements the POTS extension pickup model: when a second device on the same line lifts its handset during an active call, it joins the conversation with its own WebRTC peer connection to the remote party. The original call continues undisturbed.

- New message types: `extension_pickup`, `extension_connect`, `extension_active`
- `msg.Extension` flag on SDP/ICE routes extension signaling to specific hardware IDs rather than broadcasting to all devices on the line
- Extension hangup only tears down the extension's connection; the main call continues
- When the main call ends, all active extensions on that line receive a hangup
- Relay tracks active extensions in a lightweight map (no DB changes needed)

### How it works (the POTS model)

In the 90s, picking up a second phone on your line meant you joined the conversation immediately. No button press, no "add party" action. Just lift the handset.

For Digits: when device B on line X picks up while device A is on a call with line Y, the server creates a parallel WebRTC connection between B and Y. Device A's existing connection to Y is untouched. Y now hears audio from both A and B.

### Firmware changes needed (not in this PR)

The firmware needs to:
1. Detect handset lift while the line has an active call (device was in idle/ringing state but the line is busy)
2. Send `TypeExtensionPickup` with the device's hardware_id
3. Handle `TypeExtensionConnect` by creating a new RTCPeerConnection to the indicated peer
4. Tag SDP/ICE messages with `extension: true` so the server routes them correctly
5. Handle `TypeExtensionActive` on the original device to show an "extension in use" indicator

### Sequence diagram

```
Device A (line X)     Server          Device Y (line Z)      Device B (line X)
     |                  |                   |                      |
     |--- TypeCall ---->|--- TypeRing ----->|                      |
     |<-- TypeAnswer ---|<-- TypeAnswer ----|                      |
     |<== SDP/ICE ======|====== SDP/ICE ===>|                      |
     |   [call active]  |  [call active]    |                      |
     |                  |                   |    [user lifts handset]
     |                  |<---- ExtensionPickup --------------------|
     |<- ExtActive -----|                   |                      |
     |                  |--- ExtConnect --->|--- ExtConnect ------->|
     |                  |<== SDP/ICE (ext) =|=== SDP/ICE (ext) ===>|
     |                  |  [ext connected]  |    [ext connected]   |
     |                  |                   |                      |
     |                  |   [B hangs up ext only, A-Y continues]   |
```

## Test plan

- [x] `go test ./...` all pass
- [x] `golangci-lint run ./...` zero issues
- [x] TestExtensionPickup_HappyPath: full flow from pickup to connect messages
- [x] TestExtensionPickup_NoActiveCall: error when no call is active
- [x] TestExtensionPickup_NoHardwareID: error without hardware_id
- [x] TestExtensionHangup_OnlyExtensionCleared: main call survives extension hangup
- [x] TestMainCallEnd_ClearsExtensions: extension gets hangup when main call ends
- [ ] Integration tests (requires firmware support to fully exercise)
- [ ] E2E with real devices

Depends on #494 (merged)