### PR TITLE
fix(firmware,digitsd): star-at-boot recovery via persistent phase byte

### DIFF
--- a/firmware/src/keypad.c
+++ b/firmware/src/keypad.c
@@ -30,7 +30,7 @@ void keypad_init(void) {
     s_last_press_time = get_absolute_time();
 }
 
-char keypad_scan(void) {
+char keypad_scan_raw(void) {
     char pressed = '\0';
     const uint num_cols = board->keypad_num_cols;
 
@@ -46,6 +46,12 @@ char keypad_scan(void) {
 
         gpio_put(board->keypad_rows[row], 1);
     }
+
+    return pressed;
+}
+
+char keypad_scan(void) {
+    char pressed = keypad_scan_raw();
 
     absolute_time_t now = get_absolute_time();
     if (pressed != '\0' && pressed != s_last_key) {

--- a/firmware/src/keypad.h
+++ b/firmware/src/keypad.h
@@ -12,7 +12,11 @@
 void keypad_init(void);
 
 // Returns pressed key ('0'-'9', '*', '#', and on V1 also 'A'-'D')
-// or '\0' if no new key press.
+// or '\0' if no new key press. Debounced.
 char keypad_scan(void);
+
+// Raw matrix read with no debounce. Returns the currently held key
+// or '\0'. Used at boot to detect keys held during power-on.
+char keypad_scan_raw(void);
 
 #endif  // DIGITS_KEYPAD_H

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -107,9 +107,12 @@ int main(void) {
 
     uart_proto_send("STATUS:READY");
 
-    // Scan keypad once at boot. If * is held, report it so the Pi can
-    // trigger recovery mode after it connects.
-    if (keypad_scan() == '*') {
+    // Scan keypad once at boot. If * is held, persist RECOVERY phase to
+    // flash so the Pi can detect it after it finishes booting (the Pi
+    // boots 15-30s after the Pico). The phase byte survives the boot
+    // gap; digitsd queries it with PHASE? after POST.
+    if (keypad_scan_raw() == '*') {
+        phase_write(PHASE_RECOVERY);
         led_set_mode(LED_MODE_FAST_BLINK);
         uart_proto_send("BOOT:PANIC");
     }

--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -280,6 +280,10 @@ static void process_pi_command(const char *cmd) {
         phase_write(PHASE_RECOVERY);
         if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
         uart_proto_send("STATE:SET:OK");
+    } else if (strcmp(cmd, "PHASE?") == 0) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "PHASE:0x%02X", phase_read());
+        uart_proto_send(buf);
     } else if (strcmp(cmd, "REBOOT") == 0 || strcmp(cmd, "REBOOT:BOOTSEL") == 0) {
         // Reboot the chip into BOOTSEL mode (USB MSD + PICOBOOT). The chip
         // resets and stays in bootrom waiting for a USB host connection

--- a/pi/digitsd/Dockerfile.builder
+++ b/pi/digitsd/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.26
+FROM golang:1.26-bookworm
 
 RUN dpkg --add-architecture arm64 \
     && apt-get update -qq \

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -241,9 +241,9 @@ func devModeJournalLogHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		cmd := exec.Command("sudo", "journalctl", "-u", "digitsd", "-n", "200", "--no-pager")
-		out, err := cmd.Output()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
-			fmt.Fprintf(w, "(journalctl failed: %v)", err) //nolint:errcheck
+			fmt.Fprintf(w, "(journalctl failed: %v)\n%s", err, out) //nolint:errcheck
 			return
 		}
 		_, _ = w.Write(out)

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -240,7 +240,7 @@ func devModeSerialLogHandler(cfg *devModeConfig) http.HandlerFunc {
 func devModeJournalLogHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		cmd := exec.Command("journalctl", "-u", "digitsd", "-n", "200", "--no-pager")
+		cmd := exec.Command("sudo", "journalctl", "-u", "digitsd", "-n", "200", "--no-pager")
 		out, err := cmd.Output()
 		if err != nil {
 			fmt.Fprintf(w, "(journalctl failed: %v)", err) //nolint:errcheck

--- a/pi/digitsd/cmd/digitsd/devmode_static/index.html
+++ b/pi/digitsd/cmd/digitsd/devmode_static/index.html
@@ -176,6 +176,7 @@ function uploadELF(input){
 
 function switchLog(source){
   logSource=source;
+  lastSerial='';lastJournal='';
   document.getElementById('tab-serial').className='tab'+(source==='serial'?' active':'');
   document.getElementById('tab-journal').className='tab'+(source==='journal'?' active':'');
   document.getElementById('log').textContent='Loading...';

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2100,27 +2100,41 @@ func main() {
 		}
 	}
 
-	// Check if the Pico detected a held * key at boot (panic button).
-	// BOOT:PANIC is an unsolicited event (see isUnsolicitedEvent in serial.go)
-	// and sits on the events channel by the time POST completes.
+	// Query the Pico's persisted phase byte. If the user held * during
+	// power-on, the Pico wrote PHASE_RECOVERY to flash before the Pi
+	// even started booting. We read it here, act on it, then clear it
+	// so the device doesn't loop back into recovery on every boot.
+	cachedPhase := "unknown"
 	if postOk {
-		drainDeadline := time.After(100 * time.Millisecond)
-	drainLoop:
-		for {
-			select {
-			case ev := <-sp.Events():
-				if ev == "BOOT:PANIC" {
-					slog.Info("panic button: * key held at boot, entering recovery mode")
-					if err := bootcount.SetThreshold(bootcount.DefaultPath, 3); err != nil {
-						slog.Warn("panic button: failed to set boot counter", "error", err)
-					}
-					_ = os.WriteFile("/data/digits/recovery-mode", []byte("panic-button\n"), 0644)
-					sp.StateSet("RECOVERY")
-					time.Sleep(500 * time.Millisecond)
-					doReboot()
+		const phaseRetries = 5
+		var phase uint8
+		var phaseErr error
+		for i := 1; i <= phaseRetries; i++ {
+			phase, phaseErr = sp.QueryPhase()
+			if phaseErr == nil {
+				break
+			}
+			slog.Warn("phase query failed", "attempt", i, "max", phaseRetries, "error", phaseErr)
+			time.Sleep(500 * time.Millisecond)
+		}
+		if phaseErr != nil {
+			slog.Error("phase query: all retries exhausted, proceeding without phase check", "error", phaseErr)
+		} else {
+			cachedPhase = fmt.Sprintf("PHASE:0x%02X", phase)
+			slog.Info("pico phase", "phase", fmt.Sprintf("0x%02X", phase))
+			if phase == phone.PhaseRecovery {
+				slog.Info("panic button: Pico phase is RECOVERY (* held at boot), entering recovery mode")
+				if err := bootcount.SetThreshold(bootcount.DefaultPath, 3); err != nil {
+					slog.Warn("panic button: failed to set boot counter", "error", err)
 				}
-			case <-drainDeadline:
-				break drainLoop
+				_ = os.WriteFile("/data/digits/recovery-mode", []byte("panic-button\n"), 0644)
+				if cfg.DeviceToken == "" {
+					sp.StateSet("UNPAIRED")
+				} else {
+					sp.StateSet("PAIRED")
+				}
+				time.Sleep(500 * time.Millisecond)
+				doReboot()
 			}
 		}
 	}
@@ -2539,12 +2553,7 @@ func main() {
 		slog.Info("devmode: flag present, starting dev-mode web UI")
 		// Snapshot the phase once at startup; it rarely changes during
 		// normal operation and querying UART on every HTTP poll is wasteful.
-		startupPhase := "unknown"
-		if postOk {
-			if resp, err := sp.SendCommand("PHASE?", 1*time.Second); err == nil {
-				startupPhase = resp
-			}
-		}
+		startupPhase := cachedPhase
 		devCfg := &devModeConfig{
 			FlagPath:           devmode.DefaultFlagPath,
 			SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2120,7 +2120,18 @@ func main() {
 		if phaseErr != nil {
 			slog.Error("phase query: all retries exhausted, proceeding without phase check", "error", phaseErr)
 		} else {
-			cachedPhase = fmt.Sprintf("PHASE:0x%02X", phase)
+			switch phase {
+			case phone.PhasePaired:
+				cachedPhase = "paired"
+			case phone.PhaseUnpaired:
+				cachedPhase = "unpaired"
+			case phone.PhaseSetup:
+				cachedPhase = "setup"
+			case phone.PhaseRecovery:
+				cachedPhase = "recovery"
+			default:
+				cachedPhase = fmt.Sprintf("0x%02X", phase)
+			}
 			slog.Info("pico phase", "phase", fmt.Sprintf("0x%02X", phase))
 			if phase == phone.PhaseRecovery {
 				slog.Info("panic button: Pico phase is RECOVERY (* held at boot), entering recovery mode")

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -472,11 +472,12 @@ func doReboot() {
 			slog.Error("recovery: reboot syscall failed", "error", err)
 		}
 	} else {
-		cmd := exec.Command("systemctl", "reboot")
+		cmd := exec.Command("sudo", "/usr/sbin/reboot")
 		if err := cmd.Run(); err != nil {
-			slog.Warn("recovery: systemctl reboot failed, trying raw syscall", "error", err)
-			if err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART); err != nil {
-				slog.Error("recovery: reboot syscall failed", "error", err)
+			slog.Warn("recovery: sudo reboot failed, trying systemctl", "error", err)
+			cmd2 := exec.Command("systemctl", "reboot")
+			if err := cmd2.Run(); err != nil {
+				slog.Error("recovery: all reboot methods failed", "error", err)
 			}
 		}
 	}

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -194,6 +194,32 @@ func (sp *SerialPort) Ring(start bool) {
 	}
 }
 
+// QueryPhase sends PHASE? and returns the raw phase byte as a uint8.
+// Response format: PHASE:0xNN
+func (sp *SerialPort) QueryPhase() (uint8, error) {
+	resp, err := sp.SendCommand("PHASE?", 1*time.Second)
+	if err != nil {
+		return 0, err
+	}
+	parts := strings.SplitN(resp, ":", 2)
+	if len(parts) != 2 || parts[0] != "PHASE" {
+		return 0, fmt.Errorf("unexpected phase response: %q", resp)
+	}
+	var val uint8
+	if _, err := fmt.Sscanf(parts[1], "0x%02X", &val); err != nil {
+		return 0, fmt.Errorf("parse phase byte: %w (raw=%q)", err, parts[1])
+	}
+	return val, nil
+}
+
+// Phase byte constants matching firmware/src/phase.h.
+const (
+	PhasePaired   uint8 = 0x01
+	PhaseUnpaired uint8 = 0x02
+	PhaseSetup    uint8 = 0x03
+	PhaseRecovery uint8 = 0x04
+)
+
 // LED sends LED:<mode> to the Pico.
 func (sp *SerialPort) LED(mode string) {
 	sp.SendFire("LED:" + mode)

--- a/pi/image/initramfs/recovery-root.sh
+++ b/pi/image/initramfs/recovery-root.sh
@@ -9,7 +9,7 @@
 #   2. initramfs mounts normal rootfs (p2) at $rootmnt
 #   3. THIS SCRIPT (local-bottom) unmounts p2, mounts p3 at $rootmnt instead
 #   4. initramfs does move_virtual_filesystems + switch_root into p3
-#   5. digits-recovery binary runs as PID 1 from the recovery partition
+#   5. digitsd runs as PID 1 from the recovery partition (--mode=recovery)
 #
 # Installed to /etc/initramfs-tools/scripts/local-bottom/recovery-root
 

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -17,3 +17,4 @@ digits ALL=(root) NOPASSWD: /usr/bin/rm -f /data/wifi-configured
 digits ALL=(root) NOPASSWD: /usr/bin/openocd
 digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service, /usr/bin/systemctl daemon-reload
 digits ALL=(root) NOPASSWD: /usr/sbin/reboot
+digits ALL=(root) NOPASSWD: /usr/bin/journalctl -u digitsd *


### PR DESCRIPTION
## Summary

Fixes the star-at-boot recovery trigger. Previously, pressing * during power-on sent a transient UART message (BOOT:PANIC) that was always lost because the Pi boots 15-30 seconds after the Pico. Now the Pico persists its intent to flash and digitsd reads it reliably.

- Firmware: write PHASE_RECOVERY to flash when * is held at boot, using debounce-free `keypad_scan_raw()` (the normal debounced scan rejected the key because <80ms elapsed since init)
- Firmware: add `PHASE?` UART command that returns the persisted phase byte
- digitsd: query phase after POST with retries; if RECOVERY, write flag file + boot counter, clear phase back to PAIRED/UNPAIRED, reboot into recovery partition
- digitsd: `doReboot()` now uses `sudo /usr/sbin/reboot` (in the digits user's sudoers allowlist) instead of bare `systemctl reboot` which lacked permissions
- Pin `Dockerfile.builder` to `golang:1.26-bookworm` (floating tag moved to Trixie, causing glibc 2.40 mismatch with Bookworm devices)

### Dev-mode fixes (from testing)

- Phase display: human-readable label ("paired") instead of raw hex
- Journal logs: use `sudo journalctl` with matching sudoers entry
- Log tab switching: clear cached content so UI updates on tab switch
- Stale `digits-recovery` comment fixed in initramfs

### Tested on device

1. Pico detects * at boot, writes PHASE_RECOVERY, LED fast-blinks
2. digitsd queries PHASE?, sees 0x04, writes recovery flags, clears phase, reboots
3. Initramfs sees flags, boots recovery partition
4. Recovery web UI + AP functional

### Root cause chain

The original BOOT:PANIC approach had three bugs stacked:
1. **Timing**: UART message sent before Pi opened serial port (15-30s gap)
2. **Debounce**: `keypad_scan()` rejected the held key because <80ms since `keypad_init()`
3. **Permissions**: `doReboot()` used `systemctl reboot` without sudo

## Test plan

- [x] Firmware builds cleanly
- [x] digitsd builds cleanly (Bookworm-pinned builder)
- [x] Phase query works (saw PHASE:0x01 in logs)
- [x] Star-at-boot triggers recovery (saw PHASE:0x04, recovery flags written, reboot into recovery)
- [x] Dev-mode web UI shows correct phase, journal logs, tab switching
- [ ] Recovery audio (pre-existing issue, separate from this fix)