### PR TITLE
refactor(digitsd): extract initiateCallAfterDelay helper

### DIFF
--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -50,6 +50,11 @@ const (
 // so the controller self-fires here once it has the full number.
 const addDialDigitsRequired = 7
 
+// autoDialDelay is the brief silence between the last digit and the first
+// ringback tone on outgoing calls. Mimics the variable PSTN setup pause that
+// rotary phones produced between dial-pulse train end and first ring.
+const autoDialDelay = 800 * time.Millisecond
+
 // Callbacks is the interface the controller uses to drive hardware and network.
 type Callbacks interface {
 	SendTone(name string)       // Play a tone (use one of the Tone* constants)
@@ -313,21 +318,8 @@ func (c *Controller) onHookOff() {
 			c.cb.SendLED("ON")
 			slog.Info("phone: callback pickup, auto-dialing", "target", number)
 			c.state = StateCALLING
-			go func() {
-				time.Sleep(800 * time.Millisecond)
-				c.mu.Lock()
-				if c.state != StateCALLING {
-					c.mu.Unlock()
-					return
-				}
-				c.cb.SendTone(ToneRingback)
-				err := c.cb.InitiateCall(number)
-				c.mu.Unlock()
-				if err != nil {
-					slog.Info("phone: callback auto-dial failed", "number", number, "error", err)
-					c.playRejectSequence(StateCALLING)
-				}
-			}()
+			c.initiateCallAfterDelay(number, StateCALLING, "phone: callback auto-dial failed",
+				func() { c.playRejectSequence(StateCALLING) })
 		} else {
 			// Incoming: answer the call; activePeer was set when the ring arrived.
 			c.state = StateCONNECTED
@@ -430,22 +422,8 @@ func (c *Controller) onKey(digit string) {
 			c.callReturnNumber = ""
 			slog.Info("phone: CALL_RETURN -> CALLING", "number", number)
 			c.state = StateCALLING
-			go func() {
-				time.Sleep(800 * time.Millisecond)
-				c.mu.Lock()
-				if c.state != StateCALLING {
-					c.mu.Unlock()
-					return
-				}
-				c.cb.SendTone(ToneRingback)
-				err := c.cb.InitiateCall(number)
-				c.mu.Unlock()
-
-				if err != nil {
-					slog.Info("phone: call return failed, server unreachable", "number", number, "error", err)
-					c.playRejectSequence(StateCALLING)
-				}
-			}()
+			c.initiateCallAfterDelay(number, StateCALLING, "phone: call return failed, server unreachable",
+				func() { c.playRejectSequence(StateCALLING) })
 		}
 	case StateADD_DIALTONE:
 		// First key during add-dial: stop the second dial tone, start collecting.
@@ -499,22 +477,31 @@ func (c *Controller) onDial(number string) {
 		return
 	}
 	c.state = StateCALLING
-	// Brief silence before ringback: simulates PSTN call setup delay.
-	// Old rotary phones had a variable pause between last digit and first ring.
+	c.initiateCallAfterDelay(number, StateCALLING, "phone: call failed, server unreachable",
+		func() { c.playRejectSequence(StateCALLING) })
+}
+
+// initiateCallAfterDelay simulates the PSTN call-setup pause and then starts
+// the outgoing call to number. After autoDialDelay it acquires the controller
+// lock; if the FSM has moved out of expectedState (e.g., the caller hung up
+// during the pause) it returns silently. Otherwise it plays ringback, calls
+// InitiateCall, and on error logs errLogMsg with number+error attrs and runs
+// onErr (unlocked) so the caller can drive whatever local treatment the
+// failed leg requires.
+func (c *Controller) initiateCallAfterDelay(number string, expectedState State, errLogMsg string, onErr func()) {
 	go func() {
-		time.Sleep(800 * time.Millisecond)
+		time.Sleep(autoDialDelay)
 		c.mu.Lock()
-		if c.state != StateCALLING {
+		if c.state != expectedState {
 			c.mu.Unlock()
 			return
 		}
 		c.cb.SendTone(ToneRingback)
 		err := c.cb.InitiateCall(number)
 		c.mu.Unlock()
-
 		if err != nil {
-			slog.Info("phone: call failed, server unreachable", "number", number, "error", err)
-			c.playRejectSequence(StateCALLING)
+			slog.Info(errLogMsg, "number", number, "error", err)
+			onErr()
 		}
 	}()
 }
@@ -580,31 +567,17 @@ func (c *Controller) dialThirdParty(number string) {
 	c.addingPeer = number
 	c.digits = ""
 	c.state = StateADD_CALLING
-	// Brief silence before ringback: mirrors the 2-party outgoing call setup delay.
-	go func() {
-		time.Sleep(800 * time.Millisecond)
+	c.initiateCallAfterDelay(number, StateADD_CALLING, "phone: add-call failed, server unreachable", func() {
 		c.mu.Lock()
 		if c.state != StateADD_CALLING {
 			c.mu.Unlock()
 			return
 		}
-		c.cb.SendTone(ToneRingback)
-		err := c.cb.InitiateCall(number)
+		c.state = StateADD_INTERCEPT
 		c.mu.Unlock()
-
-		if err != nil {
-			slog.Info("phone: add-call failed, server unreachable", "number", number, "error", err)
-			c.mu.Lock()
-			if c.state != StateADD_CALLING {
-				c.mu.Unlock()
-				return
-			}
-			c.state = StateADD_INTERCEPT
-			c.mu.Unlock()
-			c.cb.SendTone(ToneStop)
-			c.cb.SendTone(ToneIntercept)
-		}
-	}()
+		c.cb.SendTone(ToneStop)
+		c.cb.SendTone(ToneIntercept)
+	})
 }
 
 func (c *Controller) onSignalRing() {


### PR DESCRIPTION
## Summary

Four spots in `Controller` were each spawning a near-identical goroutine to simulate the PSTN call-setup pause: sleep 800ms, take the lock, abort if the FSM moved out of an expected `*CALLING` state, play ringback, call `InitiateCall`, then log + run a per-site fallback on error. The goroutine body, locking discipline, expected-state guard, and 800ms timing were copy-pasted across:

- `onHookOff` callback-pickup auto-dial
- `*69` confirmation (`onKey` `CALL_RETURN`)
- `onDial` 2-party outgoing
- `dialThirdParty` add-leg

This extracts the shared logic into `Controller.initiateCallAfterDelay(number, expectedState, errLogMsg, onErr)`. Each caller now passes the expected state, the slog message, and an `onErr` closure: `c.playRejectSequence(StateCALLING)` for the three 2-party paths and the `ADD_INTERCEPT` transition for `dialThirdParty`.

Also pulls the 800ms out into an `autoDialDelay` constant with the rotary-PSTN rationale documented once instead of restated at each site.

## Why

One source of truth for the dial-after-delay pattern. Tuning the pause, changing the locking story, or instrumenting the path is now a single edit instead of four-with-drift-risk. `controller.go` is dense; collapsing 57 lines of duplication into a 22-line helper plus four 2-3 line call sites makes the FSM transitions easier to read end-to-end.

## Shape of the change

- One file: `pi/digitsd/internal/phone/controller.go`.
- Net: +30, -57.
- No behavior change. The four call sites preserve their pre-helper sequencing (state transition first, then schedule the delayed dial); the helper's locking, state guard, and error path are byte-for-byte equivalent to the inlined version.

## Test plan

- [x] `go build ./...` clean in `pi/digitsd/`
- [x] `go test ./internal/phone/...` clean (full FSM suite, ~14s)
- [x] `go test ./...` clean except the pre-existing `internal/assets` failure for missing generated mixer state files
- [x] `go vet ./...` clean
