### PR TITLE
fix(server): attach signaling.call_id to relay spans per tracing contract

### DIFF
--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -108,6 +108,17 @@ func (r *Relay) lineAttrs(ctx context.Context, number string) []any {
 	return []any{"line_id", lineID, "household_id", householdID}
 }
 
+// setSpanCallID attaches signaling.call_id to the current span when known.
+// HandleMessage starts the span before the call is resolved, so this fills
+// in the attribute once the tracker has it. Listed as a relay-span
+// attribute by the tracing package privacy contract.
+func setSpanCallID(ctx context.Context, callID int64) {
+	if callID == 0 {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64("signaling.call_id", callID))
+}
+
 func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer, lineStore LineStore) *Relay {
 	return &Relay{
 		Hub:            hub,
@@ -231,6 +242,7 @@ func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 			attrs := []any{"call_id", callID, "from", from, "to", msg.To}
 			attrs = append(attrs, r.lineAttrs(ctx, from)...)
 			slog.InfoContext(ctx, "call initiated", attrs...)
+			setSpanCallID(ctx, callID)
 		}
 	}
 
@@ -302,6 +314,7 @@ func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 			attrs := []any{"call_id", callID, "from", msg.To, "to", from}
 			attrs = append(attrs, r.lineAttrs(ctx, from)...)
 			slog.InfoContext(ctx, "call answered", attrs...)
+			setSpanCallID(ctx, callID)
 		}
 	}
 	r.forward(ctx, msg)
@@ -358,6 +371,7 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 				attrs := []any{"call_id", callID, "from", from, "to", peer}
 				attrs = append(attrs, r.lineAttrs(ctx, from)...)
 				slog.InfoContext(ctx, "call ended", attrs...)
+				setSpanCallID(ctx, callID)
 			}
 		}
 		_ = r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: from, To: peer})
@@ -390,6 +404,7 @@ func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
 	if r.Tracker != nil {
 		if callID := r.Tracker.CallIDForPair(from, msg.To); callID != 0 {
 			slog.DebugContext(ctx, "sdp forwarded", "call_id", callID, "from", from, "to", msg.To)
+			setSpanCallID(ctx, callID)
 		}
 	}
 	r.forward(ctx, msg)
@@ -420,6 +435,7 @@ func (r *Relay) handleICE(ctx context.Context, from string, msg *Message) {
 	if r.Tracker != nil {
 		if callID := r.Tracker.CallIDForPair(from, msg.To); callID != 0 {
 			slog.DebugContext(ctx, "ice forwarded", "call_id", callID, "from", from, "to", msg.To)
+			setSpanCallID(ctx, callID)
 		}
 	}
 	r.forward(ctx, msg)
@@ -545,6 +561,7 @@ func (r *Relay) handleExtensionPickup(ctx context.Context, from string, msg *Mes
 	pickupAttrs := []any{"line", from, "hardware_id", msg.HardwareID, "peer", peer}
 	if callID := r.Tracker.CallIDForPair(from, peer); callID != 0 {
 		pickupAttrs = append(pickupAttrs, "call_id", callID)
+		setSpanCallID(ctx, callID)
 	}
 	pickupAttrs = append(pickupAttrs, r.lineAttrs(ctx, from)...)
 	slog.InfoContext(ctx, "extension pickup", pickupAttrs...)
@@ -621,6 +638,7 @@ func (r *Relay) clearExtension(ctx context.Context, hardwareID string) {
 		if r.Tracker != nil {
 			if callID := r.Tracker.CallIDForPair(ext.LineNumber, ext.PeerNumber); callID != 0 {
 				attrs = append(attrs, "call_id", callID)
+				setSpanCallID(ctx, callID)
 			}
 		}
 		attrs = append(attrs, r.lineAttrs(ctx, ext.LineNumber)...)
@@ -656,6 +674,7 @@ func (r *Relay) clearExtensionsForCall(ctx context.Context, lineNumber string) {
 		if r.Tracker != nil {
 			if callID := r.Tracker.CallIDForPair(lineNumber, c.peer); callID != 0 {
 				attrs = append(attrs, "call_id", callID)
+				setSpanCallID(ctx, callID)
 			}
 		}
 		attrs = append(attrs, lineAttrs...)


### PR DESCRIPTION
## Summary

The tracing package privacy contract in `server/internal/tracing/tracing.go` lists `call_id` as one of the attributes carried by relay signaling spans, alongside `signaling.from` and `signaling.to`:

> Relay signaling spans: message type, internal line numbers (signaling.from, signaling.to), and call_id.

But the span started in `Relay.HandleMessage` only attaches `signaling.type`, `signaling.from`, and `signaling.to`. The `call_id` attribute the doc promises is never emitted, so traces in Tempo cannot be filtered by call without crossing over to Loki.

This PR wires up `signaling.call_id` via a small helper, called from each handler at the same point the slog log line already emits `call_id`. Result: traces match the documented contract and align with the structured-log threading work that landed in #506 and #511.

## Motivated by (last 24h)

- #515 feat(server): add OpenTelemetry spans to relay message handling: introduced the doc claim and the spans, but did not attach call_id.
- #506 feat(server): thread call_id, line_id, household_id through relay signaling logs: established call_id on slog log lines.
- #511 feat(server): thread call_id, line_id, household_id through extension log lines: extended the same threading to the extension handlers.

## Notes

- Helper drops out cleanly when `callID == 0` (e.g. the message arrived before tracker setup) so handlers do not need their own guards.
- No new attribute is emitted; PII categorization is unchanged. `call_id` is the same opaque internal identifier already covered by the tracing privacy doc and already present in slog logs and Postgres.
- No tests touched: the relay package has no existing span assertions to update.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/signaling/...` and `./internal/tracing/...` pass
- [ ] CI golangci-lint v2 (local lint blocked: golangci-lint v2.5.0 built with go1.25 cannot load configs targeting go1.26.1; CI runner has matching toolchain)