### PR TITLE
refactor(digitsd): drop unused HealthChecker interface

### DIFF
--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -54,10 +54,6 @@ func IsReady(m Module) bool {
 	return m.Status().State == StateReady
 }
 
-type HealthChecker interface {
-	HealthCheck() error
-}
-
 type Registration struct {
 	Module   Module
 	Deps     []string

--- a/pi/digitsd/internal/subsystem/serial.go
+++ b/pi/digitsd/internal/subsystem/serial.go
@@ -62,10 +62,3 @@ func (s *SerialModule) Shutdown(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (s *SerialModule) HealthCheck() error {
-	if s.port == nil {
-		return fmt.Errorf("not initialized")
-	}
-	return s.port.Ping()
-}


### PR DESCRIPTION
## Why

`subsystem.HealthChecker` was declared in `internal/subsystem/module.go` but had no callers anywhere in the tree: no type assertion, no parameter use, no manager call. The only implementer, `SerialModule.HealthCheck`, was never invoked. The Manager runs `Init`/`Status`/`Shutdown` but does not poll modules for health.

Verified with `rg HealthCheck` across the whole repo: only the declaration and the unused method showed up.

## Change

- Remove `HealthChecker` interface from `internal/subsystem/module.go`
- Remove `SerialModule.HealthCheck` from `internal/subsystem/serial.go`

Keeps the subsystem package's public surface in line with what is actually wired up. If per-module health polling is wanted later, the right place to start is the Manager, not a stale interface.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (subsystem + cmd/digitsd)
- [x] `golangci-lint run ./...` clean