### PR TITLE
fix(server): per-hardware-ID version tracking for multi-handset lines (#497)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if grep -qi 'Co-Authored-By' "$1"; then
+if grep -qiP '^Co-Authored-By:' "$1"; then
     echo ""
     echo "commit rejected: Co-Authored-By trailer detected"
     echo ""

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if grep -qi 'Co-Authored-By' "$1"; then
+    echo ""
+    echo "commit rejected: Co-Authored-By trailer detected"
+    echo ""
+    echo "  Co-Authored-By trailers are not allowed in this repo."
+    echo "  Remove the trailer and try again."
+    echo ""
+    exit 1
+fi

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -1,0 +1,34 @@
+name: commit-msg-lint
+
+on:
+  pull_request:
+
+jobs:
+  check-trailers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject Co-Authored-By trailers
+        run: |
+          MESSAGES=$(git log --format=%B origin/${{ github.base_ref }}..HEAD)
+
+          if echo "$MESSAGES" | grep -qi 'Co-Authored-By'; then
+            echo ""
+            echo "FAILED: one or more commits contain a Co-Authored-By trailer."
+            echo ""
+            echo "Offending commits:"
+            git log --format="%h %s" origin/${{ github.base_ref }}..HEAD | while read -r line; do
+              HASH=$(echo "$line" | cut -d' ' -f1)
+              if git log --format=%B -1 "$HASH" | grep -qi 'Co-Authored-By'; then
+                echo "  $line"
+              fi
+            done
+            echo ""
+            echo "Remove the trailers before merging."
+            exit 1
+          fi
+
+          echo "No Co-Authored-By trailers found."

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -3,6 +3,9 @@ name: commit-msg-lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-trailers:
     runs-on: ubuntu-latest
@@ -12,15 +15,17 @@ jobs:
           fetch-depth: 0
 
       - name: Reject Co-Authored-By trailers
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          MESSAGES=$(git log --format=%B origin/${{ github.base_ref }}..HEAD)
+          MESSAGES=$(git log --format=%B origin/"$BASE_REF"..HEAD)
 
           if echo "$MESSAGES" | grep -qi 'Co-Authored-By'; then
             echo ""
             echo "FAILED: one or more commits contain a Co-Authored-By trailer."
             echo ""
             echo "Offending commits:"
-            git log --format="%h %s" origin/${{ github.base_ref }}..HEAD | while read -r line; do
+            git log --format="%h %s" origin/"$BASE_REF"..HEAD | while read -r line; do
               HASH=$(echo "$line" | cut -d' ' -f1)
               if git log --format=%B -1 "$HASH" | grep -qi 'Co-Authored-By'; then
                 echo "  $line"

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -20,14 +20,14 @@ jobs:
         run: |
           MESSAGES=$(git log --format=%B origin/"$BASE_REF"..HEAD)
 
-          if echo "$MESSAGES" | grep -qi 'Co-Authored-By'; then
+          if echo "$MESSAGES" | grep -qiP '^Co-Authored-By:'; then
             echo ""
             echo "FAILED: one or more commits contain a Co-Authored-By trailer."
             echo ""
             echo "Offending commits:"
             git log --format="%h %s" origin/"$BASE_REF"..HEAD | while read -r line; do
               HASH=$(echo "$line" | cut -d' ' -f1)
-              if git log --format=%B -1 "$HASH" | grep -qi 'Co-Authored-By'; then
+              if git log --format=%B -1 "$HASH" | grep -qiP '^Co-Authored-By:'; then
                 echo "  $line"
               fi
             done

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -362,8 +362,8 @@ func (h *Hub) Unregister(number string, conn *Conn) {
 		if d != nil {
 			d.Notify()
 		}
-		if ds != nil && remaining == 0 {
-			ds.SetOffline(context.Background(), number)
+		if ds != nil {
+			ds.SetOffline(context.Background(), number, conn.HardwareID)
 		}
 	}
 }
@@ -542,11 +542,20 @@ type DeviceInfoSnapshot struct {
 // DeviceInfo returns version info for the first connected device on a line.
 // Returns nil if no device is online.
 func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
+	all := h.AllDeviceInfo(number)
+	if len(all) == 0 {
+		return nil
+	}
+	return &all[0]
+}
+
+// AllDeviceInfo returns version info for all connected devices on a line.
+func (h *Hub) AllDeviceInfo(number string) []DeviceInfoSnapshot {
 	h.mu.RLock()
 	ds := h.state
 	h.mu.RUnlock()
 	if ds != nil {
-		return ds.DeviceInfo(context.Background(), number)
+		return ds.AllDeviceInfo(context.Background(), number)
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -554,15 +563,18 @@ func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
 	if len(conns) == 0 {
 		return nil
 	}
-	c := conns[0]
-	return &DeviceInfoSnapshot{
-		HardwareID:      c.HardwareID,
-		PiVersion:       c.PiVersion,
-		PiCommit:        c.PiCommit,
-		FirmwareVersion: c.FirmwareVersion,
-		FirmwareCommit:  c.FirmwareCommit,
-		RemoteAddr:      c.RemoteAddr,
+	snapshots := make([]DeviceInfoSnapshot, len(conns))
+	for i, c := range conns {
+		snapshots[i] = DeviceInfoSnapshot{
+			HardwareID:      c.HardwareID,
+			PiVersion:       c.PiVersion,
+			PiCommit:        c.PiCommit,
+			FirmwareVersion: c.FirmwareVersion,
+			FirmwareCommit:  c.FirmwareCommit,
+			RemoteAddr:      c.RemoteAddr,
+		}
 	}
+	return snapshots
 }
 
 // SetUpdateStatus stores the latest update status for a phone.
@@ -628,10 +640,11 @@ func (h *Hub) UpdateDeviceInfo(number, piVer, piCommit, fwVer, fwCommit, localAd
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
 	conn.RemoteAddr = localAddr
+	hwID := conn.HardwareID
 	ds := h.state
 	h.mu.Unlock()
 	if ds != nil {
-		ds.UpdateDeviceInfo(context.Background(), number, DevicePresence{
+		ds.UpdateDeviceInfo(context.Background(), hwID, DevicePresence{
 			PiVersion:       piVer,
 			PiCommit:        piCommit,
 			FirmwareVersion: fwVer,
@@ -659,11 +672,10 @@ func (h *Hub) UpdateDeviceInfoByHardware(hardwareID, piVer, piCommit, fwVer, fwC
 	conn.FirmwareVersion = fwVer
 	conn.FirmwareCommit = fwCommit
 	conn.RemoteAddr = localAddr
-	number := conn.Number
 	ds := h.state
 	h.mu.Unlock()
 	if ds != nil {
-		ds.UpdateDeviceInfo(context.Background(), number, DevicePresence{
+		ds.UpdateDeviceInfo(context.Background(), hardwareID, DevicePresence{
 			PiVersion:       piVer,
 			PiCommit:        piCommit,
 			FirmwareVersion: fwVer,
@@ -674,18 +686,20 @@ func (h *Hub) UpdateDeviceInfoByHardware(hardwareID, piVer, piCommit, fwVer, fwC
 	return true
 }
 
-// TouchLastSeen updates the in-memory last-seen timestamp for all devices
-// on the given number.
-func (h *Hub) TouchLastSeen(number string) {
+// TouchLastSeen updates the last-seen timestamp for a specific device on a
+// line. If hardwareID is empty, all devices on the line are touched.
+func (h *Hub) TouchLastSeen(number, hardwareID string) {
 	now := time.Now()
 	h.mu.Lock()
-	for _, conn := range h.conns[number] {
-		conn.LastSeen = now
+	for _, c := range h.conns[number] {
+		if hardwareID == "" || c.HardwareID == hardwareID {
+			c.LastSeen = now
+		}
 	}
 	ds := h.state
 	h.mu.Unlock()
-	if ds != nil {
-		ds.TouchLastSeen(context.Background(), number)
+	if ds != nil && hardwareID != "" {
+		ds.TouchLastSeen(context.Background(), number, hardwareID)
 	}
 }
 

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -197,6 +197,55 @@ func TestBroadcastSkipsFullBuffers(t *testing.T) {
 	}
 }
 
+func TestAllDeviceInfoMultipleDevices(t *testing.T) {
+	hub := NewHub()
+	c1 := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-001", PiVersion: "1.0.0", FirmwareVersion: "0.5.0"}
+	c2 := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-002", PiVersion: "1.2.0", FirmwareVersion: "0.8.0"}
+	_ = hub.Register("3140001", c1)
+	_ = hub.Register("3140001", c2)
+
+	infos := hub.AllDeviceInfo("3140001")
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(infos))
+	}
+	versions := map[string]string{}
+	for _, info := range infos {
+		versions[info.HardwareID] = info.PiVersion
+	}
+	if versions["hw-001"] != "1.0.0" {
+		t.Errorf("hw-001 PiVersion = %q, want 1.0.0", versions["hw-001"])
+	}
+	if versions["hw-002"] != "1.2.0" {
+		t.Errorf("hw-002 PiVersion = %q, want 1.2.0", versions["hw-002"])
+	}
+}
+
+func TestAllDeviceInfoReturnsNilForOffline(t *testing.T) {
+	hub := NewHub()
+	infos := hub.AllDeviceInfo("3140099")
+	if infos != nil {
+		t.Errorf("expected nil for unregistered number, got %d items", len(infos))
+	}
+}
+
+func TestAllDeviceInfoAfterUnregister(t *testing.T) {
+	hub := NewHub()
+	c1 := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-001", PiVersion: "1.0.0"}
+	c2 := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-002", PiVersion: "1.2.0"}
+	_ = hub.Register("3140001", c1)
+	_ = hub.Register("3140001", c2)
+
+	hub.Unregister("3140001", c1)
+
+	infos := hub.AllDeviceInfo("3140001")
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 device after unregister, got %d", len(infos))
+	}
+	if infos[0].HardwareID != "hw-002" {
+		t.Errorf("remaining device = %q, want hw-002", infos[0].HardwareID)
+	}
+}
+
 func TestDeviceInfoSnapshotJSONOmitsRemoteAddr(t *testing.T) {
 	snap := DeviceInfoSnapshot{
 		PiVersion:       "1.2.3",

--- a/server/internal/signaling/state_redis.go
+++ b/server/internal/signaling/state_redis.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	deviceKeyPrefix    = "digits:device:"
+	lineDevicesPrefix  = "digits:line-devices:"
 	updateStatusPrefix = "digits:update-status:"
 
 	deviceTTL       = 90 * time.Second
@@ -38,11 +39,16 @@ func NewDeviceState(client redis.UniversalClient, podID string) *DeviceState {
 }
 
 func (s *DeviceState) SetOnline(ctx context.Context, number string, p DevicePresence) {
-	key := deviceKeyPrefix + number
+	if p.HardwareID == "" {
+		return
+	}
+	devKey := deviceKeyPrefix + p.HardwareID
+	setKey := lineDevicesPrefix + number
 	now := strconv.FormatInt(time.Now().Unix(), 10)
 
 	fields := map[string]interface{}{
 		"pod_id":      p.PodID,
+		"number":      number,
 		"hardware_id": p.HardwareID,
 		"pi_version":  p.PiVersion,
 		"pi_commit":   p.PiCommit,
@@ -53,23 +59,33 @@ func (s *DeviceState) SetOnline(ctx context.Context, number string, p DevicePres
 	}
 
 	pipe := s.client.Pipeline()
-	pipe.HSet(ctx, key, fields)
-	pipe.Expire(ctx, key, deviceTTL)
+	pipe.HSet(ctx, devKey, fields)
+	pipe.Expire(ctx, devKey, deviceTTL)
+	pipe.SAdd(ctx, setKey, p.HardwareID)
+	pipe.Expire(ctx, setKey, deviceTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: SetOnline failed", "number", number, "err", err)
+		slog.Error("redis: SetOnline failed", "number", number, "hardware_id", p.HardwareID, "err", err)
 	}
 }
 
-func (s *DeviceState) SetOffline(ctx context.Context, number string) {
-	key := deviceKeyPrefix + number
-	if err := s.client.Del(ctx, key).Err(); err != nil {
-		slog.Error("redis: SetOffline failed", "number", number, "err", err)
+func (s *DeviceState) SetOffline(ctx context.Context, number, hardwareID string) {
+	if hardwareID == "" {
+		return
+	}
+	devKey := deviceKeyPrefix + hardwareID
+	setKey := lineDevicesPrefix + number
+
+	pipe := s.client.Pipeline()
+	pipe.Del(ctx, devKey)
+	pipe.SRem(ctx, setKey, hardwareID)
+	if _, err := pipe.Exec(ctx); err != nil {
+		slog.Error("redis: SetOffline failed", "number", number, "hardware_id", hardwareID, "err", err)
 	}
 }
 
 func (s *DeviceState) IsOnline(ctx context.Context, number string) bool {
-	key := deviceKeyPrefix + number
-	n, err := s.client.Exists(ctx, key).Result()
+	key := lineDevicesPrefix + number
+	n, err := s.client.SCard(ctx, key).Result()
 	if err != nil {
 		slog.Error("redis: IsOnline failed", "number", number, "err", err)
 		return false
@@ -79,8 +95,8 @@ func (s *DeviceState) IsOnline(ctx context.Context, number string) bool {
 
 func (s *DeviceState) OnlineNumbers(ctx context.Context) []string {
 	var numbers []string
-	pattern := deviceKeyPrefix + "*"
-	prefixLen := len(deviceKeyPrefix)
+	pattern := lineDevicesPrefix + "*"
+	prefixLen := len(lineDevicesPrefix)
 
 	iter := s.client.Scan(ctx, 0, pattern, 100).Iterator()
 	for iter.Next(ctx) {
@@ -98,33 +114,74 @@ func (s *DeviceState) OnlineNumbers(ctx context.Context) []string {
 }
 
 func (s *DeviceState) DeviceInfo(ctx context.Context, number string) *DeviceInfoSnapshot {
-	key := deviceKeyPrefix + number
-	vals, err := s.client.HGetAll(ctx, key).Result()
-	if err != nil {
-		slog.Error("redis: DeviceInfo failed", "number", number, "err", err)
+	all := s.AllDeviceInfo(ctx, number)
+	if len(all) == 0 {
 		return nil
 	}
-	if len(vals) == 0 {
-		return nil
-	}
-	return &DeviceInfoSnapshot{
-		PiVersion:       vals["pi_version"],
-		PiCommit:        vals["pi_commit"],
-		FirmwareVersion: vals["fw_version"],
-		FirmwareCommit:  vals["fw_commit"],
-		RemoteAddr:      vals["remote_addr"],
-	}
+	return &all[0]
 }
 
-func (s *DeviceState) UpdateDeviceInfo(ctx context.Context, number string, p DevicePresence) {
-	key := deviceKeyPrefix + number
+func (s *DeviceState) AllDeviceInfo(ctx context.Context, number string) []DeviceInfoSnapshot {
+	setKey := lineDevicesPrefix + number
+	hwIDs, err := s.client.SMembers(ctx, setKey).Result()
+	if err != nil {
+		slog.Error("redis: AllDeviceInfo SMembers failed", "number", number, "err", err)
+		return nil
+	}
+	if len(hwIDs) == 0 {
+		return nil
+	}
+
+	pipe := s.client.Pipeline()
+	cmds := make([]*redis.MapStringStringCmd, len(hwIDs))
+	for i, hwID := range hwIDs {
+		cmds[i] = pipe.HGetAll(ctx, deviceKeyPrefix+hwID)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		slog.Error("redis: AllDeviceInfo pipeline failed", "number", number, "err", err)
+		return nil
+	}
+
+	var stale []string
+	var snapshots []DeviceInfoSnapshot
+	for i, cmd := range cmds {
+		vals, err := cmd.Result()
+		if err != nil || len(vals) == 0 {
+			stale = append(stale, hwIDs[i])
+			continue
+		}
+		snapshots = append(snapshots, DeviceInfoSnapshot{
+			HardwareID:      vals["hardware_id"],
+			PiVersion:       vals["pi_version"],
+			PiCommit:        vals["pi_commit"],
+			FirmwareVersion: vals["fw_version"],
+			FirmwareCommit:  vals["fw_commit"],
+			RemoteAddr:      vals["remote_addr"],
+		})
+	}
+
+	if len(stale) > 0 {
+		staleIfaces := make([]interface{}, len(stale))
+		for i, id := range stale {
+			staleIfaces[i] = id
+		}
+		if err := s.client.SRem(ctx, setKey, staleIfaces...).Err(); err != nil {
+			slog.Error("redis: AllDeviceInfo stale cleanup failed", "number", number, "err", err)
+		}
+	}
+
+	return snapshots
+}
+
+func (s *DeviceState) UpdateDeviceInfo(ctx context.Context, hardwareID string, p DevicePresence) {
+	if hardwareID == "" {
+		return
+	}
+	key := deviceKeyPrefix + hardwareID
 	fields := make(map[string]interface{})
 
 	if p.PodID != "" {
 		fields["pod_id"] = p.PodID
-	}
-	if p.HardwareID != "" {
-		fields["hardware_id"] = p.HardwareID
 	}
 	if p.PiVersion != "" {
 		fields["pi_version"] = p.PiVersion
@@ -147,38 +204,67 @@ func (s *DeviceState) UpdateDeviceInfo(ctx context.Context, number string, p Dev
 	}
 
 	if err := s.client.HSet(ctx, key, fields).Err(); err != nil {
-		slog.Error("redis: UpdateDeviceInfo failed", "number", number, "err", err)
+		slog.Error("redis: UpdateDeviceInfo failed", "hardware_id", hardwareID, "err", err)
 	}
 }
 
-func (s *DeviceState) TouchLastSeen(ctx context.Context, number string) {
-	key := deviceKeyPrefix + number
+func (s *DeviceState) TouchLastSeen(ctx context.Context, number, hardwareID string) {
+	if hardwareID == "" {
+		return
+	}
+	devKey := deviceKeyPrefix + hardwareID
 	now := strconv.FormatInt(time.Now().Unix(), 10)
 
 	pipe := s.client.Pipeline()
-	pipe.HSet(ctx, key, "last_seen", now)
-	pipe.Expire(ctx, key, deviceTTL)
+	pipe.HSet(ctx, devKey, "last_seen", now)
+	pipe.Expire(ctx, devKey, deviceTTL)
+	if number != "" {
+		pipe.Expire(ctx, lineDevicesPrefix+number, deviceTTL)
+	}
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: TouchLastSeen failed", "number", number, "err", err)
+		slog.Error("redis: TouchLastSeen failed", "hardware_id", hardwareID, "err", err)
 	}
 }
 
 func (s *DeviceState) LastSeenAt(ctx context.Context, number string) *time.Time {
-	key := deviceKeyPrefix + number
-	val, err := s.client.HGet(ctx, key, "last_seen").Result()
-	if err != nil {
-		if err != redis.Nil {
-			slog.Error("redis: LastSeenAt failed", "number", number, "err", err)
+	setKey := lineDevicesPrefix + number
+	hwIDs, err := s.client.SMembers(ctx, setKey).Result()
+	if err != nil || len(hwIDs) == 0 {
+		if err != nil {
+			slog.Error("redis: LastSeenAt SMembers failed", "number", number, "err", err)
 		}
 		return nil
 	}
-	unix, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		slog.Error("redis: LastSeenAt parse failed", "number", number, "val", val, "err", err)
+
+	pipe := s.client.Pipeline()
+	cmds := make([]*redis.StringCmd, len(hwIDs))
+	for i, hwID := range hwIDs {
+		cmds[i] = pipe.HGet(ctx, deviceKeyPrefix+hwID, "last_seen")
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		slog.Error("redis: LastSeenAt pipeline failed", "number", number, "err", err)
 		return nil
 	}
-	t := time.Unix(unix, 0)
-	return &t
+
+	var latest time.Time
+	for _, cmd := range cmds {
+		val, err := cmd.Result()
+		if err != nil {
+			continue
+		}
+		unix, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			continue
+		}
+		t := time.Unix(unix, 0)
+		if t.After(latest) {
+			latest = t
+		}
+	}
+	if latest.IsZero() {
+		return nil
+	}
+	return &latest
 }
 
 func (s *DeviceState) SetUpdateStatus(ctx context.Context, number, status, detail string) {

--- a/server/internal/signaling/state_redis_integration_test.go
+++ b/server/internal/signaling/state_redis_integration_test.go
@@ -26,9 +26,11 @@ func TestDeviceStateIntegrationTwoPods(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	t.Cleanup(func() {
-		iter := client.Scan(ctx, 0, "digits:device:test-*", 100).Iterator()
-		for iter.Next(ctx) {
-			_ = client.Del(ctx, iter.Val())
+		for _, pattern := range []string{"digits:device:*", "digits:line-devices:test-*"} {
+			iter := client.Scan(ctx, 0, pattern, 100).Iterator()
+			for iter.Next(ctx) {
+				_ = client.Del(ctx, iter.Val())
+			}
 		}
 	})
 
@@ -53,7 +55,7 @@ func TestDeviceStateIntegrationTwoPods(t *testing.T) {
 		t.Errorf("PiVersion = %q, want %q", info.PiVersion, "2.0.0")
 	}
 
-	dsA.SetOffline(ctx, "test-5551234")
+	dsA.SetOffline(ctx, "test-5551234", "hw-int-1")
 	if dsB.IsOnline(ctx, "test-5551234") {
 		t.Fatal("pod B should see device as offline after unregister")
 	}
@@ -74,13 +76,14 @@ func TestDeviceStateTTLExpiryIntegration(t *testing.T) {
 	defer func() { _ = client.Close() }()
 
 	t.Cleanup(func() {
-		_ = client.Del(ctx, "digits:device:test-ttl-5551234")
+		_ = client.Del(ctx, "digits:device:hw-ttl-1")
+		_ = client.Del(ctx, "digits:line-devices:test-ttl-5551234")
 	})
 
 	ds := NewDeviceState(client, "pod-ttl")
-	ds.SetOnline(ctx, "test-ttl-5551234", DevicePresence{})
+	ds.SetOnline(ctx, "test-ttl-5551234", DevicePresence{HardwareID: "hw-ttl-1"})
 
-	ttl, err := client.TTL(ctx, "digits:device:test-ttl-5551234").Result()
+	ttl, err := client.TTL(ctx, "digits:device:hw-ttl-1").Result()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/internal/signaling/state_redis_test.go
+++ b/server/internal/signaling/state_redis_test.go
@@ -50,7 +50,7 @@ func TestDeviceStateSetOffline(t *testing.T) {
 		HardwareID: "hw-abc",
 	})
 
-	ds.SetOffline(ctx, "5551234")
+	ds.SetOffline(ctx, "5551234", "hw-abc")
 
 	if ds.IsOnline(ctx, "5551234") {
 		t.Fatal("expected device to be offline after SetOffline")
@@ -136,7 +136,7 @@ func TestDeviceStateUpdateDeviceInfo(t *testing.T) {
 		FirmwareVersion: "0.5.0",
 	})
 
-	ds.UpdateDeviceInfo(ctx, "5551234", DevicePresence{
+	ds.UpdateDeviceInfo(ctx, "hw-abc", DevicePresence{
 		PiVersion:  "1.1.0",
 		RemoteAddr: "192.168.1.50",
 	})
@@ -167,7 +167,7 @@ func TestDeviceStateTouchLastSeen(t *testing.T) {
 
 	mr.FastForward(60 * time.Second)
 
-	ds.TouchLastSeen(ctx, "5551234")
+	ds.TouchLastSeen(ctx, "5551234", "hw-abc")
 
 	ts := ds.LastSeenAt(ctx, "5551234")
 	if ts == nil {
@@ -183,7 +183,7 @@ func TestDeviceStateTouchLastSeen(t *testing.T) {
 		t.Errorf("LastSeenAt too far from now: %v", diff)
 	}
 
-	ttl := mr.TTL("digits:device:5551234")
+	ttl := mr.TTL("digits:device:hw-abc")
 	if ttl < 80*time.Second || ttl > 91*time.Second {
 		t.Errorf("TTL after TouchLastSeen = %v, want ~90s", ttl)
 	}
@@ -235,4 +235,77 @@ func TestDeviceStateTTLExpiry(t *testing.T) {
 	if ds.IsOnline(ctx, "5551234") {
 		t.Fatal("expected offline after TTL expiry")
 	}
+}
+
+func TestDeviceStateAllDeviceInfoMultiDevice(t *testing.T) {
+	ds, _ := newTestDeviceState(t)
+	ctx := context.Background()
+
+	ds.SetOnline(ctx, "5551234", DevicePresence{
+		PodID:           "pod-1",
+		HardwareID:      "hw-aaa",
+		PiVersion:       "1.0.0",
+		FirmwareVersion: "0.5.0",
+	})
+	ds.SetOnline(ctx, "5551234", DevicePresence{
+		PodID:           "pod-1",
+		HardwareID:      "hw-bbb",
+		PiVersion:       "1.2.0",
+		FirmwareVersion: "0.8.0",
+	})
+
+	infos := ds.AllDeviceInfo(ctx, "5551234")
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(infos))
+	}
+
+	versions := map[string]string{}
+	for _, info := range infos {
+		versions[info.HardwareID] = info.PiVersion
+	}
+	if versions["hw-aaa"] != "1.0.0" || versions["hw-bbb"] != "1.2.0" {
+		t.Errorf("unexpected versions: %v", versions)
+	}
+}
+
+func TestDeviceStateSetOfflineRemovesOneDevice(t *testing.T) {
+	ds, _ := newTestDeviceState(t)
+	ctx := context.Background()
+
+	ds.SetOnline(ctx, "5551234", DevicePresence{
+		PodID: "pod-1", HardwareID: "hw-aaa", PiVersion: "1.0.0",
+	})
+	ds.SetOnline(ctx, "5551234", DevicePresence{
+		PodID: "pod-1", HardwareID: "hw-bbb", PiVersion: "1.2.0",
+	})
+
+	ds.SetOffline(ctx, "5551234", "hw-aaa")
+
+	if !ds.IsOnline(ctx, "5551234") {
+		t.Fatal("line should still be online with one remaining device")
+	}
+
+	infos := ds.AllDeviceInfo(ctx, "5551234")
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 device after removing one, got %d", len(infos))
+	}
+	if infos[0].HardwareID != "hw-bbb" {
+		t.Errorf("remaining device = %q, want hw-bbb", infos[0].HardwareID)
+	}
+}
+
+func TestDeviceStateEmptyHardwareIDSkipped(t *testing.T) {
+	ds, _ := newTestDeviceState(t)
+	ctx := context.Background()
+
+	ds.SetOnline(ctx, "5551234", DevicePresence{PodID: "pod-1"})
+
+	if ds.IsOnline(ctx, "5551234") {
+		t.Fatal("device with empty hardware ID should not register in Redis")
+	}
+
+	ds.SetOffline(ctx, "5551234", "")
+
+	ds.TouchLastSeen(ctx, "5551234", "")
+	ds.UpdateDeviceInfo(ctx, "", DevicePresence{PiVersion: "1.0.0"})
 }

--- a/server/internal/web/handler_changelog.go
+++ b/server/internal/web/handler_changelog.go
@@ -52,26 +52,26 @@ func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
 
 func buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []string, h *Handler) []changelogRelease {
 	releases := idx.SortedReleases(component)
-	total := len(lines)
 	out := make([]changelogRelease, 0, len(releases))
 
+	var totalDevices int
 	versionCounts := make(map[string]int)
 	for _, number := range lines {
-		info := h.hub.DeviceInfo(number)
-		if info == nil {
-			continue
-		}
-		var ver string
-		switch component {
-		case updates.ComponentPi:
-			ver = info.PiVersion
-		case updates.ComponentFirmware:
-			ver = info.FirmwareVersion
-		default:
-			continue
-		}
-		if ver != "" {
-			versionCounts[ver]++
+		infos := h.hub.AllDeviceInfo(number)
+		for _, info := range infos {
+			var ver string
+			switch component {
+			case updates.ComponentPi:
+				ver = info.PiVersion
+			case updates.ComponentFirmware:
+				ver = info.FirmwareVersion
+			default:
+				continue
+			}
+			if ver != "" {
+				versionCounts[ver]++
+				totalDevices++
+			}
 		}
 	}
 
@@ -81,7 +81,7 @@ func buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []
 			Notes:      r.Notes,
 			Date:       r.Date,
 			PhoneCount: versionCounts[r.Version],
-			TotalCount: total,
+			TotalCount: totalDevices,
 		})
 	}
 	return out

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -408,15 +408,13 @@ func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string, lineN
 		}
 	}
 	for _, number := range lineNumbers {
-		info := h.hub.DeviceInfo(number)
-		if info == nil {
-			continue
-		}
-		if latestPi != "" && info.PiVersion != "" && updates.CompareSemver(info.PiVersion, latestPi) < 0 {
-			return true
-		}
-		if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
-			return true
+		for _, info := range h.hub.AllDeviceInfo(number) {
+			if latestPi != "" && info.PiVersion != "" && updates.CompareSemver(info.PiVersion, latestPi) < 0 {
+				return true
+			}
+			if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
+				return true
+			}
 		}
 	}
 	return false

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -20,6 +20,18 @@ import (
 
 const maxLineNameRunes = 50
 
+func oldestVersions(infos []signaling.DeviceInfoSnapshot) (fw, pi string) {
+	for _, info := range infos {
+		if info.FirmwareVersion != "" && (fw == "" || updates.CompareSemver(info.FirmwareVersion, fw) < 0) {
+			fw = info.FirmwareVersion
+		}
+		if info.PiVersion != "" && (pi == "" || updates.CompareSemver(info.PiVersion, pi) < 0) {
+			pi = info.PiVersion
+		}
+	}
+	return
+}
+
 func validateLineName(raw string) (string, error) {
 	name := strings.TrimSpace(raw)
 	if name == "" {
@@ -97,7 +109,11 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 
 	rows := make([]lineRow, len(lines))
 	for i, l := range lines {
-		info := h.hub.DeviceInfo(l.Number)
+		infos := h.hub.AllDeviceInfo(l.Number)
+		var info *signaling.DeviceInfoSnapshot
+		if len(infos) > 0 {
+			info = &infos[0]
+		}
 		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
 		row.OnlineDeviceCount = h.hub.ConnectionCount(l.Number)
 
@@ -110,12 +126,13 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 			}
 		}
 
-		if idx != nil && info != nil {
-			if latestFw != "" && info.FirmwareVersion != "" && updates.CompareSemver(info.FirmwareVersion, latestFw) < 0 {
-				row.FirmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, info.FirmwareVersion, latestFw)
+		if idx != nil {
+			oldestFw, oldestPi := oldestVersions(infos)
+			if latestFw != "" && oldestFw != "" && updates.CompareSemver(oldestFw, latestFw) < 0 {
+				row.FirmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, oldestFw, latestFw)
 			}
-			if latestPi != "" && info.PiVersion != "" && updates.CompareSemver(info.PiVersion, latestPi) < 0 {
-				row.PiUpdateNotes = idx.RangeReleases(updates.ComponentPi, info.PiVersion, latestPi)
+			if latestPi != "" && oldestPi != "" && updates.CompareSemver(oldestPi, latestPi) < 0 {
+				row.PiUpdateNotes = idx.RangeReleases(updates.ComponentPi, oldestPi, latestPi)
 			}
 		}
 		rows[i] = row
@@ -324,15 +341,20 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		lastSeenAt = &t
 	}
 
-	devInfo := h.hub.DeviceInfo(number)
+	allInfos := h.hub.AllDeviceInfo(number)
+	var devInfo *signaling.DeviceInfoSnapshot
+	if len(allInfos) > 0 {
+		devInfo = &allInfos[0]
+	}
 
 	var piUpdateNotes, firmwareUpdateNotes []updates.Release
-	if idx != nil && devInfo != nil {
-		if latestPi != "" && devInfo.PiVersion != "" && updates.CompareSemver(devInfo.PiVersion, latestPi) < 0 {
-			piUpdateNotes = idx.RangeReleases(updates.ComponentPi, devInfo.PiVersion, latestPi)
+	if idx != nil {
+		oldestFw, oldestPi := oldestVersions(allInfos)
+		if latestPi != "" && oldestPi != "" && updates.CompareSemver(oldestPi, latestPi) < 0 {
+			piUpdateNotes = idx.RangeReleases(updates.ComponentPi, oldestPi, latestPi)
 		}
-		if latestFw != "" && devInfo.FirmwareVersion != "" && updates.CompareSemver(devInfo.FirmwareVersion, latestFw) < 0 {
-			firmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, devInfo.FirmwareVersion, latestFw)
+		if latestFw != "" && oldestFw != "" && updates.CompareSemver(oldestFw, latestFw) < 0 {
+			firmwareUpdateNotes = idx.RangeReleases(updates.ComponentFirmware, oldestFw, latestFw)
 		}
 	}
 

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -138,7 +138,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
 	ws.SetPongHandler(func(string) error {
 		_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
-		h.hub.TouchLastSeen(number)
+		h.hub.TouchLastSeen(number, conn.HardwareID)
 		return nil
 	})
 


### PR DESCRIPTION
## Summary

- **Redis schema change**: device state rekey from `digits:device:<number>` to `digits:device:<hardwareID>` with a secondary `digits:line-devices:<number>` set, so each handset on a multi-device line gets its own version record.
- **Hub.AllDeviceInfo**: new method returns version snapshots for all connected devices on a line, replacing the single-device `DeviceInfo` in the three broken consumers.
- **Changelog histogram**: now counts individual devices, not lines. "N of M phones" reflects actual device adoption.
- **Notification dot**: triggers if ANY handset on ANY line is behind, deterministic regardless of connection order.
- **Phones list/detail update chip**: shows update notes for the oldest version on the line (covers all pending updates).
- **Co-Authored-By guard**: commit-msg hook in `.githooks/` rejects trailers locally, CI workflow (`commit-msg-lint.yml`) fails PRs with trailers.

## Test plan

- [x] All existing signaling tests pass (hub, relay, device state)
- [x] New multi-device Redis tests: AllDeviceInfo, SetOffline removes one device, empty hardware ID skipped
- [x] New hub tests: AllDeviceInfo with multiple devices, after unregister, nil for offline
- [x] golangci-lint clean
- [ ] Integration: verify changelog histogram with two handsets on one line shows both in counts
- [ ] Integration: verify notification dot appears when one handset is behind, other is current

Fixes #497