### PR TITLE
feat(server): configurable WebSocket rate limit via SIGNALD_WS_RATE_LIMIT

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -235,10 +235,11 @@ func run(ctx context.Context) error {
 		Emailer:        emailSender,
 		Metrics:        mreg,
 	}, web.HandlerConfig{
-		Addr:        cfg.Addr,
-		BaseURL:     cfg.BaseURL,
-		AdminSecret: cfg.AdminSecret,
-		DevMode:     cfg.DevMode,
+		Addr:              cfg.Addr,
+		BaseURL:           cfg.BaseURL,
+		AdminSecret:       cfg.AdminSecret,
+		DevMode:           cfg.DevMode,
+		WSRateLimitPerMin: cfg.WSRateLimitPerMin,
 	})
 	if err != nil {
 		return fmt.Errorf("create handler: %w", err)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	// the local pod. Empty disables Redis (single-instance mode).
 	RedisURL string
 
+	// WSRateLimitPerMin overrides the default WebSocket upgrade rate limit
+	// (per IP, per minute). Default is 30. Set higher for load testing.
+	WSRateLimitPerMin int
+
 	// Release index source. Exactly one of FakeUpdates or GitHubRepo (owner/repo)
 	// should be set. FakeUpdates wins if both are set and is intended for e2e
 	// tests. An unset GitHubRepo disables the release endpoint entirely.
@@ -81,6 +85,9 @@ func Load() *Config {
 	}
 	// Redis
 	StringEnv("REDIS_URL", &c.RedisURL)
+	// Rate limits
+	c.WSRateLimitPerMin = 30
+	IntEnv("SIGNALD_WS_RATE_LIMIT", &c.WSRateLimitPerMin)
 	// Release index
 	if os.Getenv("TEST_FAKE_UPDATES") == "1" {
 		c.FakeUpdates = true

--- a/server/internal/config/env.go
+++ b/server/internal/config/env.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 // StringEnv assigns a non-empty env var to *dst, keeping the current default
 // if the variable is unset. Keeps env wiring scannable instead of a wall of
@@ -17,5 +20,15 @@ func StringEnv(key string, dst *string) {
 func BoolEnv(key string, dst *bool) {
 	if os.Getenv(key) == "true" {
 		*dst = true
+	}
+}
+
+// IntEnv parses the env var as an integer and assigns it to *dst. Keeps the
+// current default if the variable is unset or not a valid integer.
+func IntEnv(key string, dst *int) {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			*dst = n
+		}
 	}
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -282,6 +282,9 @@ type HandlerConfig struct {
 	// which matches the layout the Makefile's dev-up target runs from.
 	// The field exists mainly so tests can point at a temp directory.
 	DevStaticDir string
+	// WSRateLimitPerMin overrides the default WebSocket upgrade rate limit
+	// (per IP, per minute). Zero uses the default (30).
+	WSRateLimitPerMin int
 }
 
 // Deps bundles the stores, hub, and other collaborators the web Handler
@@ -304,6 +307,13 @@ type Deps struct {
 	InviteStore    *household.InviteStore
 	Emailer        email.Sender
 	Metrics        *metrics.Registry
+}
+
+func wsRateLimit(cfg HandlerConfig) int {
+	if cfg.WSRateLimitPerMin > 0 {
+		return cfg.WSRateLimitPerMin
+	}
+	return 30
 }
 
 func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
@@ -455,7 +465,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		googleLoginLimiter:       ratelimit.New(10, time.Minute),
 		pairingLimiter:           ratelimit.New(5, time.Minute),
 		inviteLimiter:            ratelimit.New(5, time.Minute),
-		wsLimiter:                ratelimit.New(30, time.Minute),
+		wsLimiter:                ratelimit.New(wsRateLimit(cfg), time.Minute),
 		metrics:                  deps.Metrics,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Add `SIGNALD_WS_RATE_LIMIT` env var to override the default 30/min per-IP WebSocket upgrade limit
- Add `IntEnv` helper to config package
- Default behavior unchanged when unset

For load testing: set `SIGNALD_WS_RATE_LIMIT=10000` to remove the bottleneck when hammering from a single IP. Production deployments leave it unset (30/min default).

## Test plan

- [ ] Verify default behavior: unset env var uses 30/min limit
- [ ] Verify override: `SIGNALD_WS_RATE_LIMIT=100` allows 100 upgrades/min from one IP