### PR TITLE
feat: firmware dev-mode web UI on port 8080

### DIFF
--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
+)
+
+//go:embed devmode_static
+var devmodeStaticFS embed.FS
+
+// devModeStatus holds the snapshot returned by /api/status.
+type devModeStatus struct {
+	DigitsdVersion  string `json:"digitsd_version"`
+	FirmwareVersion string `json:"firmware_version"`
+	FirmwareCommit  string `json:"firmware_commit"`
+	Phase           string `json:"phase"`
+	Online          bool   `json:"online"`
+	PhoneNumber     string `json:"phone_number"`
+	ConfigAutoUpdate bool  `json:"config_auto_update"`
+}
+
+// devModeConfig holds paths and callbacks the dev-mode HTTP server needs.
+type devModeConfig struct {
+	FlagPath           string
+	SkipFWReflashPath  string
+	SkipAutoUpdatePath string
+
+	// StatusFunc returns the current device status snapshot.
+	StatusFunc func() devModeStatus
+
+	// FlashFunc flashes a firmware ELF at the given path. Nil disables
+	// the flash endpoint.
+	FlashFunc func(elfPath string) error
+
+	// UARTLogPath is the UART log file path (same as the serial logger).
+	UARTLogPath string
+}
+
+// startDevModeServer starts the dev-mode web UI on :8080.
+// Returns the listener for shutdown; the server runs in a goroutine.
+func startDevModeServer(cfg *devModeConfig) (net.Listener, error) {
+	mux := http.NewServeMux()
+
+	staticFS, err := fs.Sub(devmodeStaticFS, "devmode_static")
+	if err != nil {
+		return nil, fmt.Errorf("devmode: embed sub: %w", err)
+	}
+	mux.Handle("/", http.FileServer(http.FS(staticFS)))
+
+	mux.HandleFunc("/api/status", devModeStatusHandler(cfg))
+	mux.HandleFunc("/api/toggle", devModeToggleHandler(cfg))
+	mux.HandleFunc("/api/flash", devModeFlashHandler(cfg))
+	mux.HandleFunc("/api/log/serial", devModeSerialLogHandler(cfg))
+	mux.HandleFunc("/api/log/journal", devModeJournalLogHandler())
+
+	ln, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		return nil, fmt.Errorf("devmode: listen :8080: %w", err)
+	}
+
+	go func() {
+		slog.Info("devmode: web UI listening on :8080")
+		if serveErr := http.Serve(ln, mux); serveErr != nil && !errors.Is(serveErr, net.ErrClosed) {
+			slog.Error("devmode: serve failed", "error", serveErr)
+		}
+	}()
+
+	return ln, nil
+}
+
+func devModeStatusHandler(cfg *devModeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var status devModeStatus
+		if cfg.StatusFunc != nil {
+			status = cfg.StatusFunc()
+		}
+		resp := map[string]any{
+			"digitsd_version":    status.DigitsdVersion,
+			"firmware_version":   status.FirmwareVersion,
+			"firmware_commit":    status.FirmwareCommit,
+			"phase":              status.Phase,
+			"online":             status.Online,
+			"phone_number":       status.PhoneNumber,
+			"config_auto_update": status.ConfigAutoUpdate,
+			"dev_mode":           devmode.Enabled(cfg.FlagPath),
+			"skip_fw_reflash":    devmode.SkipFWReflash(cfg.SkipFWReflashPath),
+			"skip_auto_update":   devmode.SkipAutoUpdate(cfg.SkipAutoUpdatePath),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}
+}
+
+func devModeToggleHandler(cfg *devModeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		var err error
+		switch req.Name {
+		case "devmode":
+			if req.Enabled {
+				err = devmode.Enable(cfg.FlagPath)
+			} else {
+				err = devmode.Disable(cfg.FlagPath)
+			}
+		case "fw_reflash":
+			err = devmode.SetSkipFWReflash(cfg.SkipFWReflashPath, req.Enabled)
+		case "auto_update":
+			err = devmode.SetSkipAutoUpdate(cfg.SkipAutoUpdatePath, req.Enabled)
+		default:
+			http.Error(w, "unknown toggle: "+req.Name, http.StatusBadRequest)
+			return
+		}
+
+		if err != nil {
+			slog.Error("devmode: toggle failed", "name", req.Name, "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		slog.Info("devmode: toggle", "name", req.Name, "enabled", req.Enabled)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"}) //nolint:errcheck
+	}
+}
+
+func devModeFlashHandler(cfg *devModeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		if cfg.FlashFunc == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"error": "flash not available (no SWD capability)"}) //nolint:errcheck
+			return
+		}
+
+		file, header, err := r.FormFile("firmware")
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "no firmware file in request"}) //nolint:errcheck
+			return
+		}
+		defer file.Close() //nolint:errcheck
+
+		// Write to staging area.
+		stagingDir := "/data/digits/staging"
+		if err := os.MkdirAll(stagingDir, 0755); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "create staging dir: " + err.Error()}) //nolint:errcheck
+			return
+		}
+		destPath := filepath.Join(stagingDir, "dev-upload.elf")
+		out, err := os.Create(destPath)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "create staging file: " + err.Error()}) //nolint:errcheck
+			return
+		}
+		if _, err := io.Copy(out, file); err != nil {
+			_ = out.Close()
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "write file: " + err.Error()}) //nolint:errcheck
+			return
+		}
+		_ = out.Close()
+
+		slog.Info("devmode: firmware upload received", "filename", header.Filename, "size", header.Size, "staged", destPath)
+
+		// Flash in background.
+		go func() {
+			if flashErr := cfg.FlashFunc(destPath); flashErr != nil {
+				slog.Error("devmode: flash failed", "error", flashErr)
+			} else {
+				slog.Info("devmode: flash succeeded")
+			}
+		}()
+
+		json.NewEncoder(w).Encode(map[string]string{"message": "Flashing " + header.Filename + " -- check serial log for progress"}) //nolint:errcheck
+	}
+}
+
+func devModeSerialLogHandler(cfg *devModeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if cfg.UARTLogPath == "" {
+			fmt.Fprint(w, "(no UART log path configured)") //nolint:errcheck
+			return
+		}
+		data, err := os.ReadFile(cfg.UARTLogPath)
+		if err != nil {
+			fmt.Fprintf(w, "(cannot read log: %v)", err) //nolint:errcheck
+			return
+		}
+		// Tail: return last 64KB max.
+		const maxBytes = 64 * 1024
+		if len(data) > maxBytes {
+			data = data[len(data)-maxBytes:]
+		}
+		_, _ = w.Write(data)
+	}
+}
+
+func devModeJournalLogHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		cmd := exec.Command("journalctl", "-u", "digitsd", "-n", "200", "--no-pager")
+		out, err := cmd.Output()
+		if err != nil {
+			fmt.Fprintf(w, "(journalctl failed: %v)", err) //nolint:errcheck
+			return
+		}
+		_, _ = w.Write(out)
+	}
+}

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -20,15 +20,16 @@ import (
 //go:embed devmode_static
 var devmodeStaticFS embed.FS
 
-// devModeStatus holds the snapshot returned by /api/status.
+// devModeStatus holds the snapshot returned by /api/status. Not serialized
+// directly -- the handler merges it with dynamic flag state into a map.
 type devModeStatus struct {
-	DigitsdVersion  string `json:"digitsd_version"`
-	FirmwareVersion string `json:"firmware_version"`
-	FirmwareCommit  string `json:"firmware_commit"`
-	Phase           string `json:"phase"`
-	Online          bool   `json:"online"`
-	PhoneNumber     string `json:"phone_number"`
-	ConfigAutoUpdate bool  `json:"config_auto_update"`
+	DigitsdVersion   string
+	FirmwareVersion  string
+	FirmwareCommit   string
+	Phase            string
+	Online           bool
+	PhoneNumber      string
+	ConfigAutoUpdate bool
 }
 
 // devModeConfig holds paths and callbacks the dev-mode HTTP server needs.
@@ -192,8 +193,16 @@ func devModeFlashHandler(cfg *devModeConfig) http.HandlerFunc {
 
 		slog.Info("devmode: firmware upload received", "filename", header.Filename, "size", header.Size, "staged", destPath)
 
-		// Flash in background.
+		// Guard against concurrent flash operations (shares the same
+		// atomic with the OTA updater).
+		if !updateInProgress.CompareAndSwap(false, true) {
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "another flash/update is already in progress"}) //nolint:errcheck
+			return
+		}
+
 		go func() {
+			defer updateInProgress.Store(false)
 			if flashErr := cfg.FlashFunc(destPath); flashErr != nil {
 				slog.Error("devmode: flash failed", "error", flashErr)
 			} else {

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -161,17 +161,25 @@ func devModeFlashHandler(cfg *devModeConfig) http.HandlerFunc {
 			return
 		}
 
+		if !updateInProgress.CompareAndSwap(false, true) {
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "another flash/update is already in progress"}) //nolint:errcheck
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 4<<20) // 4 MB max
 		file, header, err := r.FormFile("firmware")
 		if err != nil {
+			updateInProgress.Store(false)
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "no firmware file in request"}) //nolint:errcheck
 			return
 		}
 		defer file.Close() //nolint:errcheck
 
