### PR TITLE
fix(digitsd): clear *69 callback-ring state in Controller.Reset

### DIFF
--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -213,14 +213,19 @@ func (s State) IsDialPhase() bool {
 	return s == StateDIALTONE || s == StateDIALING
 }
 
-// Reset forces the controller back to IDLE with no pending digits.
-// Used after terminal service codes (shutdown, reboot, etc.) where the
-// daemon is going down and the FSM state no longer matters.
+// Reset forces the controller back to IDLE with no pending digits or
+// per-call state. Used after terminal service codes (shutdown, reboot)
+// and from the WebSocket reconnect teardown, where leaving the *69
+// callback-ring fields populated would mis-route the next unrelated
+// incoming call's pickup into an auto-dial of the stale callback target.
 func (c *Controller) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.state = StateIDLE
 	c.digits = ""
+	c.callReturnNumber = ""
+	c.callReturnRinging = false
+	c.callReturnTarget = ""
 }
 
 // ResetToDialtone forces the controller back to DIALTONE with no pending

--- a/pi/digitsd/internal/phone/controller_call_return_test.go
+++ b/pi/digitsd/internal/phone/controller_call_return_test.go
@@ -296,3 +296,45 @@ func TestController_OnHookFromConnectedDoesNotFireAbandon(t *testing.T) {
 		t.Fatalf("abandon callback should not fire from CONNECTED, got %d", cb.CallReturnAbandons())
 	}
 }
+
+// TestController_ResetClearsCallbackRingState is the regression guard for the
+// WebSocket-reconnect teardown path. The reconnect code in cmd/digitsd/main.go
+// calls ctrl.Reset() to force the FSM back to IDLE; before this fix Reset()
+// only cleared state and digits, so the *69 callback-ring fields
+// (callReturnRinging / callReturnTarget) survived the teardown. A subsequent
+// unrelated incoming call would then auto-dial the stale callback target on
+// pickup instead of answering the new caller.
+func TestController_ResetClearsCallbackRingState(t *testing.T) {
+	cb := &mockCallbacks{}
+	ctrl := NewController(cb, "3140001")
+
+	// Server detected the *69 retry target free, so the controller is ringing
+	// the requester with the distinctive callback pattern.
+	ctrl.HandleCallReturnRing("3140002")
+	if ctrl.State() != StateRINGING {
+		t.Fatalf("setup: expected RINGING, got %s", ctrl.State())
+	}
+
+	// WebSocket drops and reconnects mid-callback-ring. The reconnect code
+	// path calls Reset to drop the FSM back to IDLE.
+	ctrl.Reset()
+	if ctrl.State() != StateIDLE {
+		t.Fatalf("expected IDLE after Reset, got %s", ctrl.State())
+	}
+
+	// Now an unrelated incoming call rings. Pickup must answer it, not
+	// auto-dial the stale 3140002 callback target.
+	ctrl.HandleSignal("ring", "3140003")
+	if ctrl.State() != StateRINGING {
+		t.Fatalf("expected RINGING for unrelated incoming call, got %s", ctrl.State())
+	}
+	ctrl.HandleEvent("HOOK:OFF")
+	if ctrl.State() != StateCONNECTED {
+		t.Fatalf("expected CONNECTED on pickup, got %s", ctrl.State())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if calls := cb.Calls(); len(calls) != 0 {
+		t.Fatalf("expected no auto-dial after Reset cleared callback fields, got %v", calls)
+	}
+}


### PR DESCRIPTION
## Cross-PR finding

Holistic review of merges in the last 24h spotted a state-machine drift across the WebSocket-reconnect teardown and the *69 callback-ring fields:

- **#526 (`fix(digitsd): tear down stale call state on WebSocket reconnect`)** added the reconnect teardown in `cmd/digitsd/main.go`. After a successful reconnect with a non-IDLE controller, it runs `cb.TearDownAllMeshPeers(); cb.HangupCall(); ctrl.Reset()` to drop the local call that the server already cleaned up.
- **#527 (`feat(digitsd): add *69 call return (phase 1)`)** introduced `StateCALL_RETURN` and the `callReturnNumber` field on the controller.
- **#529 (`feat: *69 busy-retry with distinctive ring and *89 cancel (phase 2)`)** introduced the *69 callback-ring fields `callReturnRinging` and `callReturnTarget` plus the auto-dial branch inside `onHookOff` for `StateRINGING`.

`Controller.Reset()` was added before any of the *69 fields existed and only clears `state` and `digits`. When the WebSocket drops mid-callback-ring (`StateRINGING` with `callReturnRinging=true`), the reconnect teardown forces state to IDLE but leaves the callback-ring fields populated.

User-visible consequence:

1. *69 retry has fired, server detected the target free, requester is ringing with the distinctive short-short-long pattern (`callReturnRinging=true`, `callReturnTarget=X`).
2. WebSocket drops before the user picks up.
3. WS reconnects. Teardown runs `HangupCall()` (which clears the daemon's `callReturnOrigin` atomic) and `ctrl.Reset()`. State -> IDLE, but `callReturnRinging` and `callReturnTarget` remain set.
4. An unrelated incoming call rings. `onSignalRing` transitions IDLE -> RINGING and does not touch the callback fields.
5. User picks up. `onHookOff` for `StateRINGING` checks `if c.callReturnRinging` (true) and auto-dials `callReturnTarget=X` instead of answering the unrelated incoming call.

This is the same class of bug as the daemon-side leak that #538 fixed for the on-hook path, just on the controller side and via a different exit path.

## Fix

Make `Controller.Reset()` actually reset the per-call FSM state by clearing `callReturnNumber`, `callReturnRinging`, and `callReturnTarget` in addition to `state` and `digits`. The terminal-service-code call site (shutdown/reboot/factory reset) doesn't care either way since the daemon is exiting; the WS-reconnect call site needs the full clear.

The daemon's `callReturnOrigin` atomic is already cleared by `cb.HangupCall()` before `ctrl.Reset()` runs, so this PR doesn't touch the daemon side.

## Test plan

- New `TestController_ResetClearsCallbackRingState` is a regression guard: `HandleCallReturnRing` -> `Reset` -> unrelated `HandleSignal("ring", ...)` -> `HOOK:OFF` must answer the new ring (state CONNECTED, no auto-dial), not call `InitiateCall(stale_target)`.
- Existing `TestController_Reset`, `TestController_CallReturnRing`, `TestController_CallReturnPickupAutoDials`, `TestController_Star69AbandonedFiresAbandon` still pass.
- `go test ./pi/digitsd/internal/phone/...` clean.
- `go vet ./pi/digitsd/...` clean.
- (golangci-lint v2.5.0 in this environment is built against Go 1.25 and refuses the project's Go 1.26 target; same constraint as #538.)

## Motivated by (last 24h)

- #526: fix(digitsd): tear down stale call state on WebSocket reconnect
- #527: feat(digitsd): add *69 call return (phase 1)
- #529: feat: *69 busy-retry with distinctive ring and *89 cancel (phase 2)
- #538: fix(digitsd): clear callReturnOrigin when *69 announcement is abandoned (parallel daemon-side leak in the on-hook path)
