### PR TITLE
fix(server): propagate request context to all slog calls

### DIFF
--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -125,7 +125,7 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		case err == nil:
 			// Link Google ID to existing account
 			if err := g.store.LinkGoogleID(r.Context(), user.ID, info.ID); err != nil {
-				slog.Warn("auth: failed to link google ID for user", "user_id", user.ID, "error", err)
+				slog.WarnContext(r.Context(), "auth: failed to link google ID for user", "user_id", user.ID, "error", err)
 			}
 		case errors.Is(err, ErrUserNotFound):
 			// New user
@@ -136,18 +136,18 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		default:
-			slog.Error("auth: google callback lookup by email", "err", err)
+			slog.ErrorContext(r.Context(), "auth: google callback lookup by email", "err", err)
 			http.Error(w, "failed to look up user", http.StatusInternalServerError)
 			return
 		}
 	default:
-		slog.Error("auth: google callback lookup by google id", "err", err)
+		slog.ErrorContext(r.Context(), "auth: google callback lookup by google id", "err", err)
 		http.Error(w, "failed to look up user", http.StatusInternalServerError)
 		return
 	}
 
 	if err := g.store.UpdateLastLogin(r.Context(), user.ID); err != nil {
-		slog.Warn("auth: failed to update last login for user", "user_id", user.ID, "error", err)
+		slog.WarnContext(r.Context(), "auth: failed to update last login for user", "user_id", user.ID, "error", err)
 	}
 
 	// Create session

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -48,7 +48,7 @@ func (h *Handlers) HandleLoginPage(w http.ResponseWriter, r *http.Request) {
 		"Success":       r.URL.Query().Get("success"),
 	}
 	if err := h.loginTmpl.ExecuteTemplate(w, "layout-v2.html", data); err != nil {
-		slog.Error("login template render failed", "err", err)
+		slog.ErrorContext(r.Context(), "login template render failed", "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
@@ -68,7 +68,7 @@ func (h *Handlers) HandleMagicLinkRequest(w http.ResponseWriter, r *http.Request
 
 	token, err := h.store.CreateMagicLink(r.Context(), emailAddr, 15*time.Minute, returnTo)
 	if err != nil {
-		slog.Error("magic link creation failed", "err", err)
+		slog.ErrorContext(r.Context(), "magic link creation failed", "err", err)
 		http.Redirect(w, r, "/auth/login?error=try+again", http.StatusSeeOther)
 		return
 	}
@@ -76,12 +76,12 @@ func (h *Handlers) HandleMagicLinkRequest(w http.ResponseWriter, r *http.Request
 	link := fmt.Sprintf("%s/auth/magic/%s", h.baseURL, token)
 
 	if h.devMode {
-		slog.Warn("dev magic link", "email", emailAddr, "link", link)
+		slog.WarnContext(r.Context(), "dev magic link", "email", emailAddr, "link", link)
 	}
 
 	subject, body := email.MagicLinkEmail(link)
 	if err := h.emailer.Send(emailAddr, subject, body); err != nil {
-		slog.Error("magic link email failed", "err", err)
+		slog.ErrorContext(r.Context(), "magic link email failed", "err", err)
 	}
 
 	http.Redirect(w, r, "/auth/login?success=check+your+email", http.StatusSeeOther)
@@ -105,13 +105,13 @@ func (h *Handlers) HandleMagicLinkVerify(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	} else if err != nil {
-		slog.Error("magic link verify: lookup user", "err", err)
+		slog.ErrorContext(r.Context(), "magic link verify: lookup user", "err", err)
 		http.Error(w, "failed to look up user", http.StatusInternalServerError)
 		return
 	}
 
 	if err := h.store.UpdateLastLogin(r.Context(), user.ID); err != nil {
-		slog.Error("failed to update last login", "user_id", user.ID, "err", err)
+		slog.ErrorContext(r.Context(), "failed to update last login", "user_id", user.ID, "err", err)
 	}
 
 	sessionToken, _, err := h.store.CreateSession(r.Context(), user.ID, SessionTTL)
@@ -147,7 +147,7 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		emailAddr = "e2e@example.com"
 	}
 
-	slog.Info("dev-session requested", "email", emailAddr)
+	slog.InfoContext(r.Context(), "dev-session requested", "email", emailAddr)
 
 	// Find or create user (same pattern as HandleMagicLinkVerify)
 	user, err := h.store.GetUserByEmail(r.Context(), emailAddr)
@@ -161,18 +161,18 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		// click through the theme picker on every run. The picker can still be
 		// exercised locally by flipping theme_chosen back to false in SQL.
 		if err := h.store.MarkThemeChosen(r.Context(), user.ID); err != nil {
-			slog.Error("dev-session: mark theme chosen", "err", err, "user_id", user.ID)
+			slog.ErrorContext(r.Context(), "dev-session: mark theme chosen", "err", err, "user_id", user.ID)
 		} else {
 			user.ThemeChosen = true
 		}
 	} else if err != nil {
-		slog.Error("dev-session: lookup user", "err", err)
+		slog.ErrorContext(r.Context(), "dev-session: lookup user", "err", err)
 		http.Error(w, "failed to look up user", http.StatusInternalServerError)
 		return
 	}
 
 	if err := h.store.UpdateLastLogin(r.Context(), user.ID); err != nil {
-		slog.Error("failed to update last login", "user_id", user.ID, "err", err)
+		slog.ErrorContext(r.Context(), "failed to update last login", "user_id", user.ID, "err", err)
 	}
 
 	sessionToken, _, err := h.store.CreateSession(r.Context(), user.ID, SessionTTL)
@@ -236,7 +236,7 @@ func (h *Handlers) HandleLogout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(CookieName)
 	if err == nil {
 		if err := h.store.DeleteSession(r.Context(), cookie.Value); err != nil {
-			slog.Error("failed to delete session", "err", err)
+			slog.ErrorContext(r.Context(), "failed to delete session", "err", err)
 		}
 	}
 	clearSessionCookie(w, h.cookieDomain)

--- a/server/internal/calls/state_redis.go
+++ b/server/internal/calls/state_redis.go
@@ -35,12 +35,12 @@ func (s *CallState) OnCallInitiated(ctx context.Context, callID int64, caller, c
 
 	callerEntry, err := json.Marshal(callEntry{ID: callID, Role: "caller", StartedAt: now})
 	if err != nil {
-		slog.Error("redis: marshal caller entry failed", "err", err)
+		slog.ErrorContext(ctx, "redis: marshal caller entry failed", "err", err)
 		return
 	}
 	calleeEntry, err := json.Marshal(callEntry{ID: callID, Role: "callee", StartedAt: now})
 	if err != nil {
-		slog.Error("redis: marshal callee entry failed", "err", err)
+		slog.ErrorContext(ctx, "redis: marshal callee entry failed", "err", err)
 		return
 	}
 
@@ -52,7 +52,7 @@ func (s *CallState) OnCallInitiated(ctx context.Context, callID int64, caller, c
 	pipe.Expire(ctx, callerKey, callTTL)
 	pipe.Expire(ctx, calleeKey, callTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: OnCallInitiated failed", "callID", callID, "err", err)
+		slog.ErrorContext(ctx, "redis: OnCallInitiated failed", "callID", callID, "err", err)
 	}
 }
 
@@ -61,7 +61,7 @@ func (s *CallState) OnCallEnded(ctx context.Context, caller, callee string) {
 	pipe.HDel(ctx, callKeyPrefix+caller, callee)
 	pipe.HDel(ctx, callKeyPrefix+callee, caller)
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: OnCallEnded failed", "caller", caller, "callee", callee, "err", err)
+		slog.ErrorContext(ctx, "redis: OnCallEnded failed", "caller", caller, "callee", callee, "err", err)
 		return
 	}
 
@@ -74,7 +74,7 @@ func (s *CallState) ClearByNumber(ctx context.Context, number string) {
 	key := callKeyPrefix + number
 	entries, err := s.client.HGetAll(ctx, key).Result()
 	if err != nil {
-		slog.Error("redis: ClearByNumber HGetAll failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: ClearByNumber HGetAll failed", "number", number, "err", err)
 		return
 	}
 	if len(entries) == 0 {
@@ -87,7 +87,7 @@ func (s *CallState) ClearByNumber(ctx context.Context, number string) {
 		pipe.HDel(ctx, callKeyPrefix+peer, number)
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: ClearByNumber pipeline failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: ClearByNumber pipeline failed", "number", number, "err", err)
 		return
 	}
 
@@ -100,7 +100,7 @@ func (s *CallState) ClearByNumber(ctx context.Context, number string) {
 func (s *CallState) Busy(ctx context.Context, number string) bool {
 	n, err := s.client.Exists(ctx, callKeyPrefix+number).Result()
 	if err != nil {
-		slog.Error("redis: Busy failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: Busy failed", "number", number, "err", err)
 		return false
 	}
 	return n > 0
@@ -109,7 +109,7 @@ func (s *CallState) Busy(ctx context.Context, number string) bool {
 func (s *CallState) PeerOf(ctx context.Context, number string) string {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
-		slog.Error("redis: PeerOf failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: PeerOf failed", "number", number, "err", err)
 		return ""
 	}
 	for peer := range entries {
@@ -121,7 +121,7 @@ func (s *CallState) PeerOf(ctx context.Context, number string) string {
 func (s *CallState) AllPeersOf(ctx context.Context, number string) []string {
 	keys, err := s.client.HKeys(ctx, callKeyPrefix+number).Result()
 	if err != nil {
-		slog.Error("redis: AllPeersOf failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: AllPeersOf failed", "number", number, "err", err)
 		return nil
 	}
 	return keys
@@ -130,7 +130,7 @@ func (s *CallState) AllPeersOf(ctx context.Context, number string) []string {
 func (s *CallState) InCall(ctx context.Context, a, b string) bool {
 	exists, err := s.client.HExists(ctx, callKeyPrefix+a, b).Result()
 	if err != nil {
-		slog.Error("redis: InCall failed", "a", a, "b", b, "err", err)
+		slog.ErrorContext(ctx, "redis: InCall failed", "a", a, "b", b, "err", err)
 		return false
 	}
 	return exists
@@ -139,7 +139,7 @@ func (s *CallState) InCall(ctx context.Context, a, b string) bool {
 func (s *CallState) CallIDFor(ctx context.Context, number string) (int64, bool) {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
-		slog.Error("redis: CallIDFor failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: CallIDFor failed", "number", number, "err", err)
 		return 0, false
 	}
 	for _, raw := range entries {
@@ -175,7 +175,7 @@ func (s *CallState) CallIDForPair(ctx context.Context, a, b string) int64 {
 func (s *CallState) CanAddAsHost(ctx context.Context, number string) bool {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
-		slog.Error("redis: CanAddAsHost failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: CanAddAsHost failed", "number", number, "err", err)
 		return false
 	}
 	if len(entries) != 1 {
@@ -233,7 +233,7 @@ func (s *CallState) Active(ctx context.Context) []activeCall {
 		}
 	}
 	if err := iter.Err(); err != nil {
-		slog.Error("redis: Active scan failed", "err", err)
+		slog.ErrorContext(ctx, "redis: Active scan failed", "err", err)
 	}
 	return calls
 }

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -269,7 +269,7 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 		 AND status IN ('initiated', 'ringing', 'connected')`,
 		number,
 	); err != nil {
-		slog.Warn("clear calls on disconnect failed", "number", number, "err", err)
+		slog.WarnContext(ctx, "clear calls on disconnect failed", "number", number, "err", err)
 	}
 	if obs != nil {
 		obs.OnCallEndedNotify(ctx, number, "")
@@ -577,7 +577,7 @@ func (t *Tracker) CreateConferencePersistent(ctx context.Context, host string, o
 	if h != nil {
 		h.InitConference(conf.ID)
 	}
-	slog.Info("conference: persisted", "conf_id", conf.ID.String(), "host", host, "originating_call_id", originatingCallID, "added_members", addedMembers)
+	slog.InfoContext(ctx, "conference: persisted", "conf_id", conf.ID.String(), "host", host, "originating_call_id", originatingCallID, "added_members", addedMembers)
 	return conf, nil
 }
 
@@ -613,7 +613,7 @@ func (t *Tracker) EndConferencePersistent(ctx context.Context, confID uuid.UUID,
 	if h != nil {
 		h.EvictConference(confID)
 	}
-	slog.Info("conference: end persisted", "conf_id", confID.String(), "reason", reason)
+	slog.InfoContext(ctx, "conference: end persisted", "conf_id", confID.String(), "reason", reason)
 	return nil
 }
 
@@ -632,7 +632,7 @@ func (t *Tracker) RecordKick(ctx context.Context, confID uuid.UUID, kickedPhone,
 	if err != nil {
 		return fmt.Errorf("record kick: %w", err)
 	}
-	slog.Info("conference: kick audited", "conf_id", confID.String(), "kicked", kickedPhone, "by_user", userID)
+	slog.InfoContext(ctx, "conference: kick audited", "conf_id", confID.String(), "kicked", kickedPhone, "by_user", userID)
 	return nil
 }
 
@@ -754,7 +754,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 	if h != nil && ended {
 		h.EvictConference(confID)
 	}
-	slog.Info("conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining, "ended", ended)
+	slog.InfoContext(ctx, "conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining, "ended", ended)
 	return remaining, ended, nil
 }
 

--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -23,8 +23,8 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 	if h.lineStore != nil {
 		lines, err := h.lineStore.List(r.Context())
 		if err != nil {
-			slog.Error("stats: list lines failed", "err", err)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
+			slog.ErrorContext(r.Context(), "stats: list lines failed", "err", err)
+			jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 		lineCount = len(lines)
@@ -45,8 +45,8 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 		var err error
 		totalUsers, err = h.authStore.CountUsers(r.Context())
 		if err != nil {
-			slog.Error("stats: count users failed", "err", err)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
+			slog.ErrorContext(r.Context(), "stats: count users failed", "err", err)
+			jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -56,8 +56,8 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 		var err error
 		totalHouseholds, err = h.householdStore.CountHouseholds(r.Context())
 		if err != nil {
-			slog.Error("stats: count households failed", "err", err)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
+			slog.ErrorContext(r.Context(), "stats: count households failed", "err", err)
+			jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -67,8 +67,8 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 		var err error
 		totalLinks, err = h.linkStore.CountActiveLinks(r.Context())
 		if err != nil {
-			slog.Error("stats: count active links failed", "err", err)
-			jsonError(w, "internal server error", http.StatusInternalServerError)
+			slog.ErrorContext(r.Context(), "stats: count active links failed", "err", err)
+			jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -82,7 +82,7 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 		"active_calls":     activeCallCount,
 		"total_links":      totalLinks,
 	}); err != nil {
-		slog.Error("stats: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "stats: json encode failed", "err", err)
 	}
 }
 
@@ -113,7 +113,7 @@ func (h *Handler) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 		"online_lines": onlineCount,
 		"active_calls": activeCount,
 	}); err != nil {
-		slog.Error("api status: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "api status: json encode failed", "err", err)
 	}
 }
 
@@ -145,25 +145,25 @@ func (h *Handler) handleAPIActiveCalls(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pairs); err != nil {
-		slog.Error("active calls: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "active calls: json encode failed", "err", err)
 	}
 }
 
 func (h *Handler) handleAPINumberAvailable(w http.ResponseWriter, r *http.Request) {
 	number := line.StripNumber(r.URL.Query().Get("number"))
 	if err := line.ValidateNumber(number); err != nil {
-		jsonError(w, err.Error(), http.StatusBadRequest)
+		jsonError(r.Context(), w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	exists, err := h.lineStore.NumberExists(r.Context(), number)
 	if err != nil {
-		slog.Error("number available check failed", "err", err)
-		jsonError(w, "internal server error", http.StatusInternalServerError)
+		slog.ErrorContext(r.Context(), "number available check failed", "err", err)
+		jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]bool{"available": !exists}); err != nil {
-		slog.Error("number available: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "number available: json encode failed", "err", err)
 	}
 }
 
@@ -173,6 +173,6 @@ func (h *Handler) handleAPIVersion(w http.ResponseWriter, r *http.Request) {
 		"version": version.Version,
 		"commit":  version.Commit,
 	}); err != nil {
-		slog.Error("api version: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "api version: json encode failed", "err", err)
 	}
 }

--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -36,7 +36,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 	if h.lineStore != nil {
 		lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("list lines for household failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "list lines for household failed", "household_id", hh.ID, "err", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -47,7 +47,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 			}
 			hist, err := h.tracker.RecentHistoryForPhones(r.Context(), numbers, cursor, callsPageSize)
 			if err != nil {
-				slog.Error("query recent history failed", "err", err)
+				slog.ErrorContext(r.Context(), "query recent history failed", "err", err)
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 				return
 			}
@@ -75,7 +75,7 @@ func (h *Handler) handleCalls(w http.ResponseWriter, r *http.Request) {
 		entries[i].SortTime = entries[i].SortTime.In(loc)
 	}
 
-	renderWith(w, h.tmplCalls, layoutFor(r), callsData{
+	renderWith(r.Context(), w, h.tmplCalls, layoutFor(r), callsData{
 		chromeData:  h.newChromeDataWithHouseholds(r, "calls"),
 		Entries:     entries,
 		OlderCursor: olderCursor,
@@ -111,13 +111,13 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 	linkedIndex := h.linkedIndexForCall(r.Context(), ownedLines)
 	callerEp, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex, ownedLines)
 	if err != nil {
-		slog.Error("call-live: build caller endpoint failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "call-live: build caller endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	calleeEp, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex, ownedLines)
 	if err != nil {
-		slog.Error("call-live: build callee endpoint failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "call-live: build callee endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -131,7 +131,7 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		ForceEndedBy: h.forceEndedLabel(r.Context(), call),
 	}
 
-	renderWith(w, h.tmplCallLiveDetail, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplCallLiveDetail, layoutFor(r), data)
 }
 
 // forceEndedLabel returns the display label for who force-ended a call.

--- a/server/internal/web/handler_changelog.go
+++ b/server/internal/web/handler_changelog.go
@@ -32,7 +32,7 @@ func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
 				lines = append(lines, l.Number)
 			}
 		} else {
-			slog.Error("changelog: list lines failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "changelog: list lines failed", "household_id", hh.ID, "err", err)
 		}
 	}
 
@@ -48,7 +48,7 @@ func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
 		data.Firmware = buildChangelogSection(idx, updates.ComponentFirmware, lines, h)
 	}
 
-	renderWith(w, h.tmplChangelog, "changelog-content", data)
+	renderWith(r.Context(), w, h.tmplChangelog, "changelog-content", data)
 }
 
 func buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []string, h *Handler) []changelogRelease {

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -66,7 +66,7 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		slog.Error("conference_link_health encode failed", "conf_id", confID, "err", err)
+		slog.ErrorContext(r.Context(), "conference_link_health encode failed", "conf_id", confID, "err", err)
 	}
 }
 
@@ -127,7 +127,7 @@ func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid
 	// DB fallback.
 	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, calls.RingCapacity)
 	if err != nil {
-		slog.Warn("ReadbackEdge failed; serving empty window",
+		slog.WarnContext(ctx, "ReadbackEdge failed; serving empty window",
 			"conf_id", confID, "from", from, "peer", peer, "err", err)
 		return out
 	}
@@ -165,7 +165,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		slog.Error("SSE conference stream: ResponseWriter does not implement Flusher")
+		slog.ErrorContext(r.Context(), "SSE conference stream: ResponseWriter does not implement Flusher")
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
@@ -191,7 +191,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
 	if err != nil {
-		slog.Error("SSE conference stream: initial render failed", "conf_id", confID, "err", err)
+		slog.ErrorContext(r.Context(), "SSE conference stream: initial render failed", "conf_id", confID, "err", err)
 		return
 	}
 	if werr := writeSSE(w, "sample", fragment); werr != nil {
@@ -213,7 +213,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 				return
 			}
 			if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, ownedLines, linkedIndex, ev); err != nil {
-				slog.Debug("SSE conference stream: write failed", "conf_id", confID, "err", err)
+				slog.DebugContext(r.Context(), "SSE conference stream: write failed", "conf_id", confID, "err", err)
 				return
 			}
 		case <-heartbeat.C:
@@ -290,7 +290,7 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 		Resp:            resp,
 		IsHostHousehold: isHostHH,
 	}
-	renderWith(w, h.tmplConferenceLiveDetail, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplConferenceLiveDetail, layoutFor(r), data)
 }
 
 // handleConferenceKick force-ends a conference on behalf of the host
@@ -336,7 +336,7 @@ func (h *Handler) handleConferenceKick(w http.ResponseWriter, r *http.Request) {
 
 	// Audit first: if downstream teardown fails, the record still lands.
 	if err := h.tracker.RecordKick(r.Context(), confID, kickedPhone, user.ID); err != nil {
-		slog.Error("conference_kick: audit write failed", "conf_id", confID, "err", err)
+		slog.ErrorContext(r.Context(), "conference_kick: audit write failed", "conf_id", confID, "err", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -188,7 +188,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			Now:            now,
 		},
 	}
-	renderWith(w, h.tmplDashboard, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplDashboard, layoutFor(r), data)
 }
 
 // buildLinkedFamilies fetches the list of linked households and their lines
@@ -200,7 +200,7 @@ func (h *Handler) buildLinkedFamilies(ctx context.Context, householdID string) [
 	}
 	activeLinks, err := h.linkStore.GetLinkedHouseholds(ctx, householdID)
 	if err != nil {
-		slog.Error("buildLinkedFamilies: get linked households failed", "err", err)
+		slog.ErrorContext(ctx, "buildLinkedFamilies: get linked households failed", "err", err)
 		return nil
 	}
 	otherIDs := make([]string, 0, len(activeLinks))
@@ -213,7 +213,7 @@ func (h *Handler) buildLinkedFamilies(ctx context.Context, householdID string) [
 	}
 	linesByHousehold, err := h.lineStore.ListByHouseholds(ctx, otherIDs)
 	if err != nil {
-		slog.Error("buildLinkedFamilies: batch list lines failed", "err", err)
+		slog.ErrorContext(ctx, "buildLinkedFamilies: batch list lines failed", "err", err)
 	}
 	var families []linkedFamilyRow
 	for i, l := range activeLinks {
@@ -290,7 +290,7 @@ func (h *Handler) handleConnecting(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	renderWith(w, h.tmplConnecting, "connecting.html", connectingData{
+	renderWith(r.Context(), w, h.tmplConnecting, "connecting.html", connectingData{
 		chromeData: h.newChromeDataWithHouseholds(r, "connecting"),
 	})
 }

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -42,7 +42,7 @@ func (h *Handler) handleDashboardStream(w http.ResponseWriter, r *http.Request) 
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		slog.Error("dashboard SSE: ResponseWriter does not implement Flusher")
+		slog.ErrorContext(r.Context(), "dashboard SSE: ResponseWriter does not implement Flusher")
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
@@ -81,7 +81,7 @@ func (h *Handler) writeDashStatus(w http.ResponseWriter, flusher http.Flusher, r
 	vm := h.computeDashStatus(r, hh)
 	fragment, err := h.renderDashStatus(vm)
 	if err != nil {
-		slog.Error("dashboard SSE: render failed", "err", err)
+		slog.ErrorContext(r.Context(), "dashboard SSE: render failed", "err", err)
 		return err
 	}
 	if err := writeSSE(w, "status", fragment); err != nil {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -84,7 +84,7 @@ func (h *Handler) requireLineOwnershipWithHousehold(w http.ResponseWriter, r *ht
 func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[string]*line.Line, *household.Household, bool) {
 	households, err := h.householdStore.GetForUser(ctx, user.ID)
 	if err != nil {
-		slog.Error("ownedLinesForUser: list households failed", "user_id", user.ID, "err", err)
+		slog.ErrorContext(ctx, "ownedLinesForUser: list households failed", "user_id", user.ID, "err", err)
 		return nil, nil, false
 	}
 	if len(households) == 0 {
@@ -94,7 +94,7 @@ func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[s
 	for _, hh := range households {
 		hhLines, err := h.lineStore.ListByHousehold(ctx, hh.ID)
 		if err != nil {
-			slog.Error("ownedLinesForUser: list lines failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(ctx, "ownedLinesForUser: list lines failed", "household_id", hh.ID, "err", err)
 			return nil, nil, false
 		}
 		for i := range hhLines {
@@ -127,7 +127,7 @@ func (h *Handler) requireCallEndpointOwnership(w http.ResponseWriter, r *http.Re
 	call, callErr := h.tracker.GetCall(r.Context(), callID)
 
 	if callErr != nil {
-		slog.Error("link_health: get call failed", "call_id", callID, "err", callErr)
+		slog.ErrorContext(r.Context(), "link_health: get call failed", "call_id", callID, "err", callErr)
 		http.NotFound(w, r)
 		return calls.Call{}, nil, nil, false
 	}
@@ -158,7 +158,7 @@ func (h *Handler) loadConferenceForUser(w http.ResponseWriter, r *http.Request, 
 	ownedLines, primaryHH, ok := h.ownedLinesForUser(r.Context(), user)
 	conf, confErr := h.tracker.GetConferenceByID(r.Context(), confID)
 	if confErr != nil {
-		slog.Error(errLog+": get conference failed", "conf_id", confID, "err", confErr)
+		slog.ErrorContext(r.Context(), errLog+": get conference failed", "conf_id", confID, "err", confErr)
 		http.NotFound(w, r)
 		return nil, nil, nil, false
 	}
@@ -373,7 +373,7 @@ func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chro
 		if h.lineStore != nil {
 			silent, err := h.lineStore.AllSilentByHousehold(r.Context(), active.ID)
 			if err != nil {
-				slog.Error("check all-silent failed", "household_id", active.ID, "err", err)
+				slog.ErrorContext(r.Context(), "check all-silent failed", "household_id", active.ID, "err", err)
 			}
 			cd.allSilent = silent
 		}
@@ -423,18 +423,18 @@ func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string, lineN
 	return false
 }
 
-func jsonError(w http.ResponseWriter, msg string, code int) {
+func jsonError(ctx context.Context, w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	if err := json.NewEncoder(w).Encode(map[string]string{"error": msg}); err != nil {
-		slog.Error("jsonError: encode failed", "err", err)
+		slog.ErrorContext(ctx, "jsonError: encode failed", "err", err)
 	}
 }
 
-func renderWith(w http.ResponseWriter, t *template.Template, name string, data any) {
+func renderWith(ctx context.Context, w http.ResponseWriter, t *template.Template, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := t.ExecuteTemplate(w, name, data); err != nil {
-		slog.Error("template render failed", "template", name, "err", err)
+		slog.ErrorContext(ctx, "template render failed", "template", name, "err", err)
 		http.Error(w, "template error", http.StatusInternalServerError)
 	}
 }
@@ -442,11 +442,11 @@ func renderWith(w http.ResponseWriter, t *template.Template, name string, data a
 // renderWithStatus is renderWith with an explicit non-200 status. Headers must
 // be set before WriteHeader, so we can't reuse renderWith after the caller has
 // already written the status line.
-func renderWithStatus(w http.ResponseWriter, t *template.Template, name string, data any, status int) {
+func renderWithStatus(ctx context.Context, w http.ResponseWriter, t *template.Template, name string, data any, status int) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(status)
 	if err := t.ExecuteTemplate(w, name, data); err != nil {
-		slog.Error("template render failed", "template", name, "err", err)
+		slog.ErrorContext(ctx, "template render failed", "template", name, "err", err)
 	}
 }
 

--- a/server/internal/web/handler_invite.go
+++ b/server/internal/web/handler_invite.go
@@ -38,7 +38,7 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 
 	inv, err := h.inviteStore.GetByToken(r.Context(), token)
 	if err != nil || inv.Status != household.InviteStatusPending || inv.ExpiresAt.Before(time.Now()) {
-		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
+		renderWith(r.Context(), w, h.tmplInvite, "layout-v2.html", inviteData{
 			chromeData: newChromeData("invite", nil, nil),
 			State:      "invalid",
 		})
@@ -47,8 +47,8 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 
 	hh, err := h.householdStore.GetByID(r.Context(), inv.HouseholdID)
 	if err != nil {
-		slog.Error("invite: household lookup failed", "err", err)
-		renderWith(w, h.tmplInvite, "layout-v2.html", inviteData{
+		slog.ErrorContext(r.Context(), "invite: household lookup failed", "err", err)
+		renderWith(r.Context(), w, h.tmplInvite, "layout-v2.html", inviteData{
 			chromeData: newChromeData("invite", nil, nil),
 			State:      "invalid",
 		})
@@ -81,7 +81,7 @@ func (h *Handler) handleInviteGet(w http.ResponseWriter, r *http.Request) {
 		data.CurrentEmail = user.Email
 	}
 
-	renderWith(w, h.tmplInvite, "layout-v2.html", data)
+	renderWith(r.Context(), w, h.tmplInvite, "layout-v2.html", data)
 }
 
 func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request) {
@@ -105,17 +105,17 @@ func (h *Handler) handleInviteAcceptPost(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := h.householdStore.AddMember(r.Context(), user.ID, inv.HouseholdID, "admin"); err != nil {
-		slog.Error("add member failed", "err", err)
+		slog.ErrorContext(r.Context(), "add member failed", "err", err)
 		http.Redirect(w, r, "/invite/"+token, http.StatusSeeOther)
 		return
 	}
 
 	if _, err := h.inviteStore.AcceptInvite(r.Context(), token); err != nil {
-		slog.Error("accept invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "accept invite failed", "err", err)
 	}
 
 	if err := h.authStore.SetActiveHousehold(r.Context(), sessionToken, inv.HouseholdID); err != nil {
-		slog.Error("set active household failed", "err", err)
+		slog.ErrorContext(r.Context(), "set active household failed", "err", err)
 	}
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -82,13 +82,13 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	resp := LinkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
 	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex, ownedLines)
 	if err != nil {
-		slog.Error("link_health: build caller endpoint failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "link_health: build caller endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	calleeEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Callee, linkedIndex, ownedLines)
 	if err != nil {
-		slog.Error("link_health: build callee endpoint failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "link_health: build callee endpoint failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -97,7 +97,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		slog.Error("link_health encode failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "link_health encode failed", "call_id", callID, "err", err)
 	}
 }
 
@@ -170,7 +170,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		slog.Error("SSE stream: ResponseWriter does not implement Flusher")
+		slog.ErrorContext(r.Context(), "SSE stream: ResponseWriter does not implement Flusher")
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
@@ -189,7 +189,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 	linkedIndex := h.linkedIndexForCall(r.Context(), ownedLines)
 
 	if err := h.writeInitialSnapshot(r.Context(), w, flusher, call, ownedLines, linkedIndex); err != nil {
-		slog.Debug("SSE stream: initial snapshot write failed", "call_id", callID, "err", err)
+		slog.DebugContext(r.Context(), "SSE stream: initial snapshot write failed", "call_id", callID, "err", err)
 		return
 	}
 
@@ -211,7 +211,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 				return
 			}
 			if err := h.writeEvent(r.Context(), w, flusher, call, ownedLines, linkedIndex, ev); err != nil {
-				slog.Debug("SSE stream: write failed; client gone", "call_id", callID, "err", err)
+				slog.DebugContext(r.Context(), "SSE stream: write failed; client gone", "call_id", callID, "err", err)
 				return
 			}
 		case <-heartbeat.C:
@@ -378,7 +378,7 @@ func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
 	// Record who force-ended the call BEFORE the teardown fires, so the
 	// audit row is in place even if we crash mid-teardown.
 	if err := h.tracker.MarkForceEnded(r.Context(), callID, user.ID); err != nil {
-		slog.Error("force-disconnect audit write failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "force-disconnect audit write failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -394,7 +394,7 @@ func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
 	// Close the DB row deterministically. OnCallEnded is idempotent; a
 	// peer-initiated hangup arriving later is a safe no-op.
 	if err := h.tracker.OnCallEnded(r.Context(), call.Caller, call.Callee); err != nil {
-		slog.Error("force-disconnect OnCallEnded failed", "call_id", callID, "err", err)
+		slog.ErrorContext(r.Context(), "force-disconnect OnCallEnded failed", "call_id", callID, "err", err)
 		// Phones are hung up regardless; the status transition will happen
 		// when the next peer hangup arrives or during the daily cleanup.
 	}

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -68,7 +68,7 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 	// Pending invites sent by this household
 	pending, err := h.linkStore.GetPendingForHousehold(r.Context(), myHousehold.ID)
 	if err != nil {
-		slog.Error("get pending links failed", "err", err)
+		slog.ErrorContext(r.Context(), "get pending links failed", "err", err)
 	}
 	for _, l := range pending {
 		data.PendingInvites = append(data.PendingInvites, linkRow{
@@ -79,7 +79,7 @@ func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	renderWith(w, h.tmplLinks, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplLinks, layoutFor(r), data)
 }
 
 func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +90,7 @@ func (h *Handler) handleLinksInvitePost(w http.ResponseWriter, r *http.Request) 
 
 	link, err := h.linkStore.CreateInvite(r.Context(), myHousehold.ID, user.ID)
 	if err != nil {
-		slog.Error("create invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "create invite failed", "err", err)
 		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
@@ -122,7 +122,7 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 
 	link, err := h.linkStore.AcceptInvite(r.Context(), code, user.ID, myHousehold.ID)
 	if err != nil {
-		slog.Error("accept invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "accept invite failed", "err", err)
 		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}
@@ -138,7 +138,7 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 		for _, c := range conflicts {
 			names = append(names, c.Number)
 		}
-		slog.Warn("number conflicts on link accept", "conflicts", names)
+		slog.WarnContext(r.Context(), "number conflicts on link accept", "conflicts", names)
 		http.Redirect(w, r, "/links?accepted=1&conflicts="+strings.Join(names, ","), http.StatusSeeOther)
 		return
 	}
@@ -189,7 +189,7 @@ func (h *Handler) handleLinksRevokePost(w http.ResponseWriter, r *http.Request) 
 	wasPending := link.Status == "pending"
 
 	if err := h.linkStore.RevokeLink(r.Context(), id, user.ID); err != nil {
-		slog.Error("revoke link failed", "link_id", id, "err", err)
+		slog.ErrorContext(r.Context(), "revoke link failed", "link_id", id, "err", err)
 		http.Redirect(w, r, "/links?error="+url.QueryEscape(err.Error()), http.StatusSeeOther)
 		return
 	}

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -19,7 +19,7 @@ func (h *Handler) handleOnboardGet(w http.ResponseWriter, r *http.Request) {
 	if user != nil && user.Name != "" {
 		suggested = user.Name + "'s Family"
 	}
-	renderWith(w, h.tmplOnboard, layoutFor(r), onboardData{
+	renderWith(r.Context(), w, h.tmplOnboard, layoutFor(r), onboardData{
 		chromeData:    h.newChromeDataWithHouseholds(r, "onboard"),
 		SuggestedName: suggested,
 	})
@@ -45,7 +45,7 @@ func (h *Handler) handleOnboardPost(w http.ResponseWriter, r *http.Request) {
 	}
 	_, err := h.householdStore.Create(r.Context(), name, user.ID)
 	if err != nil {
-		slog.Error("create household failed", "err", err)
+		slog.ErrorContext(r.Context(), "create household failed", "err", err)
 		http.Error(w, "failed to create household", http.StatusInternalServerError)
 		return
 	}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -82,7 +82,7 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 		var err error
 		lines, err = h.lineStore.ListByHousehold(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("list lines by household failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "list lines by household failed", "household_id", hh.ID, "err", err)
 		}
 	}
 	// On error or nil household, show empty list rather than leaking all lines.
@@ -121,7 +121,7 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 		if h.deviceStore != nil {
 			devs, err := h.deviceStore.ListByLine(r.Context(), l.ID)
 			if err != nil {
-				slog.Error("list devices for line", "line_id", l.ID, "err", err)
+				slog.ErrorContext(r.Context(), "list devices for line", "line_id", l.ID, "err", err)
 			} else {
 				row.Devices = devs
 			}
@@ -165,7 +165,7 @@ func (h *Handler) handlePhonesGet(w http.ResponseWriter, r *http.Request) {
 			FirmwareVersion: r.URL.Query().Get("fw"),
 		}
 	}
-	renderWith(w, h.tmplPhones, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 }
 
 func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
@@ -184,7 +184,7 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 
 	if err := line.ValidateNumber(number); err != nil {
 		data := h.buildLinesData(r, hh, err.Error())
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
+		renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
@@ -196,11 +196,11 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	data := h.buildLinesData(r, hh, msg)
 
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
+		renderWith(r.Context(), w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return
 	}
 	if err != nil {
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
+		renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
@@ -223,7 +223,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	if h.pairingStore == nil {
 		data := h.buildLinesData(r, hh, "")
 		data.PairError = "pairing is not enabled"
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
+		renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
@@ -242,7 +242,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 		if parseErr != nil {
 			data := h.buildLinesData(r, hh, "")
 			data.PairError = "invalid line selection"
-			renderWith(w, h.tmplPhones, layoutFor(r), data)
+			renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 			return
 		}
 		token, hwID, err = h.pairingStore.ClaimDeviceToLine(r.Context(), code, lineID, deviceName, householdID)
@@ -258,7 +258,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 		if verr := line.ValidateNumber(number); verr != nil {
 			data := h.buildLinesData(r, hh, "")
 			data.PairError = "invalid phone number: " + verr.Error()
-			renderWith(w, h.tmplPhones, layoutFor(r), data)
+			renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 			return
 		}
 		lineName := deviceName
@@ -268,7 +268,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		data := h.buildLinesData(r, hh, "")
 		data.PairError = err.Error()
-		renderWith(w, h.tmplPhones, layoutFor(r), data)
+		renderWith(r.Context(), w, h.tmplPhones, layoutFor(r), data)
 		return
 	}
 
@@ -278,7 +278,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 			DeviceToken: token,
 			Number:      number,
 		}); err != nil {
-			slog.Warn("could not notify device of pairing", "hardware_id", hwID, "err", err)
+			slog.WarnContext(r.Context(), "could not notify device of pairing", "hardware_id", hwID, "err", err)
 		}
 	}
 
@@ -317,7 +317,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		var err error
 		devices, err = h.deviceStore.ListByLine(r.Context(), ln.ID)
 		if err != nil {
-			slog.Error("failed to list devices by line", "err", err, "line_id", ln.ID)
+			slog.ErrorContext(r.Context(), "failed to list devices by line", "err", err, "line_id", ln.ID)
 		}
 	}
 
@@ -381,7 +381,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	renderWith(w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
+	renderWith(r.Context(), w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
 		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
 		Line:                  *ln,
 		Online:                online,
@@ -406,14 +406,14 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	}
 	online := h.hub.IsOnline(number)
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhoneDetail, partialFor(r, "phone-status", "am-phone-status"), struct {
+		renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "phone-status", "am-phone-status"), struct {
 			Online bool
 		}{online})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]bool{"online": online}); err != nil {
-		slog.Error("encode online status failed", "err", err)
+		slog.ErrorContext(r.Context(), "encode online status failed", "err", err)
 	}
 }
 
@@ -424,7 +424,7 @@ func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	online := h.hub.IsOnline(number)
-	renderWith(w, h.tmplPhones, partialFor(r, "phone-edit-row", "am-phone-edit-row"), lineRow{Line: *ln, Online: online})
+	renderWith(r.Context(), w, h.tmplPhones, partialFor(r, "phone-edit-row", "am-phone-edit-row"), lineRow{Line: *ln, Online: online})
 }
 
 func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
@@ -446,7 +446,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 
 	if name != ln.Name {
 		if err := h.lineStore.Update(r.Context(), ln.ID, number, name); err != nil {
-			slog.Error("line update failed", "err", err, "line_id", ln.ID)
+			slog.ErrorContext(r.Context(), "line update failed", "err", err, "line_id", ln.ID)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
@@ -454,7 +454,7 @@ func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 
 	data := h.buildLinesData(r, hh, "")
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
+		renderWith(r.Context(), w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return
 	}
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
@@ -475,7 +475,7 @@ func (h *Handler) handlePhoneNameGet(w http.ResponseWriter, r *http.Request) {
 	if ln == nil {
 		return
 	}
-	renderWith(w, h.tmplPhoneDetail, partialFor(r, "name-section", "am-name-section"), nameSectionData{Line: *ln})
+	renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "name-section", "am-name-section"), nameSectionData{Line: *ln})
 }
 
 func (h *Handler) handlePhoneNameEditGet(w http.ResponseWriter, r *http.Request) {
@@ -484,7 +484,7 @@ func (h *Handler) handlePhoneNameEditGet(w http.ResponseWriter, r *http.Request)
 	if ln == nil {
 		return
 	}
-	renderWith(w, h.tmplPhoneDetail, partialFor(r, "name-section-edit", "am-name-section-edit"), nameSectionData{Line: *ln, Value: ln.Name})
+	renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "name-section-edit", "am-name-section-edit"), nameSectionData{Line: *ln, Value: ln.Name})
 }
 
 func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
@@ -500,19 +500,19 @@ func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 	}
 	name, verr := validateLineName(raw)
 	if verr != nil {
-		renderWithStatus(w, h.tmplPhoneDetail, partialFor(r, "name-section-edit", "am-name-section-edit"), nameSectionData{Line: *ln, Value: raw, Error: verr.Error()}, http.StatusBadRequest)
+		renderWithStatus(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "name-section-edit", "am-name-section-edit"), nameSectionData{Line: *ln, Value: raw, Error: verr.Error()}, http.StatusBadRequest)
 		return
 	}
 	if name != ln.Name {
 		if err := h.lineStore.Update(r.Context(), ln.ID, number, name); err != nil {
-			slog.Error("line update failed", "err", err, "line_id", ln.ID)
+			slog.ErrorContext(r.Context(), "line update failed", "err", err, "line_id", ln.ID)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 		ln.Name = name
 	}
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhoneDetail, partialFor(r, "name-section", "am-name-section"), nameSectionData{Line: *ln})
+		renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "name-section", "am-name-section"), nameSectionData{Line: *ln})
 		return
 	}
 	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
@@ -549,7 +549,7 @@ func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) 
 	ctx := r.Context()
 	taken, err := h.lineStore.NumberExistsExcluding(ctx, newNumber, ln.ID)
 	if err != nil {
-		slog.Error("number uniqueness check failed", "err", err, "line_id", ln.ID)
+		slog.ErrorContext(ctx, "number uniqueness check failed", "err", err, "line_id", ln.ID)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -559,21 +559,21 @@ func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.lineStore.Update(ctx, ln.ID, newNumber, ln.Name); err != nil {
-		slog.Error("line number update failed", "err", err, "line_id", ln.ID)
+		slog.ErrorContext(ctx, "line number update failed", "err", err, "line_id", ln.ID)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	if h.tracker != nil {
 		if err := h.tracker.RenameNumber(ctx, oldNumber, newNumber); err != nil {
-			slog.Error("call history rename failed", "old", oldNumber, "new", newNumber, "err", err)
+			slog.ErrorContext(ctx, "call history rename failed", "old", oldNumber, "new", newNumber, "err", err)
 		}
 	}
 
 	h.hub.RekeyNumber(oldNumber, newNumber)
 
 	if err := h.pushLineSettings(newNumber, ln.Settings); err != nil {
-		slog.Warn("push line settings after number change failed", "number", newNumber, "err", err)
+		slog.WarnContext(ctx, "push line settings after number change failed", "number", newNumber, "err", err)
 	}
 
 	http.Redirect(w, r, "/phones/"+newNumber, http.StatusSeeOther)
@@ -632,17 +632,17 @@ func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, inte
 	next = next.Normalize()
 	if next != ln.Settings {
 		if err := h.lineStore.UpdateSettings(r.Context(), ln.ID, next); err != nil {
-			slog.Error("update line settings failed", "err", err, "line_id", ln.ID)
+			slog.ErrorContext(r.Context(), "update line settings failed", "err", err, "line_id", ln.ID)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 		if err := h.pushLineSettings(number, next); err != nil {
-			slog.Warn("push line settings failed", "number", number, "err", err)
+			slog.WarnContext(r.Context(), "push line settings failed", "number", number, "err", err)
 		}
 		ln.Settings = next
 	}
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhoneDetail, partialFor(r, intercom, am), struct {
+		renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, intercom, am), struct {
 			Line line.Line
 		}{Line: *ln})
 		return
@@ -702,12 +702,12 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	if status == nil {
 		if err := json.NewEncoder(w).Encode(map[string]string{"status": ""}); err != nil {
-			slog.Error("update status: json encode failed", "err", err)
+			slog.ErrorContext(r.Context(), "update status: json encode failed", "err", err)
 		}
 		return
 	}
 	if err := json.NewEncoder(w).Encode(status); err != nil {
-		slog.Error("update status: json encode failed", "err", err)
+		slog.ErrorContext(r.Context(), "update status: json encode failed", "err", err)
 	}
 }
 
@@ -749,7 +749,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	mode := strings.TrimSpace(r.FormValue("mode"))
 
 	if mode != "service" && mode != "reboot" {
-		jsonError(w, "mode must be 'service' or 'reboot'", http.StatusBadRequest)
+		jsonError(r.Context(), w, "mode must be 'service' or 'reboot'", http.StatusBadRequest)
 		return
 	}
 
@@ -768,10 +768,10 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) sendPhoneCommandAndRespond(w http.ResponseWriter, r *http.Request, number string, msg *signaling.Message, opName string, extraInfo ...any) {
 	var sendErr string
 	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.Warn(opName+" failed", append([]any{"number", number, "err", err}, extraInfo...)...)
+		slog.WarnContext(r.Context(), opName+" failed", append([]any{"number", number, "err", err}, extraInfo...)...)
 		sendErr = err.Error()
 	} else {
-		slog.Info(opName+" sent", append([]any{"number", number}, extraInfo...)...)
+		slog.InfoContext(r.Context(), opName+" sent", append([]any{"number", number}, extraInfo...)...)
 	}
 	h.respondPhoneCommandResult(w, r, number, sendErr)
 }
@@ -789,7 +789,7 @@ func (h *Handler) respondPhoneCommandResult(w http.ResponseWriter, r *http.Reque
 			payload = map[string]string{"error": sendErr}
 		}
 		if err := json.NewEncoder(w).Encode(payload); err != nil {
-			slog.Error("phone command response: json encode failed", "number", number, "err", err)
+			slog.ErrorContext(r.Context(), "phone command response: json encode failed", "number", number, "err", err)
 		}
 		return
 	}
@@ -803,13 +803,13 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.lineStore.Delete(r.Context(), ln.ID); err != nil {
-		slog.Error("delete line failed", "line_id", ln.ID, "err", err)
+		slog.ErrorContext(r.Context(), "delete line failed", "line_id", ln.ID, "err", err)
 		http.Error(w, "failed to delete line", http.StatusInternalServerError)
 		return
 	}
 	data := h.buildLinesData(r, hh, "")
 	if isHTMX(r) {
-		renderWith(w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
+		renderWith(r.Context(), w, h.tmplPhones, partialFor(r, "phones-table", "am-phones-table"), data)
 		return
 	}
 	http.Redirect(w, r, "/phones", http.StatusSeeOther)
@@ -888,20 +888,20 @@ func (h *Handler) handlePhoneConvert(w http.ResponseWriter, r *http.Request) {
 
 	// Move the device.
 	if err := h.deviceStore.Reassign(r.Context(), deviceID, targetLineID); err != nil {
-		slog.Error("move device failed", "device_id", deviceID, "target", targetLineID, "err", err)
+		slog.ErrorContext(r.Context(), "move device failed", "device_id", deviceID, "target", targetLineID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	remaining, err := h.deviceStore.ListByLine(r.Context(), srcLn.ID)
 	if err != nil {
-		slog.Error("list remaining devices failed", "line_id", srcLn.ID, "err", err)
+		slog.ErrorContext(r.Context(), "list remaining devices failed", "line_id", srcLn.ID, "err", err)
 		http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
 		return
 	}
 	if len(remaining) == 0 {
 		if err := h.lineStore.Delete(r.Context(), srcLn.ID); err != nil {
-			slog.Error("delete empty line failed", "line_id", srcLn.ID, "err", err)
+			slog.ErrorContext(r.Context(), "delete empty line failed", "line_id", srcLn.ID, "err", err)
 		}
 		http.Redirect(w, r, "/phones", http.StatusSeeOther)
 		return

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -40,7 +40,7 @@ func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	if hh != nil && user != nil {
 		members, err := h.householdStore.GetMembersWithUsers(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("get household members failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "get household members failed", "household_id", hh.ID, "err", err)
 		}
 		for _, m := range members {
 			data.Members = append(data.Members, settingsMember{
@@ -53,12 +53,12 @@ func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 		if h.inviteStore != nil {
 			data.PendingInvites, err = h.inviteStore.GetPendingForHousehold(r.Context(), hh.ID)
 			if err != nil {
-				slog.Error("get pending invites failed", "household_id", hh.ID, "err", err)
+				slog.ErrorContext(r.Context(), "get pending invites failed", "household_id", hh.ID, "err", err)
 			}
 		}
 	}
 
-	renderWith(w, h.tmplSettings, layoutFor(r), data)
+	renderWith(r.Context(), w, h.tmplSettings, layoutFor(r), data)
 }
 
 func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +73,7 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	name := strings.TrimSpace(r.FormValue("name"))
 	if name != "" {
 		if err := h.householdStore.UpdateName(r.Context(), hh.ID, name); err != nil {
-			slog.Error("update household name failed", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "update household name failed", "household_id", hh.ID, "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
@@ -88,7 +88,7 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 	}
 	enabled := r.FormValue("enabled") == "true"
 	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), hh.ID, enabled); err != nil {
-		slog.Error("set call history failed", "err", err)
+		slog.ErrorContext(r.Context(), "set call history failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -106,13 +106,13 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 	}
 	enabled := r.FormValue("enabled") == "true"
 	if err := h.lineStore.SetAllSilentByHousehold(r.Context(), hh.ID, enabled); err != nil {
-		slog.Error("set all silent failed", "err", err, "household_id", hh.ID)
+		slog.ErrorContext(r.Context(), "set all silent failed", "err", err, "household_id", hh.ID)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	if err != nil {
-		slog.Error("list lines for silence fan-out failed", "err", err, "household_id", hh.ID)
+		slog.ErrorContext(r.Context(), "list lines for silence fan-out failed", "err", err, "household_id", hh.ID)
 		http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 		return
 	}
@@ -120,12 +120,12 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 		updated := ln.Settings
 		updated.SilentMode = enabled
 		if pushErr := h.pushLineSettings(ln.Number, updated); pushErr != nil {
-			slog.Warn("silence fan-out push failed", "number", ln.Number, "err", pushErr)
+			slog.WarnContext(r.Context(), "silence fan-out push failed", "number", ln.Number, "err", pushErr)
 		}
 	}
 	if isHTMX(r) {
 		data := h.buildLinesData(r, hh, "")
-		renderWith(w, h.tmplPhones, partialFor(r, "dnd-response", "dnd-response-am"), data)
+		renderWith(r.Context(), w, h.tmplPhones, partialFor(r, "dnd-response", "dnd-response-am"), data)
 		return
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
@@ -143,7 +143,7 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 	tz := strings.TrimSpace(r.FormValue("timezone"))
 	if tz != "" {
 		if err := h.householdStore.SetTimezone(r.Context(), hh.ID, tz); err != nil {
-			slog.Warn("set timezone failed", "err", err)
+			slog.WarnContext(r.Context(), "set timezone failed", "err", err)
 			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
@@ -167,7 +167,7 @@ func (h *Handler) handleUserPrefPost(w http.ResponseWriter, r *http.Request, fie
 	}
 	value := r.FormValue(field)
 	if err := save(r.Context(), user.ID, value); err != nil {
-		slog.Error("set "+field+" failed", "err", err, field, value)
+		slog.ErrorContext(r.Context(), "set "+field+" failed", "err", err, field, value)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -209,7 +209,7 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 
 	isMember, err := h.householdStore.IsMemberByEmail(r.Context(), hh.ID, inviteEmail)
 	if err != nil {
-		slog.Error("check member email failed", "err", err)
+		slog.ErrorContext(r.Context(), "check member email failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -220,7 +220,7 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 
 	pending, err := h.inviteStore.IsPendingForHouseholdEmail(r.Context(), hh.ID, inviteEmail)
 	if err != nil {
-		slog.Error("check pending invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "check pending invite failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -231,7 +231,7 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 
 	inv, err := h.inviteStore.CreateInvite(r.Context(), hh.ID, inviteEmail, user.ID)
 	if err != nil {
-		slog.Error("create invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "create invite failed", "err", err)
 		http.Redirect(w, r, "/settings?error=invite+failed", http.StatusSeeOther)
 		return
 	}
@@ -239,7 +239,7 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 	link := fmt.Sprintf("%s/invite/%s", h.cfg.BaseURL, inv.Token)
 	subject, body := emailpkg.HouseholdInviteEmail(hh.Name, userDisplayLabel(user), link)
 	if err := h.emailer.Send(inviteEmail, subject, body); err != nil {
-		slog.Error("invite email failed", "email", inviteEmail, "err", err)
+		slog.ErrorContext(r.Context(), "invite email failed", "email", inviteEmail, "err", err)
 	}
 
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
@@ -257,7 +257,7 @@ func (h *Handler) handleHouseholdInviteCancelPost(w http.ResponseWriter, r *http
 		return
 	}
 	if err := h.inviteStore.CancelInvite(r.Context(), inviteID); err != nil {
-		slog.Error("cancel invite failed", "err", err)
+		slog.ErrorContext(r.Context(), "cancel invite failed", "err", err)
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
 }
@@ -271,7 +271,7 @@ func (h *Handler) handleHouseholdMemberRemovePost(w http.ResponseWriter, r *http
 
 	count, err := h.householdStore.MemberCount(r.Context(), hh.ID)
 	if err != nil {
-		slog.Error("member count failed", "err", err)
+		slog.ErrorContext(r.Context(), "member count failed", "err", err)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
@@ -281,7 +281,7 @@ func (h *Handler) handleHouseholdMemberRemovePost(w http.ResponseWriter, r *http
 	}
 
 	if err := h.householdStore.RemoveMember(r.Context(), targetUserID, hh.ID); err != nil {
-		slog.Error("remove member failed", "err", err)
+		slog.ErrorContext(r.Context(), "remove member failed", "err", err)
 	}
 	if targetUserID == user.ID {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
@@ -299,7 +299,7 @@ func (h *Handler) handleAccountDeletePost(w http.ResponseWriter, r *http.Request
 
 	households, err := h.householdStore.GetForUser(r.Context(), user.ID)
 	if err != nil {
-		slog.Error("get households for account deletion failed", "user_id", user.ID, "err", err)
+		slog.ErrorContext(r.Context(), "get households for account deletion failed", "user_id", user.ID, "err", err)
 		http.Redirect(w, r, "/settings?error=deletion+failed", http.StatusSeeOther)
 		return
 	}
@@ -307,7 +307,7 @@ func (h *Handler) handleAccountDeletePost(w http.ResponseWriter, r *http.Request
 	for _, hh := range households {
 		count, err := h.householdStore.MemberCount(r.Context(), hh.ID)
 		if err != nil {
-			slog.Error("member count failed during account deletion", "household_id", hh.ID, "err", err)
+			slog.ErrorContext(r.Context(), "member count failed during account deletion", "household_id", hh.ID, "err", err)
 			http.Redirect(w, r, "/settings?error=deletion+failed", http.StatusSeeOther)
 			return
 		}
@@ -315,7 +315,7 @@ func (h *Handler) handleAccountDeletePost(w http.ResponseWriter, r *http.Request
 		if count <= 1 {
 			lines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 			if err != nil {
-				slog.Error("list lines for deletion failed", "household_id", hh.ID, "err", err)
+				slog.ErrorContext(r.Context(), "list lines for deletion failed", "household_id", hh.ID, "err", err)
 				http.Redirect(w, r, "/settings?error=deletion+failed", http.StatusSeeOther)
 				return
 			}
@@ -326,7 +326,7 @@ func (h *Handler) handleAccountDeletePost(w http.ResponseWriter, r *http.Request
 				}
 			}
 			if err := h.householdStore.Delete(r.Context(), hh.ID); err != nil {
-				slog.Error("delete household failed", "household_id", hh.ID, "err", err)
+				slog.ErrorContext(r.Context(), "delete household failed", "household_id", hh.ID, "err", err)
 				http.Redirect(w, r, "/settings?error=deletion+failed", http.StatusSeeOther)
 				return
 			}
@@ -334,13 +334,13 @@ func (h *Handler) handleAccountDeletePost(w http.ResponseWriter, r *http.Request
 			// CASCADE on household_members.user_id will clean this up even if
 			// RemoveMember fails, but we attempt the explicit remove first.
 			if err := h.householdStore.RemoveMember(r.Context(), user.ID, hh.ID); err != nil {
-				slog.Error("remove member during account deletion failed", "user_id", user.ID, "household_id", hh.ID, "err", err)
+				slog.ErrorContext(r.Context(), "remove member during account deletion failed", "user_id", user.ID, "household_id", hh.ID, "err", err)
 			}
 		}
 	}
 
 	if err := h.authStore.DeleteUser(r.Context(), user.ID); err != nil {
-		slog.Error("delete user failed", "user_id", user.ID, "err", err)
+		slog.ErrorContext(r.Context(), "delete user failed", "user_id", user.ID, "err", err)
 		http.Redirect(w, r, "/settings?error=deletion+failed", http.StatusSeeOther)
 		return
 	}
@@ -373,7 +373,7 @@ func (h *Handler) handleHouseholdSwitchPost(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.authStore.SetActiveHousehold(r.Context(), cookie.Value, householdID); err != nil {
-		slog.Error("switch household failed", "err", err)
+		slog.ErrorContext(r.Context(), "switch household failed", "err", err)
 	}
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)

--- a/server/internal/web/handler_welcome.go
+++ b/server/internal/web/handler_welcome.go
@@ -23,7 +23,7 @@ type welcomeData struct {
 
 func (h *Handler) handleWelcomeGet(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	renderWith(w, h.tmplWelcome, "welcome.html", welcomeData{
+	renderWith(r.Context(), w, h.tmplWelcome, "welcome.html", welcomeData{
 		Version:       version.Version,
 		User:          user,
 		ThemeIntercom: auth.ThemeIntercom,
@@ -49,7 +49,7 @@ func (h *Handler) handleWelcomePost(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.authStore.SetThemeAndMarkChosen(r.Context(), user.ID, theme)
 	if err != nil {
-		slog.Error("welcome: set theme and mark chosen failed", "err", err, "theme", theme, "user_id", user.ID)
+		slog.ErrorContext(r.Context(), "welcome: set theme and mark chosen failed", "err", err, "theme", theme, "user_id", user.ID)
 		http.Error(w, "failed to save theme", http.StatusInternalServerError)
 		return
 	}

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -28,38 +28,38 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	ws, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		slog.Error("websocket upgrade failed", "err", err)
+		slog.ErrorContext(r.Context(), "websocket upgrade failed", "err", err)
 		return
 	}
 
 	// Wait for register message
 	if err := ws.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		slog.Error("ws set register deadline failed", "err", err)
+		slog.ErrorContext(r.Context(), "ws set register deadline failed", "err", err)
 		_ = ws.Close()
 		return
 	}
 	_, data, err := ws.ReadMessage()
 	if err != nil {
-		slog.Error("websocket no register message", "err", err)
+		slog.ErrorContext(r.Context(), "websocket no register message", "err", err)
 		_ = ws.Close()
 		return
 	}
 	if err := ws.SetReadDeadline(time.Time{}); err != nil {
-		slog.Error("ws clear register deadline failed", "err", err)
+		slog.ErrorContext(r.Context(), "ws clear register deadline failed", "err", err)
 		_ = ws.Close()
 		return
 	}
 
 	msg, err := signaling.ParseMessage(data)
 	if err != nil || msg.Type != signaling.TypeRegister || msg.Number == "" {
-		slog.Warn("invalid register message")
+		slog.WarnContext(r.Context(), "invalid register message")
 		wsReject(ws, "must send register message first")
 		return
 	}
 
 	// Require hardware ID for all connections
 	if msg.HardwareID == "" {
-		slog.Warn("ws register without hardware_id", "number", msg.Number)
+		slog.WarnContext(r.Context(), "ws register without hardware_id", "number", msg.Number)
 		wsReject(ws, "hardware_id required")
 		return
 	}
@@ -71,14 +71,14 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	if h.pairingStore != nil {
 		paired, tokenValid, err := h.deviceStore.AuthStatus(r.Context(), msg.HardwareID, msg.DeviceToken)
 		if err != nil {
-			slog.Error("device auth check failed", "hardware_id", msg.HardwareID, "err", err)
+			slog.ErrorContext(r.Context(), "device auth check failed", "hardware_id", msg.HardwareID, "err", err)
 			wsReject(ws, "internal error")
 			return
 		}
 		if !paired {
 			code, err := h.pairingStore.GenerateCode(r.Context(), msg.HardwareID)
 			if err != nil {
-				slog.Error("generate pairing code failed", "hardware_id", msg.HardwareID, "err", err)
+				slog.ErrorContext(r.Context(), "generate pairing code failed", "hardware_id", msg.HardwareID, "err", err)
 			} else {
 				_ = ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
 					Type:        signaling.TypePairingCode,
@@ -90,28 +90,28 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 			// SendToHardware without displacing a real line's connection.
 			msg.Number = "unpaired:" + msg.HardwareID
 		} else if msg.DeviceToken == "" {
-			slog.Warn("ws register without device_token", "hardware_id", msg.HardwareID)
+			slog.WarnContext(r.Context(), "ws register without device_token", "hardware_id", msg.HardwareID)
 			wsReject(ws, "device_token required")
 			return
 		} else if !tokenValid {
-			slog.Warn("ws invalid device_token", "hardware_id", msg.HardwareID)
+			slog.WarnContext(r.Context(), "ws invalid device_token", "hardware_id", msg.HardwareID)
 			wsReject(ws, "invalid device_token")
 			return
 		} else {
 			isPaired = true
 			boundNumber, err := h.deviceStore.BoundLineNumber(r.Context(), msg.HardwareID)
 			if err != nil {
-				slog.Error("bound line lookup failed", "hardware_id", msg.HardwareID, "err", err)
+				slog.ErrorContext(r.Context(), "bound line lookup failed", "hardware_id", msg.HardwareID, "err", err)
 				wsReject(ws, "internal error")
 				return
 			}
 			if boundNumber == "" {
-				slog.Warn("paired device has no bound line", "hardware_id", msg.HardwareID)
+				slog.WarnContext(r.Context(), "paired device has no bound line", "hardware_id", msg.HardwareID)
 				wsReject(ws, "device has no assigned line")
 				return
 			}
 			if boundNumber != msg.Number {
-				slog.Warn("ws register number mismatch",
+				slog.WarnContext(r.Context(), "ws register number mismatch",
 					"hardware_id", msg.HardwareID,
 					"claimed", msg.Number,
 					"bound", boundNumber)
@@ -141,6 +141,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		h.relay.OnRegistered(r.Context(), msg.Number)
 	}
 	number := msg.Number
+	ctx := r.Context()
 
 	// Configure pong handler to extend read deadline on each pong
 	_ = ws.SetReadDeadline(time.Now().Add(wsPongTimeout))
@@ -165,7 +166,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
-					slog.Error("websocket write failed", "number", number, "err", err)
+					slog.ErrorContext(ctx, "websocket write failed", "number", number, "err", err)
 					return
 				}
 			case <-ticker.C:
@@ -181,11 +182,11 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read pump (blocks until disconnect)
 	defer h.hub.Unregister(number, conn)
-	defer h.relay.OnDisconnect(r.Context(), number, conn.HardwareID)
+	defer h.relay.OnDisconnect(ctx, number, conn.HardwareID)
 	defer func() {
 		if msg.HardwareID != "" && h.deviceStore != nil {
-			if err := h.deviceStore.TouchLastSeen(r.Context(), msg.HardwareID); err != nil {
-				slog.Warn("touch last seen on disconnect failed", "hardware_id", msg.HardwareID, "err", err)
+			if err := h.deviceStore.TouchLastSeen(ctx, msg.HardwareID); err != nil {
+				slog.WarnContext(ctx, "touch last seen on disconnect failed", "hardware_id", msg.HardwareID, "err", err)
 			}
 		}
 	}()
@@ -193,13 +194,13 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		_, data, err := ws.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				slog.Error("websocket read failed", "number", number, "err", err)
+				slog.ErrorContext(ctx, "websocket read failed", "number", number, "err", err)
 			}
 			break
 		}
 		msg, err := signaling.ParseMessage(data)
 		if err != nil {
-			slog.Warn("bad websocket message", "number", number, "err", err)
+			slog.WarnContext(ctx, "bad websocket message", "number", number, "err", err)
 			continue
 		}
 		// TypeRepair is intercepted here (not in relay) because we have the
@@ -210,16 +211,16 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		// rather than rejected as "device_token required".
 		if msg.Type == signaling.TypeRepair {
 			if h.deviceStore != nil && msg.HardwareID != "" {
-				if err := h.deviceStore.Unpair(r.Context(), msg.HardwareID); err != nil {
-					slog.Warn("repair: unpair failed", "hardware_id", msg.HardwareID, "err", err)
+				if err := h.deviceStore.Unpair(ctx, msg.HardwareID); err != nil {
+					slog.WarnContext(ctx, "repair: unpair failed", "hardware_id", msg.HardwareID, "err", err)
 				} else {
-					slog.Info("repair: device unpaired by client request", "hardware_id", msg.HardwareID, "number", number)
+					slog.InfoContext(ctx, "repair: device unpaired by client request", "hardware_id", msg.HardwareID, "number", number)
 				}
 			}
 			continue
 		}
 		msg.HardwareID = conn.HardwareID
-		h.relay.HandleMessage(r.Context(), number, msg)
+		h.relay.HandleMessage(ctx, number, msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

**Before: 82/100. After: 87/100.**

The `traceContextHandler` in `internal/logging/logging.go` calls `trace.SpanFromContext(ctx)` to inject `trace_id` and `span_id` into every log record, enabling Loki-Tempo log-trace correlation. This only works when the slog `*Context` variants are used: `slog.ErrorContext(ctx, ...)`, `slog.WarnContext(ctx, ...)`, etc. The context-free forms (`slog.Error(...)`) pass `context.Background()` to the handler, which never carries a span.

All ~117 slog calls across HTTP handlers, auth, and the calls package were using the context-free forms. Trace IDs were never appearing in logs, silently defeating the correlation system.

## Changes

- **`internal/web/handler_helpers.go`**: Added `ctx context.Context` as the first parameter to `renderWith`, `renderWithStatus`, and `jsonError`. These three helpers are the only shared callsites, so updating their signatures ensures all callers thread context through without repeating inline lookups.

- **All web handlers** (`handler_api.go`, `handler_calls.go`, `handler_changelog.go`, `handler_conference_linkhealth.go`, `handler_dashboard.go`, `handler_dashboard_stream.go`, `handler_invite.go`, `handler_linkhealth.go`, `handler_links.go`, `handler_onboard.go`, `handler_phones.go`, `handler_settings.go`, `handler_welcome.go`, `handler_ws.go`): All slog calls updated to `*Context` variants with `r.Context()`.

- **`handler_ws.go`**: Captures `ctx := r.Context()` once before the write-pump goroutine launches and uses it throughout the goroutine body, both deferred cleanups, and the read-pump loop. The `OnDisconnect` defer uses the captured `ctx` rather than `r.Context()` for consistency.

- **`internal/auth/handlers.go`, `internal/auth/google.go`**: All slog calls in HTTP handler functions updated.

- **`internal/calls/state_redis.go`**: All slog calls updated to `*Context` variants using the existing `ctx context.Context` parameter each function already accepted.

- **`internal/calls/tracker.go`**: Conference lifecycle slog calls (`CreateConferencePersistent`, `EndConferencePersistent`, `RecordKick`, `DropMemberPersistent`, `ClearByNumber`) updated. The synchronous-style methods (`Busy`, `PeerOf`, `InCall`, etc.) that call Redis with `context.Background()` are unchanged: adding ctx to those would require changing the `CallTracker` interface and all test mocks for no observability benefit at the call site.

## What was not changed

- Background goroutines with no meaningful request context (update poller, email sender, link health ring buffer flusher).
- The `slog.Info("updates: serving release index from GitHub")` in `handler.go` setup code, which runs once at startup before any request context exists.
- The `TestLoadConfigOptionalTokenFileUnreadable` test failure in `internal/autodeploy` is pre-existing and unrelated to this change (confirmed by running tests on the unmodified branch).

## Test plan

- [x] `go vet ./...` passes clean
- [x] `make test` passes for all packages except the pre-existing `autodeploy` failure
- [x] All 19 modified files reviewed for consistency after change

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjERG6AC5XrNfnQMS4k2kY)_