### PR TITLE
fix(server): log discarded FindNumberConflicts error in handleLinksAcceptInvitePost

### DIFF
--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -132,7 +132,10 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 	if link.HouseholdBID != nil {
 		bID = *link.HouseholdBID
 	}
-	conflicts, _ := h.linkStore.FindNumberConflicts(r.Context(), link.HouseholdAID, bID)
+	conflicts, err := h.linkStore.FindNumberConflicts(r.Context(), link.HouseholdAID, bID)
+	if err != nil {
+		slog.WarnContext(r.Context(), "find number conflicts failed", "err", err)
+	}
 	if len(conflicts) > 0 {
 		var names []string
 		for _, c := range conflicts {


### PR DESCRIPTION
## Why

Daily holistic review across the last 24h of merged server PRs surfaced one sibling site for the swallowed-DB-error convention set by #555.

#555 fixed `handler_dashboard.go` so a failure of `RecentForPhones` no longer silently rendered as an empty call history. The same shape sits in `handler_links.go:135`:

```go
conflicts, _ := h.linkStore.FindNumberConflicts(r.Context(), link.HouseholdAID, bID)
```

After `LinkStore.AcceptInvite` succeeds, the handler queries `FindNumberConflicts` to decide whether to redirect with `?conflicts=...`. If the DB call fails, the assignment to `_` discards the error, `conflicts` is nil, `len(conflicts) > 0` is false, and the user is redirected to `/links?accepted=1` as if the link was accepted with no conflicts at all. The on-call has no log line to correlate against. A genuinely conflicting link looks indistinguishable from a clean one.

## Change

Capture the error and log it at `WarnContext` exactly like the dashboard fix:

```go
conflicts, err := h.linkStore.FindNumberConflicts(r.Context(), link.HouseholdAID, bID)
if err != nil {
    slog.WarnContext(r.Context(), "find number conflicts failed", "err", err)
}
```

`conflicts` stays nil on error, so the existing `len(conflicts) > 0` branch and nil-range below it are still safe; no behavior change on the success path.

## Motivated by (last 24h)

- #555 `refactor(server): remove orphaned comment, log swallowed error, align const block`

## Test plan

- [x] `go build ./...` clean
- [x] `go test -short ./...` clean
- Local `golangci-lint` v2.5.0 refuses go1.26.1 modules (same situation as #554), so lint is delegated to CI.