### PR TITLE
feat(server): segmented radio line selector + convert line to extension

### DIFF
--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2086,6 +2086,49 @@ body.am .deck-kick-confirm .deck-confirm__go {
 .am-phones__pair-field-hint--err { color: var(--chip-red-dk); }
 .am-phones__pair-field-hint.hidden { display: none; }
 
+body.am .seg-radio {
+  display: inline-flex;
+  border: 1px solid var(--btn-press);
+  border-radius: 5px;
+  overflow: hidden;
+  box-shadow: 0 2px 0 var(--btn-press), 0 3px 4px rgba(40,30,15,0.3);
+}
+body.am .seg-radio__opt { cursor: pointer; margin: 0; }
+body.am .seg-radio__opt input { position: absolute; opacity: 0; pointer-events: none; }
+body.am .seg-radio__opt + .seg-radio__opt { border-left: 1px solid var(--btn-press); }
+body.am .seg-radio__label {
+  padding: 5px 12px;
+  font-family: var(--font-body);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  background: linear-gradient(180deg, var(--btn-top) 0%, var(--btn) 55%, var(--btn-bot) 100%);
+}
+body.am .seg-radio__opt:hover .seg-radio__label { filter: brightness(1.03); }
+body.am .seg-radio__opt input:checked + .seg-radio__label {
+  background: linear-gradient(180deg, #4a84b4 0%, var(--chip-blue) 100%);
+  color: #f0f6fa;
+  box-shadow: inset 0 1px 0 rgba(160,200,230,0.55);
+}
+body.am .seg-radio__opt input:focus-visible + .seg-radio__label {
+  outline: 2px solid rgba(255,165,32,0.55);
+}
+body.am .pair-mode-field {
+  border: none;
+  padding: 0;
+  margin: 0 0 10px;
+}
+body.am .pair-mode-field legend {
+  font-family: var(--font-body);
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--label);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
 /* Shared banner primitives: digits.css and dialup.css both style these, AM
    must too or the banners on /settings, /links, /login render unstyled. */
 .banner { padding: 10px 14px; border-radius: 6px; font-family: var(--font-body); font-size: 12px; display: flex; align-items: center; gap: 10px; border: 1px solid transparent; margin-bottom: 14px; }

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -2858,3 +2858,54 @@ body.dialup .phone-silent__text {
 }
 .dialup-hh-option:hover { background: var(--dialup-blue); color: #fff; }
 .dialup-hh-option.is-active { font-weight: 700; }
+
+/* Segmented radio: Win95 beveled variant */
+.seg-radio {
+  display: inline-flex;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
+}
+.seg-radio__opt { cursor: pointer; margin: 0; }
+.seg-radio__opt + .seg-radio__opt { border-left: none; }
+.seg-radio__opt input { position: absolute; opacity: 0; pointer-events: none; }
+.seg-radio__label {
+  font-family: var(--dialup-font, 'Tahoma', system-ui, sans-serif);
+  font-size: 11px;
+  font-weight: normal;
+  letter-spacing: 0;
+  padding: 3px 10px;
+  background: var(--dialup-chrome);
+  color: var(--dialup-ink);
+  border-top: 2px solid var(--dialup-bevel-hi);
+  border-left: 2px solid var(--dialup-bevel-hi);
+  border-right: 2px solid var(--dialup-bevel-ll);
+  border-bottom: 2px solid var(--dialup-bevel-ll);
+}
+.seg-radio__opt:hover .seg-radio__label { background: var(--dialup-chrome-l); }
+.seg-radio__opt input:checked + .seg-radio__label {
+  background: var(--dialup-white);
+  color: var(--dialup-ink);
+  border-top: 2px solid var(--dialup-bevel-ll);
+  border-left: 2px solid var(--dialup-bevel-ll);
+  border-right: 2px solid var(--dialup-bevel-hi);
+  border-bottom: 2px solid var(--dialup-bevel-hi);
+}
+.seg-radio__opt input:focus-visible + .seg-radio__label {
+  outline: 1px dotted var(--dialup-ink);
+  outline-offset: -4px;
+}
+.pair-mode-field {
+  border: none;
+  padding: 0;
+  margin: 0 0 8px;
+}
+.pair-mode-field legend {
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--dialup-ink);
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0;
+  margin-bottom: 3px;
+}

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -488,6 +488,45 @@ hr { border: 0; border-top: 1px solid var(--rule); margin: 0; }
 
 .btn--sm { padding: 5px 10px; font-size: 12.5px; border-radius: 6px; }
 
+/* --------- Segmented radio --------- */
+
+.seg-radio {
+  display: inline-flex;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-1);
+  overflow: hidden;
+}
+.seg-radio__opt {
+  cursor: pointer;
+  margin: 0;
+}
+.seg-radio__opt + .seg-radio__opt { border-left: 1px solid var(--rule); }
+.seg-radio__opt input { position: absolute; opacity: 0; pointer-events: none; }
+.seg-radio__label {
+  display: block;
+  padding: 6px 14px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--ink-soft);
+  background: var(--paper);
+  transition: background-color 0.12s, color 0.12s;
+}
+.seg-radio__opt:hover .seg-radio__label { background: var(--paper-2); }
+.seg-radio__opt input:checked + .seg-radio__label {
+  background: var(--ink);
+  color: var(--paper);
+}
+.seg-radio__opt input:focus-visible + .seg-radio__label {
+  outline: 2px solid var(--brass);
+  outline-offset: -2px;
+}
+.pair-mode-field {
+  border: none;
+  padding: 0;
+  margin: 0 0 14px;
+}
+.pair-mode-field legend { padding: 0; }
+
 /* --------- Forms --------- */
 
 .field { margin-bottom: 14px; }

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -55,13 +55,19 @@
           </div>
 
           {{if .Lines}}
