### PR TITLE
docs(digitsd): align voicemail comments with current behavior

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -115,8 +115,8 @@ func (d *daemonCallbacks) VoicemailPickup() {
 
 // VoicemailAutoAnswer completes the SDP/ICE handshake for an unanswered call,
 // opens a voicemail recorder, brings up the audio pipeline, and plays the
-// greeting beep. It mirrors the slow path of AnswerCall but diverges in three
-// ways:
+// outgoing greeting followed by the prompt beep. It mirrors the slow path of
+// AnswerCall but diverges in three ways:
 //
 //  1. No mixer.AddWebRTCSource: caller audio does not play through the
 //     earpiece during voicemail. Decoded PCM is sent to voicemailWebRTCCh
@@ -125,9 +125,10 @@ func (d *daemonCallbacks) VoicemailPickup() {
 //  2. OnRemoteTrack runs the same three-phase startup as the live call path
 //     (discard until pipeline ready, drain to live, then feed) but in the
 //     live phase ALSO tees the raw Opus payload into the recorder.
-//  3. After SDP exchange and pipeline start, a small goroutine plays a
-//     greeting beep and then transitions the controller into the recording
-//     state.
+//  3. After SDP exchange and pipeline start, a small goroutine plays the
+//     outgoing greeting (custom .frames if recorded, otherwise the embedded
+//     default WAV) followed by the prompt beep, then mutes the outbound mic
+//     and transitions the controller into the recording state.
 func (d *daemonCallbacks) VoicemailAutoAnswer() {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -5,8 +5,7 @@ package main
 // daemonCallbacks struct definition stays on main.go; only methods that
 // drive the inbound / outbound 2-party WebRTC path live here.
 //
-// Conference (mesh) callbacks and signaling primitives stay on main.go;
-// they get their own file in the next refactor commit.
+// Conference (mesh) callbacks live in conference.go.
 
 import (
 	"context"

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -27,7 +27,7 @@ const (
 	StateADD_INTERCEPT   State = "ADD_INTERCEPT"   // Add-leg failed (busy, timeout, refused); B on hold, flash to recover
 	StateCONFERENCE_MERGED State = "CONFERENCE_MERGED" // Three-way call active
 	StateCALL_RETURN       State = "CALL_RETURN"       // *69: waiting for announcement + "1" confirmation
-	StateVOICEMAIL_GREETING        State = "VOICEMAIL_GREETING"        // auto-answered; playing beep
+	StateVOICEMAIL_GREETING        State = "VOICEMAIL_GREETING"        // auto-answered; playing outgoing greeting then beep
 	StateVOICEMAIL_RECORDING       State = "VOICEMAIL_RECORDING"       // recording caller audio
 	StateVOICEMAIL_RECORD_GREETING State = "VOICEMAIL_RECORD_GREETING" // user is recording their custom outgoing greeting (*97)
 	StateVOICEMAIL_PLAYBACK        State = "VOICEMAIL_PLAYBACK"        // user dialed retrieval code; playing back stored messages
@@ -233,9 +233,12 @@ func (c *Controller) State() State {
 }
 
 // IsCallActive reports whether the phone is currently in a call or actively
-// ringing. Voicemail greeting/recording also count as active: the WebRTC peer
-// connection is up, the recorder is open, and any teardown path (e.g. WebSocket
-// reconnect) must run the full HangupCall flow to finalize cleanly.
+// ringing. All three voicemail states also count as active: an inbound-call
+// voicemail (VOICEMAIL_GREETING, VOICEMAIL_RECORDING) holds an open WebRTC
+// peer and a message recorder, and a custom-greeting recording session
+// (VOICEMAIL_RECORD_GREETING) holds an open audio pipeline and greeting
+// recorder with no WebRTC peer. Any teardown path (e.g. WebSocket reconnect)
+// must run the full HangupCall flow so these resources finalize cleanly.
 func (c *Controller) IsCallActive() bool {
 	switch c.State() {
 	case StateCALLING, StateRINGING, StateCONNECTED,


### PR DESCRIPTION
Replaces #563, which conflicts with #564's main.go split.

Four comment fixes (no behavior change):

- `StateVOICEMAIL_GREETING` const comment now mentions the outgoing greeting before the prompt beep.
- `IsCallActive` docstring distinguishes inbound-call voicemail states (`VOICEMAIL_GREETING` / `VOICEMAIL_RECORDING`: peer + message recorder) from the custom-greeting recording state (`VOICEMAIL_RECORD_GREETING`: pipeline + greeting recorder, no peer).
- `VoicemailAutoAnswer` docstring describes the full flow: greeting (custom or default) -> prompt beep -> outbound mic mute -> record.
- `webrtc.go` header drops the stale forward-reference to a "next refactor commit": `conference.go` already exists.

## Test plan

- [x] `cd pi/digitsd && go build ./...`
- [x] `cd pi/digitsd && golangci-lint run ./...`
- Comment-only; no runtime behavior to test on hardware.