-		// Write to staging area.
 		stagingDir := "/data/digits/staging"
 		if err := os.MkdirAll(stagingDir, 0755); err != nil {
+			updateInProgress.Store(false)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": "create staging dir: " + err.Error()}) //nolint:errcheck
 			return
@@ -179,12 +187,14 @@ func devModeFlashHandler(cfg *devModeConfig) http.HandlerFunc {
 		destPath := filepath.Join(stagingDir, "dev-upload.elf")
 		out, err := os.Create(destPath)
 		if err != nil {
+			updateInProgress.Store(false)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": "create staging file: " + err.Error()}) //nolint:errcheck
 			return
 		}
 		if _, err := io.Copy(out, file); err != nil {
 			_ = out.Close()
+			updateInProgress.Store(false)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": "write file: " + err.Error()}) //nolint:errcheck
 			return
@@ -192,14 +202,6 @@ func devModeFlashHandler(cfg *devModeConfig) http.HandlerFunc {
 		_ = out.Close()
 
 		slog.Info("devmode: firmware upload received", "filename", header.Filename, "size", header.Size, "staged", destPath)
-
-		// Guard against concurrent flash operations (shares the same
-		// atomic with the OTA updater).
-		if !updateInProgress.CompareAndSwap(false, true) {
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{"error": "another flash/update is already in progress"}) //nolint:errcheck
-			return
-		}
 
 		go func() {
 			defer updateInProgress.Store(false)

--- a/pi/digitsd/cmd/digitsd/devmode_static/index.html
+++ b/pi/digitsd/cmd/digitsd/devmode_static/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Digits Dev Mode</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#0f1117;color:#e6edf3;min-height:100vh;display:flex;justify-content:center;padding:20px}
+.container{max-width:700px;width:100%;padding-top:12px}
+header{text-align:center;margin-bottom:20px}
+header h1{font-size:22px;font-weight:600;color:#58a6ff}
+header .subtitle{color:#8b949e;margin-top:4px;font-size:13px}
+.panel{background:#161b22;border:1px solid #30363d;border-radius:8px;padding:14px 16px;margin-bottom:14px}
+.panel h2{font-size:14px;font-weight:600;margin-bottom:10px;color:#c9d1d9}
+.status-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px 16px}
+.status-item{display:flex;justify-content:space-between;font-size:13px;padding:4px 0;border-bottom:1px solid #21262d}
+.status-item .label{color:#8b949e}
+.status-item .value{color:#e6edf3;font-family:monospace;font-size:12px}
+.status-item .value.ok{color:#3fb950}
+.status-item .value.warn{color:#d29922}
+.status-item .value.error{color:#f85149}
+.toggle-row{display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #21262d}
+.toggle-row:last-child{border-bottom:none}
+.toggle-row .info{flex:1}
+.toggle-row .info .name{font-size:13px;color:#c9d1d9}
+.toggle-row .info .desc{font-size:11px;color:#8b949e;margin-top:2px}
+.toggle{position:relative;width:44px;height:24px;flex-shrink:0;margin-left:12px}
+.toggle input{opacity:0;width:0;height:0}
+.toggle .slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#30363d;border-radius:12px;transition:.2s}
+.toggle .slider:before{content:"";position:absolute;height:18px;width:18px;left:3px;bottom:3px;background:#8b949e;border-radius:50%;transition:.2s}
+.toggle input:checked+.slider{background:#238636}
+.toggle input:checked+.slider:before{transform:translateX(20px);background:#fff}
+.upload-area{margin-top:8px}
+.upload-area input[type=file]{display:none}
+.upload-btn{display:inline-block;padding:6px 14px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;font-size:13px;cursor:pointer;transition:background .15s}
+.upload-btn:hover{background:#30363d}
+.upload-status{font-size:12px;color:#8b949e;margin-top:6px;min-height:16px}
+.upload-status.error{color:#f85149}
+.upload-status.ok{color:#3fb950}
+.log-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+.log-header h2{margin-bottom:0}
+.log-controls{display:flex;gap:6px;align-items:center}
+.btn-small{background:#21262d;border:1px solid #30363d;border-radius:4px;color:#8b949e;font-size:11px;padding:3px 8px;cursor:pointer;transition:background .15s}
+.btn-small:hover{background:#30363d;color:#e6edf3}
+.btn-small.active{background:#30363d;color:#58a6ff;border-color:#58a6ff}
+.log-box{background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:10px;font:11px/1.5 monospace;color:#3fb950;max-height:400px;overflow-y:auto;white-space:pre-wrap;word-break:break-word}
+.tab-bar{display:flex;gap:4px}
+.tab{padding:4px 10px;background:#21262d;border:1px solid #30363d;border-radius:4px;color:#8b949e;font-size:12px;cursor:pointer;transition:background .15s}
+.tab:hover{background:#30363d;color:#e6edf3}
+.tab.active{background:#161b22;color:#58a6ff;border-color:#58a6ff}
+</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <h1>Digits Dev Mode</h1>
+    <p class="subtitle">Firmware development tools</p>
+  </header>
+
+  <div class="panel">
+    <h2>Device Status</h2>
+    <div class="status-grid" id="status-grid">
+      <div class="status-item"><span class="label">digitsd</span><span class="value" id="st-digitsd">--</span></div>
+      <div class="status-item"><span class="label">firmware</span><span class="value" id="st-firmware">--</span></div>
+      <div class="status-item"><span class="label">phase</span><span class="value" id="st-phase">--</span></div>
+      <div class="status-item"><span class="label">online</span><span class="value" id="st-online">--</span></div>
+      <div class="status-item"><span class="label">phone</span><span class="value" id="st-phone">--</span></div>
+      <div class="status-item"><span class="label">auto-update</span><span class="value" id="st-autoupdate">--</span></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Toggles</h2>
+    <div class="toggle-row">
+      <div class="info">
+        <div class="name">Dev Mode</div>
+        <div class="desc">When off, this web UI will not start on next boot</div>
+      </div>
+      <label class="toggle"><input type="checkbox" id="tog-devmode" onchange="toggle('devmode',this.checked)"><span class="slider"></span></label>
+    </div>
+    <div class="toggle-row">
+      <div class="info">
+        <div class="name">Skip Auto-Update</div>
+        <div class="desc">Prevent OTA updates from replacing your dev builds</div>
+      </div>
+      <label class="toggle"><input type="checkbox" id="tog-autoupdate" onchange="toggle('auto_update',this.checked)"><span class="slider"></span></label>
+    </div>
+    <div class="toggle-row">
+      <div class="info">
+        <div class="name">Skip Firmware Reflash</div>
+        <div class="desc">Prevent bundled firmware from overwriting Pico on boot</div>
+      </div>
+      <label class="toggle"><input type="checkbox" id="tog-reflash" onchange="toggle('fw_reflash',this.checked)"><span class="slider"></span></label>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Flash Firmware ELF</h2>
+    <div class="upload-area">
+      <label class="upload-btn" for="elf-file">Choose ELF file...</label>
+      <input type="file" id="elf-file" accept=".elf" onchange="uploadELF(this)">
+      <span id="elf-name" style="font-size:12px;color:#8b949e;margin-left:8px"></span>
+    </div>
+    <div class="upload-status" id="upload-status"></div>
+  </div>
+
+  <div class="panel">
+    <div class="log-header">
+      <h2>Logs</h2>
+      <div class="log-controls">
+        <div class="tab-bar">
+          <button class="tab active" id="tab-serial" onclick="switchLog('serial')">Serial</button>
+          <button class="tab" id="tab-journal" onclick="switchLog('journal')">Journal</button>
+        </div>
+        <button class="btn-small" id="log-pause" onclick="togglePause()">Pause</button>
+      </div>
+    </div>
+    <div class="log-box" id="log">Loading...</div>
+  </div>
+</div>
+
+<script>
+var paused=false,logSource='serial',lastSerial='',lastJournal='';
+
+function pollStatus(){
+  fetch('/api/status').then(function(r){return r.json()}).then(function(d){
+    document.getElementById('st-digitsd').textContent=d.digitsd_version||'--';
+    var fw=d.firmware_version||'--';
+    if(d.firmware_commit&&d.firmware_commit!=='unknown'&&d.firmware_commit!=='')fw+=' ('+d.firmware_commit.substring(0,7)+')';
+    document.getElementById('st-firmware').textContent=fw;
+    document.getElementById('st-phase').textContent=d.phase||'--';
+    var onEl=document.getElementById('st-online');
+    onEl.textContent=d.online?'yes':'no';
+    onEl.className='value '+(d.online?'ok':'warn');
+    document.getElementById('st-phone').textContent=d.phone_number||'--';
+    document.getElementById('st-autoupdate').textContent=d.config_auto_update?'on':'off';
+
+    document.getElementById('tog-devmode').checked=d.dev_mode;
+    document.getElementById('tog-autoupdate').checked=d.skip_auto_update;
+    document.getElementById('tog-reflash').checked=d.skip_fw_reflash;
+  }).catch(function(){}).finally(function(){setTimeout(pollStatus,3000)});
+}
+pollStatus();
+
+function toggle(name,val){
+  fetch('/api/toggle',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({name:name,enabled:val})
+  }).catch(function(e){alert('Toggle failed: '+e)});
+}
+
+function uploadELF(input){
+  var f=input.files[0];
+  if(!f)return;
+  document.getElementById('elf-name').textContent=f.name;
+  var status=document.getElementById('upload-status');
+  status.textContent='Uploading...';
+  status.className='upload-status';
+  var form=new FormData();
+  form.append('firmware',f);
+  fetch('/api/flash',{method:'POST',body:form}).then(function(r){
+    return r.json().then(function(d){return{ok:r.ok,data:d}});
+  }).then(function(res){
+    if(res.ok){
+      status.textContent=res.data.message||'Flash started';
+      status.className='upload-status ok';
+    }else{
+      status.textContent=res.data.error||'Flash failed';
+      status.className='upload-status error';
+    }
+  }).catch(function(e){
+    status.textContent='Upload failed: '+e;
+    status.className='upload-status error';
+  });
+}
+
+function switchLog(source){
+  logSource=source;
+  document.getElementById('tab-serial').className='tab'+(source==='serial'?' active':'');
+  document.getElementById('tab-journal').className='tab'+(source==='journal'?' active':'');
+  document.getElementById('log').textContent='Loading...';
+}
+
+function togglePause(){
+  paused=!paused;
+  document.getElementById('log-pause').textContent=paused?'Resume':'Pause';
+  document.getElementById('log-pause').className='btn-small'+(paused?' active':'');
+}
+
+function pollLog(){
+  if(paused){setTimeout(pollLog,1500);return}
+  var url=logSource==='serial'?'/api/log/serial':'/api/log/journal';
+  fetch(url).then(function(r){return r.text()}).then(function(t){
+    var el=document.getElementById('log');
+    var prev=logSource==='serial'?lastSerial:lastJournal;
+    if(t!==prev){
+      if(logSource==='serial')lastSerial=t;else lastJournal=t;
+      var atBottom=el.scrollTop+el.clientHeight>=el.scrollHeight-30;
+      el.textContent=t||'(empty)';
+      if(atBottom)el.scrollTop=el.scrollHeight;
+    }
+  }).catch(function(){}).finally(function(){setTimeout(pollLog,1500)});
+}
+pollLog();
+</script>
+</body>
+</html>

--- a/pi/digitsd/cmd/digitsd/devmode_test.go
+++ b/pi/digitsd/cmd/digitsd/devmode_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
+)
+
+func TestDevModeStatusHandler(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+		StatusFunc: func() devModeStatus {
+			return devModeStatus{
+				DigitsdVersion:   "1.2.3",
+				FirmwareVersion:  "1.5.0",
+				FirmwareCommit:   "abc1234",
+				Phase:            "0x01",
+				Online:           true,
+				PhoneNumber:      "3140001",
+				ConfigAutoUpdate: true,
+			}
+		},
+	}
+	_ = devmode.Enable(cfg.FlagPath)
+
+	h := devModeStatusHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["digitsd_version"] != "1.2.3" {
+		t.Errorf("digitsd_version = %v, want 1.2.3", body["digitsd_version"])
+	}
+	if body["dev_mode"] != true {
+		t.Errorf("dev_mode = %v, want true", body["dev_mode"])
+	}
+	if body["firmware_version"] != "1.5.0" {
+		t.Errorf("firmware_version = %v, want 1.5.0", body["firmware_version"])
+	}
+	if body["online"] != true {
+		t.Errorf("online = %v, want true", body["online"])
+	}
+}
+
+func TestDevModeStatusHandler_NilStatusFunc(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+	}
+
+	h := devModeStatusHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+}
+
+func TestDevModeToggleHandler_DevMode(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+	}
+
+	h := devModeToggleHandler(cfg)
+
+	// Enable dev mode.
+	body := `{"name":"devmode","enabled":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/toggle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable: status code = %d, want 200", w.Code)
+	}
+	if !devmode.Enabled(cfg.FlagPath) {
+		t.Error("dev-mode flag not created")
+	}
+
+	// Disable dev mode.
+	body = `{"name":"devmode","enabled":false}`
+	req = httptest.NewRequest(http.MethodPost, "/api/toggle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable: status code = %d, want 200", w.Code)
+	}
+	if devmode.Enabled(cfg.FlagPath) {
+		t.Error("dev-mode flag not removed")
+	}
+}
+
+func TestDevModeToggleHandler_FWReflash(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+	}
+
+	h := devModeToggleHandler(cfg)
+	body := `{"name":"fw_reflash","enabled":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/toggle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+	if !devmode.SkipFWReflash(cfg.SkipFWReflashPath) {
+		t.Error("skip-fw-reflash flag not created")
+	}
+}
+
+func TestDevModeToggleHandler_AutoUpdate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+	}
+
+	h := devModeToggleHandler(cfg)
+	body := `{"name":"auto_update","enabled":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/toggle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+	if !devmode.SkipAutoUpdate(cfg.SkipAutoUpdatePath) {
+		t.Error("skip-auto-update flag not created")
+	}
+}
+
+func TestDevModeToggleHandler_BadMethod(t *testing.T) {
+	cfg := &devModeConfig{}
+	h := devModeToggleHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/toggle", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status code = %d, want 405", w.Code)
+	}
+}
+
+func TestDevModeToggleHandler_UnknownToggle(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &devModeConfig{
+		FlagPath:           filepath.Join(dir, "dev-mode"),
+		SkipFWReflashPath:  filepath.Join(dir, "skip-fw-reflash"),
+		SkipAutoUpdatePath: filepath.Join(dir, "skip-auto-update"),
+	}
+	h := devModeToggleHandler(cfg)
+	body := `{"name":"bogus","enabled":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/toggle", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status code = %d, want 400", w.Code)
+	}
+}
+
+func TestDevModeFlashHandler_NoFlashFunc(t *testing.T) {
+	cfg := &devModeConfig{}
+	h := devModeFlashHandler(cfg)
+	req := httptest.NewRequest(http.MethodPost, "/api/flash", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status code = %d, want 503", w.Code)
+	}
+}
+
+func TestDevModeFlashHandler_BadMethod(t *testing.T) {
+	cfg := &devModeConfig{}
+	h := devModeFlashHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/flash", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status code = %d, want 405", w.Code)
+	}
+}
+
+func TestDevModeSerialLogHandler_NoPath(t *testing.T) {
+	cfg := &devModeConfig{}
+	h := devModeSerialLogHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/log/serial", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "no UART log") {
+		t.Errorf("body = %q, want mention of no UART log", w.Body.String())
+	}
+}
+
+func TestDevModeSerialLogHandler_WithFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "uart.log")
+	content := "line1\nline2\nline3\n"
+	if err := os.WriteFile(logPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &devModeConfig{UARTLogPath: logPath}
+	h := devModeSerialLogHandler(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/api/log/serial", nil)
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Body.String() != content {
+		t.Errorf("body = %q, want %q", w.Body.String(), content)
+	}
+}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2581,7 +2581,7 @@ func main() {
 		if devErr != nil {
 			slog.Warn("devmode: failed to start web UI", "error", devErr)
 		} else {
-			defer devLn.Close()
+			defer func() { _ = devLn.Close() }()
 		}
 	}
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -873,7 +873,7 @@ func (d *daemonCallbacks) HangupCall() {
 	d.mu.Unlock()
 	slog.Info("call disconnected", "peer", peer, "sync_elapsed", time.Since(t0).Round(time.Microsecond))
 
-	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateEnabled.Load() {
+	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
 		slog.Info("auto-update: call ended, running deferred update")
 		if d.triggerAutoUpdate != nil {
 			go d.triggerAutoUpdate()
@@ -2011,11 +2011,12 @@ func main() {
 	// path doesn't fire when the Pico responds.
 	if postOk && fwVersion != "" {
 		bundled := readBundledFirmwareVersion()
+		needsReflash := firmwareNeedsReflash(fwVersion, bundled)
 		skipReflash := devmode.SkipFWReflash(devmode.DefaultSkipFWReflashPath)
-		if skipReflash && firmwareNeedsReflash(fwVersion, bundled) {
+		if needsReflash && skipReflash {
 			slog.Info("firmware reflash: skip flag present, keeping current Pico firmware",
 				"pico", fwVersion, "bundled", bundled)
-		} else if firmwareNeedsReflash(fwVersion, bundled) {
+		} else if needsReflash {
 			slog.Warn("firmware version mismatch with bundled image",
 				"pico", fwVersion, "bundled", bundled,
 				"action", "auto-reflash")
@@ -2463,9 +2464,11 @@ func main() {
 		fwVer, _ := cb.getFirmwareVersion()
 		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVer, flashCapable.Load(), requeryFirmware)
 	}
-	if cb.autoUpdateEnabled.Load() {
+	if cb.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
 		slog.Info("auto-update: enabled, checking for updates on startup")
 		go cb.triggerAutoUpdate()
+	} else if devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+		slog.Info("auto-update: suppressed by dev-mode skip flag")
 	}
 
 	// 8. Create phone Controller
@@ -3040,7 +3043,7 @@ func main() {
 
 			case sigclient.TypeReleaseAvailable:
 				slog.Info("signal: release_available", "pi", msg.LatestPiVersion, "fw", msg.LatestFWVersion)
-				if cb.autoUpdateEnabled.Load() {
+				if cb.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
 					go cb.triggerAutoUpdate()
 				}
 
@@ -3212,7 +3215,9 @@ func main() {
 				}
 
 				au := msg.LineSettings.AutoUpdate
-				if au != cb.autoUpdateEnabled.Load() {
+				if devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+					slog.Info("line_settings: ignoring server auto_update push (dev-mode skip flag)", "server_wants", au)
+				} else if au != cb.autoUpdateEnabled.Load() {
 					cb.autoUpdateEnabled.Store(au)
 					slog.Info("line_settings applied", "auto_update", au)
 					if err := cb.setAutoUpdateConfig(au); err != nil {

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2531,6 +2531,60 @@ func main() {
 	phone.RestoreVolume()
 	slog.Info("digitsd ready")
 
+	// Dev-mode web UI on :8080 (only when the flag file is present).
+	if devmode.Enabled(devmode.DefaultFlagPath) {
+		slog.Info("devmode: flag present, starting dev-mode web UI")
+		devCfg := &devModeConfig{
+			FlagPath:           devmode.DefaultFlagPath,
+			SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,
+			SkipAutoUpdatePath: devmode.DefaultSkipAutoUpdatePath,
+			UARTLogPath:        uartLogPath,
+			StatusFunc: func() devModeStatus {
+				fwVer, fwCom := cb.getFirmwareVersion()
+				phase := "unknown"
+				if postOk {
+					if resp, err := sp.SendCommand("PHASE?", 1*time.Second); err == nil {
+						phase = resp
+					}
+				}
+				return devModeStatus{
+					DigitsdVersion:   version.Version,
+					FirmwareVersion:  fwVer,
+					FirmwareCommit:   fwCom,
+					Phase:            phase,
+					Online:           cb.paired.Load(),
+					PhoneNumber:      effectiveNumber,
+					ConfigAutoUpdate: cb.autoUpdateEnabled.Load(),
+				}
+			},
+		}
+		if flashCapable.Load() {
+			devCfg.FlashFunc = func(elfPath string) error {
+				// Move the uploaded ELF to the standard firmware path, then
+				// invoke the same flash script the OTA updater uses.
+				if err := os.Rename(elfPath, defaultFirmwarePath); err != nil {
+					return fmt.Errorf("stage firmware: %w", err)
+				}
+				cmd := exec.Command("setsid", "bash", defaultFlashScript, defaultFirmwarePath)
+				cmd.Env = append(os.Environ(), "SKIP_SERVICE_CONTROL=1")
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					return fmt.Errorf("flash script: %w", err)
+				}
+				slog.Info("devmode: flash script succeeded")
+				requeryFirmware()
+				return nil
+			}
+		}
+		devLn, devErr := startDevModeServer(devCfg)
+		if devErr != nil {
+			slog.Warn("devmode: failed to start web UI", "error", devErr)
+		} else {
+			defer devLn.Close()
+		}
+	}
+
 	// Start hardware watchdog (if available)
 	if wd, err := watchdog.Open("/dev/watchdog"); err == nil {
 		wd.Start(5 * time.Second)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2534,6 +2534,14 @@ func main() {
 	// Dev-mode web UI on :8080 (only when the flag file is present).
 	if devmode.Enabled(devmode.DefaultFlagPath) {
 		slog.Info("devmode: flag present, starting dev-mode web UI")
+		// Snapshot the phase once at startup; it rarely changes during
+		// normal operation and querying UART on every HTTP poll is wasteful.
+		startupPhase := "unknown"
+		if postOk {
+			if resp, err := sp.SendCommand("PHASE?", 1*time.Second); err == nil {
+				startupPhase = resp
+			}
+		}
 		devCfg := &devModeConfig{
 			FlagPath:           devmode.DefaultFlagPath,
 			SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,
@@ -2541,17 +2549,11 @@ func main() {
 			UARTLogPath:        uartLogPath,
 			StatusFunc: func() devModeStatus {
 				fwVer, fwCom := cb.getFirmwareVersion()
-				phase := "unknown"
-				if postOk {
-					if resp, err := sp.SendCommand("PHASE?", 1*time.Second); err == nil {
-						phase = resp
-					}
-				}
 				return devModeStatus{
 					DigitsdVersion:   version.Version,
 					FirmwareVersion:  fwVer,
 					FirmwareCommit:   fwCom,
-					Phase:            phase,
+					Phase:            startupPhase,
 					Online:           cb.paired.Load(),
 					PhoneNumber:      effectiveNumber,
 					ConfigAutoUpdate: cb.autoUpdateEnabled.Load(),

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/bootcount"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
 	"github.com/justinlindh/digits/pi/digitsd/internal/contacts"
+	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	"github.com/justinlindh/digits/pi/digitsd/internal/subsystem"
@@ -2010,7 +2011,11 @@ func main() {
 	// path doesn't fire when the Pico responds.
 	if postOk && fwVersion != "" {
 		bundled := readBundledFirmwareVersion()
-		if firmwareNeedsReflash(fwVersion, bundled) {
+		skipReflash := devmode.SkipFWReflash(devmode.DefaultSkipFWReflashPath)
+		if skipReflash && firmwareNeedsReflash(fwVersion, bundled) {
+			slog.Info("firmware reflash: skip flag present, keeping current Pico firmware",
+				"pico", fwVersion, "bundled", bundled)
+		} else if firmwareNeedsReflash(fwVersion, bundled) {
 			slog.Warn("firmware version mismatch with bundled image",
 				"pico", fwVersion, "bundled", bundled,
 				"action", "auto-reflash")

--- a/pi/digitsd/internal/devmode/devmode.go
+++ b/pi/digitsd/internal/devmode/devmode.go
@@ -1,0 +1,81 @@
+// Package devmode manages the dev-mode flag and associated toggle files
+// on the Digits device data partition.
+package devmode
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Default paths on the device data partition.
+const (
+	DefaultFlagPath           = "/data/digits/dev-mode"
+	DefaultSkipFWReflashPath  = "/data/digits/skip-fw-reflash"
+	DefaultSkipAutoUpdatePath = "/data/digits/skip-auto-update"
+)
+
+// Enabled reports whether the dev-mode flag file exists at path.
+func Enabled(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Enable creates the dev-mode flag file at path, creating parent
+// directories as needed.
+func Enable(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte("1\n"), 0644)
+}
+
+// Disable removes the dev-mode flag file. No error if already absent.
+func Disable(path string) error {
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// SkipFWReflash reports whether the firmware reflash skip flag is set.
+func SkipFWReflash(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// SetSkipFWReflash creates or removes the firmware reflash skip flag.
+func SetSkipFWReflash(path string, skip bool) error {
+	if skip {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(path, []byte("1\n"), 0644)
+	}
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// SkipAutoUpdate reports whether the auto-update skip flag is set.
+func SkipAutoUpdate(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// SetSkipAutoUpdate creates or removes the auto-update skip flag.
+func SetSkipAutoUpdate(path string, skip bool) error {
+	if skip {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(path, []byte("1\n"), 0644)
+	}
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/pi/digitsd/internal/devmode/devmode.go
+++ b/pi/digitsd/internal/devmode/devmode.go
@@ -1,5 +1,7 @@
 // Package devmode manages the dev-mode flag and associated toggle files
-// on the Digits device data partition.
+// on the Digits device data partition. Each flag is a flat file whose
+// presence means "on". All functions are safe for concurrent use (they
+// operate on independent filesystem paths).
 package devmode
 
 import (
@@ -14,39 +16,17 @@ const (
 	DefaultSkipAutoUpdatePath = "/data/digits/skip-auto-update"
 )
 
-// Enabled reports whether the dev-mode flag file exists at path.
-func Enabled(path string) bool {
+// FlagSet reports whether a flag file exists at path.
+func FlagSet(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
 
-// Enable creates the dev-mode flag file at path, creating parent
-// directories as needed.
-func Enable(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte("1\n"), 0644)
-}
-
-// Disable removes the dev-mode flag file. No error if already absent.
-func Disable(path string) error {
-	err := os.Remove(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	return err
-}
-
-// SkipFWReflash reports whether the firmware reflash skip flag is set.
-func SkipFWReflash(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-// SetSkipFWReflash creates or removes the firmware reflash skip flag.
-func SetSkipFWReflash(path string, skip bool) error {
-	if skip {
+// SetFlag creates or removes a flag file. When set is true the file is
+// created (parent dirs included); when false the file is removed. Removing
+// a file that does not exist is not an error.
+func SetFlag(path string, set bool) error {
+	if set {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
@@ -59,23 +39,12 @@ func SetSkipFWReflash(path string, skip bool) error {
 	return err
 }
 
-// SkipAutoUpdate reports whether the auto-update skip flag is set.
-func SkipAutoUpdate(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
+// Convenience aliases -- keep call sites readable and grep-friendly.
 
-// SetSkipAutoUpdate creates or removes the auto-update skip flag.
-func SetSkipAutoUpdate(path string, skip bool) error {
-	if skip {
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			return err
-		}
-		return os.WriteFile(path, []byte("1\n"), 0644)
-	}
-	err := os.Remove(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	return err
-}
+func Enabled(path string) bool                    { return FlagSet(path) }
+func Enable(path string) error                    { return SetFlag(path, true) }
+func Disable(path string) error                   { return SetFlag(path, false) }
+func SkipFWReflash(path string) bool              { return FlagSet(path) }
+func SetSkipFWReflash(path string, skip bool) error  { return SetFlag(path, skip) }
+func SkipAutoUpdate(path string) bool             { return FlagSet(path) }
+func SetSkipAutoUpdate(path string, skip bool) error { return SetFlag(path, skip) }

--- a/pi/digitsd/internal/devmode/devmode_test.go
+++ b/pi/digitsd/internal/devmode/devmode_test.go
@@ -1,0 +1,98 @@
+package devmode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnabled_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if Enabled(filepath.Join(dir, "dev-mode")) {
+		t.Error("Enabled returned true for missing file")
+	}
+}
+
+func TestEnable_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dev-mode")
+	if err := Enable(path); err != nil {
+		t.Fatal(err)
+	}
+	if !Enabled(path) {
+		t.Error("Enabled returned false after Enable")
+	}
+}
+
+func TestDisable_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dev-mode")
+	if err := Enable(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := Disable(path); err != nil {
+		t.Fatal(err)
+	}
+	if Enabled(path) {
+		t.Error("Enabled returned true after Disable")
+	}
+}
+
+func TestDisable_NoErrorWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dev-mode")
+	if err := Disable(path); err != nil {
+		t.Errorf("Disable on missing file returned error: %v", err)
+	}
+}
+
+func TestSkipFWReflash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skip-fw-reflash")
+	if SkipFWReflash(path) {
+		t.Error("SkipFWReflash returned true for missing file")
+	}
+	if err := SetSkipFWReflash(path, true); err != nil {
+		t.Fatal(err)
+	}
+	if !SkipFWReflash(path) {
+		t.Error("SkipFWReflash returned false after SetSkipFWReflash(true)")
+	}
+	if err := SetSkipFWReflash(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if SkipFWReflash(path) {
+		t.Error("SkipFWReflash returned true after SetSkipFWReflash(false)")
+	}
+}
+
+func TestSkipAutoUpdate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skip-auto-update")
+	if SkipAutoUpdate(path) {
+		t.Error("SkipAutoUpdate returned true for missing file")
+	}
+	if err := SetSkipAutoUpdate(path, true); err != nil {
+		t.Fatal(err)
+	}
+	if !SkipAutoUpdate(path) {
+		t.Error("SkipAutoUpdate returned false after set true")
+	}
+	if err := SetSkipAutoUpdate(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if SkipAutoUpdate(path) {
+		t.Error("SkipAutoUpdate returned true after set false")
+	}
+}
+
+func TestEnable_CreatesDirIfNeeded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "dev-mode")
+	if err := Enable(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a persistent dev-mode flag (`/data/digits/dev-mode`) that gates a web UI on port 8080 during normal-mode boot
- Web UI shows device status (digitsd version, firmware version, phase, online state, phone number, auto-update config)
- Three toggles: dev-mode on/off, skip auto-update, skip firmware reflash on boot
- Firmware ELF upload for manual SWD flash (reuses existing flash-pico.sh and updateInProgress guard)
- Live serial log and journalctl output with tab switching and pause
- New `internal/devmode` package with generic flag file helpers (`FlagSet`/`SetFlag`)
- Refactored the inline `os.Stat("/data/digits/skip-fw-reflash")` in the boot path to use `devmode.SkipFWReflash`

## Test plan

- [ ] Unit tests pass: `go test ./internal/devmode/... ./cmd/digitsd/... -v`
- [ ] golangci-lint clean: `golangci-lint run ./internal/devmode/... ./cmd/digitsd/...`
- [ ] ARM64 cross-build succeeds: `make build` in `pi/digitsd/`
- [ ] On device: `touch /data/digits/dev-mode && sudo systemctl restart digitsd`, then open `http://<device-ip>:8080`
- [ ] Verify status panel shows correct firmware/digitsd versions
- [ ] Toggle dev-mode off, reboot, confirm :8080 does not start
- [ ] Toggle skip-fw-reflash on, reboot with mismatched bundled firmware, confirm Pico is not reflashed
- [ ] Upload a firmware ELF, confirm flash-pico.sh runs and firmware version updates
- [ ] Verify serial and journal log tabs stream correctly