### PR TITLE
feat(server): support CNPG postgresql parameters in Helm chart

### DIFF
--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -50,6 +50,10 @@ spec:
   postgresql:
     shared_preload_libraries:
       {{- toYaml .Values.cnpg.userdb.sharedPreloadLibraries | nindent 6 }}
+    {{- if .Values.cnpg.userdb.parameters }}
+    parameters:
+      {{- toYaml .Values.cnpg.userdb.parameters | nindent 6 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.observability.enabled }}
   monitoring:


### PR DESCRIPTION
## Summary

- Add `parameters` support to the CNPG Cluster template so Helm values can set Postgres configuration like `max_connections`.

Needed for load testing: the default `max_connections=100` saturates under high concurrency.

## Test plan

- [ ] `helm template` renders the `parameters` block correctly
- [ ] ArgoCD syncs and Postgres restarts with new max_connections