### PR TITLE
fix(digitsd): tear down stale call state on WebSocket reconnect

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -3297,6 +3297,20 @@ func main() {
 					continue
 				}
 				slog.Info("signal: reconnected")
+
+				// Tear down any active call. The server cleaned up its
+				// side on disconnect (OnDisconnect), but the local WebRTC
+				// peer connection and audio pipeline survive the WebSocket
+				// drop. Without this, the phone's ICE agent keeps sending
+				// renegotiation messages for a call the server no longer
+				// tracks, producing "sdp/ice without active call" errors.
+				if ctrl.State() != phone.StateIDLE {
+					slog.Info("signal: tearing down stale call after reconnect", "state", ctrl.State())
+					cb.TearDownAllMeshPeers()
+					cb.HangupCall()
+					ctrl.Reset()
+				}
+
 				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
 				requestICEServers(sig)
 				break


### PR DESCRIPTION
## What

After a WebSocket reconnect, tear down any active call/conference state before resuming normal operation.

## Why

When a phone loses its WebSocket connection (especially off-LAN devices going through NPM/Traefik), the server runs `OnDisconnect` and clears its call tracking. But the Pi's local WebRTC peer connection and audio pipeline survive the WebSocket drop. On reconnect, the ICE agent resumes sending SDP/ICE renegotiation messages for a call the server no longer knows about, producing a stream of "sdp/ice without active call" warnings that trigger the `DigitsSignalingErrors` critical alert.

Observed on a real off-LAN device that reconnected and sent stale ICE candidates to two different numbers for several minutes.

## Changes

After successful reconnect in the main event loop, check `ctrl.State() != phone.StateIDLE`. If in any call/conference state, call `TearDownAllMeshPeers()` + `HangupCall()` + `ctrl.Reset()` before sending device_info. The hangup message sent to the server is harmless (server ignores hangups for nonexistent calls).

## Test plan

- [x] `go build ./cmd/digitsd/` compiles
- [x] `make test` passes (one pre-existing failure in `assets` unrelated to this change)
- [ ] Deploy to a test phone, make a call, kill the WebSocket (e.g. restart signald pod), verify the phone tears down the call cleanly and reconnects to idle
- [ ] Verify no more "sdp/ice without active call" errors after reconnect