### PR TITLE
feat(digitsd): mic kill switch test in dev-mode dashboard

### DIFF
--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -328,6 +328,10 @@ func devModeMicTestHandler(cfg *devModeConfig) http.HandlerFunc {
 
 func devModeMicTestDownloadHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		if micRecording.Load() {
 			http.Error(w, "recording in progress", http.StatusConflict)
 			return

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 )
@@ -47,6 +48,10 @@ type devModeConfig struct {
 
 	// UARTLogPath is the UART log file path (same as the serial logger).
 	UARTLogPath string
+
+	// CaptureDevice is the ALSA device name for mic capture (e.g.
+	// "digits_capture" on V2 or "plughw:CARD=Zero,DEV=0" on V1).
+	CaptureDevice string
 }
 
 // startDevModeServer starts the dev-mode web UI on :8080.
@@ -63,6 +68,8 @@ func startDevModeServer(cfg *devModeConfig) (net.Listener, error) {
 	mux.HandleFunc("/api/status", devModeStatusHandler(cfg))
 	mux.HandleFunc("/api/toggle", devModeToggleHandler(cfg))
 	mux.HandleFunc("/api/flash", devModeFlashHandler(cfg))
+	mux.HandleFunc("/api/mic-test", devModeMicTestHandler(cfg))
+	mux.HandleFunc("/api/mic-test/download", devModeMicTestDownloadHandler())
 	mux.HandleFunc("/api/log/serial", devModeSerialLogHandler(cfg))
 	mux.HandleFunc("/api/log/journal", devModeJournalLogHandler())
 
@@ -247,5 +254,84 @@ func devModeJournalLogHandler() http.HandlerFunc {
 			return
 		}
 		_, _ = w.Write(out)
+	}
+}
+
+const micTestPath = "/tmp/mic-test.wav"
+
+var (
+	micRecording atomic.Bool
+	micLastErr   atomic.Value // stores string; empty means no error
+)
+
+func devModeMicTestHandler(cfg *devModeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodPost:
+			if !micRecording.CompareAndSwap(false, true) {
+				w.WriteHeader(http.StatusConflict)
+				json.NewEncoder(w).Encode(map[string]string{"error": "recording already in progress"}) //nolint:errcheck
+				return
+			}
+			micLastErr.Store("")
+
+			device := cfg.CaptureDevice
+			if device == "" {
+				device = "default"
+			}
+
+			go func() {
+				defer micRecording.Store(false)
+				cmd := exec.Command("arecord",
+					"-D", device,
+					"-f", "S16_LE",
+					"-r", "48000",
+					"-c", "2",
+					"-d", "5",
+					micTestPath)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					msg := fmt.Sprintf("arecord: %v: %s", err, out)
+					slog.Error("devmode: mic test failed", "error", msg)
+					micLastErr.Store(msg)
+				} else {
+					slog.Info("devmode: mic test recording completed")
+				}
+			}()
+
+			json.NewEncoder(w).Encode(map[string]any{"status": "recording", "duration": 5}) //nolint:errcheck
+
+		case http.MethodGet:
+			if micRecording.Load() {
+				json.NewEncoder(w).Encode(map[string]string{"status": "recording"}) //nolint:errcheck
+				return
+			}
+			if v := micLastErr.Load(); v != nil {
+				if errStr, _ := v.(string); errStr != "" {
+					json.NewEncoder(w).Encode(map[string]string{"status": "error", "error": errStr}) //nolint:errcheck
+					return
+				}
+			}
+			if _, err := os.Stat(micTestPath); err != nil {
+				json.NewEncoder(w).Encode(map[string]string{"status": "idle"}) //nolint:errcheck
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"status": "ready"}) //nolint:errcheck
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func devModeMicTestDownloadHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if micRecording.Load() {
+			http.Error(w, "recording in progress", http.StatusConflict)
+			return
+		}
+		http.ServeFile(w, r, micTestPath)
 	}
 }