-          <div class="field">
-            <span class="field__label">Line</span>
-            <div class="pair-mode-tabs" style="display: flex; gap: 0; margin-bottom: 8px;">
-              <button type="button" class="btn btn--sm pair-mode-tab is-active" data-mode="new" onclick="setPairMode('new')">New line</button>
-              <button type="button" class="btn btn--sm pair-mode-tab" data-mode="existing" onclick="setPairMode('existing')">Add extension</button>
+          <fieldset class="field pair-mode-field">
+            <legend class="field__label">Line</legend>
+            <div class="seg-radio">
+              <label class="seg-radio__opt">
+                <input type="radio" name="pair_mode_radio" value="new" checked onchange="setPairMode('new')">
+                <span class="seg-radio__label">New line</span>
+              </label>
+              <label class="seg-radio__opt">
+                <input type="radio" name="pair_mode_radio" value="existing" onchange="setPairMode('existing')">
+                <span class="seg-radio__label">Add extension</span>
+              </label>
             </div>
-          </div>
+          </fieldset>
           {{end}}
 
           <div id="new-line-fields">
@@ -247,8 +253,6 @@
   window.setPairMode = function(mode) {
     pairMode = mode;
     pairModeHidden.value = mode;
-    var tabs = document.querySelectorAll('.pair-mode-tab');
-    tabs.forEach(function(t) { t.classList.toggle('is-active', t.dataset.mode === mode); });
     if (mode === 'existing') {
       newLineFields.classList.add('hidden');
       existingLineFields.classList.remove('hidden');
@@ -640,16 +644,48 @@
 
       <form class="am-phones__pair-form" action="/phones/pair" method="POST" id="pair-form">
         <input type="hidden" name="code" id="pair-code-hidden" value="">
+        <input type="hidden" name="pair_mode" id="pair-mode-hidden" value="new">
 
         <div class="am-phones__pair-field">
           <label class="am-phones__pair-field-label" for="pair-code-manual">Or type the code</label>
           <input type="text" id="pair-code-manual" name="code_manual" placeholder="123456" pattern="\d{6}" maxlength="6" inputmode="numeric" autocomplete="off">
         </div>
 
-        <div class="am-phones__pair-field">
-          <label class="am-phones__pair-field-label" for="line-number-input">Line number</label>
-          <input type="text" id="line-number-input" name="number" placeholder="314-0001" pattern="\d{3}-?\d{4}" maxlength="8" required>
-          <span id="number-hint" class="am-phones__pair-field-hint am-phones__pair-field-hint--err hidden">Line number is already in use.</span>
+        {{if .Lines}}
+        <fieldset class="pair-mode-field">
+          <legend class="am-phones__pair-field-label">Line</legend>
+          <div class="seg-radio">
+            <label class="seg-radio__opt">
+              <input type="radio" name="pair_mode_radio" value="new" checked onchange="setPairMode('new')">
+              <span class="seg-radio__label">New line</span>
+            </label>
+            <label class="seg-radio__opt">
+              <input type="radio" name="pair_mode_radio" value="existing" onchange="setPairMode('existing')">
+              <span class="seg-radio__label">Add extension</span>
+            </label>
+          </div>
+        </fieldset>
+        {{end}}
+
+        <div id="new-line-fields">
+          <div class="am-phones__pair-field">
+            <label class="am-phones__pair-field-label" for="line-number-input">Line number</label>
+            <input type="text" id="line-number-input" name="number" placeholder="314-0001" pattern="\d{3}-?\d{4}" maxlength="8">
+            <span id="number-hint" class="am-phones__pair-field-hint am-phones__pair-field-hint--err hidden">Line number is already in use.</span>
+          </div>
+        </div>
+
+        <div id="existing-line-fields" class="hidden">
+          <div class="am-phones__pair-field">
+            <label class="am-phones__pair-field-label" for="existing-line-select">Add to line</label>
+            <select name="existing_line_id" id="existing-line-select">
+              <option value="">Choose a line...</option>
+              {{range .Lines}}
+              <option value="{{.Line.ID}}">{{fmtPhone .Line.Number}} - {{.Line.Name}}</option>
+              {{end}}
+            </select>
+            <span class="am-phones__pair-field-hint" style="font-size: 10px;">All handsets on the line ring together.</span>
+          </div>
         </div>
 
         <div class="am-phones__pair-field">

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -256,7 +256,6 @@
     if (mode === 'existing') {
       newLineFields.classList.add('hidden');
       existingLineFields.classList.remove('hidden');
-      numberInput.removeAttribute('required');
     } else {
       newLineFields.classList.remove('hidden');
       existingLineFields.classList.add('hidden');


### PR DESCRIPTION
## Summary

- Replaced the "New line" / "Add extension" toggle buttons with a proper radio group styled as a segmented control. The old buttons didn't communicate selected state clearly.
- Added theme-specific segmented radio variants: intercom uses ink/paper fill, dialup uses Win95 beveled borders, answering-machine uses chicklet gradients with blue active state.
- Added the missing `pair_mode` and "Add extension" support to the answering-machine phones template, which previously only supported new-line pairing.
- **New: "Make extension" action on existing lines.** Each row in the lines table now has a "Make extension" button that opens an inline form to merge the line into another. Moves all devices to the target line and deletes the source. Includes confirmation dialog. Available across all three themes.

## Screenshots

### Segmented Radio (from original PR scope)

#### Intercom (light)
| New line | Add extension |
|---|---|
| ![intercom](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-intercom.png) | ![intercom-ext](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-intercom-extension.png) |

#### Intercom (dark)
![intercom-dark](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-intercom-dark.png)

#### Dialup
![dialup](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-dialup.png)

#### Answering Machine
| New line | Add extension |
|---|---|
| ![am](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-am.png) | ![am-ext](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-522-am-extension.png) |

### Convert Line to Extension (new feature)

#### Intercom
| Lines table | Inline convert form |
|---|---|
| ![table](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-523-convert-intercom.png) | ![form](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-523-convert-intercom-form.png) |

#### Dialup
| Lines table | Inline convert form |
|---|---|
| ![table](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-523-convert-dialup.png) | ![form](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-523-convert-dialup-form.png) |

#### Answering Machine
![am](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-523-convert-am.png)

## Test plan

- [x] Verified radio toggle works in all 3 themes + intercom dark mode
- [x] Verified toggling switches between "Line number" and "Add to line" fields
- [x] Verified "Make extension" button appears on all rows when 2+ lines exist
- [x] Verified inline convert form shows target line dropdown
- [x] `TestConvertLineToExtension`: devices moved, source line deleted
- [x] `TestConvertLineToSelfRejected`: self-convert returns 400
- [x] `TestReassignLine` + `TestReassignLineNoDevices`: device store integration tests pass
- [x] Unit tests pass
- [x] golangci-lint clean