### PR TITLE
fix(server): use cluster-wide presence check for call setup

### DIFF
--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -159,7 +159,7 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 }
 
 func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
-	if r.Hub.ConnectionCount(msg.To) == 0 {
+	if !r.Hub.IsOnline(msg.To) {
 		r.observeError("peer_unreachable")
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "phone not connected"})
 		return


### PR DESCRIPTION
## Summary

- `handleCall` gate-checked `Hub.ConnectionCount(target)`, which only counts local WebSocket connections on the current pod. With 3 signald replicas, caller and callee almost always land on different pods, so `ConnectionCount` returns 0 and the server rejects every cross-pod call with "phone not connected" before any call state is created.
- Switched to `Hub.IsOnline(target)`, which queries Redis-backed `DeviceState` when available. Falls back to local connections in single-instance mode.
- All downstream plumbing (`SendTo`, `CallTracker.InCall`, `OnCallInitiated`) already uses Redis for cross-pod delivery and state. This was the only broken link.

Surfaced by the first external household trying to call: both directions failed with "sdp without active call" in the logs because the call was rejected before any state was created, then the device's SDP/ICE arrived orphaned.

## Test plan

- [x] `go test ./internal/signaling/` passes
- [x] Full `make test` passes
- [x] `golangci-lint run ./...` clean
- [ ] Deploy to k8s, verify cross-pod calls succeed between households