### PR TITLE
refactor(digitsd): collapse wifi.Scanner into a package function

### DIFF
--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -56,9 +56,8 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		})
 	}
 
-	scanner := &wifi.SystemScanner{}
 	mux.HandleFunc("/api/networks", func(w http.ResponseWriter, r *http.Request) {
-		networks, err := scanner.Scan()
+		networks, err := wifi.Scan()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pi/digitsd/internal/wifi/scan.go
+++ b/pi/digitsd/internal/wifi/scan.go
@@ -14,15 +14,8 @@ type Network struct {
 	Signal int    `json:"signal"` // dBm
 }
 
-// Scanner discovers nearby Wi-Fi networks.
-type Scanner interface {
-	Scan() ([]Network, error)
-}
-
-// SystemScanner uses `iw dev wlan0 scan` on the host.
-type SystemScanner struct{}
-
-func (s *SystemScanner) Scan() ([]Network, error) {
+// Scan discovers nearby Wi-Fi networks via `iw dev wlan0 scan` on the host.
+func Scan() ([]Network, error) {
 	cmd := exec.Command("iw", "dev", "wlan0", "scan", "-u")
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
## Why

`wifi.Scanner` was a one-method interface with one implementation, `SystemScanner` (a zero-size struct), and one caller: the `/api/networks` handler in `cmd/digitsd/setup.go`. No mock implementation existed, no test passed a fake through the interface, and the parsing path is already covered by `parseIWScan`'s own tests.

The interface plus stateless struct was a layer of indirection that bought nothing.

## Change

- Replace the `Scanner` interface and `SystemScanner` struct in `internal/wifi/scan.go` with a single `wifi.Scan()` function.
- Update the one call site in `cmd/digitsd/setup.go` to call `wifi.Scan()` directly.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (wifi + cmd/digitsd)
- [x] `golangci-lint run ./...` clean