### PR TITLE
chore(ci): drop stale dead-module references missed by #450 and #470

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,9 +21,8 @@ FAILED=0
 MODULES=""
 for file in $STAGED_GO_FILES; do
     case "$file" in
-        server/*)          MODULES="$MODULES server" ;;
-        pi/digitsd/*)      MODULES="$MODULES pi/digitsd" ;;
-        pi/digits-setup/*) MODULES="$MODULES pi/digits-setup" ;;
+        server/*)     MODULES="$MODULES server" ;;
+        pi/digitsd/*) MODULES="$MODULES pi/digitsd" ;;
     esac
 done
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ artifacts/*
 
 # Compiled binaries
 pi/digitsd/digitsd
-pi/digits-setup/digits-setup
-pi/digits-recovery/bin/
 server/bin/
 
 # rnnoise test binaries (keep lib/ and rnnoise.h)


### PR DESCRIPTION
## Summary
- `.gitignore` still listed `pi/digits-setup/digits-setup` and `pi/digits-recovery/bin/` as build outputs, but those directories were deleted in #450.
- `.githooks/pre-commit` still routed `pi/digits-setup/*` staged files to a `pi/digits-setup` golangci-lint module, also gone since #450.
- #470 went looking for stale `digits-setup` references in committed docs and config and caught the user-facing ones, but the two repo-tooling files above slipped through. This PR finishes that sweep.

No behavior change for any path that exists today: both case arms / glob patterns now match nothing.

## Test plan
- [x] `bash -n .githooks/pre-commit` (syntax check)
- [x] No Go module touched, so no build/test/lint run needed
