### PR TITLE
docs: rewrite README for current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ The hook switch physically disconnects the microphone circuit when the handset i
 
 The server is designed to be self-hosted. If you do not want to use the public instance at [app.digits.family](https://app.digits.family), you can run the same code on your own infrastructure. See [Self-hosting](docs/hosting/self-hosting.md).
 
+## Contributing
+
+This is a personal project, not a company. Contributions to both the software and the hardware are welcome.
+
+On the software side, the server is vanilla Go with htmx and Tailwind, the Pi daemon is Go with WebRTC, and the firmware is C on the Pico SDK. Standard open source workflow: fork, branch, PR.
+
+On the hardware side, I am not an electrical engineer. I learned KiCad, read datasheets, and iterated until the board worked. The result is a functional PCB with minimal errata, which I'm genuinely proud of, but there is a lot of room for someone with real PCB design experience to improve the layout, power integrity, signal routing, and DFM. If you have those skills and this project interests you, I would particularly welcome that kind of help. The schematics and board files are all KiCad and licensed CC BY-SA 4.0.
+
 ## Documentation
 
 - [Why Digits?](https://digits.family/why)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 Each phone is a gutted vintage desk phone with two processors inside: an RP2040 handling real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a Raspberry Pi Zero 2 W running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and call signaling. A Go server handles call routing, device pairing, and household management. There's a free public instance at [app.digits.family](https://app.digits.family), or you can run your own.
 
+[Architecture](#architecture) · [Hardware](#hardware) · [Project Structure](#project-structure) · [Quick Start](#quick-start) · [Hosting](#hosting) · [Web App](#web-app) · [Service Codes](#service-codes) · [Party Line](#party-line-three-way-calling) · [Easter Eggs](#easter-eggs) · [Privacy](#privacy) · [Contributing](#contributing) · [Docs](#documentation) · [License](#license)
+
 ## Architecture
 
 | Component | Role |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ make test
 
 The server is a single Go binary (`signald`) backed by Postgres. Docker Compose is the straightforward way to run it: clone the repo, fill in an `.env` file, `docker compose up -d`. The [self-hosting guide](docs/hosting/self-hosting.md) covers TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
 
-There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There is no good reason for a three-phone family network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It is what runs in production. Completely unnecessary, but it works and it is there if you want it.
+There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There is no good reason for a family phone network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It is what runs in production. Completely unnecessary, but it works and it is there if you want it.
 
 ## Web App
 

--- a/README.md
+++ b/README.md
@@ -28,63 +28,41 @@
 
 ---
 
-Each phone is a gutted vintage desk phone with two processors inside: a **Pico H** running C firmware for real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a **Raspberry Pi Zero 2 W** running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and signaling. A **Go server** handles call routing, device pairing, household management, and a web dashboard. There's a free public instance at [app.digits.family](https://app.digits.family), or you can self-host.
-
-Lift the handset, hear a dial tone, punch in a number. The bell rings on the other end. Calls are encrypted, the server never touches media, and when the handset goes back on the cradle the mic is physically disconnected.
-
-## Privacy
-
-Calls use WebRTC with DTLS-SRTP encryption, the same standard used by Signal and FaceTime. Voice data is encrypted end-to-end between the two phones on the call. The server handles connection setup only: it brokers the signaling handshake (who's calling whom), but it never has access to the audio stream. We can't listen to your calls. We designed the system so that it's technically impossible for us to even if we tried.
-
-When the handset is on the cradle, the hook switch physically disconnects the microphone circuit. Not muted in software. Electrically disconnected. You can trust physics.
-
-**What the server does store:** user accounts (email, name), household membership, phone line assignments, device pairing tokens, and session data. Call metadata is logged: who called whom, when, and for how long. Connection quality telemetry (packet loss, jitter, bandwidth) is collected during calls for diagnostics.
-
-**What the server never stores:** voice audio, call recordings, transcripts, location data, or anything about what was said on a call. There is no mechanism to record calls; the architecture makes it impossible. The server doesn't even know what was said.
-
-The public server at [app.digits.family](https://app.digits.family) is free and runs the same code that's in this repo. If you'd rather not trust anyone else's infrastructure, the whole thing is designed to self-host. The signaling server is a single Go binary with a Postgres database. Run it on a VPS, a home server, whatever. Your network is yours either way.
-
-## Hardware
-
-The project has gone through three hardware iterations, each a different build strategy for the same phone:
-
-| Rev | Construction | Audio | Ringer | Status |
-|-----|-------------|-------|--------|--------|
-| [V0](docs/build/components.md) | Perfboard, off-the-shelf modules | Codec Zero HAT (DA7212) | L298N + step-up transformer | Done, documented end-to-end |
-| [V1](hardware/pcb/v1/) | Hand-assembled PCB | Codec Zero HAT (DA7212) | L298N + step-up transformer | Fabricated, has [errata](hardware/pcb/v1/ERRATA.md) |
-| [V2](hardware/pcb/v2/) | Contract-assembled (JLCPCB) | Onboard TLV320AIC3104 | Onboard DRV8871 | Deployed, ~10 units in use |
-
-**V1** is a bench-build target: single-sided, mostly through-hole, hand-solderable. External modules handle audio (Codec Zero HAT) and bell ringing (L298N H-bridge plus a step-up transformer).
-
-**V2** is a fab-service target: onboard audio codec (TLV320AIC3104, 32-pin QFN) and ringer driver (DRV8871). Arrives pre-assembled from JLCPCB. Cleaner result, no internal wiring, but not practical to hand-solder.
-
-Both use KiCad. Schematics, PCB layouts, Gerbers, and BOMs are in [`hardware/pcb/`](hardware/pcb/). The firmware abstracts board differences at runtime, so the same binary runs on V1 and V2.
+Each phone is a gutted vintage desk phone with two processors inside: an RP2040 handling real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a Raspberry Pi Zero 2 W running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and call signaling. A Go server handles call routing, device pairing, and household management. There's a free public instance at [app.digits.family](https://app.digits.family), or you can run your own.
 
 ## Architecture
 
 | Component | Role |
 |-----------|------|
-| **Pico H** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. |
-| **Pi Zero 2 W** (digitsd, Go) | VoIP daemon: WebRTC media (Opus codec, DTLS-SRTP), signaling client, call state machine, Wi-Fi setup, OTA updates. |
+| **RP2040** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. V0/V1 use a Pico H module; V2 has the RP2040 onboard. |
+| **Pi Zero 2 W** (digitsd, Go) | VoIP daemon: WebRTC media, Opus codec, DTLS-SRTP, signaling client, call state machine, Wi-Fi setup, OTA updates. |
 | **Audio codec** | Mic input and earpiece output. DA7212 HAT on V0/V1, onboard TLV320AIC3104 on V2. |
 | **Signaling server** (Go) | WebSocket relay for SDP/ICE exchange, PostgreSQL persistence, device pairing, household management, web dashboard. |
 
-The server never sees call audio. Each call is a direct peer-to-peer WebRTC session between two phones (or three, for party-line calls), with the server only brokering the initial signaling handshake.
+Calls are peer-to-peer WebRTC sessions between two phones (or three, for party-line calls). The server brokers the signaling handshake but never handles media.
 
 See [Architecture deep-dive](docs/architecture/overview.md) for the full call path, data model, and NAT traversal.
 
-## Web App
+## Hardware
 
-The server includes a web dashboard for managing your network: pairing phones, organizing households, viewing call history, and configuring per-line settings like voice style and Do Not Disturb schedules.
+Three hardware iterations, each a different build strategy:
 
-<p align="center">
-  <img src="https://digits.family/images/screenshots/dashboard.png" width="720" alt="Digits web dashboard">
-</p>
+| Rev | Construction | Audio | Ringer | Status |
+|-----|-------------|-------|--------|--------|
+| [V0](docs/build/components.md) | Perfboard, off-the-shelf modules | Codec Zero HAT (DA7212) | L298N + step-up transformer | Done, documented end-to-end |
+| [V1](hardware/pcb/v1/) | Hand-assembled PCB, Pico H module | Codec Zero HAT (DA7212) | L298N + step-up transformer | Fabricated, has [errata](hardware/pcb/v1/ERRATA.md) |
+| [V2](hardware/pcb/v2/) | Contract-assembled (JLCPCB), onboard RP2040 | Onboard TLV320AIC3104 | Onboard DRV8871 | Deployed, ~10 units in use |
+
+**V1** is a bench-build target: single-sided, mostly through-hole, hand-solderable. External modules handle audio (Codec Zero HAT) and bell ringing (L298N H-bridge plus a step-up transformer).
+
+**V2** is a fab-service target: onboard RP2040, audio codec (TLV320AIC3104, 32-pin QFN), and ringer driver (DRV8871). Arrives pre-assembled from JLCPCB. Not practical to hand-solder.
+
+Schematics, PCB layouts, Gerbers, and BOMs are in [`hardware/pcb/`](hardware/pcb/). All designed in KiCad. The firmware abstracts board differences at runtime, so the same binary runs on V1 and V2.
 
 ## Project Structure
 
 ```text
-firmware/       Pico H firmware (C, CMake, Pico SDK)
+firmware/       RP2040 firmware (C, CMake, Pico SDK)
 pi/digitsd/     Pi-side VoIP daemon (Go, cross-compiled to arm64)
 pi/image/       Raspberry Pi OS image builder
 server/         Signaling server + web dashboard (Go, htmx, Tailwind)
@@ -124,9 +102,17 @@ make test
 
 ## Hosting
 
-The server is a single Go binary (`signald`) backed by Postgres. Docker Compose is the straightforward way to run it: clone the repo, fill in an `.env` file, `docker compose up -d`, done. The [self-hosting guide](docs/hosting/self-hosting.md) walks through the full setup including TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
+The server is a single Go binary (`signald`) backed by Postgres. Docker Compose is the straightforward way to run it: clone the repo, fill in an `.env` file, `docker compose up -d`. The [self-hosting guide](docs/hosting/self-hosting.md) covers TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
 
-There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There's no good reason for a three-phone family network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It's what runs in production. Again, completely unnecessary, but it works and it's there if you want it.
+There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There is no good reason for a three-phone family network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It is what runs in production. Completely unnecessary, but it works and it is there if you want it.
+
+## Web App
+
+The server includes a web dashboard for pairing phones, organizing households, viewing call history, and configuring per-line settings.
+
+<p align="center">
+  <img src="https://digits.family/images/screenshots/dashboard.png" width="720" alt="Digits web dashboard">
+</p>
 
 ## Service Codes
 
@@ -151,7 +137,7 @@ Hidden codes entered on the keypad while the handset is off-hook.
 
 ## Party Line (Three-Way Calling)
 
-Classic 90s residential three-way calling. During an active call, press and briefly release the hook switch (a "flash", 100-600 ms on-hook) and you'll hear a second dial tone. Dial a third number, talk to them privately, then flash again to merge all three into a single call. Everyone hears everyone.
+Classic 90s residential three-way calling. During an active call, press and briefly release the hook switch (a "flash", 100-600 ms on-hook) to get a second dial tone. Dial a third number, talk to them privately, then flash again to merge all three into a single call.
 
 | Gesture | What happens |
 |---------|--------------|
@@ -175,6 +161,18 @@ Hidden sequences that play audio clips through the earpiece. Each keypress must 
 | `5-5-4-2` | Towelie: *"That's it! That's the melody to Funky Town!"* |
 | `0-0-0-0` | Rick Astley: *"Never gonna give you up..."* |
 | `8-6-7-5-3-0-9` | Tommy Tutone: *"Jenny I got your number... 867-5309!"* (intercepts the dial) |
+
+## Privacy
+
+Calls use WebRTC with DTLS-SRTP. Voice data is encrypted end-to-end between the two devices on the call. The signaling server facilitates connection setup but never has access to the audio stream. Even if the server were compromised, there would be no voice data to extract.
+
+The hook switch physically disconnects the microphone circuit when the handset is on the cradle. This is an electrical disconnect, not a software mute.
+
+**What the server stores:** user accounts (email, name), household membership, phone line assignments, device pairing tokens, session data, call metadata (caller, callee, timestamps, duration), and connection quality telemetry (packet loss, jitter, bandwidth).
+
+**What the server does not store:** voice audio, call recordings, transcripts, or location data. There is no mechanism in the server to capture call audio.
+
+The server is designed to be self-hosted. If you do not want to use the public instance at [app.digits.family](https://app.digits.family), you can run the same code on your own infrastructure. See [Self-hosting](docs/hosting/self-hosting.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ---
 
-Each phone is a gutted vintage desk phone with two processors inside: a **Pico H** running C firmware for real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a **Raspberry Pi Zero 2 W** running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and signaling. A self-hosted **Go server** handles call routing, device pairing, household management, and a web dashboard.
+Each phone is a gutted vintage desk phone with two processors inside: a **Pico H** running C firmware for real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a **Raspberry Pi Zero 2 W** running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and signaling. A **Go server** handles call routing, device pairing, household management, and a web dashboard. There's a free public instance at [app.digits.family](https://app.digits.family), or you can self-host.
 
 Lift the handset, hear a dial tone, punch in a number. The bell rings on the other end. Calls are encrypted, the server never touches media, and when the handset goes back on the cradle the mic is physically disconnected.
 
@@ -42,7 +42,7 @@ When the handset is on the cradle, the hook switch physically disconnects the mi
 
 **What the server never stores:** voice audio, call recordings, transcripts, location data, or anything about what was said on a call. There is no mechanism to record calls; the architecture makes it impossible. The server doesn't even know what was said.
 
-If you don't want to trust anyone else's server, the whole thing is designed to self-host. The signaling server is a single Go binary with a Postgres database. Run it on a VPS, a home server, whatever. Your network is yours.
+The public server at [app.digits.family](https://app.digits.family) is free and runs the same code that's in this repo. If you'd rather not trust anyone else's infrastructure, the whole thing is designed to self-host. The signaling server is a single Go binary with a Postgres database. Run it on a VPS, a home server, whatever. Your network is yours either way.
 
 ## Hardware
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each phone is a gutted vintage desk phone with two processors inside: an RP2040 
 |-----------|------|
 | **RP2040** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. V0/V1 use a Pico H module; V2 has the RP2040 onboard. |
 | **Pi Zero 2 W** (digitsd, Go) | VoIP daemon: WebRTC media, Opus codec, DTLS-SRTP, signaling client, call state machine, Wi-Fi setup, OTA updates. |
-| **Audio codec** | Mic input and earpiece output. DA7212 HAT on V0/V1, onboard TLV320AIC3104 on V2. |
+| **Audio codec** | Mic input and earpiece output. Codec Zero HAT (DA7212) on V0/V1, onboard TLV320AIC3104 on V2. |
 | **Signaling server** (Go) | WebSocket relay for SDP/ICE exchange, PostgreSQL persistence, device pairing, household management, web dashboard. |
 
 Calls are peer-to-peer WebRTC sessions between two phones (or three, for party-line calls). The server brokers the signaling handshake but never handles media.
@@ -84,8 +84,10 @@ pi/digitsd/     Pi-side VoIP daemon (Go, cross-compiled to arm64)
 pi/image/       Raspberry Pi OS image builder
 server/         Signaling server + web dashboard (Go, htmx, Tailwind)
 hardware/pcb/   KiCad schematics, PCB layouts, Gerbers, BOMs
+charts/digits/  Helm chart for Kubernetes deployment
+tools/          Build scripts for firmware, Pi binaries, and OS images
 docs/           Architecture notes, build guides, self-hosting
-scripts/        Build and flash helpers
+scripts/        Firmware build and flash helpers
 ```
 
 ## Quick Start
@@ -95,7 +97,7 @@ scripts/        Build and flash helpers
 ```bash
 cd server
 make build     # builds bin/signald
-make run       # build + run (defaults to :8080)
+make run       # build + run (defaults to :8443)
 make test      # go test ./...
 ```
 
@@ -143,6 +145,7 @@ Hidden codes entered on the keypad while the handset is off-hook.
 | `*##*` | Reboot | Immediate reboot. |
 | `*#0*` | Force re-pair | Clears device token, reboots into pairing mode. |
 | `*#73887#` | Wi-Fi setup | Reboots into AP mode for Wi-Fi reconfiguration. (`*#SETUP#` on keypad.) |
+| `*#873283#` | Update check | Checks for OTA firmware and daemon updates. (`*#UPDATE#` on keypad.) |
 | `*#00000#` | Factory reset | Wipes config, Wi-Fi, contacts. Fresh AP + pairing mode. |
 
 ### Confirmation feedback
@@ -183,7 +186,7 @@ Hidden sequences that play audio clips through the earpiece. Each keypress must 
 
 Calls use WebRTC with DTLS-SRTP. Voice data is encrypted end-to-end between the two devices on the call. The signaling server facilitates connection setup but never has access to the audio stream. Even if the server were compromised, there would be no voice data to extract.
 
-The hook switch physically disconnects the microphone circuit when the handset is on the cradle. This is an electrical disconnect, not a software mute.
+A dedicated hardware kill switch (separate from the hook switch) physically disconnects the microphone circuit when the handset is on the cradle. This is an electrical disconnect, not a software mute.
 
 **What the server stores:** user accounts (email, name), household membership, phone line assignments, device pairing tokens, session data, call metadata (caller, callee, timestamps, duration), and connection quality telemetry (packet loss, jitter, bandwidth).
 

--- a/README.md
+++ b/README.md
@@ -30,21 +30,22 @@
 
 Each phone is a gutted vintage desk phone with two processors inside: an RP2040 handling real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a Raspberry Pi Zero 2 W running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and call signaling. A Go server handles call routing, device pairing, and household management. There's a free public instance at [app.digits.family](https://app.digits.family), or you can run your own.
 
-<p align="center">
-  <a href="#architecture">Architecture</a> &middot;
-  <a href="#hardware">Hardware</a> &middot;
-  <a href="#project-structure">Project Structure</a> &middot;
-  <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#hosting">Hosting</a> &middot;
-  <a href="#web-app">Web App</a> &middot;
-  <a href="#service-codes">Service Codes</a> &middot;
-  <a href="#party-line-three-way-calling">Party Line</a> &middot;
-  <a href="#easter-eggs">Easter Eggs</a> &middot;
-  <a href="#privacy">Privacy</a> &middot;
-  <a href="#contributing">Contributing</a> &middot;
-  <a href="#documentation">Docs</a> &middot;
-  <a href="#license">License</a>
-</p>
+## Table of Contents
+
+- [Architecture](#architecture)
+- [Hardware](#hardware)
+- [Project Structure](#project-structure)
+- [Quick Start](#quick-start)
+- [Hosting](#hosting)
+- [Web App](#web-app)
+- [Service Codes](#service-codes)
+  - [Confirmation feedback](#confirmation-feedback)
+- [Party Line](#party-line-three-way-calling)
+- [Easter Eggs](#easter-eggs)
+- [Privacy](#privacy)
+- [Contributing](#contributing)
+- [Documentation](#documentation)
+- [License](#license)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://digits.family/favicon.svg" width="64" alt="Digits">
+</p>
+
 <h1 align="center">Digits</h1>
 
 <p align="center">
@@ -12,7 +16,8 @@
   <a href="https://github.com/justinlindh/digits/releases?q=fw%2Fv"><img src="https://img.shields.io/github/v/release/justinlindh/digits?filter=fw/v*&label=firmware" alt="Firmware release"></a>
   <img src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" alt="Go 1.26">
   <img src="https://img.shields.io/badge/C-Pico_SDK-A8B9CC?logo=c&logoColor=white" alt="C / Pico SDK">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="AGPL-3.0 License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/code-AGPL--3.0-blue" alt="AGPL-3.0 License"></a>
+  <a href="hardware/pcb/"><img src="https://img.shields.io/badge/hardware-CC_BY--SA_4.0-green" alt="CC BY-SA 4.0 License"></a>
 </p>
 
 <p align="center">
@@ -23,34 +28,69 @@
 
 ---
 
-Each Digits endpoint combines:
-- **Pico H** -- phone UX and real-time hardware control (hook switch, keypad, bell, tones, indicators)
-- **Raspberry Pi Zero 2 W** -- Linux-side services (VoIP stack, crypto/session logic, orchestration)
-- **Raspberry Pi Codec Zero (DA7212)** -- audio input/output on the Pi side
+Each phone is a gutted vintage desk phone with two processors inside: a **Pico H** running C firmware for real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a **Raspberry Pi Zero 2 W** running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and signaling. A self-hosted **Go server** handles call routing, device pairing, household management, and a web dashboard.
 
-The goal is a self-hosted, private, retro-style calling system with modern encrypted transport under the hood.
+Lift the handset, hear a dial tone, punch in a number. The bell rings on the other end. Calls are encrypted, the server never touches media, and when the handset goes back on the cradle the mic is physically disconnected.
+
+## Privacy
+
+Calls use WebRTC with DTLS-SRTP encryption, the same standard used by Signal and FaceTime. Voice data is encrypted end-to-end between the two phones on the call. The server handles connection setup only: it brokers the signaling handshake (who's calling whom), but it never has access to the audio stream. We can't listen to your calls. We designed the system so that it's technically impossible for us to even if we tried.
+
+When the handset is on the cradle, the hook switch physically disconnects the microphone circuit. Not muted in software. Electrically disconnected. You can trust physics.
+
+**What the server does store:** user accounts (email, name), household membership, phone line assignments, device pairing tokens, and session data. Call metadata is logged: who called whom, when, and for how long. Connection quality telemetry (packet loss, jitter, bandwidth) is collected during calls for diagnostics.
+
+**What the server never stores:** voice audio, call recordings, transcripts, location data, or anything about what was said on a call. There is no mechanism to record calls; the architecture makes it impossible. The server doesn't even know what was said.
+
+If you don't want to trust anyone else's server, the whole thing is designed to self-host. The signaling server is a single Go binary with a Postgres database. Run it on a VPS, a home server, whatever. Your network is yours.
+
+## Hardware
+
+The project has gone through three hardware iterations, each a different build strategy for the same phone:
+
+| Rev | Construction | Audio | Ringer | Status |
+|-----|-------------|-------|--------|--------|
+| [V0](docs/build/components.md) | Perfboard, off-the-shelf modules | Codec Zero HAT (DA7212) | L298N + step-up transformer | Done, documented end-to-end |
+| [V1](hardware/pcb/v1/) | Hand-assembled PCB | Codec Zero HAT (DA7212) | L298N + step-up transformer | Fabricated, has [errata](hardware/pcb/v1/ERRATA.md) |
+| [V2](hardware/pcb/v2/) | Contract-assembled (JLCPCB) | Onboard TLV320AIC3104 | Onboard DRV8871 | Deployed, ~10 units in use |
+
+**V1** is a bench-build target: single-sided, mostly through-hole, hand-solderable. External modules handle audio (Codec Zero HAT) and bell ringing (L298N H-bridge plus a step-up transformer).
+
+**V2** is a fab-service target: onboard audio codec (TLV320AIC3104, 32-pin QFN) and ringer driver (DRV8871). Arrives pre-assembled from JLCPCB. Cleaner result, no internal wiring, but not practical to hand-solder.
+
+Both use KiCad. Schematics, PCB layouts, Gerbers, and BOMs are in [`hardware/pcb/`](hardware/pcb/). The firmware abstracts board differences at runtime, so the same binary runs on V1 and V2.
 
 ## Architecture
 
-A single phone unit is split into two cooperating processors:
-
 | Component | Role |
 |-----------|------|
-| **Pico H** (firmware) | Low-level telephony, timing-sensitive I/O, UART protocol to Pi |
-| **Pi Zero 2 W** (digitsd) | Go daemon for VoIP, signaling, WebRTC media, Opus codec, call control |
-| **Codec Zero** (DA7212) | Audio pHAT with mic input (3.5mm TRS), speaker output (screw terminal) |
-| **Signaling Server** (Go) | WebSocket relay for SDP/ICE, PostgreSQL persistence, web app |
+| **Pico H** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. |
+| **Pi Zero 2 W** (digitsd, Go) | VoIP daemon: WebRTC media (Opus codec, DTLS-SRTP), signaling client, call state machine, Wi-Fi setup, OTA updates. |
+| **Audio codec** | Mic input and earpiece output. DA7212 HAT on V0/V1, onboard TLV320AIC3104 on V2. |
+| **Signaling server** (Go) | WebSocket relay for SDP/ICE exchange, PostgreSQL persistence, device pairing, household management, web dashboard. |
+
+The server never sees call audio. Each call is a direct peer-to-peer WebRTC session between two phones (or three, for party-line calls), with the server only brokering the initial signaling handshake.
 
 See [Architecture deep-dive](docs/architecture/overview.md) for the full call path, data model, and NAT traversal.
+
+## Web App
+
+The server includes a web dashboard for managing your network: pairing phones, organizing households, viewing call history, and configuring per-line settings like voice style and Do Not Disturb schedules.
+
+<p align="center">
+  <img src="https://digits.family/images/screenshots/dashboard.png" width="720" alt="Digits web dashboard">
+</p>
 
 ## Project Structure
 
 ```text
-firmware/   Pico H firmware (C/CMake + Pico SDK)
-pi/         Pi Zero userland -- digitsd VoIP daemon, setup tools, image builder
-server/     Go signaling server (WebSocket relay, web app)
-docs/       Hardware build guides, architecture, self-hosting
-scripts/    Build and flash helpers
+firmware/       Pico H firmware (C, CMake, Pico SDK)
+pi/digitsd/     Pi-side VoIP daemon (Go, cross-compiled to arm64)
+pi/image/       Raspberry Pi OS image builder
+server/         Signaling server + web dashboard (Go, htmx, Tailwind)
+hardware/pcb/   KiCad schematics, PCB layouts, Gerbers, BOMs
+docs/           Architecture notes, build guides, self-hosting
+scripts/        Build and flash helpers
 ```
 
 ## Quick Start
@@ -64,30 +104,33 @@ make run       # build + run (defaults to :8080)
 make test      # go test ./...
 ```
 
-Requires Go 1.26+ and PostgreSQL. The server reads `DATABASE_URL` and runs migrations automatically on startup.
+Requires Go 1.26+ and PostgreSQL. The server reads `DATABASE_URL` and runs migrations on startup.
 
-### Firmware (Pico H)
+### Firmware
 
 ```bash
-export PICO_SDK_PATH=/path/to/pico-sdk
-./scripts/build.sh
-./scripts/flash.sh   # hold BOOTSEL, plug in USB, then run
+./scripts/build.sh     # auto-detects PICO_SDK_PATH
+./scripts/flash.sh     # hold BOOTSEL, plug in USB, then run
 ```
 
-### Pi Daemon (digitsd)
+### Pi Daemon
 
 ```bash
 cd pi/digitsd
-make build          # cross-compiles to linux/arm64
-make build-local    # native build
+make build             # cross-compiles to linux/arm64 via Docker
+make build-local       # native build (requires cross-compile libs)
 make test
 ```
 
-Requires cross-compile toolchain: `gcc-aarch64-linux-gnu`, `libasound2-dev:arm64`, `libopus-dev:arm64`, `libopusfile-dev:arm64`.
+## Hosting
+
+The server is a single Go binary (`signald`) backed by Postgres. Docker Compose is the straightforward way to run it: clone the repo, fill in an `.env` file, `docker compose up -d`, done. The [self-hosting guide](docs/hosting/self-hosting.md) walks through the full setup including TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
+
+There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There's no good reason for a three-phone family network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It's what runs in production. Again, completely unnecessary, but it works and it's there if you want it.
 
 ## Service Codes
 
-Hidden codes entered on the keypad during an active call.
+Hidden codes entered on the keypad while the handset is off-hook.
 
 | Code | Action | Details |
 |------|--------|---------|
@@ -101,10 +144,10 @@ Hidden codes entered on the keypad during an active call.
 
 ### Confirmation feedback
 
-- **Volume change:** 1 beep, then dial tone resumes.
-- **Audio test:** 2 beeps (start speaking), 1 beep (playback done), dial tone resumes.
-- **Shutdown:** 3 beeps, then powers off.
-- **Reboot:** 2 beeps, then reboots.
+- **Volume change.** 1 beep, then dial tone resumes.
+- **Audio test.** 2 beeps (start speaking), 1 beep (playback done), dial tone resumes.
+- **Shutdown.** 3 beeps, then powers off.
+- **Reboot.** 2 beeps, then reboots.
 
 ## Party Line (Three-Way Calling)
 
@@ -133,22 +176,17 @@ Hidden sequences that play audio clips through the earpiece. Each keypress must 
 | `0-0-0-0` | Rick Astley: *"Never gonna give you up..."* |
 | `8-6-7-5-3-0-9` | Tommy Tutone: *"Jenny I got your number... 867-5309!"* (intercepts the dial) |
 
-## Hardware
-
-A custom carrier PCB is in pre-production that replaces the hand-wired protoboard with a single drop-in board. It integrates power regulation (12V to 5V), the Pico socket, Pi+Codec Zero header, and all off-board connectors (keypad, hook switch, bell ringer, handset audio, LED). Designed in KiCad, sized to fit the original Sangyn phone mounting posts.
-
-Status: boards ordered, components sourced, pending assembly and validation.
-
 ## Documentation
 
-- [Why Digits?](https://digits.family/why) -- the problem and vision
-- [How it works](https://digits.family/how-it-works) -- overview for parents and curious people
-- [Architecture](docs/architecture/overview.md) -- technical deep-dive
-- [Party Line](docs/architecture/party-line.md) -- three-way calling end-to-end
-- [Build one](docs/build/components.md) -- BOM and hardware guide
-- [Wiring](docs/build/wiring.md) -- electrical spec and GPIO map
-- [Self-hosting](docs/hosting/self-hosting.md) -- run your own signaling server
+- [Why Digits?](https://digits.family/why)
+- [How it works](https://digits.family/how-it-works)
+- [Build one](https://digits.family/build)
+- [Architecture](docs/architecture/overview.md)
+- [Party Line](docs/architecture/party-line.md)
+- [Self-hosting](docs/hosting/self-hosting.md)
 
 ## License
 
-[AGPL-3.0](LICENSE)
+Code (firmware, server, tooling): [AGPL-3.0](LICENSE)
+
+Hardware (schematics, PCB layout, BOM): [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,21 @@
 
 Each phone is a gutted vintage desk phone with two processors inside: an RP2040 handling real-time phone hardware (keypad scanning, hook switch, bell ringer, DTMF tones) and a Raspberry Pi Zero 2 W running a Go daemon for VoIP, end-to-end encrypted media (DTLS-SRTP), and call signaling. A Go server handles call routing, device pairing, and household management. There's a free public instance at [app.digits.family](https://app.digits.family), or you can run your own.
 
-[Architecture](#architecture) · [Hardware](#hardware) · [Project Structure](#project-structure) · [Quick Start](#quick-start) · [Hosting](#hosting) · [Web App](#web-app) · [Service Codes](#service-codes) · [Party Line](#party-line-three-way-calling) · [Easter Eggs](#easter-eggs) · [Privacy](#privacy) · [Contributing](#contributing) · [Docs](#documentation) · [License](#license)
+<p align="center">
+  <a href="#architecture">Architecture</a> &middot;
+  <a href="#hardware">Hardware</a> &middot;
+  <a href="#project-structure">Project Structure</a> &middot;
+  <a href="#quick-start">Quick Start</a> &middot;
+  <a href="#hosting">Hosting</a> &middot;
+  <a href="#web-app">Web App</a> &middot;
+  <a href="#service-codes">Service Codes</a> &middot;
+  <a href="#party-line-three-way-calling">Party Line</a> &middot;
+  <a href="#easter-eggs">Easter Eggs</a> &middot;
+  <a href="#privacy">Privacy</a> &middot;
+  <a href="#contributing">Contributing</a> &middot;
+  <a href="#documentation">Docs</a> &middot;
+  <a href="#license">License</a>
+</p>
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

The README was still describing the prototype era. This rewrites it to reflect where the project actually is.

- **Logo.** Keypad mark from digits.family at the top.
- **Hardware.** Iterations table covering V0 (perfboard), V1 (hand-assembled PCB), and V2 (JLCPCB contract-assembled, ~10 units deployed). Replaces the outdated "boards ordered, pending assembly" blurb.
- **Privacy.** Honest section covering what the server stores (accounts, households, call metadata, connection telemetry), what it never stores (voice audio, recordings, transcripts), how encryption makes it architecturally impossible to access call content, and the hardware kill switch. Points to self-hosting for anyone who wants full control.
- **Hosting.** Brief section covering Docker Compose (links to self-hosting guide) and the Helm chart (with appropriate honesty about over-engineering).
- **Architecture.** Updated to show audio codec varies by hardware rev instead of hardcoding to Codec Zero.
- **License.** Added CC BY-SA 4.0 badge for hardware alongside AGPL-3.0 for code.
- **Web App.** Dashboard screenshot and brief description.
- **Project structure.** Expanded to match current layout (`hardware/pcb/`, `pi/image/`).

## Test plan

- [ ] Verify logo renders on GitHub (favicon SVG from digits.family)
- [ ] Verify dashboard screenshot renders (PNG from digits.family)
- [ ] Verify all internal links resolve (`hardware/pcb/`, `docs/`, etc.)
- [ ] Verify all external links resolve (digits.family pages, shields.io badges)