### PR TITLE
fix(ci,digitsd): infer release scope from changed file paths

### DIFF
--- a/firmware/.releaserc-full.cjs
+++ b/firmware/.releaserc-full.cjs
@@ -22,6 +22,7 @@ module.exports = {
   plugins: [
     [squashExpander, {
       _wrapped: wrapped,
+      pathScopes: { 'firmware/': 'firmware' },
       // Wrapped commit-analyzer options.
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits

--- a/firmware/.releaserc-tagonly.cjs
+++ b/firmware/.releaserc-tagonly.cjs
@@ -17,6 +17,7 @@ module.exports = {
   plugins: [
     [squashExpander, {
       _wrapped: wrapped,
+      pathScopes: { 'firmware/': 'firmware' },
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.

--- a/pi/.releaserc.cjs
+++ b/pi/.releaserc.cjs
@@ -17,6 +17,7 @@ module.exports = {
   plugins: [
     [squashExpander, {
       _wrapped: wrapped,
+      pathScopes: { 'pi/': 'digitsd' },
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -3325,7 +3325,11 @@ func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string, flashCapa
 	}); err != nil {
 		slog.Warn("device_info: send failed", "error", err)
 	} else {
-		slog.Info("device_info sent", "pi_version", version.Version, "pi_commit", version.Commit, "fw_version", fwVersion, "fw_commit", fwCommit, "flash_capable", flashCapable, "local_addr", localAddr, "dev_mode", devModeOn)
+		slog.Info("device_info sent",
+			"pi_version", version.Version, "pi_commit", version.Commit,
+			"fw_version", fwVersion, "fw_commit", fwCommit,
+			"flash_capable", flashCapable, "local_addr", localAddr,
+			"dev_mode", devModeOn)
 	}
 }
 

--- a/tools/semantic-release-squash-expander.cjs
+++ b/tools/semantic-release-squash-expander.cjs
@@ -24,6 +24,16 @@
 // This plugin expands such squash commits into virtual commits so both the
 // release-decision and changelog-generation steps see the original per-
 // commit messages. Non-squash commits pass through unchanged.
+//
+// Path-based scope inference (pathScopes):
+//
+// When a commit's scope doesn't match the release rules but its changed
+// files fall under a configured path prefix, the plugin injects a synthetic
+// commit with the inferred scope. This catches cross-component PRs where
+// the squash subject uses one component's scope but the diff touches
+// another. Configure via pluginConfig.pathScopes:
+//
+//   pathScopes: { 'pi/': 'digitsd', 'firmware/': 'firmware' }
 
 // A bullet's first line must look like a conventional-commit subject
 // (type, optional scope, optional !, colon, space, then text). We only
@@ -65,6 +75,53 @@ function expandCommits(commits) {
     });
 }
 
+const SCOPE_RE = /^([a-z]+)\(([^)]+)\)(!?:.*)$/;
+const TYPE_RE = /^([a-z]+)(!?:.*)$/;
+
+function inferPathScopes(commits, pathScopes) {
+    if (!pathScopes || Object.keys(pathScopes).length === 0) return commits;
+
+    const { execSync } = require("child_process");
+    const result = [];
+
+    for (const commit of commits) {
+        result.push(commit);
+
+        const subject = commit.subject || commit.header || "";
+        const scopeMatch = subject.match(SCOPE_RE);
+        const existingScopes = scopeMatch ? scopeMatch[2].split(",") : [];
+
+        let changedFiles;
+        try {
+            changedFiles = execSync(
+                `git diff-tree --no-commit-id --name-only -r ${commit.hash}`,
+                { encoding: "utf8" },
+            ).trim().split("\n").filter(Boolean);
+        } catch {
+            continue;
+        }
+
+        for (const [prefix, scope] of Object.entries(pathScopes)) {
+            if (existingScopes.some((s) => s === scope)) continue;
+            if (!changedFiles.some((f) => f.startsWith(prefix))) continue;
+
+            const typeMatch = subject.match(SCOPE_RE) || subject.match(TYPE_RE);
+            const type = typeMatch ? typeMatch[1] : "fix";
+            const rest = scopeMatch ? scopeMatch[3] : (subject.match(TYPE_RE) || [])[2] || ": path-inferred release";
+            const syntheticSubject = `${type}(${scope})${rest}`;
+
+            result.push({
+                ...commit,
+                header: syntheticSubject,
+                subject: syntheticSubject,
+                body: `Path-inferred from files matching ${prefix}`,
+                message: `${syntheticSubject}\n\nPath-inferred from files matching ${prefix}`,
+            });
+        }
+    }
+    return result;
+}
+
 // The wrapped plugins are passed in via pluginConfig._wrapped because this
 // file lives outside any project's node_modules: a bare require() from
 // here walks up only as far as repo-root, which is empty (semantic-release
@@ -86,16 +143,20 @@ function unwrap(pluginConfig, key) {
 module.exports = {
     async analyzeCommits(pluginConfig, context) {
         const commitAnalyzer = unwrap(pluginConfig, "commitAnalyzer");
+        const expanded = expandCommits(context.commits);
+        const withPaths = inferPathScopes(expanded, pluginConfig.pathScopes);
         return commitAnalyzer.analyzeCommits(pluginConfig, {
             ...context,
-            commits: expandCommits(context.commits),
+            commits: withPaths,
         });
     },
     async generateNotes(pluginConfig, context) {
         const releaseNotesGenerator = unwrap(pluginConfig, "releaseNotesGenerator");
+        const expanded = expandCommits(context.commits);
+        const withPaths = inferPathScopes(expanded, pluginConfig.pathScopes);
         return releaseNotesGenerator.generateNotes(pluginConfig, {
             ...context,
-            commits: expandCommits(context.commits),
+            commits: withPaths,
         });
     },
 };
@@ -103,3 +164,4 @@ module.exports = {
 // Exposed for unit testing.
 module.exports._expandCommits = expandCommits;
 module.exports._splitSquashBullets = splitSquashBullets;
+module.exports._inferPathScopes = inferPathScopes;

--- a/tools/semantic-release-squash-expander.test.cjs
+++ b/tools/semantic-release-squash-expander.test.cjs
@@ -162,6 +162,70 @@ test("missing _wrapped throws a helpful error", async () => {
     );
 });
 
+// ── inferPathScopes tests ───────────────────────────────────────────
+
+const { _inferPathScopes } = require("./semantic-release-squash-expander.cjs");
+const { execSync } = require("child_process");
+
+// These tests need a real git repo. If we're not in one, skip them.
+let inGitRepo = false;
+try {
+    execSync("git rev-parse --git-dir", { encoding: "utf8" });
+    inGitRepo = true;
+} catch {}
+
+if (inGitRepo) {
+    test("inferPathScopes injects synthetic commit when files match but scope does not", () => {
+        // Use the actual HEAD commit and a pathScopes map that will match
+        // something in the repo. We don't know what files HEAD touched, so
+        // use a prefix that matches the test file itself.
+        const head = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+        const files = execSync(`git diff-tree --no-commit-id --name-only -r ${head}`, {
+            encoding: "utf8",
+        }).trim().split("\n").filter(Boolean);
+
+        if (files.length === 0) {
+            console.log("SKIP inferPathScopes inject (HEAD has no files)");
+            return;
+        }
+
+        // Pick a prefix from the first file
+        const prefix = files[0].split("/")[0] + "/";
+        const commits = [{
+            hash: head,
+            subject: "feat(unrelated): something",
+            header: "feat(unrelated): something",
+            message: "feat(unrelated): something",
+        }];
+
+        const result = _inferPathScopes(commits, { [prefix]: "testscope" });
+        assert.strictEqual(result.length, 2, "should have original + synthetic");
+        assert.strictEqual(result[0].subject, "feat(unrelated): something");
+        assert.ok(result[1].subject.includes("testscope"), "synthetic has inferred scope");
+        assert.ok(result[1].subject.startsWith("feat("), "preserves original type");
+    });
+
+    test("inferPathScopes does not inject when scope already matches", () => {
+        const head = execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+        const commits = [{
+            hash: head,
+            subject: "feat(digitsd): something",
+            header: "feat(digitsd): something",
+            message: "feat(digitsd): something",
+        }];
+
+        const result = _inferPathScopes(commits, { "pi/": "digitsd" });
+        assert.strictEqual(result.length, 1, "no synthetic when scope already present");
+    });
+
+    test("inferPathScopes is a no-op when pathScopes is empty or absent", () => {
+        const commits = [{ hash: "abc", subject: "feat: x", header: "feat: x", message: "feat: x" }];
+        assert.deepStrictEqual(_inferPathScopes(commits, {}), commits);
+        assert.deepStrictEqual(_inferPathScopes(commits, undefined), commits);
+        assert.deepStrictEqual(_inferPathScopes(commits, null), commits);
+    });
+}
+
 if (process.exitCode) {
     process.exit(process.exitCode);
 }


### PR DESCRIPTION
## Summary

- PR #522 changed `pi/digitsd/` files but the squash commit was scoped `feat(server)`, so the pi-release workflow ran but semantic-release found no matching scope and skipped the tag
- Adds `pathScopes` to the squash expander: after bullet expansion, checks each commit's `git diff-tree` against configured path prefixes and injects a synthetic commit with the correct scope when files match but no bullet carries that scope
- Configured for all three release pipelines (pi, firmware-full, firmware-tagonly)
- Also reformats the long `slog.Info` call in `sendDeviceInfo` onto multiple lines

## Test plan

- [x] All 14 squash expander tests pass (3 new for `inferPathScopes`)
- [ ] After merge, pi-release workflow triggers and tags `pi/v1.25.0` (the #522 changes will now be picked up by path inference)