--- a/pi/digitsd/cmd/digitsd/devmode_static/index.html
+++ b/pi/digitsd/cmd/digitsd/devmode_static/index.html
@@ -49,6 +49,14 @@ header .subtitle{color:#8b949e;margin-top:4px;font-size:13px}
 .tab{padding:4px 10px;background:#21262d;border:1px solid #30363d;border-radius:4px;color:#8b949e;font-size:12px;cursor:pointer;transition:background .15s}
 .tab:hover{background:#30363d;color:#e6edf3}
 .tab.active{background:#161b22;color:#58a6ff;border-color:#58a6ff}
+.mic-desc{font-size:12px;color:#8b949e;margin-bottom:10px;line-height:1.5}
+.mic-controls{display:flex;align-items:center;gap:10px}
+.mic-status{font-size:12px;color:#8b949e;min-height:16px}
+.mic-status.error{color:#f85149}
+.mic-status.ok{color:#3fb950}
+.mic-playback{margin-top:10px;display:flex;align-items:center;gap:10px}
+.mic-playback audio{height:32px;flex:1}
+.mic-countdown{font-family:monospace;font-size:13px;color:#d29922}
 </style>
 </head>
 <body>
@@ -92,6 +100,19 @@ header .subtitle{color:#8b949e;margin-top:4px;font-size:13px}
         <div class="desc">Prevent bundled firmware from overwriting Pico on boot</div>
       </div>
       <label class="toggle"><input type="checkbox" id="tog-reflash" onchange="toggle('fw_reflash',this.checked)"><span class="slider"></span></label>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h2>Mic Kill Switch Test</h2>
+    <p class="mic-desc">Records 5 seconds from the mic to verify the hardware kill switch. Lift the handset and speak to confirm the mic is active, then place it back on the cradle and record again to confirm silence.</p>
+    <div class="mic-controls">
+      <button class="upload-btn" id="mic-record" onclick="startMicTest()">Record 5 seconds</button>
+      <span class="mic-status" id="mic-status"></span>
+    </div>
+    <div class="mic-playback" id="mic-playback" style="display:none">
+      <audio id="mic-audio" controls></audio>
+      <a class="btn-small" href="/api/mic-test/download" download="mic-test.wav">Download</a>
     </div>
   </div>
 
@@ -147,6 +168,67 @@ function toggle(name,val){
   fetch('/api/toggle',{method:'POST',headers:{'Content-Type':'application/json'},
     body:JSON.stringify({name:name,enabled:val})
   }).catch(function(e){alert('Toggle failed: '+e)});
+}
+
+function startMicTest(){
+  var btn=document.getElementById('mic-record');
+  var status=document.getElementById('mic-status');
+  var playback=document.getElementById('mic-playback');
+  btn.disabled=true;
+  playback.style.display='none';
+  status.textContent='Starting...';
+  status.className='mic-status';
+  fetch('/api/mic-test',{method:'POST'}).then(function(r){return r.json()}).then(function(d){
+    if(d.error){
+      status.textContent=d.error;
+      status.className='mic-status error';
+      btn.disabled=false;
+      return;
+    }
+    var dur=d.duration||5;
+    var left=dur;
+    status.textContent='Recording... '+left+'s';
+    status.className='mic-status mic-countdown';
+    var iv=setInterval(function(){
+      left--;
+      if(left>0){status.textContent='Recording... '+left+'s'}
+      else{clearInterval(iv);status.textContent='Finishing...';status.className='mic-status'}
+    },1000);
+    setTimeout(function(){pollMicDone(btn,status,playback,0)},((dur)+0.5)*1000);
+  }).catch(function(e){
+    status.textContent='Failed: '+e;
+    status.className='mic-status error';
+    btn.disabled=false;
+  });
+}
+
+function pollMicDone(btn,status,playback,attempts){
+  if(attempts>=20){
+    btn.disabled=false;
+    status.textContent='Timed out waiting for recording';
+    status.className='mic-status error';
+    return;
+  }
+  fetch('/api/mic-test').then(function(r){return r.json()}).then(function(d){
+    if(d.status==='recording'){
+      setTimeout(function(){pollMicDone(btn,status,playback,attempts+1)},500);
+      return;
+    }
+    btn.disabled=false;
+    if(d.status==='error'){
+      status.textContent=d.error;
+      status.className='mic-status error';
+    }else if(d.status==='ready'){
+      status.textContent='Done';
+      status.className='mic-status ok';
+      playback.style.display='flex';
+      var audio=document.getElementById('mic-audio');
+      audio.src='/api/mic-test/download?t='+Date.now();
+      audio.load();
+    }
+  }).catch(function(){
+    setTimeout(function(){pollMicDone(btn,status,playback,attempts+1)},500);
+  });
 }
 
 function uploadELF(input){

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2570,6 +2570,7 @@ func main() {
 			SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,
 			SkipAutoUpdatePath: devmode.DefaultSkipAutoUpdatePath,
 			UARTLogPath:        uartLogPath,
+			CaptureDevice:      audio.CodecCaptureDevice(),
 			StatusFunc: func() devModeStatus {
 				fwVer, fwCom := cb.getFirmwareVersion()
 				return devModeStatus{

--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -859,6 +859,11 @@ if [[ "$DEV_MODE" == true ]]; then
     mkdir -p "${DATA_MNT}/ssh"
     ssh-keygen -t rsa -b 4096 -f "${DATA_MNT}/ssh/ssh_host_rsa_key" -N '' -q
     ssh-keygen -t ed25519 -f "${DATA_MNT}/ssh/ssh_host_ed25519_key" -N '' -q
+
+    # Enable the dev-mode web UI (port 8080). Placed before the skeleton
+    # tar so the flag survives factory reset on dev images.
+    touch "${DATA_MNT}/digits/dev-mode"
+    chown 999:992 "${DATA_MNT}/digits/dev-mode"
 fi
 
 # Create compressed data skeleton archive
@@ -1370,7 +1375,7 @@ SSHDEV
     # race with sshd or pollute /etc/ssh.
     hostside_mask_service "$ROOTFS_MNT" "regenerate_ssh_host_keys.service"
 
-    info "DEV MODE: SSH enabled, user 'dev', password 'digits', passwordless sudo"
+    info "DEV MODE: SSH enabled, user 'dev', password 'digits', passwordless sudo, dev web UI on :8080"
 fi
 
 # ── step 23: final cleanup (host-side) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add a "Mic Kill Switch Test" panel to the dev-mode web UI on `:8080` that records 5 seconds from the ALSA capture device via `arecord`, then presents an inline `<audio>` player and download link for the WAV
- Auto-detect V1 (Codec Zero) vs V2 (TLV320AIC3104) capture device via `audio.CodecCaptureDevice()`
- Auto-enable dev-mode on dev images by placing the `/data/digits/dev-mode` flag file in the data-skeleton tar (survives factory reset)

## Test plan

- [ ] Build a dev image (`make image-v2-dev`), boot, verify dev web UI starts on `:8080` without manual flag file creation
- [ ] Lift handset, click "Record 5 seconds", play back recording in browser: should hear voice
- [ ] Place handset on cradle (kill switch engaged), record again, play back: should be silence
- [ ] Verify factory reset preserves dev-mode flag (recovery wipe + reboot)
- [ ] Verify recording while audio pipeline is active (during a call) returns an error in the UI