### PR TITLE
refactor(server): add typed sentinel errors to household package

### DIFF
--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -54,7 +54,7 @@ func generateInviteToken() (string, error) {
 
 const inviteColumns = `id, household_id, email, invited_by, token, status, created_at, accepted_at, expires_at`
 
-func scanInvite(row interface{ Scan(...any) error }) (*HouseholdInvite, error) {
+func scanInvite(row rowScanner) (*HouseholdInvite, error) {
 	inv := &HouseholdInvite{}
 	err := row.Scan(&inv.ID, &inv.HouseholdID, &inv.Email, &inv.InvitedBy,
 		&inv.Token, &inv.Status, &inv.CreatedAt, &inv.AcceptedAt, &inv.ExpiresAt)

--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -276,7 +276,7 @@ func (s *LinkStore) FindNumberConflicts(ctx context.Context, householdAID, house
 	for rows.Next() {
 		c := NumberConflict{HouseholdAID: householdAID, HouseholdBID: householdBID}
 		if err := rows.Scan(&c.Number, &c.PhoneAName, &c.PhoneBName); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan conflict: %w", err)
 		}
 		conflicts = append(conflicts, c)
 	}

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -10,6 +10,12 @@ import (
 	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
+// ErrNotFound is returned by GetByID and Delete when no matching household exists.
+var ErrNotFound = errors.New("household not found")
+
+// ErrNotMember is returned by GetRole and RemoveMember when the user is not a member of the household.
+var ErrNotMember = errors.New("not a member of this household")
+
 // Household represents a family/household group.
 type Household struct {
 	ID                 string
@@ -60,7 +66,7 @@ func (s *Store) GetByID(ctx context.Context, id string) (*Household, error) {
 		id,
 	).Scan(&h.ID, &h.Name, &h.CallHistoryEnabled, &h.Timezone, &h.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("household not found")
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get household: %w", err)
@@ -102,7 +108,7 @@ func (s *Store) GetRole(ctx context.Context, userID, householdID string) (string
 		userID, householdID,
 	).Scan(&role)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("user is not a member of this household")
+		return "", ErrNotMember
 	}
 	if err != nil {
 		return "", fmt.Errorf("get role: %w", err)
@@ -143,14 +149,14 @@ func (s *Store) GetMembersWithUsers(ctx context.Context, householdID string) ([]
 		householdID,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get members with users: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var members []MemberWithUser
 	for rows.Next() {
 		var m MemberWithUser
 		if err := rows.Scan(&m.UserID, &m.Email, &m.Name, &m.Role); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan member: %w", err)
 		}
 		members = append(members, m)
 	}
@@ -216,7 +222,7 @@ func (s *Store) RemoveMember(ctx context.Context, userID, householdID string) er
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return fmt.Errorf("user is not a member of this household")
+		return ErrNotMember
 	}
 	return nil
 }
@@ -252,7 +258,7 @@ func (s *Store) Delete(ctx context.Context, householdID string) error {
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return fmt.Errorf("household not found")
+		return ErrNotFound
 	}
 	return nil
 }

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -4,6 +4,7 @@ package household
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -147,8 +148,8 @@ func TestGetRole_NotMember(t *testing.T) {
 	}
 
 	_, err = s.GetRole(context.Background(), otherID, h.ID)
-	if err == nil {
-		t.Error("expected error for non-member, got nil")
+	if !errors.Is(err, ErrNotMember) {
+		t.Errorf("expected ErrNotMember, got %v", err)
 	}
 }
 
@@ -407,8 +408,8 @@ func TestStore_Delete_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	err := s.Delete(ctx, "00000000-0000-0000-0000-000000000000")
-	if err == nil {
-		t.Error("expected error for non-existent household, got nil")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Code review grade: 82 -> 86 / 100

Full audit of `server/` against idiomatics, cleanliness, project layout, and test coverage. One cluster of related issues was found in `internal/household/`.

### Before (82/100)

The `household` package was the only store package without typed sentinel errors:

- `auth` defines `ErrUserNotFound`
- `line` defines `ErrNotFound`
- `household` returned bare `fmt.Errorf("household not found")` strings that callers cannot distinguish from other errors using `errors.Is`

Two scan loops also returned errors without context, inconsistent with every other method in the package.

### After (86/100)

**`household/store.go`**

- Add `ErrNotFound` and `ErrNotMember` package-level sentinel errors
- Use `ErrNotFound` in `GetByID` and `Delete` (replacing unwrappable `fmt.Errorf` strings)
- Use `ErrNotMember` in `GetRole` and `RemoveMember` (same)
- Wrap the missing error context in `GetMembersWithUsers` (query error and scan error)

**`household/link.go`**

- Wrap the bare scan error in `FindNumberConflicts` with context (consistent with `scanLinks` in the same file)

**`household/invite.go`**

- Use the package-level `rowScanner` type in `scanInvite` instead of an inline anonymous interface; `rowScanner` is already defined in `link.go` in the same package

**`household/store_test.go`**

- Upgrade `TestGetRole_NotMember` and `TestStore_Delete_NotFound` from `err == nil` guards to `errors.Is(err, ErrNotMember)` / `errors.Is(err, ErrNotFound)` assertions; the old tests would pass even if the wrong non-nil error was returned

### What was not changed

The rest of the server scored well: project layout is correct standard Go, error handling and logging are exemplary throughout, test coverage is high, and no stale or unreferenced code was found. The `rowScanner` interface being independently defined in `auth`, `household`, and `line` is a pre-existing condition; centralizing it into `dbutil` would touch three unrelated packages for minimal gain (YAGNI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCtomNhQXFtFnKpzjDXcpH)_