### PR TITLE
refactor(digitsd): collapse Module.IsReady into a free function

### DIFF
--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -171,11 +171,11 @@ func runRecoveryMode(web *subsystem.WebModule, serial *subsystem.SerialModule, a
 
 	var sp *phone.SerialPort
 	var mixer *audio.Mixer
-	if serial != nil && serial.IsReady() {
+	if serial != nil && subsystem.IsReady(serial) {
 		sp = serial.Port()
 		sp.StateSet("RECOVERY")
 	}
-	if audioMod != nil && audioMod.IsReady() {
+	if audioMod != nil && subsystem.IsReady(audioMod) {
 		mixer = audioMod.Mixer()
 	}
 

--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -37,7 +37,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		slog.Warn("setup: failed to clear boot counter", "error", err)
 	}
 
-	if serial != nil && serial.IsReady() {
+	if serial != nil && subsystem.IsReady(serial) {
 		serial.Port().StateSet("SETUP")
 	}
 
@@ -116,7 +116,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "verifying"}) //nolint:errcheck
 
-		if serial != nil && serial.IsReady() {
+		if serial != nil && subsystem.IsReady(serial) {
 			serial.Port().LED("LOCK")
 			serial.Port().LED("CONNECTING")
 		}
@@ -129,14 +129,14 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 					state.verifying = false
 					state.lastAttempt = &wifi.VerifyResult{Error: fmt.Sprintf("internal error: %v", r)}
 					state.mu.Unlock()
-					if serial != nil && serial.IsReady() {
+					if serial != nil && subsystem.IsReady(serial) {
 						serial.Port().LED("UNLOCK")
 					}
 				}
 			}()
 
 			slog.Info("setup: verifying WiFi credentials", "ssid", req.SSID)
-			if audio != nil && audio.IsReady() {
+			if audio != nil && subsystem.IsReady(audio) {
 				audio.Mixer().PlayOnce("wifi_connecting")
 				waitForOnceComplete(audio.Mixer(), 5*time.Second)
 			}
@@ -159,20 +159,20 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 
 			if result.Connected && result.Error == "" {
 				slog.Info("setup: WiFi configured, rebooting")
-				if serial != nil && serial.IsReady() {
+				if serial != nil && subsystem.IsReady(serial) {
 					serial.Port().LED("UNLOCK")
 					serial.Port().LED("ON")
 				}
-				if audio != nil && audio.IsReady() {
+				if audio != nil && subsystem.IsReady(audio) {
 					audio.Mixer().PlayOnce("wifi_connected")
 					waitForOnceComplete(audio.Mixer(), 10*time.Second)
 				}
 				doReboot()
 			} else {
-				if serial != nil && serial.IsReady() {
+				if serial != nil && subsystem.IsReady(serial) {
 					serial.Port().LED("UNLOCK")
 				}
-				if audio != nil && audio.IsReady() {
+				if audio != nil && subsystem.IsReady(audio) {
 					audio.Mixer().PlayOnce("wifi_failed")
 				}
 			}
@@ -183,7 +183,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 
 	// Voice prompt loop: when the user picks up the handset, play setup
 	// instructions on a timer, similar to recovery's voice menu.
-	if serial != nil && serial.IsReady() && audio != nil && audio.IsReady() {
+	if serial != nil && subsystem.IsReady(serial) && audio != nil && subsystem.IsReady(audio) {
 		go setupVoiceLoop(serial, audio)
 	}
 

--- a/pi/digitsd/internal/subsystem/audio.go
+++ b/pi/digitsd/internal/subsystem/audio.go
@@ -76,9 +76,8 @@ func (a *AudioModule) Init(ctx context.Context) error {
 	return nil
 }
 
-func (a *AudioModule) Mixer() *audio.Mixer    { return a.mixer }
-func (a *AudioModule) IsReady() bool          { return a.status.State == StateReady }
-func (a *AudioModule) Status() ModuleStatus   { return a.status }
+func (a *AudioModule) Mixer() *audio.Mixer  { return a.mixer }
+func (a *AudioModule) Status() ModuleStatus { return a.status }
 
 func (a *AudioModule) Shutdown(ctx context.Context) error {
 	if a.mixer != nil {

--- a/pi/digitsd/internal/subsystem/gpclk0.go
+++ b/pi/digitsd/internal/subsystem/gpclk0.go
@@ -50,7 +50,6 @@ func (g *GPCLK0Module) Retrigger() error {
 	return enableGPCLK0()
 }
 
-func (g *GPCLK0Module) IsReady() bool                      { return g.status.State == StateReady }
 func (g *GPCLK0Module) Status() ModuleStatus               { return g.status }
 func (g *GPCLK0Module) Shutdown(ctx context.Context) error { return nil }
 

--- a/pi/digitsd/internal/subsystem/kernmods.go
+++ b/pi/digitsd/internal/subsystem/kernmods.go
@@ -72,7 +72,6 @@ func (k *KernModsModule) Init(ctx context.Context) error {
 	return nil
 }
 
-func (k *KernModsModule) IsReady() bool                      { return k.status.State == StateReady }
 func (k *KernModsModule) Status() ModuleStatus               { return k.status }
 func (k *KernModsModule) Shutdown(ctx context.Context) error { return nil }
 

--- a/pi/digitsd/internal/subsystem/manager.go
+++ b/pi/digitsd/internal/subsystem/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) Shutdown(ctx context.Context) {
 		var wg sync.WaitGroup
 		for _, r := range layer {
 			r := r
-			if !r.Module.IsReady() {
+			if !IsReady(r.Module) {
 				continue
 			}
 			wg.Add(1)

--- a/pi/digitsd/internal/subsystem/manager_test.go
+++ b/pi/digitsd/internal/subsystem/manager_test.go
@@ -32,12 +32,6 @@ func (s *stubModule) Init(_ context.Context) error {
 	return nil
 }
 
-func (s *stubModule) IsReady() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.ready
-}
-
 func (s *stubModule) Status() ModuleStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -44,9 +44,14 @@ type ModuleStatus struct {
 type Module interface {
 	Name() string
 	Init(ctx context.Context) error
-	IsReady() bool
 	Status() ModuleStatus
 	Shutdown(ctx context.Context) error
+}
+
+// IsReady reports whether m has finished its Init successfully and has not
+// since failed or been disabled.
+func IsReady(m Module) bool {
+	return m.Status().State == StateReady
 }
 
 type HealthChecker interface {

--- a/pi/digitsd/internal/subsystem/mounts.go
+++ b/pi/digitsd/internal/subsystem/mounts.go
@@ -34,6 +34,5 @@ func (m *MountsModule) Init(ctx context.Context) error {
 	return nil
 }
 
-func (m *MountsModule) IsReady() bool                      { return m.status.State == StateReady }
 func (m *MountsModule) Status() ModuleStatus               { return m.status }
 func (m *MountsModule) Shutdown(ctx context.Context) error { return nil }

--- a/pi/digitsd/internal/subsystem/reaper.go
+++ b/pi/digitsd/internal/subsystem/reaper.go
@@ -50,8 +50,7 @@ func (r *ReaperModule) Init(ctx context.Context) error {
 	return nil
 }
 
-func (r *ReaperModule) IsReady() bool                      { return r.status.State == StateReady }
-func (r *ReaperModule) Status() ModuleStatus               { return r.status }
+func (r *ReaperModule) Status() ModuleStatus { return r.status }
 func (r *ReaperModule) Shutdown(ctx context.Context) error {
 	close(r.stop)
 	return nil

--- a/pi/digitsd/internal/subsystem/serial.go
+++ b/pi/digitsd/internal/subsystem/serial.go
@@ -54,7 +54,6 @@ func (s *SerialModule) Init(ctx context.Context) error {
 }
 
 func (s *SerialModule) Port() *phone.SerialPort { return s.port }
-func (s *SerialModule) IsReady() bool           { return s.status.State == StateReady }
 func (s *SerialModule) Status() ModuleStatus    { return s.status }
 
 func (s *SerialModule) Shutdown(ctx context.Context) error {

--- a/pi/digitsd/internal/subsystem/web.go
+++ b/pi/digitsd/internal/subsystem/web.go
@@ -59,8 +59,7 @@ func (w *WebModule) Init(ctx context.Context) error {
 	return nil
 }
 
-func (w *WebModule) Mux() *http.ServeMux { return w.mux }
-func (w *WebModule) IsReady() bool       { return w.status.State == StateReady }
+func (w *WebModule) Mux() *http.ServeMux  { return w.mux }
 func (w *WebModule) Status() ModuleStatus { return w.status }
 
 func (w *WebModule) Shutdown(ctx context.Context) error {

--- a/pi/digitsd/internal/subsystem/wifiap.go
+++ b/pi/digitsd/internal/subsystem/wifiap.go
@@ -123,7 +123,6 @@ func (w *WiFiAPModule) Teardown() error {
 	return nil
 }
 
-func (w *WiFiAPModule) IsReady() bool                      { return w.status.State == StateReady }
 func (w *WiFiAPModule) Status() ModuleStatus               { return w.status }
 func (w *WiFiAPModule) Shutdown(ctx context.Context) error { return w.Teardown() }
 


### PR DESCRIPTION
## Summary

Every `subsystem.Module` implementation had the identical one-liner `return m.status.State == StateReady`. The interface declared `IsReady` alongside `Status`, so nine modules each carried a parallel accessor that restated information already exposed via `Status()`.

This drops `IsReady` from the interface and from every concrete module, replaces it with a single `subsystem.IsReady(m Module) bool` helper, and routes the manager's shutdown gate plus the `cmd/digitsd` setup/recovery callers through it.

## Why

One predicate definition instead of nine, and the `Module` interface no longer carries a method that just paraphrases `Status()`. Adding a tenth module from now on is one less mechanical accessor to copy.

## Shape of the change

- `internal/subsystem/module.go`: drop `IsReady() bool` from the interface, add `func IsReady(m Module) bool`.
- 9 module files (`audio`, `gpclk0`, `kernmods`, `mounts`, `reaper`, `serial`, `web`, `wifiap`, plus the test stub): delete the per-module `IsReady` method.
- `internal/subsystem/manager.go`: shutdown gate now calls `IsReady(r.Module)`.
- `cmd/digitsd/setup.go`, `cmd/digitsd/recovery.go`: 11 call sites switched from `serial.IsReady()` to `subsystem.IsReady(serial)` (same shape).

Net: +22, -31.

## Test plan

- [x] `go build ./...` clean in `pi/digitsd/`
- [x] `go test ./...` clean (one pre-existing failure in `internal/assets` from missing generated mixer state files, unrelated)
- [x] `go vet ./...` clean
