### PR TITLE
fix(digitsd): restrict easter eggs to first-dialed sequence and fix volume mid-call

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2232,6 +2232,7 @@ func main() {
 	// so the dial tone loops under the user's DTMF beeps. Same regression
 	// covered by controller_test.go:1694.
 	var resetToDialtone func()
+	var getPhoneState func() phone.State
 	confirm := func(promptName string, action func()) {
 		mixer.StopTone()
 		mixer.PlayOnce(promptName)
@@ -2250,6 +2251,10 @@ func main() {
 	svcCodes.OnVolume = func(level int) {
 		if err := phone.SetVolume(level); err != nil {
 			slog.Warn("volume set failed", "error", err)
+		}
+		if getPhoneState != nil && !getPhoneState().IsDialPhase() {
+			doubleBeep()
+			return
 		}
 		mixer.StopAll()
 		time.Sleep(250 * time.Millisecond)
@@ -2507,6 +2512,7 @@ func main() {
 		ctrl.ResetToDialtone()
 		sp.SendFire("DIAL:RESET")
 	}
+	getPhoneState = func() phone.State { return ctrl.State() }
 
 	// 8b. Contacts cache: optional dial safelist, persisted to disk.
 	// An empty cache leaves the checker nil so no-contacts phones allow
@@ -2774,7 +2780,8 @@ func main() {
 					mixer.PlayOnce(dtmfName)
 				}
 				// Forward DTMF to the remote peer if a call is connected.
-				if ctrl.State() == phone.StateCONNECTED {
+				state := ctrl.State()
+				if state == phone.StateCONNECTED {
 					cb.mu.Lock()
 					peer := cb.callPeer
 					cb.mu.Unlock()
@@ -2786,24 +2793,27 @@ func main() {
 						})
 					}
 				}
-				// Mid-service-code: route the key only to svcCodes so easter
-				// eggs (e.g., "0000" Rick Roll) cannot eat digits belonging
-				// to a code like "*#00000#" (factory reset). Otherwise: try
-				// easter eggs first, then fall through to service codes.
+				// Easter eggs only fire during the dialing phase and only
+				// when not mid-service-code. Service codes are always
+				// processed regardless of call state, but the FSM reset
+				// is suppressed when a call is active.
 				inCode := svcCodes.InCode()
-				if inCode || !easterEggs.AddKey(key) {
+				dialPhase := state.IsDialPhase()
+				eggTriggered := false
+				if !inCode && dialPhase {
+					eggTriggered = easterEggs.AddKey(key)
+				}
+				if !eggTriggered {
 					switch svcCodes.AddKey(key) {
 					case phone.ServiceCodeTerminal:
 						ctrl.Reset()
-						// Drop the digits the firmware accumulated while the
-						// user was typing the service code (see comment near
-						// the confirmer cancel above). Otherwise post-code
-						// dialing fires DIAL on a stale prefix.
 						sp.SendFire("DIAL:RESET")
-						continue // skip forwarding to controller
+						continue
 					case phone.ServiceCodeNonTerminal:
-						ctrl.ResetToDialtone()
-						sp.SendFire("DIAL:RESET")
+						if dialPhase {
+							ctrl.ResetToDialtone()
+							sp.SendFire("DIAL:RESET")
+						}
 						continue
 					}
 				}

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -170,6 +170,11 @@ func (c *Controller) IsCallActive() bool {
 	}
 }
 
+// IsDialPhase reports whether s is a dialing state (DIALTONE or DIALING).
+func (s State) IsDialPhase() bool {
+	return s == StateDIALTONE || s == StateDIALING
+}
+
 // Reset forces the controller back to IDLE with no pending digits.
 // Used after terminal service codes (shutdown, reboot, etc.) where the
 // daemon is going down and the FSM state no longer matters.

--- a/pi/digitsd/internal/phone/eastereggs.go
+++ b/pi/digitsd/internal/phone/eastereggs.go
@@ -19,13 +19,16 @@ type EasterEgg struct {
 }
 
 // EasterEggDetector watches keypress timing to detect easter egg sequences.
-// Each key must arrive within MinGap–MaxGap of the previous one.
+// Each key must arrive within MinGap–MaxGap of the previous one, and the
+// sequence must be the very first keys pressed in a dialing session (no
+// suffix matching).
 type EasterEggDetector struct {
-	mu     sync.Mutex
-	eggs   []EasterEgg
-	maxLen int // longest trigger length, computed once at construction
-	buf    []timedKey
-	play   func(clip string) // callback to play a clip
+	mu      sync.Mutex
+	eggs    []EasterEgg
+	maxLen  int // longest trigger length, computed once at construction
+	buf     []timedKey
+	tainted bool // set when non-egg keys precede; cleared by Reset
+	play    func(clip string)
 
 	MaxGap time.Duration
 	MinGap time.Duration
@@ -49,33 +52,39 @@ func NewEasterEggDetector(eggs []EasterEgg, play func(clip string)) *EasterEggDe
 }
 
 // AddKey processes a keypress. Returns true if an easter egg was triggered.
+// The sequence must be the very first keys pressed in a dialing session:
+// typing any non-matching prefix taints the detector until the next Reset.
 func (d *EasterEggDetector) AddKey(key string) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	if d.tainted {
+		return false
+	}
+
 	now := time.Now()
 
-	// Check timing against last entry
 	if len(d.buf) > 0 {
 		gap := now.Sub(d.buf[len(d.buf)-1].when)
 		if gap > d.MaxGap || gap < d.MinGap {
+			d.tainted = true
 			d.buf = d.buf[:0]
+			return false
 		}
 	}
 
 	d.buf = append(d.buf, timedKey{key: key, when: now})
 
-	// Keep buffer trimmed to longest trigger.
 	if len(d.buf) > d.maxLen {
-		d.buf = d.buf[len(d.buf)-d.maxLen:]
+		d.tainted = true
+		d.buf = d.buf[:0]
+		return false
 	}
 
 	seq := d.sequence()
 
-	// Check each egg (longest triggers first to avoid partial false matches)
 	for _, e := range d.eggs {
-		tLen := len(e.Trigger)
-		if len(seq) >= tLen && seq[len(seq)-tLen:] == e.Trigger {
+		if seq == e.Trigger {
 			d.buf = d.buf[:0]
 			slog.Info("phone: easter egg detected", "name", e.Name)
 			if d.play != nil {
@@ -89,10 +98,11 @@ func (d *EasterEggDetector) AddKey(key string) bool {
 	return false
 }
 
-// Reset clears the buffer (e.g., on hang-up).
+// Reset clears the buffer and tainted flag (e.g., on hang-up).
 func (d *EasterEggDetector) Reset() {
 	d.mu.Lock()
 	d.buf = d.buf[:0]
+	d.tainted = false
 	d.mu.Unlock()
 }
 

--- a/pi/digitsd/internal/phone/eastereggs.go
+++ b/pi/digitsd/internal/phone/eastereggs.go
@@ -46,7 +46,7 @@ func NewEasterEggDetector(eggs []EasterEgg, play func(clip string)) *EasterEggDe
 		eggs:   eggs,
 		maxLen: maxLen,
 		play:   play,
-		MaxGap: 1500 * time.Millisecond,
+		MaxGap: 5 * time.Second,
 		MinGap: 100 * time.Millisecond,
 	}
 }

--- a/pi/digitsd/internal/phone/eastereggs_test.go
+++ b/pi/digitsd/internal/phone/eastereggs_test.go
@@ -126,20 +126,53 @@ func TestEasterEggNoFalsePositive(t *testing.T) {
 }
 
 func TestEasterEggAfterOtherDigits(t *testing.T) {
-	played := make(chan string, 1)
 	d := NewEasterEggDetector([]EasterEgg{
 		{Name: "Funky Town", Trigger: "5542", Clip: "funkytown"},
-	}, func(clip string) { played <- clip })
+	}, func(clip string) { t.Errorf("should not trigger after prefix digits, got %s", clip) })
 	d.MinGap = 0
 
 	for _, k := range "123" {
 		d.AddKey(string(k))
 	}
 	for _, k := range "5542" {
+		if d.AddKey(string(k)) {
+			t.Error("should not trigger when other digits were pressed first")
+		}
+	}
+}
+
+func TestEasterEggSuffixNoFalsePositive(t *testing.T) {
+	d := NewEasterEggDetector([]EasterEgg{
+		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
+	}, func(clip string) { t.Errorf("should not trigger on suffix match, got %s", clip) })
+	d.MinGap = 0
+
+	for _, k := range "5550000" {
+		if d.AddKey(string(k)) {
+			t.Error("5550000 should not trigger 0000 easter egg")
+		}
+	}
+}
+
+func TestEasterEggResetClearsTaint(t *testing.T) {
+	played := make(chan string, 1)
+	d := NewEasterEggDetector([]EasterEgg{
+		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
+	}, func(clip string) { played <- clip })
+	d.MinGap = 0
+
+	for _, k := range "555" {
 		d.AddKey(string(k))
 	}
-	if got := waitForClip(t, played); got != "funkytown" {
-		t.Errorf("expected 'funkytown' after prefix, got %q", got)
+	d.Reset()
+	for _, k := range "000" {
+		d.AddKey(string(k))
+	}
+	if !d.AddKey("0") {
+		t.Error("0000 should trigger after Reset clears taint")
+	}
+	if got := waitForClip(t, played); got != "rickroll" {
+		t.Errorf("expected 'rickroll', got %q", got)
 	}
 }
 

--- a/pi/digitsd/internal/phone/servicecodes_test.go
+++ b/pi/digitsd/internal/phone/servicecodes_test.go
@@ -342,33 +342,23 @@ func TestFactoryResetVsRickRollEasterEgg(t *testing.T) {
 	}
 }
 
-// TestEasterEggFiresAfterLoneStar guards the suppression-window scope: a
-// stray '*' followed by digits is normal-dial input, not a service code, and
-// must not block easter eggs (which require the full '*#' prefix to suppress).
-func TestEasterEggFiresAfterLoneStar(t *testing.T) {
+// TestEasterEggBlockedAfterLoneStar verifies that a stray '*' prefix
+// prevents the following "0000" from triggering the Rick Roll easter egg.
+// Easter eggs require an exact match from the start of the dialing session.
+func TestEasterEggBlockedAfterLoneStar(t *testing.T) {
 	svc := NewServiceCodeHandler()
-	rickRoll := make(chan string, 1)
 	eggs := NewEasterEggDetector([]EasterEgg{
 		{Name: "Rick Roll", Trigger: "0000", Clip: "rickroll"},
-	}, func(clip string) { rickRoll <- clip })
+	}, func(clip string) { t.Errorf("should not trigger after * prefix, got %s", clip) })
 	eggs.MinGap = 0
 
 	for _, k := range "*0000" {
 		key := string(k)
 		if !svc.InCode() {
 			if eggs.AddKey(key) {
-				continue
+				t.Error("easter egg should not trigger with * prefix")
 			}
 		}
 		svc.AddKey(key)
-	}
-
-	select {
-	case clip := <-rickRoll:
-		if clip != "rickroll" {
-			t.Errorf("expected rickroll, got %q", clip)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("Rick Roll should fire for *0000 (lone '*' is not a service code)")
 	}
 }


### PR DESCRIPTION
## Summary

- Easter egg detector now uses exact matching instead of suffix matching, so dialing a number like 555-0000 no longer triggers the Rick Roll easter egg. A `tainted` flag ensures only the very first keys after hook-off can match.
- Easter egg detection is now gated to DIALTONE/DIALING states only, preventing any trigger during connected calls.
- Volume service code (*#*N) mid-call no longer calls `mixer.StopAll()` or plays dial tone. It applies the ALSA volume and plays a confirmation beep without disrupting call audio or resetting the FSM.
- `ServiceCodeNonTerminal` handler no longer resets FSM to DIALTONE when a call is active.
- Added `State.IsDialPhase()` method and consolidated `ctrl.State()` to a single call per key event.

## Test plan
- [x] All phone package tests pass (73/73, including 3 new tests)
- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` clean (0 issues)
- [ ] Manual: pick up, dial `0000` rapidly -> Rick Roll plays
- [ ] Manual: pick up, dial `555-0000` -> call placed, no Rick Roll
- [ ] Manual: during a connected call, press `*#*5` -> volume changes, call audio uninterrupted, no dial tone