### PR TITLE
refactor(server): thread ctx through callEndObserver and checkPendingReturn

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -66,7 +66,7 @@ type dashNotifier interface {
 // OnCallEnded or ClearByNumber). Used by the relay to trigger pending
 // call-return retries.
 type callEndObserver interface {
-	OnCallEndedNotify(caller, callee string)
+	OnCallEndedNotify(ctx context.Context, caller, callee string)
 }
 
 type Tracker struct {
@@ -220,7 +220,7 @@ func (t *Tracker) OnCallEnded(ctx context.Context, caller, callee string) error 
 		caller, callee, callee, caller,
 	)
 	if obs != nil {
-		obs.OnCallEndedNotify(caller, callee)
+		obs.OnCallEndedNotify(ctx, caller, callee)
 	}
 	return err
 }
@@ -272,7 +272,7 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 		slog.Warn("clear calls on disconnect failed", "number", number, "err", err)
 	}
 	if obs != nil {
-		obs.OnCallEndedNotify(number, "")
+		obs.OnCallEndedNotify(ctx, number, "")
 	}
 }
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -752,7 +752,7 @@ func (r *Relay) handleCallReturnRetry(ctx context.Context, from string, msg *Mes
 	}
 	r.pendingReturnsMu.Unlock()
 	slog.InfoContext(ctx, "call_return: retry registered", "requester", from, "target", target)
-	r.checkPendingReturn(from)
+	r.checkPendingReturn(ctx, from)
 }
 
 func (r *Relay) handleCallReturnCancel(ctx context.Context, from string) {
@@ -766,7 +766,7 @@ func (r *Relay) handleCallReturnCancel(ctx context.Context, from string) {
 	_ = r.Hub.SendTo(from, &Message{Type: TypeCallReturnCancelled})
 }
 
-func (r *Relay) checkPendingReturn(requester string) {
+func (r *Relay) checkPendingReturn(ctx context.Context, requester string) {
 	r.pendingReturnsMu.Lock()
 	pending, ok := r.pendingReturns[requester]
 	if !ok {
@@ -792,14 +792,14 @@ func (r *Relay) checkPendingReturn(requester string) {
 		if !stillPending {
 			return
 		}
-		slog.Info("call_return: target free, ringing requester", "requester", requester, "target", target)
+		slog.InfoContext(ctx, "call_return: target free, ringing requester", "requester", requester, "target", target)
 		_ = r.Hub.SendTo(requester, &Message{Type: TypeCallReturnRing, Number: target})
 	}
 }
 
 // OnCallEndedNotify is called by the tracker when a 2-party call ends.
 // It checks if any pending call-return retries should now fire.
-func (r *Relay) OnCallEndedNotify(caller, callee string) {
+func (r *Relay) OnCallEndedNotify(ctx context.Context, caller, callee string) {
 	r.pendingReturnsMu.Lock()
 	var toCheck []string
 	for requester, pending := range r.pendingReturns {
@@ -815,7 +815,7 @@ func (r *Relay) OnCallEndedNotify(caller, callee string) {
 	r.pendingReturnsMu.Unlock()
 
 	for _, requester := range toCheck {
-		r.checkPendingReturn(requester)
+		r.checkPendingReturn(ctx, requester)
 	}
 
 	if callee == "" {

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1223,7 +1223,7 @@ func TestRelayCallReturnRetryBusyThenFree(t *testing.T) {
 	}
 
 	delete(tracker.calls, "3140002→3140003")
-	relay.OnCallEndedNotify("3140002", "3140003")
+	relay.OnCallEndedNotify(context.Background(), "3140002", "3140003")
 
 	select {
 	case data := <-conn1.Send:
@@ -1266,7 +1266,7 @@ func TestRelayCallReturnCancel(t *testing.T) {
 	}
 
 	delete(tracker.calls, "3140002→3140003")
-	relay.OnCallEndedNotify("3140002", "3140003")
+	relay.OnCallEndedNotify(context.Background(), "3140002", "3140003")
 
 	select {
 	case <-conn1.Send:
@@ -1297,7 +1297,7 @@ func TestRelayCallReturnExpiry(t *testing.T) {
 	relay.pendingReturnsMu.Unlock()
 
 	delete(tracker.calls, "3140002→3140003")
-	relay.OnCallEndedNotify("3140002", "3140003")
+	relay.OnCallEndedNotify(context.Background(), "3140002", "3140003")
 
 	select {
 	case <-conn1.Send:


### PR DESCRIPTION
## Cross-PR finding

Holistic review of merges in the last 24h spotted drift between the tracing cluster and the *69 cluster:

- #515 (OTel relay spans) systematically converted `slog.X(...)` to `slog.XContext(ctx, ...)` across `server/internal/signaling/relay.go` so every relay log line carries the active span and a `trace_id`.
- #529 (*69 busy-retry phase 2, merged hours later) added `checkPendingReturn(requester string)` and `Relay.OnCallEndedNotify(caller, callee)` without a `ctx` parameter. Adjacent new logs in the same PR (`handleCallReturnRetry`, `handleCallReturnCancel`) used `slog.InfoContext`, but `checkPendingReturn`'s `"call_return: target free, ringing requester"` line at relay.go:795 fell back to plain `slog.Info` because no `ctx` was in scope.

Net effect: one log line out of dozens in `relay.go` produces logs without span correlation, and the fresh convention is one accidental copy-paste away from spreading.

## Fix

Plumb `ctx` through the chain:

- `server/internal/calls/tracker.go`: `callEndObserver.OnCallEndedNotify` now takes `ctx context.Context`. Both internal callsites (`OnCallEnded`, `ClearByNumber`) already had `ctx` in scope.
- `server/internal/signaling/relay.go`: `Relay.OnCallEndedNotify` and `checkPendingReturn` take `ctx`; the previously-orphaned `slog.Info` becomes `slog.InfoContext(ctx, ...)`, matching every other log call in the file.
- `server/internal/signaling/relay_test.go`: three callers updated to pass `context.Background()`.

## Test

- `go build ./...` clean.
- `go test ./internal/calls/... ./internal/signaling/... ./internal/web/...` all pass.
- `go vet ./...` clean.
- (`golangci-lint v2.5.0` in this environment was built with go1.25 and refuses go1.26 modules; CI will run lint normally.)

Motivated by merged PRs: #515, #529 (also #506, #511, #519 as part of the tracing cluster context).