### PR TITLE
fix(digitsd): clear callReturnOrigin when *69 announcement is abandoned

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -348,6 +348,10 @@ func (d *daemonCallbacks) OnCallReturnCancel() {
 	}
 }
 
+func (d *daemonCallbacks) OnCallReturnAbandon() {
+	d.callReturnOrigin.Store(false)
+}
+
 func (d *daemonCallbacks) AnswerCall() {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -71,6 +71,7 @@ type Callbacks interface {
 	OnCallReturn()                                        // *69 detected: query server for last inbound caller
 	SendRingPattern(id int)                               // Send RING:PATTERN:<id> for distinctive ring
 	OnCallReturnCancel()                                  // *89 detected: cancel pending call-return retry
+	OnCallReturnAbandon()                                 // CALL_RETURN exited via on-hook without dialing
 }
 
 // ContactChecker determines whether a number is in the local contact list.
@@ -341,6 +342,7 @@ func (c *Controller) onHookOn() {
 		return
 	}
 	wasConnectedOrCalling := c.state == StateCONNECTED || c.state == StateCALLING
+	wasCallReturn := c.state == StateCALL_RETURN
 	inConferenceFlow := c.confID != "" ||
 		c.state == StateADD_DIALTONE ||
 		c.state == StateADD_DIALING ||
@@ -371,6 +373,12 @@ func (c *Controller) onHookOn() {
 	c.cb.SendLED("OFF")
 	if wasConnectedOrCalling || inConferenceFlow {
 		c.cb.HangupCall()
+	} else if wasCallReturn {
+		// Abandoning the *69 announcement (or *89 cancel announcement) by
+		// hanging up never triggers HangupCall, so the daemon's
+		// callReturnOrigin flag would otherwise persist and steer the next
+		// unrelated busy response into the call-return retry path.
+		go c.cb.OnCallReturnAbandon()
 	}
 	// REMOTE_HANGUP / OFFHOOK_TIMEOUT: nothing to tear down, tones/LED cleaned up above.
 }

--- a/pi/digitsd/internal/phone/controller_call_return_test.go
+++ b/pi/digitsd/internal/phone/controller_call_return_test.go
@@ -249,3 +249,50 @@ func TestController_Star89DetectedInDialing(t *testing.T) {
 		t.Fatalf("expected 1 cancel callback, got %d", cb.CallReturnCancels())
 	}
 }
