### PR TITLE
docs(digitsd): align voicemail comments with current behavior

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -425,8 +425,8 @@ func (d *daemonCallbacks) VoicemailPickup() {
 
 // VoicemailAutoAnswer completes the SDP/ICE handshake for an unanswered call,
 // opens a voicemail recorder, brings up the audio pipeline, and plays the
-// greeting beep. It mirrors the slow path of AnswerCall but diverges in three
-// ways:
+// outgoing greeting followed by the prompt beep. It mirrors the slow path of
+// AnswerCall but diverges in three ways:
 //
 //  1. No mixer.AddWebRTCSource: caller audio does not play through the
 //     earpiece during voicemail. Decoded PCM is sent to voicemailWebRTCCh
@@ -435,9 +435,10 @@ func (d *daemonCallbacks) VoicemailPickup() {
 //  2. OnRemoteTrack runs the same three-phase startup as the live call path
 //     (discard until pipeline ready, drain to live, then feed) but in the
 //     live phase ALSO tees the raw Opus payload into the recorder.
-//  3. After SDP exchange and pipeline start, a small goroutine plays a
-//     greeting beep and then transitions the controller into the recording
-//     state.
+//  3. After SDP exchange and pipeline start, a small goroutine plays the
+//     outgoing greeting (custom .frames if recorded, otherwise the embedded
+//     default WAV) followed by the prompt beep, then mutes the mic and
+//     transitions the controller into the recording state.
 func (d *daemonCallbacks) VoicemailAutoAnswer() {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -27,7 +27,7 @@ const (
 	StateADD_INTERCEPT   State = "ADD_INTERCEPT"   // Add-leg failed (busy, timeout, refused); B on hold, flash to recover
 	StateCONFERENCE_MERGED State = "CONFERENCE_MERGED" // Three-way call active
 	StateCALL_RETURN       State = "CALL_RETURN"       // *69: waiting for announcement + "1" confirmation
-	StateVOICEMAIL_GREETING        State = "VOICEMAIL_GREETING"        // auto-answered; playing beep
+	StateVOICEMAIL_GREETING        State = "VOICEMAIL_GREETING"        // auto-answered; playing outgoing greeting then beep
 	StateVOICEMAIL_RECORDING       State = "VOICEMAIL_RECORDING"       // recording caller audio
 	StateVOICEMAIL_RECORD_GREETING State = "VOICEMAIL_RECORD_GREETING" // user is recording their custom outgoing greeting (*97)
 )
@@ -228,9 +228,12 @@ func (c *Controller) State() State {
 }
 
 // IsCallActive reports whether the phone is currently in a call or actively
-// ringing. Voicemail greeting/recording also count as active: the WebRTC peer
-// connection is up, the recorder is open, and any teardown path (e.g. WebSocket
-// reconnect) must run the full HangupCall flow to finalize cleanly.
+// ringing. All three voicemail states also count as active: an inbound-call
+// voicemail (VOICEMAIL_GREETING, VOICEMAIL_RECORDING) holds an open WebRTC
+// peer and a message recorder, and a custom-greeting recording session
+// (VOICEMAIL_RECORD_GREETING) holds an open audio pipeline and greeting
+// recorder. Any teardown path (e.g. WebSocket reconnect) must run the full
+// HangupCall flow so these resources finalize cleanly.
 func (c *Controller) IsCallActive() bool {
 	switch c.State() {
 	case StateCALLING, StateRINGING, StateCONNECTED,


### PR DESCRIPTION
## Why

Daily holistic review across the voicemail phase sequence merged in the last 24h surfaced three stale comments. Each was correct at the time it was written in PR #560 but PR #562 changed the behavior they described without updating the prose.

## Motivated by (last 24h)

- #559 `feat(digitsd): voicemail storage package and config schema`
- #560 `feat(digitsd): record voicemail on missed-call timeout` (authored the now-stale comments)
- #562 `feat(digitsd): voicemail greeting playback and *97 custom recording` (changed the behavior, left the comments)

## What changed

Three comment-only edits, no behavior change:

1. **`pi/digitsd/internal/phone/controller.go`** state constant for `StateVOICEMAIL_GREETING` said `// auto-answered; playing beep`. Since #562 added outgoing greeting playback ahead of the beep, the state now spans both. Updated to `// auto-answered; playing outgoing greeting then beep`.

2. **`pi/digitsd/internal/phone/controller.go`** `Controller.IsCallActive` docstring claimed all voicemail states hold an open WebRTC peer. That is true for `VOICEMAIL_GREETING` / `VOICEMAIL_RECORDING` but not for the new `VOICEMAIL_RECORD_GREETING` state introduced in #562, which is mic-capture-only with no peer connection. Reworded to distinguish the inbound-call states (peer + message recorder) from the custom-greeting-record state (pipeline + greeting recorder), and to spell out why all three still need the full `HangupCall` teardown.

3. **`pi/digitsd/cmd/digitsd/main.go`** `VoicemailAutoAnswer` outer docstring summary and step (3) still described the goroutine as "plays a greeting beep". The inner goroutine comment block was updated in #562; the function-level docstring above the func was not. Updated to mention the custom-or-default greeting, the prompt beep, and the mic mute before recording.

## Test plan

- [x] Comment-only diff, no code paths changed (`git diff` is exclusively prose inside `//` comments)
- digitsd full build delegated to CI: the local box does not have the ALSA / Opus C headers required to build `pi/digitsd/internal/audio`, and `internal/phone` transitively imports it. Same situation noted in #557.
- No em dashes introduced; no other rule violations.