### PR TITLE
refactor(server): unexport HealthStore.Latest and LatestEdge

### DIFF
--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -303,11 +303,11 @@ func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample)
 }
 
-// Latest returns the most recent samples for caller and callee on a 2-party
+// latest returns the most recent samples for caller and callee on a 2-party
 // call, captured under a single lock so the two values are consistent. nil
 // pointers if no sample has been recorded for that endpoint yet. nil/nil if
-// the call is unknown.
-func (s *HealthStore) Latest(callID int64, caller, callee string) (*Sample, *Sample) {
+// the call is unknown. Test-only; production reads use Window/Readback.
+func (s *HealthStore) latest(callID int64, caller, callee string) (*Sample, *Sample) {
 	key := SessionKey{CallID: callID}
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
@@ -362,8 +362,9 @@ func (s *HealthStore) WindowEdge(confID uuid.UUID, from, peer string) []Sample {
 	return s.windowSession(SessionKey{ConfID: confID}, from, peer)
 }
 
-// LatestEdge returns the most recent sample for a conference edge or nil.
-func (s *HealthStore) LatestEdge(confID uuid.UUID, from, peer string) *Sample {
+// latestEdge returns the most recent sample for a conference edge or nil.
+// Test-only; production reads use WindowEdge/ReadbackEdge.
+func (s *HealthStore) latestEdge(confID uuid.UUID, from, peer string) *Sample {
 	return s.latestSession(SessionKey{ConfID: confID}, from, peer)
 }
 

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -21,7 +21,7 @@ func TestHealthStoreRecordAndLatest(t *testing.T) {
 	s.Record(1, "A", sample(200, 0.7))
 	s.Record(1, "B", sample(150, 0.2))
 
-	callerLatest, calleeLatest := s.Latest(1, "A", "B")
+	callerLatest, calleeLatest := s.latest(1, "A", "B")
 	if callerLatest == nil || *callerLatest.LossPct != 0.7 {
 		t.Fatalf("Latest A: got %+v want 0.7", callerLatest)
 	}
@@ -57,7 +57,7 @@ func TestHealthStoreEvict(t *testing.T) {
 	if win := s.Window(1, "A"); len(win) != 0 {
 		t.Fatalf("post-evict window: got %d want 0", len(win))
 	}
-	a, b := s.Latest(1, "A", "B")
+	a, b := s.latest(1, "A", "B")
 	if a != nil || b != nil {
 		t.Fatalf("post-evict latest: got (%v,%v)", a, b)
 	}
@@ -88,7 +88,7 @@ func TestHealthStoreConcurrentWritersSameRing(t *testing.T) {
 	if len(win) != RingCapacity {
 		t.Fatalf("window size: got %d want %d", len(win), RingCapacity)
 	}
-	a, _ := s.Latest(1, "A", "B")
+	a, _ := s.latest(1, "A", "B")
 	if a == nil {
 		t.Fatalf("Latest returned nil after %d concurrent samples", writers*samplesPerWriter)
 	}
@@ -119,7 +119,7 @@ func TestHealthStoreConcurrentCallsAndEndpoints(t *testing.T) {
 	}
 	wg.Wait()
 	for id := int64(1); id <= 4; id++ {
-		if a, b := s.Latest(id, "A", "B"); a == nil || b == nil {
+		if a, b := s.latest(id, "A", "B"); a == nil || b == nil {
 			t.Fatalf("call %d missing samples: %v %v", id, a, b)
 		}
 	}
@@ -134,7 +134,7 @@ func TestHealthStoreRecordIsNoOpAfterEvict(t *testing.T) {
 	if win := s.Window(1, "A"); len(win) != 0 {
 		t.Fatalf("post-evict Record must not create entry; got window len %d", len(win))
 	}
-	a, b := s.Latest(1, "A", "B")
+	a, b := s.latest(1, "A", "B")
 	if a != nil || b != nil {
 		t.Fatalf("post-evict Record must not resurrect rings; got (%v,%v)", a, b)
 	}
@@ -394,7 +394,7 @@ func TestHealthStoreConferenceRoundTrip(t *testing.T) {
 		t.Fatalf("sample LossPct not preserved")
 	}
 
-	latest := s.LatestEdge(confID, "A", "B")
+	latest := s.latestEdge(confID, "A", "B")
 	if latest == nil {
 		t.Fatal("LatestEdge nil")
 	}


### PR DESCRIPTION
## What

Lowercase `HealthStore.Latest` to `latest` and `HealthStore.LatestEdge` to `latestEdge`. Tests in `package calls` are renamed to match.

## Why

Both methods are only consumed by the package's own unit tests:

```
$ rg -n '\.Latest\(|\.LatestEdge\(' server/
internal/calls/linkhealth_test.go:24:  callerLatest, calleeLatest := s.Latest(1, "A", "B")
internal/calls/linkhealth_test.go:60,91,122,137: ...
internal/calls/linkhealth_test.go:397: latest := s.LatestEdge(confID, "A", "B")
```

Production read paths use `Window`/`WindowEdge` (in-memory ring snapshot) and `Readback`/`ReadbackEdge` (DB-backed pagination). The `Latest` variants exist for a joint-lock atomic dual-endpoint read tests need to assert that two endpoints' latest samples are simultaneously visible after a `Record` call. That's a test invariant, not a consumer API, and exporting it suggests a contract no caller actually relies on.

Easy to re-export later if a real consumer appears.

## Test plan

- `go build ./...` clean.
- `go test ./internal/calls/...` passes.
- `go test ./...` passes (modulo the pre-existing `TestLoadConfigOptionalTokenFileUnreadable` flake when running as root).
- `golangci-lint run ./...` clean.