+
+func TestController_Star69AbandonedFiresAbandon(t *testing.T) {
+	cb := &mockCallbacks{}
+	ctrl := NewController(cb, "3140001")
+
+	ctrl.HandleEvent("HOOK:OFF")
+	ctrl.HandleEvent("KEY:*")
+	ctrl.HandleEvent("KEY:6")
+	ctrl.HandleEvent("KEY:9")
+	if ctrl.State() != StateCALL_RETURN {
+		t.Fatalf("expected CALL_RETURN, got %s", ctrl.State())
+	}
+
+	ctrl.HandleEvent("HOOK:ON")
+	if ctrl.State() != StateIDLE {
+		t.Fatalf("expected IDLE after hangup, got %s", ctrl.State())
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for cb.CallReturnAbandons() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if cb.CallReturnAbandons() != 1 {
+		t.Fatalf("expected 1 abandon callback, got %d", cb.CallReturnAbandons())
+	}
+}
+
+func TestController_OnHookFromConnectedDoesNotFireAbandon(t *testing.T) {
+	cb := &mockCallbacks{}
+	ctrl := NewController(cb, "3140001")
+
+	ctrl.HandleSignal("ring", "3140002")
+	if ctrl.State() != StateRINGING {
+		t.Fatalf("expected RINGING, got %s", ctrl.State())
+	}
+	ctrl.HandleEvent("HOOK:OFF")
+	if ctrl.State() != StateCONNECTED {
+		t.Fatalf("expected CONNECTED, got %s", ctrl.State())
+	}
+
+	ctrl.HandleEvent("HOOK:ON")
+
+	time.Sleep(50 * time.Millisecond)
+	if cb.CallReturnAbandons() != 0 {
+		t.Fatalf("abandon callback should not fire from CONNECTED, got %d", cb.CallReturnAbandons())
+	}
+}

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -25,6 +25,7 @@ type mockCallbacks struct {
 	callReturns        int
 	ringPatterns       []int
 	callReturnCancels  int
+	callReturnAbandons int
 	flashEnabledLog    []bool            // each SetFlashEnabled call recorded in order
 	mutedPeers         map[string]bool   // phone -> current mute state
 	torndownPeers      []string          // peers that had TearDownPeer called
@@ -137,6 +138,11 @@ func (m *mockCallbacks) OnCallReturnCancel() {
 	defer m.mu.Unlock()
 	m.callReturnCancels++
 }
+func (m *mockCallbacks) OnCallReturnAbandon() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callReturnAbandons++
+}
 
 // Snapshot accessors — return copies under lock so test assertions are
 // race-free against goroutines started by the controller.
@@ -184,6 +190,11 @@ func (m *mockCallbacks) CallReturnCancels() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.callReturnCancels
+}
+func (m *mockCallbacks) CallReturnAbandons() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callReturnAbandons
 }
 func (m *mockCallbacks) CallConnectedCalls() int {
 	m.mu.Lock()


### PR DESCRIPTION
## Cross-PR finding

Holistic review of merges in the last 24h spotted a state-machine drift across the *69 phase 1/phase 2 split:

- **#527 (`feat(digitsd): add *69 call return (phase 1)`)** introduced `StateCALL_RETURN`, the FSM state during the *69 announcement. Hanging up while in this state goes through `onHookOn`, which short-circuits to `StateIDLE` without invoking `HangupCall` (the state was never CONNECTED, CALLING, or a conference flow).
- **#529 (`feat: *69 busy-retry with distinctive ring and *89 cancel (phase 2)`)** added a `callReturnOrigin atomic.Bool` flag, set in `OnCallReturn` (entry to `StateCALL_RETURN`) and cleared only in `HangupCall` and the busy-handler consume path.

These two contracts are incompatible. Concrete user-visible consequence:

1. User picks up, dials `*69`, hears "the last call you received was from ...", hangs up without pressing `1`.
2. `callReturnOrigin` stays `true` (no `HangupCall` ever ran).
3. User picks up later, dials a normal number, that target happens to be busy.
4. `digitsd/cmd/digitsd/main.go` (the `TypeBusy` handler in #529) reads the leaked flag and plays the `call_return_retry` announcement and sends `TypeCallReturnRetry` to the server.
5. `signaling/relay.go` registers a pending busy-retry the user never asked for. When the unrelated target later frees up, the user is rung with the distinctive short-short-long pattern and `controller.HandleCallReturnRing` auto-dials on pickup.

The controller's `onSignalBusy` keeps `StateCALLING` on busy (intentional, so the user can hang up at their own pace), so the +500ms guard inside the `TypeBusy` goroutine doesn't catch this; the retry path runs.

## Fix

Add an `OnCallReturnAbandon` callback that the controller fires from `onHookOn` when the prior state was `StateCALL_RETURN`. The daemon clears `callReturnOrigin` in response. Lifecycle is now:

- Set: `OnCallReturn` (entering `StateCALL_RETURN` for *69).
- Cleared: `HangupCall` (call ended), busy-handler consume (retry registered), **`OnCallReturnAbandon`** (announcement abandoned by hook-on).

The callback also fires when the user hangs up during the *89 cancel announcement, which is harmless: that path never sets the flag.

## Test plan

- New `TestController_Star69AbandonedFiresAbandon` asserts the abandon callback fires once after a `*69`-then-hangup sequence.
- New `TestController_OnHookFromConnectedDoesNotFireAbandon` is a regression guard: hanging up from CONNECTED (where HangupCall already handles teardown) must not fire the abandon callback.
- `go test ./pi/digitsd/internal/phone/...` clean.
- `go vet ./...` clean.
- (golangci-lint v2.5.0 in this environment is built against Go 1.25 and refuses the project's Go 1.26 target; it could not run here.)

## Motivated by (last 24h)

- #527: feat(digitsd): add *69 call return (phase 1)
- #529: feat: *69 busy-retry with distinctive ring and *89 cancel (phase 2)