### PR TITLE
fix(server): propagate ctx to slog calls in signaling package

### DIFF
--- a/server/internal/signaling/conference.go
+++ b/server/internal/signaling/conference.go
@@ -12,11 +12,11 @@ import (
 func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Message) {
 	held := msg.HeldPeer
 	active := msg.ActivePeer
-	slog.Info("conference: merge requested", "host", host, "held", held, "active", active)
+	slog.InfoContext(ctx, "conference: merge requested", "host", host, "held", held, "active", active)
 
 	// 1. Validate: host is in both calls.
 	if !r.Tracker.InCall(host, held) || !r.Tracker.InCall(host, active) {
-		slog.Warn("conference: merge rejected", "host", host, "reason", "host_not_in_both_calls", "held", held, "active", active)
+		slog.WarnContext(ctx, "conference: merge rejected", "host", host, "reason", "host_not_in_both_calls", "held", held, "active", active)
 		r.sendRejection(host, msg.ConfID, "host_not_in_both_calls")
 		return
 	}
@@ -24,7 +24,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	// 2. Validate: neither added member is already in a conference.
 	for _, p := range []string{held, active} {
 		if r.Tracker.Conferences().IsBusy(p) {
-			slog.Warn("conference: merge rejected", "host", host, "reason", "member_already_in_conference", "busy_member", p)
+			slog.WarnContext(ctx, "conference: merge rejected", "host", host, "reason", "member_already_in_conference", "busy_member", p)
 			r.sendRejection(host, msg.ConfID, "member_already_in_conference")
 			return
 		}
@@ -33,18 +33,18 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	// 3. Look up the originating call id (A-held).
 	callID := r.Tracker.CallIDForPair(host, held)
 	if callID == 0 {
-		slog.Warn("conference: merge rejected", "host", host, "reason", "call_id_unknown", "held", held)
+		slog.WarnContext(ctx, "conference: merge rejected", "host", host, "reason", "call_id_unknown", "held", held)
 		r.sendRejection(host, msg.ConfID, "call_id_unknown")
 		return
 	}
 
 	conf, err := r.Tracker.CreateConferencePersistent(ctx, host, callID, []string{held, active})
 	if err != nil {
-		slog.Error("create conference", "err", err)
+		slog.ErrorContext(ctx, "create conference", "err", err)
 		r.sendRejection(host, msg.ConfID, "create_failed")
 		return
 	}
-	slog.Info("conference: created", "conf_id", conf.ID.String(), "host", host, "held", held, "active", active, "originating_call_id", callID)
+	slog.InfoContext(ctx, "conference: created", "conf_id", conf.ID.String(), "host", host, "held", held, "active", active, "originating_call_id", callID)
 
 	// 4. Notify all three members of the membership snapshot.
 	members := []ConferenceMemberInfo{
@@ -55,10 +55,10 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 	memberMsg := &Message{Type: TypeConferenceMember, ConfID: conf.ID.String(), Members: members}
 	for _, m := range members {
 		if err := r.Hub.SendTo(m.Phone, memberMsg); err != nil {
-			slog.Warn("conference: ConferenceMember send failed", "conf_id", conf.ID.String(), "to", m.Phone, "err", err)
+			slog.WarnContext(ctx, "conference: ConferenceMember send failed", "conf_id", conf.ID.String(), "to", m.Phone, "err", err)
 		}
 	}
-	slog.Info("conference: ConferenceMember broadcast", "conf_id", conf.ID.String(), "members", len(members))
+	slog.InfoContext(ctx, "conference: ConferenceMember broadcast", "conf_id", conf.ID.String(), "members", len(members))
 
 	// 5. Instruct held and active peers to open a peer connection to each other.
 	//    Deterministic tiebreak: numerically smaller phone number is the initiator.
@@ -69,7 +69,7 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 		Peer:      active,
 		Initiator: heldIsInitiator,
 	}); err != nil {
-		slog.Warn("conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", held, "err", err)
+		slog.WarnContext(ctx, "conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", held, "err", err)
 	}
 	if err := r.Hub.SendTo(active, &Message{
 		Type:      TypeConferenceConnect,
@@ -77,9 +77,9 @@ func (r *Relay) handleConferenceMerge(ctx context.Context, host string, msg *Mes
 		Peer:      held,
 		Initiator: !heldIsInitiator,
 	}); err != nil {
-		slog.Warn("conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", active, "err", err)
+		slog.WarnContext(ctx, "conference: ConferenceConnect send failed", "conf_id", conf.ID.String(), "to", active, "err", err)
 	}
-	slog.Info("conference: ConferenceConnect dispatched", "conf_id", conf.ID.String(), "held", held, "active", active, "held_is_initiator", heldIsInitiator)
+	slog.InfoContext(ctx, "conference: ConferenceConnect dispatched", "conf_id", conf.ID.String(), "held", held, "active", active, "held_is_initiator", heldIsInitiator)
 }
 
 func (r *Relay) sendRejection(host, confID, reason string) {
@@ -95,12 +95,12 @@ func (r *Relay) endConference(ctx context.Context, confID uuid.UUID, reason stri
 	if conf == nil {
 		// Already ended (e.g. a second caller triggers endConference after a
 		// member drop already ended it). No members to notify.
-		slog.Info("conference: end skipped, already ended", "conf_id", confID.String(), "reason", reason)
+		slog.InfoContext(ctx, "conference: end skipped, already ended", "conf_id", confID.String(), "reason", reason)
 		return
 	}
-	slog.Info("conference: ending", "conf_id", confID.String(), "reason", reason, "members", len(conf.Members))
+	slog.InfoContext(ctx, "conference: ending", "conf_id", confID.String(), "reason", reason, "members", len(conf.Members))
 	if err := r.Tracker.EndConferencePersistent(ctx, confID, reason); err != nil {
-		slog.Error("end conference persist", "err", err)
+		slog.ErrorContext(ctx, "end conference persist", "err", err)
 	}
 	for p := range conf.Members {
 		if err := r.Hub.SendTo(p, &Message{
@@ -108,20 +108,20 @@ func (r *Relay) endConference(ctx context.Context, confID uuid.UUID, reason stri
 			ConfID: confID.String(),
 			Reason: reason,
 		}); err != nil {
-			slog.Warn("conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
+			slog.WarnContext(ctx, "conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
 		}
 	}
-	slog.Info("conference: ConferenceEnd broadcast", "conf_id", confID.String(), "reason", reason)
+	slog.InfoContext(ctx, "conference: ConferenceEnd broadcast", "conf_id", confID.String(), "reason", reason)
 }
 
 func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, phone, reason string) {
 	conf := r.Tracker.Conferences().Snapshot(confID)
 	if conf == nil {
 		// Already ended; nothing to drop or notify.
-		slog.Info("conference: drop skipped, already ended", "conf_id", confID.String(), "phone", phone, "reason", reason)
+		slog.InfoContext(ctx, "conference: drop skipped, already ended", "conf_id", confID.String(), "phone", phone, "reason", reason)
 		return
 	}
-	slog.Info("conference: drop member", "conf_id", confID.String(), "phone", phone, "reason", reason)
+	slog.InfoContext(ctx, "conference: drop member", "conf_id", confID.String(), "phone", phone, "reason", reason)
 	var others []string
 	for p := range conf.Members {
 		if p != phone {
@@ -130,7 +130,7 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 	}
 	remaining, _, err := r.Tracker.DropMemberPersistent(ctx, confID, phone, reason)
 	if err != nil {
-		slog.Error("drop member", "err", err)
+		slog.ErrorContext(ctx, "drop member", "err", err)
 		return
 	}
 
@@ -141,10 +141,10 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 			Peer:   phone,
 			Reason: reason,
 		}); err != nil {
-			slog.Warn("conference: ConferenceLeave send failed", "conf_id", confID.String(), "to", p, "err", err)
+			slog.WarnContext(ctx, "conference: ConferenceLeave send failed", "conf_id", confID.String(), "to", p, "err", err)
 		}
 	}
-	slog.Info("conference: ConferenceLeave broadcast", "conf_id", confID.String(), "left", phone, "notified", others)
+	slog.InfoContext(ctx, "conference: ConferenceLeave broadcast", "conf_id", confID.String(), "left", phone, "notified", others)
 	// v1: any drop ends the conference; notify remaining members explicitly so
 	// client controllers know to fully tear down (not just drop the leaver).
 	for _, p := range remaining {
@@ -153,10 +153,10 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 			ConfID: confID.String(),
 			Reason: "member_left",
 		}); err != nil {
-			slog.Warn("conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
+			slog.WarnContext(ctx, "conference: ConferenceEnd send failed", "conf_id", confID.String(), "to", p, "err", err)
 		}
 	}
-	slog.Info("conference: ConferenceEnd broadcast after drop", "conf_id", confID.String(), "remaining", remaining)
+	slog.InfoContext(ctx, "conference: ConferenceEnd broadcast after drop", "conf_id", confID.String(), "remaining", remaining)
 }
 
 // KickMember drops a member from the conference and notifies the kicked
@@ -169,7 +169,7 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 // Reason is logged on the kicked phone's ConferenceEnd message; callers
 // may pass any human-friendly string (e.g., "kicked by <display name>").
 func (r *Relay) KickMember(ctx context.Context, confID uuid.UUID, kickedPhone, reason string) {
-	slog.Info("conference: kick member", "conf_id", confID.String(), "kicked", kickedPhone, "reason", reason)
+	slog.InfoContext(ctx, "conference: kick member", "conf_id", confID.String(), "kicked", kickedPhone, "reason", reason)
 	// Notify the kicked phone first so it starts tearing down before the
 	// drop cascade reassigns the surviving pair to a continuation call.
 	// Non-member or unregistered phones get a no-op send; the caller is
@@ -179,7 +179,7 @@ func (r *Relay) KickMember(ctx context.Context, confID uuid.UUID, kickedPhone, r
 		ConfID: confID.String(),
 		Reason: reason,
 	}); err != nil {
-		slog.Warn("conference: kick ConferenceEnd send to kicked phone failed", "conf_id", confID.String(), "phone", kickedPhone, "err", err)
+		slog.WarnContext(ctx, "conference: kick ConferenceEnd send to kicked phone failed", "conf_id", confID.String(), "phone", kickedPhone, "err", err)
 	}
 	r.dropMemberFromConference(ctx, confID, kickedPhone, reason)
 }

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -192,7 +192,7 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 	h.mu.RUnlock()
 
 	if n == 0 {
-		slog.Info("drain: no connections to close")
+		slog.InfoContext(ctx, "drain: no connections to close")
 		return
 	}
 
