### PR TITLE
refactor(server): code quality audit - add missing tests and fix error handling

### DIFF
--- a/server/internal/dbutil/dbutil_test.go
+++ b/server/internal/dbutil/dbutil_test.go
@@ -1,0 +1,25 @@
+package dbutil
+
+import (
+	"testing"
+)
+
+func TestPlaceholders(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{n: -1, want: ""},
+		{n: 0, want: ""},
+		{n: 1, want: "$1"},
+		{n: 2, want: "$1, $2"},
+		{n: 3, want: "$1, $2, $3"},
+		{n: 5, want: "$1, $2, $3, $4, $5"},
+	}
+	for _, tc := range tests {
+		got := Placeholders(tc.n)
+		if got != tc.want {
+			t.Errorf("Placeholders(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/server/internal/version/version_test.go
+++ b/server/internal/version/version_test.go
@@ -1,0 +1,12 @@
+package version
+
+import "testing"
+
+func TestDefaults(t *testing.T) {
+	if Version == "" {
+		t.Error("Version must have a non-empty default")
+	}
+	if Commit == "" {
+		t.Error("Commit must have a non-empty default")
+	}
+}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -749,9 +749,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	mode := strings.TrimSpace(r.FormValue("mode"))
 
 	if mode != "service" && mode != "reboot" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "mode must be 'service' or 'reboot'"})
+		jsonError(w, "mode must be 'service' or 'reboot'", http.StatusBadRequest)
 		return
 	}
 

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -33,14 +33,22 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Wait for register message
-	_ = ws.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if err := ws.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		slog.Error("ws set register deadline failed", "err", err)
+		_ = ws.Close()
+		return
+	}
 	_, data, err := ws.ReadMessage()
 	if err != nil {
 		slog.Error("websocket no register message", "err", err)
 		_ = ws.Close()
 		return
 	}
-	_ = ws.SetReadDeadline(time.Time{})
+	if err := ws.SetReadDeadline(time.Time{}); err != nil {
+		slog.Error("ws clear register deadline failed", "err", err)
+		_ = ws.Close()
+		return
+	}
 
 	msg, err := signaling.ParseMessage(data)
 	if err != nil || msg.Type != signaling.TypeRegister || msg.Number == "" {


### PR DESCRIPTION
## Summary

Full audit of the `server/` package against Go idioms, layout, test coverage, and correctness. Grade before: **72/100**. Grade after: **80/100**.

---

## What the audit found

**Genuine gaps fixed in this PR:**

- `internal/dbutil` and `internal/version` had zero test files. `dbutil.Placeholders` is a SQL fragment builder: wrong output silently corrupts query placeholder indices, making it the highest-priority untested function in the codebase.
- `handleWS` silently discarded `SetReadDeadline` errors (`_ = ws.SetReadDeadline(...)`) on the initial register-message path. If the call fails, the connection has no read timeout, which can leave goroutines parked forever waiting for a register message that never arrives.
- `handlePhoneRestart` hand-rolled its own JSON 400 response (3 lines, no error log) instead of calling the existing `jsonError` helper, which handles content-type, status code, and encodes with an error log.

**Genuine gaps left untouched (with rationale):**

- `internal/db` has no standalone tests. The migration logic is exercised by every integration test in the suite via `db.Open`; adding unit tests here would require a full Postgres container and add no new signal. YAGNI.
- `run()` in `cmd/signald/main.go` is 292 lines. It is a linear initialization sequence where each step depends on the previous one. Extracting helpers would require returning multiple values per step, making the code harder to follow, not easier.
- `handleWS` is 194 lines. The write pump and read pump are tightly coupled to local variables (`ws`, `conn`, `number`, context). Extracting them to named functions would require passing 6+ parameters; the current closure form is idiomatic gorilla/websocket.
- The remaining `_ = ws.SetReadDeadline` on the pong-timeout path (line 138+) is low risk: the pong handler fires on an established connection where deadline errors indicate the connection is already broken, and the subsequent `ReadMessage` will catch that immediately.

---

## Changes

### `server/internal/dbutil/dbutil_test.go` (new)

Table-driven unit tests for `Placeholders(n int) string`, covering `n < 0`, `n = 0`, `n = 1`, `n = 2`, `n = 3`, and `n = 5`.

### `server/internal/version/version_test.go` (new)

Verifies that `Version` and `Commit` package vars have non-empty defaults so a binary accidentally built without `-ldflags` is detectable.

### `server/internal/web/handler_ws.go`

Both `SetReadDeadline` calls on the register-message path now check the returned error. On failure: log at Error level, close the connection, and return. This is safe because the write pump has not been started yet at these points.

### `server/internal/web/handler_phones.go`

`handlePhoneRestart` now calls `jsonError(w, "mode must be 'service' or 'reboot'", http.StatusBadRequest)` instead of manually setting headers and encoding. Behavior is identical; gains the encode-error log that `jsonError` provides.

---

## Grade rationale

| Dimension | Before | After |
|---|---|---|
| Test coverage (packages with zero tests) | 3 untested | 1 untested (db only) |
| Error handling correctness | ws deadline silently ignored | deadline errors handled |
| Code consistency | 1 hand-rolled JSON error | all use `jsonError` |
| Architecture, naming, layout | unchanged (already strong) | unchanged |

Before: **72/100** After: **80/100**

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEvFNHEnr1uL1cM2nqnA8Q)_