### PR TITLE
fix(server): stop call duration timer from ticking after call ends

### DIFF
--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -57,6 +57,15 @@ func baseTemplateFuncs() template.FuncMap {
 			}
 			return fmt.Sprintf("%d:%02d", seconds/60, seconds%60)
 		},
+		"fmtDurationClock": func(seconds int) string {
+			h := seconds / 3600
+			m := (seconds % 3600) / 60
+			s := seconds % 60
+			if h > 0 {
+				return fmt.Sprintf("%d:%02d:%02d", h, m, s)
+			}
+			return fmt.Sprintf("%02d:%02d", m, s)
+		},
 		"derefFloat32": func(p *float32) float32 {
 			if p == nil {
 				return 0

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -42,6 +42,7 @@ type ConferenceLinkHealthResp struct {
 	ConfID    uuid.UUID                  `json:"conf_id"`
 	CreatedAt time.Time                  `json:"created_at"`
 	Ended     bool                       `json:"ended"`
+	DurationS int                        `json:"duration_s"`
 	Members   []ConferenceMemberInfo     `json:"members"`
 	Edges     []ConferenceLinkHealthEdge `json:"edges"`
 }
@@ -96,6 +97,7 @@ func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls
 		ConfID:    conf.ID,
 		CreatedAt: conf.CreatedAt,
 		Ended:     conf.EndedAt != nil,
+		DurationS: conf.DurationS,
 		Members:   members,
 		Edges:     edges,
 	}

--- a/server/internal/web/templates/call-live-detail.html
+++ b/server/internal/web/templates/call-live-detail.html
@@ -7,7 +7,11 @@
       <span class="deck-kicker label">live session</span>
       <h1 class="deck-title">{{.Caller.DisplayName}} <span class="deck-arrow">&harr;</span> {{.Callee.DisplayName}}</h1>
       <div class="deck-meta">
-        <span class="deck-duration" data-duration-since="{{.Call.StartedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+        {{if .Ended}}
+          <span class="deck-duration">{{fmtDurationClock .Call.DurationS}}</span>
+        {{else}}
+          <span class="deck-duration" data-duration-since="{{.Call.StartedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+        {{end}}
         {{with .Caller.Latest}}
           {{if .ConnType}}<span class="deck-conn">via {{.ConnType}}</span>{{end}}
         {{end}}

--- a/server/internal/web/templates/conference-live-detail.html
+++ b/server/internal/web/templates/conference-live-detail.html
@@ -9,7 +9,11 @@
         {{range $i, $m := .Resp.Members}}{{if $i}} &harr; {{end}}{{$m.DisplayName}}{{end}}
       </h1>
       <div class="deck-meta">
-        <span class="deck-duration" data-duration-since="{{.Resp.CreatedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+        {{if .Resp.Ended}}
+          <span class="deck-duration">{{fmtDurationClock .Resp.DurationS}}</span>
+        {{else}}
+          <span class="deck-duration" data-duration-since="{{.Resp.CreatedAt.UnixMilli}}">&middot;&middot;:&middot;&middot;</span>
+        {{end}}
       </div>
     </div>
     {{if .Resp.Ended}}


### PR DESCRIPTION
## Summary
- The live detail page for calls and conferences unconditionally started a JS timer counting up from the start time, even for ended calls. Visiting an old call showed an ever-growing bogus duration.
- When a call/conference has ended, the page now renders a static duration in the same `mm:ss` / `h:mm:ss` clock format as the live timer, so there is no visual jump when a live call ends and the page reloads.
- Added `DurationS` to `ConferenceLinkHealthResp` so the conference template has access to the final duration.

## Test plan
- [ ] Visit an ended call at `/call/live/{id}`: timer should show static final duration, not tick
- [ ] Visit an ended conference at `/conference/live/{uuid}`: same behavior
- [ ] Start a live call, watch the timer tick, end the call: page reloads and timer freezes at the correct final value in the same format