### PR TITLE
refactor(server): collapse Tracker query lock-or-delegate dance

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -299,16 +299,24 @@ func (t *Tracker) RenameNumber(ctx context.Context, oldNumber, newNumber string)
 	return tx.Commit()
 }
 
+// callStateSnapshot returns the configured CallState (Redis-backed cluster
+// view) or nil. Read under the lock so query methods see SetCallState's write
+// per the standard memory model. Reads after the snapshot do not need the
+// lock because t.state is only assigned once at startup.
+func (t *Tracker) callStateSnapshot() *CallState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state
+}
+
 func (t *Tracker) Busy(number string) bool {
 	if t.conferences.IsBusy(number) {
 		return true
 	}
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.Busy(context.Background(), number)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, c := range t.active {
 		if c.Caller == number || c.Callee == number {
@@ -330,12 +338,10 @@ func (t *Tracker) CanAddAsHost(number string) bool {
 	if t.conferences.IsBusy(number) {
 		return false
 	}
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.CanAddAsHost(context.Background(), number)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	callerCount := 0
 	for _, c := range t.active {
@@ -352,12 +358,10 @@ func (t *Tracker) CanAddAsHost(number string) bool {
 // AllPeersOf returns all remote parties that number has active 2-party calls
 // with. Empty if number has no active calls.
 func (t *Tracker) AllPeersOf(number string) []string {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.AllPeersOf(context.Background(), number)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	var peers []string
 	for _, c := range t.active {
@@ -373,12 +377,10 @@ func (t *Tracker) AllPeersOf(number string) []string {
 // PeerOf returns the other party in an active call involving number,
 // or "" if number is not in any active call.
 func (t *Tracker) PeerOf(number string) string {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.PeerOf(context.Background(), number)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, c := range t.active {
 		if c.Caller == number {
@@ -395,12 +397,10 @@ func (t *Tracker) PeerOf(number string) string {
 // b, or 0 if no such call exists. Used by conference setup to find the
 // originating 2-party call id before migrating to mesh.
 func (t *Tracker) CallIDForPair(a, b string) int64 {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.CallIDForPair(context.Background(), a, b)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	if c, ok := t.active[callKey(a, b)]; ok {
 		return c.ID
@@ -414,12 +414,10 @@ func (t *Tracker) CallIDForPair(a, b string) int64 {
 // CallIDFor returns the active call id for an endpoint phone number.
 // Returns (0, false) if the number is not currently in a call.
 func (t *Tracker) CallIDFor(number string) (int64, bool) {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.CallIDFor(context.Background(), number)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, c := range t.active {
 		if c.Caller == number || c.Callee == number {
@@ -430,12 +428,10 @@ func (t *Tracker) CallIDFor(number string) (int64, bool) {
 }
 
 func (t *Tracker) InCall(a, b string) bool {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.InCall(context.Background(), a, b)
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	_, fwd := t.active[callKey(a, b)]
 	_, rev := t.active[callKey(b, a)]
@@ -443,12 +439,10 @@ func (t *Tracker) InCall(a, b string) bool {
 }
 
 func (t *Tracker) Active() []activeCall {
-	t.mu.Lock()
-	s := t.state
-	if s != nil {
-		t.mu.Unlock()
+	if s := t.callStateSnapshot(); s != nil {
 		return s.Active(context.Background())
 	}
+	t.mu.Lock()
 	defer t.mu.Unlock()
 	calls := make([]activeCall, 0, len(t.active))
 	for _, c := range t.active {


### PR DESCRIPTION
## Summary

Seven `Tracker` query methods (`Busy`, `CanAddAsHost`, `AllPeersOf`, `PeerOf`, `CallIDForPair`, `CallIDFor`, `InCall`, `Active`) each opened with the same five-line dance: take `t.mu`, copy `t.state` into a local, branch on nil, unlock-then-delegate or defer-unlock-then-iterate. The pattern was copy-pasted verbatim and obscured what each method actually does behind boilerplate.

Extract `callStateSnapshot()` so the dispatch shape becomes uniform: read `t.state` once under the lock, then either delegate to the Redis-backed `CallState` (no lock needed during the round trip) or re-acquire `t.mu` for the in-memory map walk. The query-specific logic now sits at the top of each method instead of three lines down.

## Why

Same intent at every site, restated seven different ways with subtly different `defer`/early-return interleavings. Now there is one snapshot helper, and every cluster-vs-local branch reads identically. Adding an eighth query method is one snapshot call instead of five lines of locking choreography to copy correctly.

## Locking equivalence

`t.state` is only assigned by `SetCallState` at startup ("Safe to call once at startup; subsequent calls overwrite"), so the snapshot-then-re-acquire window has no observable effect. The pre-refactor code also ran each Redis-backed call without `t.mu` held; this PR keeps that property.

## Shape of the change

- One file: `server/internal/calls/tracker.go`.
- Net: +26, -32.
- No behavior change. All seven methods exercise existing code paths identically; tests pass unchanged.

## Test plan

- [x] `go build ./...` clean in `server/`
- [x] `go test ./internal/calls/...` clean
- [x] `go test ./...` clean except the pre-existing `internal/autodeploy` failure (verified on clean main: same login: denied / image-pull failures, unrelated)
- [x] `go vet ./...` clean