@@ -201,7 +201,7 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 	if !ok {
 		deadline = time.Now().Add(5 * time.Second)
 	}
-	slog.Info("drain: sending close frames", "connections", n, "remaining", time.Until(deadline).Round(time.Millisecond))
+	slog.InfoContext(ctx, "drain: sending close frames", "connections", n, "remaining", time.Until(deadline).Round(time.Millisecond))
 	closeMsg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down")
 	for _, c := range snapshot {
 		if c.WS != nil {
@@ -222,7 +222,7 @@ func (h *Hub) DrainAndClose(ctx context.Context) {
 			remaining := h.totalConns()
 			h.mu.RUnlock()
 			if remaining == 0 {
-				slog.Info("drain: all connections closed gracefully")
+				slog.InfoContext(ctx, "drain: all connections closed gracefully")
 				return
 			}
 		}

--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -95,15 +95,15 @@ func (b *RedisBridge) Publish(ctx context.Context, env *Envelope) {
 	env.PodID = b.podID
 	data, err := json.Marshal(env)
 	if err != nil {
-		slog.Error("redis: marshal envelope failed", "err", err)
+		slog.ErrorContext(ctx, "redis: marshal envelope failed", "err", err)
 		return
 	}
 	if err := b.client.Publish(ctx, redisChannel, data).Err(); err != nil {
-		slog.Error("redis: publish failed", "err", err)
+		slog.ErrorContext(ctx, "redis: publish failed", "err", err)
 		return
 	}
 	b.published.Add(1)
-	slog.Debug("redis: published message", "pod", b.podID)
+	slog.DebugContext(ctx, "redis: published message", "pod", b.podID)
 }
 
 // Subscribe returns a channel that yields envelopes from other pods.
@@ -128,7 +128,7 @@ func (b *RedisBridge) Subscribe(ctx context.Context) <-chan *Envelope {
 				}
 				var env Envelope
 				if err := json.Unmarshal([]byte(redisMsg.Payload), &env); err != nil {
-					slog.Warn("redis: unmarshal envelope failed", "err", err)
+					slog.WarnContext(ctx, "redis: unmarshal envelope failed", "err", err)
 					continue
 				}
 				// Skip messages from this pod to avoid echo.


### PR DESCRIPTION
## Summary

Daily holistic review across the last 24h of merged server PRs surfaced unmigrated sites in the `signaling` package. The `slog.*Context` migration established by #540 was extended by:

- #547 (`calls/conference_state_redis.go`, 8 sites)
- #549 (`signaling/state_redis.go` 12 sites, `calls/linkhealth.go`, `updates/github.go`)

The sibling `signaling/conference.go`, `signaling/redis.go` (Publish and Subscribe), and `signaling/hub.go` (DrainAndClose) were missed even though `ctx` is already in lexical scope in every affected function. Without the `*Context` variants the `traceContextHandler` injects no `trace_id` / `span_id`, so logs for conference setup, member drops, kicks, Redis publish errors, and graceful drain were not correlated to their request spans.

## What changed

Mechanical substitution in functions and closures with `ctx` already in scope:

- `conference.go`: `handleConferenceMerge` (11), `endConference` (5), `dropMemberFromConference` (7), `KickMember` (2)
- `redis.go`: `Publish` (3, including the trailing `Debug` for the published-message line), `Subscribe` goroutine (1, `ctx` captured in closure)
- `hub.go`: `DrainAndClose` (3)

## What was deliberately not changed

Same scope discipline as #549 (only convert sites where `ctx` is already in scope; no signature changes):

- `sendRejection`, `forceCloseAll`, `deliverFromRedis`, `Register`, `Unregister`, `SendTo`, `SendToHardware`, `Broadcast`: no `ctx` parameter today. Threading one through is a contract change beyond a drift fix.
- `NewRedisBridge` constructor `slog.Info` (no ctx by construction).
- `events.Broadcaster.Notify`, `email.LogSender.Send`, and the `linkhealth.go` background-goroutine `slog.Debug` lines: already enumerated by #549 as "by design" and out of scope.

## Why this is purely additive

Behavior for callers that pass `context.Background()` is unchanged (no span, no `trace_id`); callers that already pass a request-bound context (every conference flow through `Relay`, every WebSocket Redis publish, the graceful-drain path triggered by SIGTERM) gain Loki-Tempo correlation for free.

## Test plan

- [x] `go build ./...` clean in `server/`
- [x] `go test ./...` clean across all server packages, including `internal/autodeploy` (now passes as root since #549 added the getuid skip), `internal/signaling`, `internal/calls`, `internal/web`
- [x] `go vet ./...` clean
- Local `golangci-lint` v2.5.0 refuses go1.26.1 modules (built against go1.25), so lint is delegated to CI, same as #547.

## Motivated by (last 24h)

- #549 (`refactor(server): propagate ctx to slog, fix test root skip, fix devseed errors`)
- #547 (`fix(server): propagate ctx to slog calls in ConfState`)
- #544 (`refactor(server): idiomatic Go cleanup`, the sibling cleanup in `state_redis.go`)