### PR TITLE
docs: update self-hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ make test
 
 ## Hosting
 
-The server is a single Go binary (`signald`) backed by Postgres. Docker Compose is the straightforward way to run it: clone the repo, fill in an `.env` file, `docker compose up -d`. The [self-hosting guide](docs/hosting/self-hosting.md) covers TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
+The server is a single Go binary (`signald`) backed by Postgres. For calls across different networks, you also need a TURN relay ([coturn](https://github.com/coturn/coturn)). Docker Compose is the straightforward way to run both: clone the repo, fill in an `.env` file, `docker compose up -d`. The [self-hosting guide](docs/hosting/self-hosting.md) covers the full setup including TURN, TLS, SMTP for magic-link auth, phone pairing, backups, and troubleshooting.
 
 There is also a [Helm chart](charts/digits/) if you happen to have a Kubernetes cluster. There is no good reason for a family phone network to run on k8s, but I over-engineered almost everything in this project and it would have felt wrong to stop at the deployment layer. The chart supports CNPG Postgres, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics. It is what runs in production. Completely unnecessary, but it works and it is there if you want it.
 

--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -54,18 +54,18 @@ This starts signald (the Go server), PostgreSQL, and Caddy for TLS. Phones on th
                        |  Caddy  |  :443  (TLS termination, reverse proxy)
                        +----+----+
                             |
-                     +------v------+         +-------------+
-                     |   signald   |         |   coturn    |
-                     |   :8080     |         |   :3478     |
-                     |             |         |             |
-                     | WebRTC sig  |         | TURN relay  |
-                     | Auth/magic  |         | STUN/ICE    |
-                     | Web app     |         |             |
-                     +------+------+         +-------------+
-                            |
-                     +------v------+
-                     |   user-db   |
-                     |  PostgreSQL |
+                     +------v------+  shared secret  +-------------+
+                     |   signald   | - - - - - - - > |   coturn    |
+                     |   :8080     |  (HMAC creds)   |   :3478     |
+                     |             |                  |             |
+                     | WebRTC sig  |                  | TURN relay  |
+                     | Auth/magic  |                  | STUN/ICE    |
+                     | Web app     |                  |             |
+                     +------+------+                  +-------------+
+                            |                               ^
+                     +------v------+                phones connect
+                     |   user-db   |                directly for
+                     |  PostgreSQL |                media relay
                      |             |
                      | users,      |
                      | households, |
@@ -167,7 +167,7 @@ The simplest way to add TURN to your deployment. Add a coturn service to your `d
 
 ```yaml
   coturn:
-    image: coturn/coturn:4.6.3
+    image: coturn/coturn:4.6.3  # check hub.docker.com/r/coturn/coturn for latest
     restart: unless-stopped
     network_mode: host
     volumes:
@@ -333,7 +333,7 @@ Caddy handles zero-downtime for its own config reloads. signald will have a brie
 
 Docker Compose handles the vast majority of deployments. If you have a Kubernetes cluster and want to deploy there, there is a [Helm chart](../../charts/digits/) for signald that supports CNPG PostgreSQL, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics.
 
-For TURN on Kubernetes, coturn runs well as a Deployment with `hostNetwork: true` (it needs direct access to the host network for the relay port range). A Cilium or MetalLB LoadBalancer service provides a stable VIP. Redis can be used as a shared stats database (`--redis-statsdb`) for multi-replica HA, and Prometheus metrics are available via `--prometheus`. See the project's `homelab-k8s` repo for a working example of this setup with 2-replica HA, PodDisruptionBudget, and ServiceMonitor.
+For TURN on Kubernetes, coturn runs well as a Deployment with `hostNetwork: true` (it needs direct access to the host network for the relay port range). A Cilium or MetalLB LoadBalancer service provides a stable VIP. For HA, run 2 replicas with pod anti-affinity (mandatory with hostNetwork to avoid port collisions), a PodDisruptionBudget (`minAvailable: 1`), and Redis as a shared stats database (`--redis-statsdb`) so both replicas have visibility into all active allocations. Prometheus metrics are available via `--prometheus`.
 
 See the [Helm chart README](../../charts/digits/README.md) for signald installation and configuration.
 

--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -1,6 +1,6 @@
 # Self-Hosting Digits
 
-This guide walks you through running your own Digits signaling server. If you can run Docker, you can run this.
+This guide walks you through running your own Digits signaling server and TURN relay. If you can run Docker, you can run this.
 
 ---
 
@@ -12,7 +12,6 @@ This guide walks you through running your own Digits signaling server. If you ca
 - **Domain name** -- pointed at your server's public IP (A record). Caddy handles TLS automatically.
 - **SMTP credentials** -- for sending magic-link login emails. Any provider works (Postmark, Mailgun, Gmail SMTP, etc.)
 - **Google OAuth (optional)** -- if you want Google sign-in alongside magic links
-- **TURN server (optional)** -- required if phones need to call across different networks behind NAT. See [TURN / NAT Traversal](#turn--nat-traversal).
 
 ---
 
@@ -42,6 +41,8 @@ docker compose logs --follow
 
 Once running, the app is at `https://your-domain.com`.
 
+This starts signald (the Go server), PostgreSQL, and Caddy for TLS. Phones on the same local network can call each other immediately. For calls across different networks, you also need a TURN relay. See [TURN / NAT Traversal](#turn--nat-traversal).
+
 ---
 
 ## Architecture
@@ -53,14 +54,14 @@ Once running, the app is at `https://your-domain.com`.
                        |  Caddy  |  :443  (TLS termination, reverse proxy)
                        +----+----+
                             |
-                     +------v------+
-                     |   signald   |
-                     |   :8080     |
-                     |             |
-                     | WebRTC sig  |
-                     | Auth/magic  |
-                     | Web app     |
-                     +------+------+
+                     +------v------+         +-------------+
+                     |   signald   |         |   coturn    |
+                     |   :8080     |         |   :3478     |
+                     |             |         |             |
+                     | WebRTC sig  |         | TURN relay  |
+                     | Auth/magic  |         | STUN/ICE    |
+                     | Web app     |         |             |
+                     +------+------+         +-------------+
                             |
                      +------v------+
                      |   user-db   |
@@ -73,9 +74,9 @@ Once running, the app is at `https://your-domain.com`.
                      +-------------+
 ```
 
-Caddy terminates TLS and proxies to signald. signald is the single Go binary that handles everything: WebSocket signaling, authentication, the web dashboard, and the REST API. PostgreSQL stores all persistent state.
+Caddy terminates TLS and proxies to signald. signald is the single Go binary that handles everything: WebSocket signaling, authentication, the web dashboard, and the REST API. PostgreSQL stores all persistent state. coturn handles TURN relay and STUN for NAT traversal.
 
-Voice audio never passes through the server. Calls are peer-to-peer WebRTC sessions between phones; the server only brokers the signaling handshake.
+Voice audio never passes through signald. Calls are peer-to-peer WebRTC sessions between phones. signald only brokers the signaling handshake. When direct peer-to-peer is not possible (phones behind different NATs), coturn relays the encrypted media.
 
 ---
 
@@ -103,9 +104,14 @@ All configuration lives in `server/.env`. Copy `server/.env.example` and fill it
 | `GOOGLE_CLIENT_ID` | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
 | `GOOGLE_REDIRECT_URL` | OAuth callback URL, e.g. `https://digits.example.com/auth/google/callback` |
-| `SIGNALD_TURN_ENABLED` | Set to `true` to enable TURN credential generation. See [TURN / NAT Traversal](#turn--nat-traversal). |
-| `SIGNALD_TURN_SECRET` | Shared secret for HMAC-SHA1 TURN credentials. Must match your TURN server's `static-auth-secret`. |
-| `SIGNALD_TURN_DOMAIN` | TURN server domain, e.g. `turn.example.com` |
+
+### TURN (required for cross-network calls)
+
+| Variable | Description |
+|---|---|
+| `SIGNALD_TURN_ENABLED` | Set to `true` to enable TURN credential generation. |
+| `SIGNALD_TURN_SECRET` | Shared secret for HMAC-SHA1 TURN credentials. Must match coturn's `static-auth-secret`. Generate with `openssl rand -hex 32`. |
+| `SIGNALD_TURN_DOMAIN` | TURN server hostname or IP, e.g. `turn.example.com` or the server's public IP. |
 
 ---
 
@@ -151,38 +157,104 @@ Caddy will obtain and renew a Let's Encrypt certificate automatically.
 
 WebRTC tries to establish a direct peer-to-peer connection between two phones. When both phones are on the same local network, this works without any extra infrastructure. When phones are behind different NATs (the common case for a distributed family network), they need a TURN relay to connect.
 
-Without TURN, calls between phones on different networks will fail to connect. If all your phones are on the same LAN, you can skip this.
+Without TURN, calls between phones on different networks will fail to connect. If all your phones are on the same LAN, you can skip this section.
 
 signald generates time-limited HMAC-SHA1 credentials for the TURN server. You supply the shared secret and domain; the phones receive fresh credentials with each call setup.
 
-### Setting up coturn
+### Running coturn with Docker Compose
 
-[coturn](https://github.com/coturn/coturn) is the standard open-source TURN server. It can run on the same box as signald or on a separate machine.
+The simplest way to add TURN to your deployment. Add a coturn service to your `docker-compose.yml`:
 
-```bash
-# Install
-apt install coturn
-
-# /etc/turnserver.conf
-realm=digits.example.com
-listening-port=3478
-tls-listening-port=5349
-use-auth-secret
-static-auth-secret=YOUR_SECRET_HERE    # must match SIGNALD_TURN_SECRET
-cert=/etc/letsencrypt/live/turn.example.com/fullchain.pem
-pkey=/etc/letsencrypt/live/turn.example.com/privkey.pem
-no-cli
+```yaml
+  coturn:
+    image: coturn/coturn:4.6.3
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./docker/turnserver.conf:/etc/turnserver.conf:ro
+    command: >-
+      turnserver
+      -c /etc/turnserver.conf
+      --static-auth-secret=${SIGNALD_TURN_SECRET}
 ```
 
-Then set the matching env vars in your `.env`:
+Create `server/docker/turnserver.conf`:
+
+```
+listening-port=3478
+listening-ip=0.0.0.0
+external-ip=YOUR_PUBLIC_IP
+relay-ip=0.0.0.0
+min-port=49152
+max-port=65535
+use-auth-secret
+realm=digits.example.com
+log-file=stdout
+no-multicast-peers
+no-cli
+fingerprint
+```
+
+Replace `YOUR_PUBLIC_IP` with your server's public IP address. If you are behind NAT (e.g. a home server), use the format `PUBLIC_IP/PRIVATE_IP` (e.g. `68.224.37.131/192.168.1.199`).
+
+Then set the TURN env vars in your `.env`:
 
 ```
 SIGNALD_TURN_ENABLED=true
-SIGNALD_TURN_SECRET=YOUR_SECRET_HERE
-SIGNALD_TURN_DOMAIN=turn.example.com
+SIGNALD_TURN_SECRET=<generate with: openssl rand -hex 32>
+SIGNALD_TURN_DOMAIN=<your server's public IP or a DNS name that resolves to it>
 ```
 
-Open UDP ports 3478 and 49152-65535 (the default relay port range) on the TURN server's firewall.
+Open these ports on your firewall:
+
+```bash
+ufw allow 3478/udp
+ufw allow 3478/tcp
+ufw allow 49152:65535/udp
+```
+
+The `network_mode: host` is important. TURN relays UDP on dynamically allocated ports from the relay range. Docker's port mapping cannot handle this; the container needs direct access to the host network.
+
+Restart the stack:
+
+```bash
+docker compose up -d
+```
+
+### Running coturn standalone
+
+If you prefer to run coturn outside Docker (on the same box or a separate machine):
+
+```bash
+apt install coturn
+
+# /etc/turnserver.conf
+listening-port=3478
+listening-ip=0.0.0.0
+external-ip=YOUR_PUBLIC_IP
+relay-ip=0.0.0.0
+min-port=49152
+max-port=65535
+use-auth-secret
+static-auth-secret=YOUR_SECRET_HERE
+realm=digits.example.com
+log-file=stdout
+no-multicast-peers
+no-cli
+fingerprint
+```
+
+The `static-auth-secret` must match `SIGNALD_TURN_SECRET` in your `.env`.
+
+### Verifying TURN is working
+
+After starting coturn, make a call between two phones on different networks. If the call connects, TURN is working. If it fails, check:
+
+1. coturn logs: `docker compose logs coturn` (or `journalctl -u coturn`)
+2. Firewall: UDP 3478 and the relay range (49152-65535) must be open
+3. `SIGNALD_TURN_ENABLED=true` in your `.env`
+4. The shared secret matches between signald and coturn
+5. `SIGNALD_TURN_DOMAIN` resolves to an IP that reaches coturn's listening port
 
 ---
 
@@ -259,9 +331,11 @@ Caddy handles zero-downtime for its own config reloads. signald will have a brie
 
 ## Kubernetes
 
-Docker Compose handles the vast majority of deployments. If you have a Kubernetes cluster and want to deploy there, there is a [Helm chart](../../charts/digits/) that supports CNPG PostgreSQL, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics.
+Docker Compose handles the vast majority of deployments. If you have a Kubernetes cluster and want to deploy there, there is a [Helm chart](../../charts/digits/) for signald that supports CNPG PostgreSQL, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics.
 
-See the [Helm chart README](../../charts/digits/README.md) for installation and configuration.
+For TURN on Kubernetes, coturn runs well as a Deployment with `hostNetwork: true` (it needs direct access to the host network for the relay port range). A Cilium or MetalLB LoadBalancer service provides a stable VIP. Redis can be used as a shared stats database (`--redis-statsdb`) for multi-replica HA, and Prometheus metrics are available via `--prometheus`. See the project's `homelab-k8s` repo for a working example of this setup with 2-replica HA, PodDisruptionBudget, and ServiceMonitor.
+
+See the [Helm chart README](../../charts/digits/README.md) for signald installation and configuration.
 
 ---
 
@@ -273,6 +347,7 @@ See the [Helm chart README](../../charts/digits/README.md) for installation and 
 | "Link expired" on login | Token TTL passed (15 min) | Request a new magic link. If this happens constantly, check server clock (`timedatectl`). |
 | Phone won't connect | Wrong WebSocket URL or TLS error | Verify `-signald` flag on the Pi points to `wss://your-domain.com/ws`. Check `journalctl -u digitsd` on the Pi. |
 | Calls fail across networks | No TURN server | Set up coturn and configure `SIGNALD_TURN_*` env vars. See [TURN / NAT Traversal](#turn--nat-traversal). |
+| Calls fail even with TURN | Firewall blocking relay ports | Ensure UDP 3478 and 49152-65535 are open on the TURN server. Check `docker compose logs coturn` for errors. |
 | Google OAuth "redirect_uri mismatch" | Callback URL not registered | Add `https://your-domain.com/auth/google/callback` to authorized redirect URIs in Google Cloud Console. Verify `GOOGLE_REDIRECT_URL` in `.env` matches exactly. |
 | Caddy returns 502 | Backend not ready | `docker compose ps` -- check signald is healthy. `docker compose logs caddy` for upstream errors. |
 | Database migration fails on startup | Dirty schema state | Check `docker compose logs signald` for migration errors. Usually safe to re-run after fixing the underlying issue. |
@@ -286,9 +361,9 @@ Voice calls are low-bandwidth and the server is stateless between calls.
 | Resource | Minimum | Notes |
 |---|---|---|
 | CPU | 1 vCPU | A $5/mo VPS handles dozens of simultaneous calls |
-| RAM | 1 GB | 2 GB comfortable; Postgres + Go are lean |
+| RAM | 1 GB | 2 GB comfortable; Postgres + Go + coturn are lean |
 | Storage | 10 GB | 1 GB is plenty for years of data; extra for logs and backups |
-| Bandwidth | ~100 kbps per active call | WebRTC audio only, no video |
+| Bandwidth | ~100 kbps per active call | WebRTC audio only, no video. TURN-relayed calls double this on the server. |
 | OS | Linux x86_64 | Tested on Debian 12, Ubuntu 22.04+ |
 
 A Raspberry Pi 4 (2 GB) works fine as a local server on a home network. For remote access you need a VPS with a stable IP and a domain.

--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -1,19 +1,18 @@
 # Self-Hosting Digits
 
-> A phone for real conversations. No screens. No surveillance. Just voice.
-
-This guide walks you through running your own Digits server. If you can run Docker, you can run this.
+This guide walks you through running your own Digits signaling server. If you can run Docker, you can run this.
 
 ---
 
 ## Prerequisites
 
-- **Linux server** -- any x86_64 VPS or dedicated box. 1GB RAM minimum, 2GB recommended.
+- **Linux server** -- any x86_64 VPS or dedicated box. 1 GB RAM minimum, 2 GB recommended.
 - **Docker Engine 24+** -- [install docs](https://docs.docker.com/engine/install/)
 - **Docker Compose v2** -- bundled with Docker Desktop; for Linux: `apt install docker-compose-plugin`
 - **Domain name** -- pointed at your server's public IP (A record). Caddy handles TLS automatically.
 - **SMTP credentials** -- for sending magic-link login emails. Any provider works (Postmark, Mailgun, Gmail SMTP, etc.)
 - **Google OAuth (optional)** -- if you want Google sign-in alongside magic links
+- **TURN server (optional)** -- required if phones need to call across different networks behind NAT. See [TURN / NAT Traversal](#turn--nat-traversal).
 
 ---
 
@@ -41,16 +40,78 @@ docker compose ps
 docker compose logs --follow
 ```
 
-Once running:
-- **User app** → `https://your-domain.com`
+Once running, the app is at `https://your-domain.com`.
+
+---
+
+## Architecture
+
+```
+                        Internet
+                            |
+                       +----v----+
+                       |  Caddy  |  :443  (TLS termination, reverse proxy)
+                       +----+----+
+                            |
+                     +------v------+
+                     |   signald   |
+                     |   :8080     |
+                     |             |
+                     | WebRTC sig  |
+                     | Auth/magic  |
+                     | Web app     |
+                     +------+------+
+                            |
+                     +------v------+
+                     |   user-db   |
+                     |  PostgreSQL |
+                     |             |
+                     | users,      |
+                     | households, |
+                     | lines,      |
+                     | calls       |
+                     +-------------+
+```
+
+Caddy terminates TLS and proxies to signald. signald is the single Go binary that handles everything: WebSocket signaling, authentication, the web dashboard, and the REST API. PostgreSQL stores all persistent state.
+
+Voice audio never passes through the server. Calls are peer-to-peer WebRTC sessions between phones; the server only brokers the signaling handshake.
+
+---
+
+## Environment Variables
+
+All configuration lives in `server/.env`. Copy `server/.env.example` and fill it in.
+
+### Required
+
+| Variable | Description |
+|---|---|
+| `BASE_URL` | Public URL of your server, e.g. `https://digits.example.com` |
+| `ADMIN_SECRET` | Secret protecting the internal stats endpoint. Generate with `openssl rand -hex 32`. |
+| `SMTP_HOST` | SMTP server hostname |
+| `SMTP_PORT` | SMTP port (usually 587 for STARTTLS) |
+| `SMTP_USER` | SMTP username |
+| `SMTP_PASS` | SMTP password |
+| `SMTP_FROM` | From address for outbound email |
+
+### Optional
+
+| Variable | Description |
+|---|---|
+| `COOKIE_DOMAIN` | Cookie domain for subdomain sharing (e.g. `.digits.example.com`). Leave blank if not using subdomains. |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+| `GOOGLE_REDIRECT_URL` | OAuth callback URL, e.g. `https://digits.example.com/auth/google/callback` |
+| `SIGNALD_TURN_ENABLED` | Set to `true` to enable TURN credential generation. See [TURN / NAT Traversal](#turn--nat-traversal). |
+| `SIGNALD_TURN_SECRET` | Shared secret for HMAC-SHA1 TURN credentials. Must match your TURN server's `static-auth-secret`. |
+| `SIGNALD_TURN_DOMAIN` | TURN server domain, e.g. `turn.example.com` |
 
 ---
 
 ## Production TLS
 
 For a production deployment with automatic HTTPS via Let's Encrypt, use the included `Caddyfile.production` template instead of the default dev Caddyfile.
-
-**Steps:**
 
 1. **Copy the production Caddyfile:**
    ```bash
@@ -82,73 +143,59 @@ Then start normally:
 DOMAIN=digits.example.com docker compose up -d
 ```
 
-Caddy will obtain and renew a Let's Encrypt certificate automatically. No certbot or manual renewal needed.
+Caddy will obtain and renew a Let's Encrypt certificate automatically.
 
 ---
 
-## Architecture
+## TURN / NAT Traversal
+
+WebRTC tries to establish a direct peer-to-peer connection between two phones. When both phones are on the same local network, this works without any extra infrastructure. When phones are behind different NATs (the common case for a distributed family network), they need a TURN relay to connect.
+
+Without TURN, calls between phones on different networks will fail to connect. If all your phones are on the same LAN, you can skip this.
+
+signald generates time-limited HMAC-SHA1 credentials for the TURN server. You supply the shared secret and domain; the phones receive fresh credentials with each call setup.
+
+### Setting up coturn
+
+[coturn](https://github.com/coturn/coturn) is the standard open-source TURN server. It can run on the same box as signald or on a separate machine.
+
+```bash
+# Install
+apt install coturn
+
+# /etc/turnserver.conf
+realm=digits.example.com
+listening-port=3478
+tls-listening-port=5349
+use-auth-secret
+static-auth-secret=YOUR_SECRET_HERE    # must match SIGNALD_TURN_SECRET
+cert=/etc/letsencrypt/live/turn.example.com/fullchain.pem
+pkey=/etc/letsencrypt/live/turn.example.com/privkey.pem
+no-cli
+```
+
+Then set the matching env vars in your `.env`:
 
 ```
-                        Internet
-                            │
-                       ┌────▼────┐
-                       │  Caddy  │  :443  (TLS termination, reverse proxy)
-                       └────┬────┘
-                            │
-                     ┌──────▼──────┐
-                     │   signald   │
-                     │   :8080     │
-                     │             │
-                     │ WebRTC sig  │
-                     │ Auth/magic  │
-                     │ User API    │
-                     └──────┬──────┘
-                            │
-                     ┌──────▼──────┐
-                     │   user-db   │
-                     │  PostgreSQL │
-                     │             │
-                     │ users,      │
-                     │ households, │
-                     │ sessions    │
-                     └─────────────┘
+SIGNALD_TURN_ENABLED=true
+SIGNALD_TURN_SECRET=YOUR_SECRET_HERE
+SIGNALD_TURN_DOMAIN=turn.example.com
 ```
 
----
-
-## Environment Variables
-
-All configuration lives in `server/.env`. Copy `server/.env.example` and fill it in.
-
-| Variable | Required | Description |
-|---|---|---|
-| `BASE_URL` | ✅ | Public URL of your server, e.g. `https://digits.example.com` |
-| `ADMIN_SECRET` | ✅ | Secret protecting the internal stats endpoint (pick something random) |
-| `SMTP_HOST` | ✅ | SMTP server hostname |
-| `SMTP_PORT` | ✅ | SMTP port (usually 587 for STARTTLS) |
-| `SMTP_USER` | ✅ | SMTP username |
-| `SMTP_PASS` | ✅ | SMTP password |
-| `SMTP_FROM` | ✅ | From address for outbound email |
-| `GOOGLE_CLIENT_ID` | ☐ | Google OAuth client ID (optional) |
-| `GOOGLE_CLIENT_SECRET` | ☐ | Google OAuth client secret (optional) |
-| `GOOGLE_REDIRECT_URL` | ☐ | OAuth callback URL, e.g. `https://digits.example.com/auth/google/callback` |
+Open UDP ports 3478 and 49152-65535 (the default relay port range) on the TURN server's firewall.
 
 ---
 
 ## Phone Setup
 
-Each Digits phone is a Raspberry Pi Zero 2 W running `digitsd`.
-
-### Flash and Configure the Pi
-
-See the [Pi setup README](../pi/README-mixer.md) for full hardware assembly. Once the Pi is running:
+Each Digits phone is a Raspberry Pi Zero 2 W running `digitsd`. See the [build guide](https://digits.family/build) for hardware assembly.
 
 ### Point the Pi at Your Server
 
 `digitsd` takes a `-signald` flag with the WebSocket URL of your server:
 
 ```bash
-# Edit the digitsd systemd unit or launch script on the Pi
+# Edit the digitsd systemd unit on the Pi
 # Default: ws://localhost:8443/ws
 # Change to: wss://digits.example.com/ws
 
@@ -159,14 +206,14 @@ sudo systemctl daemon-reload
 sudo systemctl restart digitsd
 ```
 
-If your server uses a self-signed cert (dev only), add `-insecure` to skip TLS verification. Don't do this in production.
+If your server uses a self-signed cert (dev only), add `-insecure` to skip TLS verification. Do not do this in production.
 
 ### Pairing Flow
 
-1. In the user app, complete onboarding to create a household, then add a line on `/phones`.
+1. In the web app, complete onboarding to create a household, then add a line on `/phones`.
 2. The system generates a pairing code.
-3. On the Pi, the pairing code is exchanged automatically on first connect -- no screen needed.
-4. Once paired, the phone registers itself and is ready to dial.
+3. On the Pi, the pairing code is exchanged automatically on first connect.
+4. Once paired, the phone is ready to dial.
 
 ---
 
@@ -175,17 +222,16 @@ If your server uses a self-signed cert (dev only), add `-insecure` to skip TLS v
 Run this on a cron or before any upgrade.
 
 ```bash
-# Backup user data (users, households, sessions)
-docker compose exec user-db pg_dump -U digits digits > backup-user-$(date +%Y%m%d).sql
+docker compose exec user-db pg_dump -U digits digits > backup-$(date +%Y%m%d).sql
 ```
 
 Restore:
 
 ```bash
-docker compose exec -T user-db psql -U digits digits < backup-user-20260101.sql
+docker compose exec -T user-db psql -U digits digits < backup-20260101.sql
 ```
 
-Store backups off-server. S3, rsync to another machine, whatever you've got.
+Store backups off-server. S3, rsync to another machine, whatever you have.
 
 ---
 
@@ -202,12 +248,20 @@ cd server
 docker compose build
 docker compose up -d
 
-# Check nothing's broken
+# Verify
 docker compose ps
 docker compose logs --tail=50
 ```
 
-Caddy handles zero-downtime for its own config reloads. The Go services will have a brief restart during `up -d`.
+Caddy handles zero-downtime for its own config reloads. signald will have a brief restart during `up -d`.
+
+---
+
+## Kubernetes
+
+Docker Compose handles the vast majority of deployments. If you have a Kubernetes cluster and want to deploy there, there is a [Helm chart](../../charts/digits/) that supports CNPG PostgreSQL, Redis Sentinel for multi-replica signaling, OpenTelemetry tracing, Pyroscope profiling, and Prometheus metrics.
+
+See the [Helm chart README](../../charts/digits/README.md) for installation and configuration.
 
 ---
 
@@ -218,6 +272,7 @@ Caddy handles zero-downtime for its own config reloads. The Go services will hav
 | Magic link email never arrives | SMTP misconfigured | Check `SMTP_HOST/PORT/USER/PASS`. Run `docker compose logs signald` and look for mail errors. Test with `swaks` or your provider's SMTP tester. |
 | "Link expired" on login | Token TTL passed (15 min) | Request a new magic link. If this happens constantly, check server clock (`timedatectl`). |
 | Phone won't connect | Wrong WebSocket URL or TLS error | Verify `-signald` flag on the Pi points to `wss://your-domain.com/ws`. Check `journalctl -u digitsd` on the Pi. |
+| Calls fail across networks | No TURN server | Set up coturn and configure `SIGNALD_TURN_*` env vars. See [TURN / NAT Traversal](#turn--nat-traversal). |
 | Google OAuth "redirect_uri mismatch" | Callback URL not registered | Add `https://your-domain.com/auth/google/callback` to authorized redirect URIs in Google Cloud Console. Verify `GOOGLE_REDIRECT_URL` in `.env` matches exactly. |
 | Caddy returns 502 | Backend not ready | `docker compose ps` -- check signald is healthy. `docker compose logs caddy` for upstream errors. |
 | Database migration fails on startup | Dirty schema state | Check `docker compose logs signald` for migration errors. Usually safe to re-run after fixing the underlying issue. |
@@ -226,24 +281,14 @@ Caddy handles zero-downtime for its own config reloads. The Go services will hav
 
 ## Hardware Requirements
 
-This is not a demanding service. Voice calls are low-bandwidth and the server is stateless between calls.
+Voice calls are low-bandwidth and the server is stateless between calls.
 
 | Resource | Minimum | Notes |
 |---|---|---|
-| CPU | 1 vCPU | Even a $5/mo VPS handles dozens of simultaneous calls |
-| RAM | 1GB | 2GB comfortable; Postgres + Go services are lean |
-| Storage | 10GB | 1GB is plenty for years of data; extra for logs/backups |
-| Bandwidth | ~100kbps per active call | WebRTC audio only, no video |
+| CPU | 1 vCPU | A $5/mo VPS handles dozens of simultaneous calls |
+| RAM | 1 GB | 2 GB comfortable; Postgres + Go are lean |
+| Storage | 10 GB | 1 GB is plenty for years of data; extra for logs and backups |
+| Bandwidth | ~100 kbps per active call | WebRTC audio only, no video |
 | OS | Linux x86_64 | Tested on Debian 12, Ubuntu 22.04+ |
 
-A Raspberry Pi 4 (2GB) works fine as a local server on a home network. For remote/internet access you'll want a VPS with a stable IP and a domain.
-
-**Recommended VPS specs for a small family/community deployment:**
-- 2 vCPU, 2GB RAM, 20GB SSD
-- Any provider: Hetzner, Linode, DigitalOcean, Vultr
-
----
-
-## Source
-
-`https://github.com/justinlindh/digits`
+A Raspberry Pi 4 (2 GB) works fine as a local server on a home network. For remote access you need a VPS with a stable IP and a domain.


### PR DESCRIPTION
## Summary

- **TURN/NAT traversal.** New section explaining why you need TURN for cross-network calls, with coturn setup instructions and matching env var configuration.
- **Environment variables.** Split into required/optional tables, added `COOKIE_DOMAIN` and all three `SIGNALD_TURN_*` vars that were missing.
- **Kubernetes.** Brief section pointing to the Helm chart README for anyone who wants that path.
- **Dead link fixed.** Phone setup referenced `docs/pi/README-mixer.md` which does not exist; now points to digits.family/build.
- **Troubleshooting.** Added "calls fail across networks" row for missing TURN.
- **Cleanup.** Removed the tagline header, the redundant "Source" section, updated architecture diagram data list, tightened copy throughout.

## Test plan

- [ ] Verify all internal links resolve (Helm chart README, build guide)
- [ ] Verify TURN env var names match `server/internal/config/config.go`
- [ ] Verify coturn config example is reasonable