### PR TITLE
refactor(server): remove orphaned comment, log swallowed error, align const block

### DIFF
--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -28,11 +28,11 @@ const (
 	TypeLineSettings  = "line_settings"  // Server → Phone: per-line config update
 	TypeLinkHealth    = "link_health"    // Phone → Server: per-call stats snapshot
 	TypeRepair        = "repair"         // Phone → Server: invalidate pairing (used by *#0* before reboot)
-	TypeCallReturn       = "call_return"        // Phone → Server: request last inbound caller
-	TypeCallReturnResult = "call_return_result" // Server → Phone: last inbound caller number
-	TypeCallReturnRetry  = "call_return_retry"  // Phone → Server: register busy-retry for *69
-	TypeCallReturnRing   = "call_return_ring"   // Server → Phone: target is free, ring with distinctive pattern
-	TypeCallReturnCancel = "call_return_cancel" // Phone → Server: cancel pending retry (*89)
+	TypeCallReturn          = "call_return"           // Phone → Server: request last inbound caller
+	TypeCallReturnResult    = "call_return_result"    // Server → Phone: last inbound caller number
+	TypeCallReturnRetry     = "call_return_retry"     // Phone → Server: register busy-retry for *69
+	TypeCallReturnRing      = "call_return_ring"      // Server → Phone: target is free, ring with distinctive pattern
+	TypeCallReturnCancel    = "call_return_cancel"    // Phone → Server: cancel pending retry (*89)
 	TypeCallReturnCancelled = "call_return_cancelled" // Server → Phone: confirm cancellation
 
 	TypeReleaseAvailable = "release_available" // Server → All: new release detected

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -142,7 +142,10 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	var callsTodayRecent []callRow
 	var callsTodayTotalSec int
 	if callHistoryEnabled && len(ownNumbers) > 0 {
-		recent, _ := h.tracker.RecentForPhones(ctx, ownNumbers, 20)
+		recent, err := h.tracker.RecentForPhones(ctx, ownNumbers, 20)
+		if err != nil {
+			slog.WarnContext(ctx, "dashboard: recent calls lookup failed", "err", err)
+		}
 		today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
 		for _, c := range recent {
 			if !c.StartedAt.After(today) {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -402,5 +402,3 @@ func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write([]byte("{}"))
 }
-
-// userDisplayLabel returns the preferred name for an audit/display context:


### PR DESCRIPTION
## Grade: 87 -> 91 / 100

Full read of the `server/` module surfaced three small but concrete issues. Fixed here; `/simplify` run produced no additional findings.

---

## What changed

**`handler_linkhealth.go`**: Deleted a dangling comment fragment at EOF:

```go
// userDisplayLabel returns the preferred name for an audit/display context:
```

This was the opening line of a doc comment left behind when `userDisplayLabel` was moved to `handler_helpers.go`. The function body (and its closing brace) were removed at the time; only this line remained, pointing at nothing.

**`handler_dashboard.go`**: The call to `RecentForPhones` was silently swallowing its error return with `_`. A DB failure would cause the dashboard to render with an empty call history and no indication of why. Changed to capture and log at `slog.WarnContext` level. Ranging over a nil slice when the error path is taken is safe in Go, so the render path is unchanged.

**`protocol.go`**: `TypeCallReturnCancelled` was added after the fact and broke the manual column alignment of the surrounding `TypeCallReturn*` constant block. Realigned the whole block so comments line up consistently.

---

## Grading rationale

| Area | Before | After | Notes |
|---|---|---|---|
| Code cleanliness | 90 | 95 | Orphaned comment and silent error gone |
| Idiomatic Go | 88 | 92 | Errors are no longer silently discarded |
| Stale / unreferenced code | 80 | 95 | Dead comment removed |
| Project layout | 95 | 95 | No change; layout was already solid |
| Test coverage | 85 | 85 | No change; existing coverage is reasonable |
| **Overall** | **87** | **91** | |

---

## Test plan

- `go build ./...` passes
- `go test -short ./...` passes (all packages green)
- `/simplify` agents (reuse, quality, efficiency) found no additional issues

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQ74qKCNidBgPDDmfm3HQX)_