### PR TITLE
chore(server): drop unused device.Store.UpdateName

### DIFF
--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -133,18 +133,6 @@ func (s *Store) AuthStatus(ctx context.Context, hardwareID, token string) (paire
 	return true, valid, nil
 }
 
-// UpdateName sets the display name for a device.
-func (s *Store) UpdateName(ctx context.Context, deviceID int64, name string) error {
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE devices SET name = $1 WHERE id = $2`,
-		name, deviceID,
-	)
-	if err != nil {
-		return fmt.Errorf("update device name: %w", err)
-	}
-	return nil
-}
-
 // BoundLineNumber returns the line number assigned to the paired device with
 // the given hardware ID. Returns ("", nil) if the device has no bound line.
 func (s *Store) BoundLineNumber(ctx context.Context, hardwareID string) (string, error) {


### PR DESCRIPTION
## What

Remove `device.Store.UpdateName(ctx, deviceID, name)`. No callers in production code, no callers in tests. Confirmed dead with `golang.org/x/tools/cmd/deadcode`:

```
$ deadcode -test ./...
internal/device/store.go:137:17: unreachable func: Store.UpdateName
```

The other `.UpdateName` matches in the codebase are on `household.Store`, which is a different type.

## Why

Exported methods are part of the package's contract. A reader scanning `device.Store` would assume `UpdateName` is reachable from somewhere. Trimming it removes that question and keeps the package surface honest about which device fields the server actually mutates (currently: `paired_at`, `device_token`, `last_seen_at`, plus reads).

## Test plan

- `go build ./...` clean.
- `go test ./...` passes (modulo the pre-existing `TestLoadConfigOptionalTokenFileUnreadable` flake when running as root, which is environmental: chmod 0000 is still readable as uid 0).
- `golangci-lint run ./...` clean.