### PR TITLE
refactor(server): use dbutil.WithTx in Tracker.RenameNumber

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -279,24 +279,21 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 // RenameNumber updates all call history records from oldNumber to newNumber
 // in a single transaction.
 func (t *Tracker) RenameNumber(ctx context.Context, oldNumber, newNumber string) error {
-	tx, err := t.db.DB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("rename number: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-	queries := []string{
-		`UPDATE calls SET caller = $1 WHERE caller = $2`,
-		`UPDATE calls SET callee = $1 WHERE callee = $2`,
-		`UPDATE conferences SET host_phone = $1 WHERE host_phone = $2`,
-		`UPDATE conference_members SET phone = $1 WHERE phone = $2`,
-		`UPDATE conference_kicks SET kicked_phone = $1 WHERE kicked_phone = $2`,
-	}
-	for _, q := range queries {
-		if _, err := tx.ExecContext(ctx, q, newNumber, oldNumber); err != nil {
-			return fmt.Errorf("rename number in call history: %w", err)
+	return dbutil.WithTx(ctx, t.db.DB, func(tx *sql.Tx) error {
+		queries := []string{
+			`UPDATE calls SET caller = $1 WHERE caller = $2`,
+			`UPDATE calls SET callee = $1 WHERE callee = $2`,
+			`UPDATE conferences SET host_phone = $1 WHERE host_phone = $2`,
+			`UPDATE conference_members SET phone = $1 WHERE phone = $2`,
+			`UPDATE conference_kicks SET kicked_phone = $1 WHERE kicked_phone = $2`,
 		}
-	}
-	return tx.Commit()
+		for _, q := range queries {
+			if _, err := tx.ExecContext(ctx, q, newNumber, oldNumber); err != nil {
+				return fmt.Errorf("rename number in call history: %w", err)
+			}
+		}
+		return nil
+	})
 }
 
 // callStateSnapshot returns the configured CallState (Redis-backed cluster


### PR DESCRIPTION
## Why

Every other transaction in `tracker.go` (and across the `pairing` and `household` stores) goes through `dbutil.WithTx`. Only `RenameNumber` still hand-rolls the `BeginTx` / `defer Rollback` / `Commit` pattern. Switching it over makes the package uniform and keeps commit-vs-rollback bookkeeping in one place.

## Change

Wrap the five UPDATE statements in `dbutil.WithTx`. The error wrap (`"rename number in call history: %w"`) is preserved; the rollback-on-early-return semantics are identical (the helper rolls back unless `fn` returns nil and `Commit` succeeds).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/calls/...` clean
- [x] `golangci-lint run ./...` clean