### PR TITLE
fix(server): propagate ctx to slog calls in ConfState

### DIFF
--- a/server/internal/calls/conference_state_redis.go
+++ b/server/internal/calls/conference_state_redis.go
@@ -47,7 +47,7 @@ func (cs *ConfState) Create(ctx context.Context, confID uuid.UUID, host string, 
 	}
 	data, err := json.Marshal(rc)
 	if err != nil {
-		slog.Error("redis: marshal conference failed", "confID", confID, "err", err)
+		slog.ErrorContext(ctx, "redis: marshal conference failed", "confID", confID, "err", err)
 		return
 	}
 
@@ -57,7 +57,7 @@ func (cs *ConfState) Create(ctx context.Context, confID uuid.UUID, host string, 
 		pipe.Set(ctx, confMemberPrefix+m, confID.String(), confTTL)
 	}
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.Error("redis: ConfState.Create failed", "confID", confID, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.Create failed", "confID", confID, "err", err)
 	}
 }
 
@@ -65,7 +65,7 @@ func (cs *ConfState) Create(ctx context.Context, confID uuid.UUID, host string, 
 func (cs *ConfState) IsBusy(ctx context.Context, phone string) bool {
 	n, err := cs.client.Exists(ctx, confMemberPrefix+phone).Result()
 	if err != nil {
-		slog.Error("redis: ConfState.IsBusy failed", "phone", phone, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.IsBusy failed", "phone", phone, "err", err)
 		return false
 	}
 	return n > 0
@@ -80,7 +80,7 @@ func (cs *ConfState) ConferenceByPhone(ctx context.Context, phone string) *Confe
 	}
 	confID, err := uuid.Parse(idStr)
 	if err != nil {
-		slog.Error("redis: ConfState.ConferenceByPhone bad UUID", "raw", idStr, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.ConferenceByPhone bad UUID", "raw", idStr, "err", err)
 		return nil
 	}
 	return cs.loadConference(ctx, confID)
@@ -95,7 +95,7 @@ func (cs *ConfState) Contains(ctx context.Context, confID uuid.UUID, phoneA, pho
 	}
 	var rc redisConference
 	if err := json.Unmarshal([]byte(data), &rc); err != nil {
-		slog.Error("redis: ConfState.Contains unmarshal failed", "confID", confID, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.Contains unmarshal failed", "confID", confID, "err", err)
 		return false
 	}
 	hasA, hasB := false, false
@@ -113,7 +113,7 @@ func (cs *ConfState) Contains(ctx context.Context, confID uuid.UUID, phoneA, pho
 // RemoveMember deletes a single member's key from Redis.
 func (cs *ConfState) RemoveMember(ctx context.Context, confID uuid.UUID, phone string) {
 	if err := cs.client.Del(ctx, confMemberPrefix+phone).Err(); err != nil {
-		slog.Error("redis: ConfState.RemoveMember failed", "confID", confID, "phone", phone, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.RemoveMember failed", "confID", confID, "phone", phone, "err", err)
 	}
 }
 
@@ -125,7 +125,7 @@ func (cs *ConfState) End(ctx context.Context, confID uuid.UUID, members []string
 		keys = append(keys, confMemberPrefix+m)
 	}
 	if err := cs.client.Del(ctx, keys...).Err(); err != nil {
-		slog.Error("redis: ConfState.End failed", "confID", confID, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.End failed", "confID", confID, "err", err)
 	}
 }
 
@@ -136,7 +136,7 @@ func (cs *ConfState) loadConference(ctx context.Context, confID uuid.UUID) *Conf
 	}
 	var rc redisConference
 	if err := json.Unmarshal([]byte(data), &rc); err != nil {
-		slog.Error("redis: ConfState.loadConference unmarshal failed", "confID", confID, "err", err)
+		slog.ErrorContext(ctx, "redis: ConfState.loadConference unmarshal failed", "confID", confID, "err", err)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Daily holistic review across the last 24h of merged server PRs surfaced one drift:

- #540 migrated the calls package to `slog.*Context` so request-bound `ctx` carries `trace_id` / `span_id` into log records (the `traceContextHandler` only injects spans when the `*Context` variants are used).
- It described its scope as "HTTP handlers, auth, and the calls package" and fully migrated the sibling `state_redis.go`.
- `conference_state_redis.go` sits in the same package, has the same Redis-store shape, and every method already takes `ctx context.Context`, but its eight `slog.Error(...)` sites were missed.
- #543 (`refactor(server): collapse Tracker query lock-or-delegate dance`) touched neighboring code in the same package and preserved the pre-existing convention without picking up the gap.

This PR converts the eight `slog.Error(...)` calls in `ConfState.Create`, `IsBusy`, `ConferenceByPhone`, `Contains`, `RemoveMember`, `End`, and `loadConference` to `slog.ErrorContext(ctx, ...)`. Now the calls-package Redis state files are uniform.

## Why this is purely additive

Mechanical substitution only. Behavior for callers that pass `context.Background()` is unchanged (no span, no `trace_id`); callers that already pass a request-bound context (for example `DropMemberPersistent` in `tracker.go`) gain Loki-Tempo correlation for free.

## Test plan

- [x] `go build ./...` clean in `server/`
- [x] `go test ./internal/calls/...` clean
- [x] `go test ./...` clean except pre-existing `internal/autodeploy` failure (same `login: denied` / `healthcheck: timeout` pattern documented in #542 and #543 as unrelated)
- [x] `go vet ./...` clean
- Local `golangci-lint` v2.5.0 refuses go1.26.1 modules (built against go1.25), so lint is delegated to CI.

## Motivated by (last 24h)

- #540 (`fix(server): propagate request context to all slog calls`)
- #543 (`refactor(server): collapse Tracker query lock-or-delegate dance`)