### PR TITLE
feat(server): voicemail UI for phones list and detail

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -174,6 +174,17 @@ type daemonCallbacks struct {
 	voicemailMu       sync.Mutex
 	voicemailPlayback *voicemailPlaybackSession // current message; nil = idle
 	voicemailMixerCh  chan []int16              // mixer source channel for "voicemail" key; nil between sessions
+
+	// Voicemail-state publish bookkeeping. publishVMMu serializes calls to
+	// publishVoicemailState so two trigger sites firing concurrently (e.g.
+	// recorder finalize racing a retrieval MarkHeard) cannot both send the
+	// same unheard count, and so dedup against publishVMLast is correct
+	// even under contention. publishVMLast holds the last successfully
+	// sent count; the sentinel -1 forces the first publish to fire
+	// regardless of value, which is what the post-connect snapshot needs
+	// to seed server-side state.
+	publishVMMu   sync.Mutex
+	publishVMLast int64
 }
 
 // getFirmwareVersion returns the current firmware version and commit under mu.
@@ -347,6 +358,80 @@ func (d *daemonCallbacks) setAutoUpdateConfig(enabled bool) error {
 	d.cfg.AutoUpdate = enabled
 	d.mu.Unlock()
 	return d.cfg.Save()
+}
+
+// voicemailStateSender is the minimal Send-only surface publishVoicemailStateOnce
+// needs from the signaling client. Defined as an interface so unit tests can
+// inject a capturing fake without standing up a real WebSocket. *sigclient.Client
+// satisfies it implicitly.
+type voicemailStateSender interface {
+	Send(*sigclient.Message) error
+}
+
+// publishVoicemailStateOnce reads the current unheard-message count from store
+// and sends a voicemail_state message via sender. When force is false, the
+// send is skipped if the count equals *last (dedup against repeated change
+// notifications). When force is true, the send is unconditional, used after
+// (re)connect to seed server-side state regardless of local cache parity.
+// Returns true when a message was actually sent.
+//
+// The caller is responsible for serializing concurrent invocations (the daemon
+// uses publishVMMu); inside this function, sender.Send and store.UnheardCount
+// can both block on I/O so neither runs under d.mu.
+//
+// On a nil store (voicemail feature disabled at boot) or any UnheardCount
+// error, no message is sent and *last is left unchanged so the next trigger
+// will retry from the same baseline.
+func publishVoicemailStateOnce(sender voicemailStateSender, store *voicemail.Store, last *int64, force bool) bool {
+	if store == nil {
+		return false
+	}
+	n, err := store.UnheardCount()
+	if err != nil {
+		slog.Warn("voicemail_state: unheard count failed, skipping publish", "error", err)
+		return false
+	}
+	if !force && int64(n) == *last {
+		return false
+	}
+	if err := sender.Send(&sigclient.Message{
+		Type:                  sigclient.TypeVoicemailState,
+		VoicemailUnheardCount: n,
+	}); err != nil {
+		slog.Warn("voicemail_state: send failed", "count", n, "error", err)
+		return false
+	}
+	*last = int64(n)
+	slog.Info("voicemail_state: published", "unheard_count", n, "forced", force)
+	return true
+}
+
+// publishVoicemailState is the change-driven wrapper used by mutation triggers
+// (recording finalize, MarkHeard, delete). Snapshots the current store,
+// serializes against concurrent callers via publishVMMu, and dedups against
+// publishVMLast so a no-op mutation does not produce a redundant wire message.
+func (d *daemonCallbacks) publishVoicemailState() {
+	d.mu.Lock()
+	store := d.voicemailStore
+	d.mu.Unlock()
+
+	d.publishVMMu.Lock()
+	defer d.publishVMMu.Unlock()
+	publishVoicemailStateOnce(d.sig, store, &d.publishVMLast, false)
+}
+
+// publishVoicemailStateInitial is the (re)connect wrapper. It sends the
+// current unheard count unconditionally so the server can seed its per-phone
+// cache on every fresh WS session, even when the local count has not changed
+// since the previous publish.
+func (d *daemonCallbacks) publishVoicemailStateInitial() {
+	d.mu.Lock()
+	store := d.voicemailStore
+	d.mu.Unlock()
+
+	d.publishVMMu.Lock()
+	defer d.publishVMMu.Unlock()
+	publishVoicemailStateOnce(d.sig, store, &d.publishVMLast, true)
 }
 
 // setVoicemailConfig replaces the local voicemail config under d.mu and
@@ -1452,6 +1537,11 @@ func main() {
 				flashCapable.Store(true)
 			}
 			sendDeviceInfo(sig, fwVer, fwCom, flashCapable.Load())
+			// Voicemail-state publish skipped here: this goroutine is
+			// launched before vmStore exists and before cb is constructed.
+			// The sig.Connect path at the next site (sendDeviceInfo
+			// after Connect) publishes the initial snapshot once cb and
+			// the store are both ready.
 		}(fwVersion, fwCommit)
 	}
 
@@ -1545,6 +1635,10 @@ func main() {
 		fwVer:               fwVersion,
 		fwCom:               fwCommit,
 		voicemailStore:      vmStore,
+		// Sentinel that forces the first publishVoicemailState call to
+		// fire regardless of count, so the post-connect snapshot seeds
+		// server-side state on every startup.
+		publishVMLast: -1,
 	}
 	if cfg.DeviceToken != "" {
 		cb.paired.Store(true)
@@ -1704,6 +1798,7 @@ func main() {
 		slog.Warn("signald connect failed, will retry", "error", err)
 	} else {
 		sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+		cb.publishVoicemailStateInitial()
 		requestICEServers(sig)
 	}
 
@@ -1945,6 +2040,7 @@ func main() {
 				slog.Info("firmware capability", "version", fwVersion, "flash_capable", hookFlash)
 				sp.SetFlashEnabled(hookFlash)
 				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+				cb.publishVoicemailStateInitial()
 			} else {
 				slog.Info("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
 			}
@@ -2478,6 +2574,7 @@ func main() {
 				}
 
 				sendDeviceInfo(sig, fwVersion, fwCommit, flashCapable.Load())
+				cb.publishVoicemailState()
 				requestICEServers(sig)
 				break
 			}

--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -369,6 +369,163 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 	}
 }
 
+// fakeVoicemailStateSender captures sent messages for unit tests so the
+// publishVoicemailStateOnce flow can be exercised without a real signaling
+// client.
+type fakeVoicemailStateSender struct {
+	sent    []sigclient.Message
+	sendErr error
+}
+
+func (f *fakeVoicemailStateSender) Send(m *sigclient.Message) error {
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sent = append(f.sent, *m)
+	return nil
+}
+
+// mustVoicemailStoreWith opens a store under t.TempDir(), records `unheard`
+// messages then `heard` messages, and marks the latter as heard. Sleeps a
+// touch between recordings to keep their UnixMilli IDs strictly increasing.
+func mustVoicemailStoreWith(t *testing.T, unheard, heard int) *voicemail.Store {
+	t.Helper()
+	s, err := voicemail.Open(t.TempDir(), voicemail.Options{})
+	if err != nil {
+		t.Fatalf("voicemail.Open: %v", err)
+	}
+	for i := 0; i < unheard+heard; i++ {
+		r, err := s.BeginRecording()
+		if err != nil {
+			t.Fatalf("BeginRecording[%d]: %v", i, err)
+		}
+		if _, err := r.AppendFrame([]byte{0xff, 0x00}); err != nil {
+			t.Fatalf("AppendFrame[%d]: %v", i, err)
+		}
+		m, err := r.Finalize()
+		if err != nil {
+			t.Fatalf("Finalize[%d]: %v", i, err)
+		}
+		if i < heard {
+			if err := s.MarkHeard(m.ID); err != nil {
+				t.Fatalf("MarkHeard[%d]: %v", i, err)
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return s
+}
+
+// TestPublishVoicemailStateOnce_Sequence walks publishVoicemailStateOnce
+// through the lifecycle a real daemon sees: post-connect snapshot (sentinel
+// -1 forces send), MarkHeard moves count down, no-op call dedups, force-send
+// at the next reconnect even when count is unchanged.
+func TestPublishVoicemailStateOnce_Sequence(t *testing.T) {
+	store := mustVoicemailStoreWith(t, 3, 1)
+	sender := &fakeVoicemailStateSender{}
+	last := int64(-1)
+
+	// Post-connect snapshot. Sentinel forces the send even though count
+	// would otherwise be "unchanged" against -1.
+	if !publishVoicemailStateOnce(sender, store, &last, true) {
+		t.Fatal("first publish (force=true) returned false, want sent")
+	}
+	if got, want := sender.sent[len(sender.sent)-1].VoicemailUnheardCount, 3; got != want {
+		t.Errorf("initial count: got %d want %d", got, want)
+	}
+	if last != 3 {
+		t.Errorf("last after initial publish: got %d want 3", last)
+	}
+
+	// Mutation trigger fires but count has not changed. Dedup skips the send.
+	if publishVoicemailStateOnce(sender, store, &last, false) {
+		t.Fatal("dedup publish returned true, want skip")
+	}
+	if got := len(sender.sent); got != 1 {
+		t.Errorf("send count after dedup: got %d want 1", got)
+	}
+
+	// Mark one heard. Mutation trigger now sees a real delta and sends.
+	msgs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var firstUnheard int64
+	for _, m := range msgs {
+		if !m.Heard {
+			firstUnheard = m.ID
+			break
+		}
+	}
+	if firstUnheard == 0 {
+		t.Fatal("no unheard message to mark")
+	}
+	if err := store.MarkHeard(firstUnheard); err != nil {
+		t.Fatalf("MarkHeard: %v", err)
+	}
+	if !publishVoicemailStateOnce(sender, store, &last, false) {
+		t.Fatal("change publish returned false, want sent")
+	}
+	if got, want := sender.sent[len(sender.sent)-1].VoicemailUnheardCount, 2; got != want {
+		t.Errorf("post-MarkHeard count: got %d want %d", got, want)
+	}
+
+	// Reconnect with unchanged count: forced publish must still fire.
+	if !publishVoicemailStateOnce(sender, store, &last, true) {
+		t.Fatal("forced reconnect publish returned false, want sent")
+	}
+	if got, want := sender.sent[len(sender.sent)-1].VoicemailUnheardCount, 2; got != want {
+		t.Errorf("forced reconnect count: got %d want %d", got, want)
+	}
+
+	// Type assertion across all sends.
+	for i, m := range sender.sent {
+		if m.Type != sigclient.TypeVoicemailState {
+			t.Errorf("send[%d].Type: got %q want %q", i, m.Type, sigclient.TypeVoicemailState)
+		}
+	}
+}
+
+// TestPublishVoicemailStateOnce_NilStore confirms a nil store (feature
+// disabled at boot) is a silent no-op: no send, no last-published mutation,
+// no error.
+func TestPublishVoicemailStateOnce_NilStore(t *testing.T) {
+	sender := &fakeVoicemailStateSender{}
+	last := int64(-1)
+	if publishVoicemailStateOnce(sender, nil, &last, true) {
+		t.Fatal("expected nil-store call to skip, got sent")
+	}
+	if len(sender.sent) != 0 {
+		t.Errorf("expected zero sends, got %d", len(sender.sent))
+	}
+	if last != -1 {
+		t.Errorf("last mutated on nil-store: got %d want -1", last)
+	}
+}
+
+// TestPublishVoicemailStateOnce_SendFailureLeavesBaseline ensures a Send
+// error does not advance *last, so the next trigger retries from the same
+// baseline rather than silently swallowing the failed publish.
+func TestPublishVoicemailStateOnce_SendFailureLeavesBaseline(t *testing.T) {
+	store := mustVoicemailStoreWith(t, 2, 0)
+	sender := &fakeVoicemailStateSender{sendErr: errors.New("ws closed")}
+	last := int64(-1)
+	if publishVoicemailStateOnce(sender, store, &last, true) {
+		t.Fatal("expected false on send error")
+	}
+	if last != -1 {
+		t.Errorf("last advanced on failed send: got %d want -1", last)
+	}
+	// Recover the sender, retry: should publish 2.
+	sender.sendErr = nil
+	if !publishVoicemailStateOnce(sender, store, &last, false) {
+		t.Fatal("retry after recovery returned false, want sent")
+	}
+	if len(sender.sent) != 1 || sender.sent[0].VoicemailUnheardCount != 2 {
+		t.Errorf("unexpected sends after retry: %+v", sender.sent)
+	}
+}
+
 // TestLineSettingsVoicemailConversion locks in the seconds->Duration wire
 // conversion used by the line_settings receiver. The receiver itself is
 // inline inside the main message loop; this mirrors its conversion math so

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -78,16 +78,24 @@ func (d *daemonCallbacks) VoicemailPickup() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	var savedPartial bool
 	d.recorderMu.Lock()
 	if d.recorder != nil {
 		if msg, err := d.recorder.Finalize(); err != nil {
 			slog.Error("voicemail pickup: finalize failed", "peer", d.callPeer, "error", err)
 		} else if msg.ID != 0 {
 			slog.Info("voicemail pickup: saved partial recording", "peer", d.callPeer, "id", msg.ID, "duration", msg.Duration)
+			savedPartial = true
 		}
 		d.recorder = nil
 	}
 	d.recorderMu.Unlock()
+
+	// Fired off the main goroutine so it can take d.mu inside
+	// publishVoicemailState once this function's defer Unlock runs.
+	if savedPartial {
+		go d.publishVoicemailState()
+	}
 
 	if d.callPeer == "" {
 		slog.Warn("voicemail pickup: no call peer")
@@ -382,6 +390,10 @@ func (d *daemonCallbacks) VoicemailRecordEnded() {
 	d.ctrl.Reset()
 	d.HangupCall()
 	d.evaluateLED()
+	// At-cap finalize already ran in the OnTrack loop before VoicemailRecordEnded
+	// was scheduled, so HangupCall's finalizedVoicemail branch did not fire and
+	// did not publish. Publish here so the server learns about the new message.
+	d.publishVoicemailState()
 }
 
 func (d *daemonCallbacks) VoicemailEnabled() (bool, time.Duration) {
@@ -682,6 +694,7 @@ func (d *daemonCallbacks) VoicemailKey(digit string) {
 		next     *voicemailPlaybackSession
 		openErr  error
 		noNext   bool
+		mutated  bool // true when "7" or "9" actually advanced the unheard count
 	)
 
 	d.voicemailMu.Lock()
@@ -704,11 +717,15 @@ func (d *daemonCallbacks) VoicemailKey(digit string) {
 	case "7":
 		if err := store.Delete(currentID); err != nil {
 			slog.Warn("voicemail: delete failed", "id", currentID, "error", err)
+		} else {
+			mutated = true
 		}
 		next, openErr = d.openNextUnheardLocked(store, 0)
 	case "9":
 		if err := store.MarkHeard(currentID); err != nil {
 			slog.Warn("voicemail: mark heard failed", "id", currentID, "error", err)
+		} else {
+			mutated = true
 		}
 		next, openErr = d.openNextUnheardLocked(store, 0)
 	case "#":
@@ -730,6 +747,13 @@ func (d *daemonCallbacks) VoicemailKey(digit string) {
 		}
 	}
 	d.voicemailMu.Unlock()
+
+	// Publish only after voicemailMu is released so the network send does
+	// not hold the playback mutex. Dedup inside publishVoicemailState makes
+	// this a no-op on Delete-of-already-heard (count unchanged).
+	if mutated {
+		d.publishVoicemailState()
+	}
 
 	if openErr != nil {
 		slog.Error("voicemail: advance failed", "digit", digit, "error", openErr)
@@ -924,6 +948,7 @@ func (d *daemonCallbacks) voicemailAdvanceFromEOF(sess *voicemailPlaybackSession
 		openErr  error
 		noNext   bool
 		isStale  bool
+		mutated  bool // true when MarkHeard succeeded and the unheard count moved
 	)
 
 	d.voicemailMu.Lock()
@@ -936,6 +961,8 @@ func (d *daemonCallbacks) voicemailAdvanceFromEOF(sess *voicemailPlaybackSession
 		d.teardownPlaybackLocked()
 		if err := store.MarkHeard(sess.id); err != nil {
 			slog.Warn("voicemail: mark heard on EOF failed", "id", sess.id, "error", err)
+		} else {
+			mutated = true
 		}
 		next, openErr = d.openNextUnheardLocked(store, 0)
 		if openErr != nil || next == nil {
@@ -949,6 +976,10 @@ func (d *daemonCallbacks) voicemailAdvanceFromEOF(sess *voicemailPlaybackSession
 
 	if isStale {
 		return
+	}
+	// Publish after voicemailMu release; dedup makes redundant calls cheap.
+	if mutated {
+		d.publishVoicemailState()
 	}
 	if openErr != nil {
 		slog.Error("voicemail: open next after EOF failed", "from_id", sess.id, "error", openErr)

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -379,6 +379,9 @@ func (d *daemonCallbacks) HangupCall() {
 		// LED state untouched here so the off-hook treatment (remote
 		// hangup, line lockout) keeps its existing visuals.
 		d.evaluateLED()
+		// Same finalize pushes a fresh count to the server so the
+		// owner-side web UI badge updates without polling.
+		d.publishVoicemailState()
 	}
 
 	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -55,6 +55,13 @@ const (
 	// for the line this device is registered as. Applied live.
 	TypeLineSettings = "line_settings"
 
+	// TypeVoicemailState is sent by the phone to the server when its local
+	// unheard-message count changes (post-connect snapshot, after a recording
+	// finalizes, after retrieval marks a message heard, after a delete).
+	// Carries VoicemailUnheardCount; the server stores the value per-phone so
+	// the web UI can render a badge without polling. Phone -> Server only.
+	TypeVoicemailState = "voicemail_state"
+
 	// TypeReleaseAvailable is sent by the server to notify the device that a
 	// new release is available. Carries LatestPiVersion and LatestFWVersion.
 	TypeReleaseAvailable = "release_available"
@@ -229,6 +236,12 @@ type Message struct {
 
 	// Link-health telemetry (link_health messages)
 	LinkHealth *LinkHealthPayload `json:"link_health,omitempty"`
+
+	// Voicemail state (voicemail_state messages). Explicit zero must round-
+	// trip after MarkHeard-all clears the badge, so this field is NOT
+	// omitempty: the server distinguishes "0 unheard" from "field missing"
+	// when reconciling its per-phone cache.
+	VoicemailUnheardCount int `json:"voicemail_unheard_count"`
 }
 
 // ParseMessage deserializes a JSON-encoded signaling message.

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -368,6 +368,48 @@ func TestLineSettingsVoicemailOmittedWhenNil(t *testing.T) {
 	}
 }
 
+func TestVoicemailStateRoundTrip(t *testing.T) {
+	in := &Message{
+		Type:                  TypeVoicemailState,
+		VoicemailUnheardCount: 7,
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"voicemail_unheard_count":7`) {
+		t.Errorf("expected voicemail_unheard_count:7 in JSON, got: %s", data)
+	}
+	got, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Type != TypeVoicemailState {
+		t.Errorf("Type: got %q want %q", got.Type, TypeVoicemailState)
+	}
+	if got.VoicemailUnheardCount != 7 {
+		t.Errorf("VoicemailUnheardCount: got %d want 7", got.VoicemailUnheardCount)
+	}
+}
+
+// TestVoicemailStateZeroNotOmitted locks in the contract that an explicit
+// zero count survives the round trip. The server distinguishes "0 unheard"
+// from "field missing" when reconciling its per-phone cache, so the wire
+// MUST carry the literal "voicemail_unheard_count":0 after MarkHeard-all.
+func TestVoicemailStateZeroNotOmitted(t *testing.T) {
+	in := &Message{
+		Type:                  TypeVoicemailState,
+		VoicemailUnheardCount: 0,
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"voicemail_unheard_count":0`)) {
+		t.Errorf("expected literal \"voicemail_unheard_count\":0 in JSON, got: %s", data)
+	}
+}
+
 func TestLineSettingsVoicemailZeroValuesParse(t *testing.T) {
 	// Server may push enabled=false with zero ints; receiver must accept it
 	// as an authoritative full-replacement payload, not silently drop fields.

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * 10-voicemail.spec.ts -- Per-line voicemail toggle on /phones plus the 5-field
+ * settings form on /phones/{number}.
+ *
+ * Tests:
+ *   - List-row toggle flips voicemail on, badge appears, persists across reload.
+ *   - Toggle flips it back off, badge disappears.
+ *   - Detail page renders the voicemail panel with the 5 fields.
+ *   - Saving valid values via the detail form persists and swaps the partial.
+ *   - Bad retrieval code is rejected (400).
+ *   - All three themes render the relevant surface (intercom, dialup, am).
+ *
+ * Skips when the test household has no paired phones.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+import { isServerUp, setTheme } from './helpers';
+
+test.beforeEach(async ({ page }, testInfo) => {
+  const up = await isServerUp();
+  testInfo.skip(!up, 'Dev server not running');
+});
+
+function isAuthOrOnboard(url: string) {
+  return url.includes('/auth/login') || url.includes('/onboard');
+}
+
+async function firstPhoneHref(page: Page): Promise<string | null> {
+  await page.goto('/phones');
+  if (isAuthOrOnboard(page.url())) {
+    return null;
+  }
+  const link = page.locator('a[href^="/phones/"]:not([href="/phones"])').first();
+  if ((await link.count()) === 0) {
+    return null;
+  }
+  return await link.getAttribute('href');
+}
+
+/**
+ * Click the list-row voicemail toggle and wait for the htmx swap. Works for
+ * both the intercom (.phone-voicemail) and answering-machine (.am-voicemail)
+ * themes since the form id is the same in both.
+ */
+async function toggleVoicemailFromList(page: Page, number: string) {
+  await page.goto('/phones');
+  // The /phones page renders the voicemail form once per layout (desktop
+  // table, mobile card, am roster); only one is visible at a time per
+  // viewport. Use .first() to grab whichever is currently rendered.
+  const form = page.locator(`form[data-voicemail][data-line="${number}"]`).first();
+  await expect(form).toBeVisible();
+  const wait = page.waitForResponse(
+    (r) => r.url().includes('/voicemail-toggle') && r.request().method() === 'POST',
+  );
+  await form.locator('button[type="submit"]').first().click();
+  await wait;
+}
+
+async function readEnabledOnDetail(page: Page): Promise<boolean> {
+  const checkbox = page.locator('#voicemail-section input[name="enabled"]').first();
+  await expect(checkbox).toBeVisible();
+  return await checkbox.isChecked();
+}
+
+test.describe('Voicemail (intercom theme)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setTheme(page.request, 'intercom').catch(() => undefined);
+  });
+
+  test('list-row toggle flips state and shows the badge', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    const number = href.split('/').pop() as string;
+
+    // Baseline: enable, then disable so we know the start state.
+    await page.goto(href);
+    if (await readEnabledOnDetail(page)) {
+      await toggleVoicemailFromList(page, number);
+    }
+    // Now off; confirm no chip on the visible row.
+    await page.goto('/phones');
+    const visibleForm = page
+      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
+      .first();
+    await expect(visibleForm.locator('.phone-voicemail__chip')).toHaveCount(0);
+
+    // Toggle on; chip should appear (muted "VM" because count is 0).
+    await toggleVoicemailFromList(page, number);
+    await expect(
+      page
+        .locator(`form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`)
+        .first(),
+    ).toBeVisible();
+
+    // Reload: state must be persisted server-side.
+    await page.goto('/phones');
+    await expect(
+      page
+        .locator(`form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`)
+        .first(),
+    ).toBeVisible();
+
+    // Detail page must reflect the same state.
+    await page.goto(href);
+    expect(await readEnabledOnDetail(page)).toBe(true);
+
+    // Cleanup: toggle off so the next test starts clean.
+    await toggleVoicemailFromList(page, number);
+    await page.goto('/phones');
+    await expect(
+      page.locator(
+        `form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`,
+      ),
+    ).toHaveCount(0);
+  });
+
+  test('detail page renders the voicemail panel with five fields', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+    await expect(page.locator('h2.panel__title', { hasText: /voicemail/i })).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
+  });
+
+  test('detail form save with valid values persists', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+
+    // Enable so the inner fields aren't disabled.
+    const enabled = page.locator('#voicemail-section input[name="enabled"]');
+    if (!(await enabled.isChecked())) {
+      await enabled.check();
+    }
+
+    await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
+    await page.locator('#voicemail-section input[name="max_message_seconds"]').fill('100');
+    await page.locator('#voicemail-section input[name="max_stored_messages"]').fill('25');
+    await page.locator('#voicemail-section input[name="retrieval_code"]').fill('*99');
+
+    const wait = page.waitForResponse(
+      (r) => r.url().endsWith('/voicemail') && r.request().method() === 'POST',
+    );
+    await page.locator('#voicemail-section button[type="submit"]').first().click();
+    const resp = await wait;
+    expect(resp.status()).toBe(200);
+
+    // Reload and confirm fields stuck.
+    await page.goto(href);
+    await expect(
+      page.locator('#voicemail-section input[name="ring_timeout_seconds"]'),
+    ).toHaveValue('30');
+    await expect(
+      page.locator('#voicemail-section input[name="retrieval_code"]'),
+    ).toHaveValue('*99');
+
+    // Cleanup: turn voicemail back off.
+    await enabled.uncheck();
+    await page.locator('#voicemail-section button[type="submit"]').first().click();
+  });
+
+  test('bad retrieval code is rejected with 400', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+
+    // Use the request context to bypass HTML5 client-side validation;
+    // we want to assert the server-side guard rail. "12345" is digits only
+    // (no * or #), which the server rejects to avoid 7-digit-dial collision.
+    const number = href.split('/').pop() as string;
+    const resp = await page.request.post(`/phones/${number}/voicemail`, {
+      form: {
+        enabled: 'on',
+        ring_timeout_seconds: '20',
+        max_message_seconds: '90',
+        max_stored_messages: '50',
+        retrieval_code: '12345',
+      },
+      maxRedirects: 0,
+    });
+    expect(resp.status()).toBe(400);
+    expect(await resp.text()).toMatch(/retrieval_code/i);
+  });
+});
+
+test.describe('Voicemail (dialup theme)', () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      await setTheme(page.request, 'dialup');
+    } catch (e) {
+      test.skip(true, `setTheme failed: ${(e as Error).message}`);
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    await setTheme(page.request, 'intercom').catch(() => undefined);
+  });
+
+  test('list-row toggle works under dialup chrome', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    const number = href.split('/').pop() as string;
+
+    // Ensure baseline is OFF regardless of what an earlier test left behind.
+    await page.goto(href);
+    if (await readEnabledOnDetail(page)) {
+      await toggleVoicemailFromList(page, number);
+    }
+
+    await page.goto('/phones');
+    const form = page
+      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
+      .first();
+    await expect(form).toBeVisible();
+
+    // Off -> on: expect the muted "VM" chip to appear.
+    await toggleVoicemailFromList(page, number);
+    await expect(
+      page
+        .locator(
+          `form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`,
+        )
+        .first(),
+    ).toBeVisible();
+
+    // Cleanup.
+    await toggleVoicemailFromList(page, number);
+  });
+});
+
+test.describe('Voicemail (answering-machine theme)', () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      await setTheme(page.request, 'answering-machine');
+    } catch (e) {
+      test.skip(true, `setTheme failed: ${(e as Error).message}`);
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    await setTheme(page.request, 'intercom').catch(() => undefined);
+  });
+
+  test('AM list shows the voicemail toggle in the roster meta', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    const number = href.split('/').pop() as string;
+
+    await page.goto('/phones');
+    const form = page
+      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
+      .first();
+    await expect(form).toBeVisible();
+    await expect(form).toHaveClass(/am-voicemail/);
+  });
+
+  test('AM detail page renders the voicemail plate with all five fields', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+    await expect(page.locator('.am-plate__label', { hasText: /voicemail/i })).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
+  });
+});

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -73,7 +73,7 @@ test.describe('Voicemail (intercom theme)', () => {
     }
     await page.goto(href);
 
-    await expect(page.locator('h2.panel__title', { hasText: /voicemail/i })).toBeVisible();
+    await expect(page.locator('h2.panel__title', { hasText: /answering machine/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
     await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
 
@@ -252,7 +252,7 @@ test.describe('Voicemail (answering-machine theme)', () => {
     }
     await page.goto(href);
 
-    await expect(page.locator('.am-plate__label', { hasText: /voicemail/i })).toBeVisible();
+    await expect(page.locator('.am-plate__label', { hasText: /answering machine/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
     await expect(page.locator('#voicemail-section details.am-voicemail-advanced')).toBeVisible();
 

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -1,14 +1,16 @@
 /**
- * 10-voicemail.spec.ts -- Per-line voicemail toggle on /phones plus the 5-field
- * settings form on /phones/{number}.
+ * 10-voicemail.spec.ts -- Detail-page voicemail panel: enable toggle, the
+ * "Advanced settings" disclosure, the unheard-count chip, and the 5-field
+ * Save flow. The list-page no longer surfaces voicemail; that direction was
+ * pulled per owner feedback.
  *
  * Tests:
- *   - List-row toggle flips voicemail on, badge appears, persists across reload.
- *   - Toggle flips it back off, badge disappears.
- *   - Detail page renders the voicemail panel with the 5 fields.
- *   - Saving valid values via the detail form persists and swaps the partial.
+ *   - Detail page renders the panel with the enable checkbox + Advanced disclosure.
+ *   - Enabling voicemail via the checkbox round-trips state through the toggle endpoint.
+ *   - Expanding Advanced reveals the 4 numeric/code fields.
+ *   - Saving valid Advanced values persists across reload.
  *   - Bad retrieval code is rejected (400).
- *   - All three themes render the relevant surface (intercom, dialup, am).
+ *   - All three themes render their respective surface (intercom, dialup, am).
  *
  * Skips when the test household has no paired phones.
  */
@@ -37,29 +39,25 @@ async function firstPhoneHref(page: Page): Promise<string | null> {
   return await link.getAttribute('href');
 }
 
-/**
- * Click the list-row voicemail toggle and wait for the htmx swap. Works for
- * both the intercom (.phone-voicemail) and answering-machine (.am-voicemail)
- * themes since the form id is the same in both.
- */
-async function toggleVoicemailFromList(page: Page, number: string) {
-  await page.goto('/phones');
-  // The /phones page renders the voicemail form once per layout (desktop
-  // table, mobile card, am roster); only one is visible at a time per
-  // viewport. Use .first() to grab whichever is currently rendered.
-  const form = page.locator(`form[data-voicemail][data-line="${number}"]`).first();
-  await expect(form).toBeVisible();
-  const wait = page.waitForResponse(
-    (r) => r.url().includes('/voicemail-toggle') && r.request().method() === 'POST',
-  );
-  await form.locator('button[type="submit"]').first().click();
-  await wait;
-}
-
 async function readEnabledOnDetail(page: Page): Promise<boolean> {
   const checkbox = page.locator('#voicemail-section input[name="enabled"]').first();
   await expect(checkbox).toBeVisible();
   return await checkbox.isChecked();
+}
+
+/**
+ * Click the enable checkbox and wait for the toggle endpoint round-trip.
+ * The checkbox has hx-post + hx-trigger=change, so a click triggers the swap
+ * of the whole voicemail section.
+ */
+async function clickEnableCheckbox(page: Page) {
+  const checkbox = page.locator('#voicemail-section input[name="enabled"]').first();
+  await expect(checkbox).toBeVisible();
+  const wait = page.waitForResponse(
+    (r) => r.url().includes('/voicemail-toggle') && r.request().method() === 'POST',
+  );
+  await checkbox.click();
+  await wait;
 }
 
 test.describe('Voicemail (intercom theme)', () => {
@@ -67,72 +65,39 @@ test.describe('Voicemail (intercom theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('list-row toggle flips state and shows the badge', async ({ page }) => {
-    const href = await firstPhoneHref(page);
-    if (!href) {
-      test.skip(true, 'No phones registered');
-      return;
-    }
-    const number = href.split('/').pop() as string;
-
-    // Baseline: enable, then disable so we know the start state.
-    await page.goto(href);
-    if (await readEnabledOnDetail(page)) {
-      await toggleVoicemailFromList(page, number);
-    }
-    // Now off; confirm no chip on the visible row.
-    await page.goto('/phones');
-    const visibleForm = page
-      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
-      .first();
-    await expect(visibleForm.locator('.phone-voicemail__chip')).toHaveCount(0);
-
-    // Toggle on; chip should appear (muted "VM" because count is 0).
-    await toggleVoicemailFromList(page, number);
-    await expect(
-      page
-        .locator(`form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`)
-        .first(),
-    ).toBeVisible();
-
-    // Reload: state must be persisted server-side.
-    await page.goto('/phones');
-    await expect(
-      page
-        .locator(`form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`)
-        .first(),
-    ).toBeVisible();
-
-    // Detail page must reflect the same state.
-    await page.goto(href);
-    expect(await readEnabledOnDetail(page)).toBe(true);
-
-    // Cleanup: toggle off so the next test starts clean.
-    await toggleVoicemailFromList(page, number);
-    await page.goto('/phones');
-    await expect(
-      page.locator(
-        `form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`,
-      ),
-    ).toHaveCount(0);
-  });
-
-  test('detail page renders the voicemail panel with five fields', async ({ page }) => {
+  test('detail page renders panel with enable checkbox + Advanced disclosure', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
       return;
     }
     await page.goto(href);
+
     await expect(page.locator('h2.panel__title', { hasText: /voicemail/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
+
+    // Advanced should be collapsed by default; the 4 fields are hidden until expanded.
+    const ringField = page.locator('#voicemail-section input[name="ring_timeout_seconds"]');
+    await expect(ringField).not.toBeVisible();
+  });
+
+  test('expanding Advanced reveals all four detail fields', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+
+    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
   });
 
-  test('detail form save with valid values persists', async ({ page }) => {
+  test('checkbox toggle swaps section partial and persists', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -140,12 +105,39 @@ test.describe('Voicemail (intercom theme)', () => {
     }
     await page.goto(href);
 
-    // Enable so the inner fields aren't disabled.
-    const enabled = page.locator('#voicemail-section input[name="enabled"]');
-    if (!(await enabled.isChecked())) {
-      await enabled.check();
+    // Baseline: ensure off.
+    if (await readEnabledOnDetail(page)) {
+      await clickEnableCheckbox(page);
+    }
+    expect(await readEnabledOnDetail(page)).toBe(false);
+
+    // Toggle on.
+    await clickEnableCheckbox(page);
+    expect(await readEnabledOnDetail(page)).toBe(true);
+
+    // Reload: persisted server-side.
+    await page.goto(href);
+    expect(await readEnabledOnDetail(page)).toBe(true);
+
+    // Cleanup: turn off.
+    await clickEnableCheckbox(page);
+  });
+
+  test('saving valid Advanced values persists across reload', async ({ page }) => {
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto(href);
+
+    // Make sure voicemail is on so the inner fields aren't disabled.
+    if (!(await readEnabledOnDetail(page))) {
+      await clickEnableCheckbox(page);
     }
 
+    // Expand Advanced and edit.
+    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
     await page.locator('#voicemail-section input[name="max_message_seconds"]').fill('100');
     await page.locator('#voicemail-section input[name="max_stored_messages"]').fill('25');
@@ -158,8 +150,9 @@ test.describe('Voicemail (intercom theme)', () => {
     const resp = await wait;
     expect(resp.status()).toBe(200);
 
-    // Reload and confirm fields stuck.
+    // Reload, expand, confirm fields stuck.
     await page.goto(href);
+    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(
       page.locator('#voicemail-section input[name="ring_timeout_seconds"]'),
     ).toHaveValue('30');
@@ -167,9 +160,8 @@ test.describe('Voicemail (intercom theme)', () => {
       page.locator('#voicemail-section input[name="retrieval_code"]'),
     ).toHaveValue('*99');
 
-    // Cleanup: turn voicemail back off.
-    await enabled.uncheck();
-    await page.locator('#voicemail-section button[type="submit"]').first().click();
+    // Cleanup: voicemail off.
+    await clickEnableCheckbox(page);
   });
 
   test('bad retrieval code is rejected with 400', async ({ page }) => {
@@ -180,9 +172,9 @@ test.describe('Voicemail (intercom theme)', () => {
     }
     await page.goto(href);
 
-    // Use the request context to bypass HTML5 client-side validation;
-    // we want to assert the server-side guard rail. "12345" is digits only
-    // (no * or #), which the server rejects to avoid 7-digit-dial collision.
+    // Bypass HTML5 client-side validation and exercise the server-side guard.
+    // "12345" is digits-only (no * or #), which the handler rejects to avoid
+    // a 7-digit-dial collision.
     const number = href.split('/').pop() as string;
     const resp = await page.request.post(`/phones/${number}/voicemail`, {
       form: {
@@ -196,6 +188,19 @@ test.describe('Voicemail (intercom theme)', () => {
     });
     expect(resp.status()).toBe(400);
     expect(await resp.text()).toMatch(/retrieval_code/i);
+  });
+
+  test('list page does NOT show a voicemail badge', async ({ page }) => {
+    // Regression guard: the list-row voicemail UI was removed per owner
+    // direction. If a future hand re-adds the badge, this test fails.
+    const href = await firstPhoneHref(page);
+    if (!href) {
+      test.skip(true, 'No phones registered');
+      return;
+    }
+    await page.goto('/phones');
+    await expect(page.locator('form[data-voicemail]')).toHaveCount(0);
+    await expect(page.locator('.phone-voicemail')).toHaveCount(0);
   });
 });
 
@@ -212,38 +217,17 @@ test.describe('Voicemail (dialup theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('list-row toggle works under dialup chrome', async ({ page }) => {
+  test('detail page renders the panel under dialup chrome', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
       return;
     }
-    const number = href.split('/').pop() as string;
-
-    // Ensure baseline is OFF regardless of what an earlier test left behind.
     await page.goto(href);
-    if (await readEnabledOnDetail(page)) {
-      await toggleVoicemailFromList(page, number);
-    }
 
-    await page.goto('/phones');
-    const form = page
-      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
-      .first();
-    await expect(form).toBeVisible();
-
-    // Off -> on: expect the muted "VM" chip to appear.
-    await toggleVoicemailFromList(page, number);
-    await expect(
-      page
-        .locator(
-          `form[data-voicemail][data-line="${number}"]:visible .phone-voicemail__chip`,
-        )
-        .first(),
-    ).toBeVisible();
-
-    // Cleanup.
-    await toggleVoicemailFromList(page, number);
+    await expect(page.locator('#voicemail-section')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
   });
 });
 
@@ -260,34 +244,21 @@ test.describe('Voicemail (answering-machine theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('AM list shows the voicemail toggle in the roster meta', async ({ page }) => {
-    const href = await firstPhoneHref(page);
-    if (!href) {
-      test.skip(true, 'No phones registered');
-      return;
-    }
-    const number = href.split('/').pop() as string;
-
-    await page.goto('/phones');
-    const form = page
-      .locator(`form[data-voicemail][data-line="${number}"]:visible`)
-      .first();
-    await expect(form).toBeVisible();
-    await expect(form).toHaveClass(/am-voicemail/);
-  });
-
-  test('AM detail page renders the voicemail plate with all five fields', async ({ page }) => {
+  test('AM detail page renders the voicemail plate with AM-styled disclosure', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
       return;
     }
     await page.goto(href);
+
     await expect(page.locator('.am-plate__label', { hasText: /voicemail/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section details.am-voicemail-advanced')).toBeVisible();
+
+    // Expand and confirm AM-styled fields show.
+    await page.locator('#voicemail-section details.am-voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
   });
 });

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -65,10 +65,18 @@ type Hub struct {
 	conns        map[string][]*Conn               // phone number -> connections (multiple devices per line)
 	hwConns      map[string]*Conn                 // hardware ID -> connection
 	updateStatus map[string]*UpdateStatusSnapshot // phone number -> last update status
-	dashEvents   dashNotifier
-	redis        redisPubSub  // nil = single-instance mode (no Redis)
-	state        *DeviceState // nil = single-instance mode (no cluster state)
-	draining     bool         // set by StartDraining; blocks new Register calls
+	// voicemailUnheard tracks the per-handset unheard-voicemail count last
+	// reported by each device. Outer key is the phone number; inner key is
+	// the originating handset's hardware ID. Per-handset because voicemail
+	// storage is local to each handset on a multi-handset line, so the
+	// line-level "you have N new messages" indicator is the SUM across
+	// handsets. In-memory only; digitsd republishes on every reconnect, so
+	// volatility is intentional.
+	voicemailUnheard map[string]map[string]int
+	dashEvents       dashNotifier
+	redis            redisPubSub  // nil = single-instance mode (no Redis)
+	state            *DeviceState // nil = single-instance mode (no cluster state)
+	draining         bool         // set by StartDraining; blocks new Register calls
 }
 
 // NewHub creates a Hub ready for use. Call SetRedis and SetDeviceState before
@@ -76,9 +84,10 @@ type Hub struct {
 // mode.
 func NewHub() *Hub {
 	return &Hub{
-		conns:        make(map[string][]*Conn),
-		hwConns:      make(map[string]*Conn),
-		updateStatus: make(map[string]*UpdateStatusSnapshot),
+		conns:            make(map[string][]*Conn),
+		hwConns:          make(map[string]*Conn),
+		updateStatus:     make(map[string]*UpdateStatusSnapshot),
+		voicemailUnheard: make(map[string]map[string]int),
 	}
 }
 
@@ -359,6 +368,15 @@ func (h *Hub) Unregister(number string, conn *Conn) {
 			}
 			if conn.HardwareID != "" {
 				delete(h.hwConns, conn.HardwareID)
+				// Drop the per-handset voicemail count too: the next
+				// reconnect republishes it. Without this a vanished
+				// handset would inflate the line-level sum forever.
+				if perHW, ok := h.voicemailUnheard[number]; ok {
+					delete(perHW, conn.HardwareID)
+					if len(perHW) == 0 {
+						delete(h.voicemailUnheard, number)
+					}
+				}
 			}
 			changed = true
 			break
@@ -392,6 +410,10 @@ func (h *Hub) RekeyNumber(oldNumber, newNumber string) {
 	if us, ok := h.updateStatus[oldNumber]; ok {
 		h.updateStatus[newNumber] = us
 		delete(h.updateStatus, oldNumber)
+	}
+	if vm, ok := h.voicemailUnheard[oldNumber]; ok {
+		h.voicemailUnheard[newNumber] = vm
+		delete(h.voicemailUnheard, oldNumber)
 	}
 }
 
@@ -644,6 +666,42 @@ func (h *Hub) ClearUpdateStatus(number string) {
 	if ds != nil {
 		ds.ClearUpdateStatus(context.Background(), number)
 	}
+}
+
+// SetVoicemailUnheard records the unheard-voicemail count last reported by
+// the handset identified by hwID on this line. hwID is required: a missing
+// hardware ID is silently dropped so a malformed message can't poison the
+// shared map under a "" key. Per-handset because voicemail is local to the
+// device; the per-line total is the sum across handsets.
+func (h *Hub) SetVoicemailUnheard(number, hwID string, count int) {
+	if hwID == "" {
+		return
+	}
+	if count < 0 {
+		count = 0
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	perHW, ok := h.voicemailUnheard[number]
+	if !ok {
+		perHW = make(map[string]int)
+		h.voicemailUnheard[number] = perHW
+	}
+	perHW[hwID] = count
+}
+
+// LineVoicemailUnheard returns the sum of unheard-voicemail counts across all
+// handsets currently tracked on this line. Zero when the line has no entries
+// (no handsets ever reported, or all handsets disconnected).
+func (h *Hub) LineVoicemailUnheard(number string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	perHW := h.voicemailUnheard[number]
+	total := 0
+	for _, n := range perHW {
+		total += n
+	}
+	return total
 }
 
 // UpdateDeviceInfo sets version info and the device-reported LAN address for

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -263,3 +263,75 @@ func TestDeviceInfoSnapshotJSONOmitsRemoteAddr(t *testing.T) {
 		t.Errorf("RemoteAddr field name appeared in JSON: %s", data)
 	}
 }
+
+func TestSetVoicemailUnheardSumsAcrossHandsets(t *testing.T) {
+	hub := NewHub()
+	hub.SetVoicemailUnheard("3140001", "hw-a", 3)
+	hub.SetVoicemailUnheard("3140001", "hw-b", 5)
+	if got := hub.LineVoicemailUnheard("3140001"); got != 8 {
+		t.Errorf("LineVoicemailUnheard: got %d, want 8", got)
+	}
+}
+
+func TestSetVoicemailUnheardOverwritesPerHandset(t *testing.T) {
+	hub := NewHub()
+	hub.SetVoicemailUnheard("3140001", "hw-a", 3)
+	hub.SetVoicemailUnheard("3140001", "hw-a", 7)
+	if got := hub.LineVoicemailUnheard("3140001"); got != 7 {
+		t.Errorf("LineVoicemailUnheard: got %d, want 7 (overwrite)", got)
+	}
+}
+
+func TestSetVoicemailUnheardRejectsEmptyHardwareID(t *testing.T) {
+	hub := NewHub()
+	hub.SetVoicemailUnheard("3140001", "", 5)
+	if got := hub.LineVoicemailUnheard("3140001"); got != 0 {
+		t.Errorf("empty hwID should be dropped, got %d", got)
+	}
+}
+
+func TestSetVoicemailUnheardClampsNegative(t *testing.T) {
+	hub := NewHub()
+	hub.SetVoicemailUnheard("3140001", "hw-a", -3)
+	if got := hub.LineVoicemailUnheard("3140001"); got != 0 {
+		t.Errorf("negative count should clamp to 0, got %d", got)
+	}
+}
+
+func TestLineVoicemailUnheardZeroForUnknownNumber(t *testing.T) {
+	hub := NewHub()
+	if got := hub.LineVoicemailUnheard("3140099"); got != 0 {
+		t.Errorf("unknown number: got %d, want 0", got)
+	}
+}
+
+func TestUnregisterClearsVoicemailUnheardForHandset(t *testing.T) {
+	hub := NewHub()
+	number := "3140001"
+	conn := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-a"}
+	hub.conns[number] = []*Conn{conn}
+	hub.hwConns["hw-a"] = conn
+	hub.SetVoicemailUnheard(number, "hw-a", 4)
+	hub.SetVoicemailUnheard(number, "hw-b", 2)
+
+	hub.Unregister(number, conn)
+	// Only hw-a's count should drop; hw-b's lingers (it's still online).
+	if got := hub.LineVoicemailUnheard(number); got != 2 {
+		t.Errorf("after unregister hw-a: got %d, want 2 (hw-b's only)", got)
+	}
+}
+
+func TestRekeyNumberMovesVoicemailUnheard(t *testing.T) {
+	hub := NewHub()
+	hub.SetVoicemailUnheard("3140001", "hw-a", 3)
+	hub.SetVoicemailUnheard("3140001", "hw-b", 4)
+
+	hub.RekeyNumber("3140001", "3140002")
+
+	if got := hub.LineVoicemailUnheard("3140001"); got != 0 {
+		t.Errorf("old number should have 0 after rekey, got %d", got)
+	}
+	if got := hub.LineVoicemailUnheard("3140002"); got != 7 {
+		t.Errorf("new number should have summed counts, got %d, want 7", got)
+	}
+}

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -36,6 +36,8 @@ const (
 	TypeCallReturnCancelled = "call_return_cancelled" // Server → Phone: confirm cancellation
 
 	TypeReleaseAvailable = "release_available" // Server → All: new release detected
+
+	TypeVoicemailState = "voicemail_state" // Phone → Server: per-handset unheard voicemail count snapshot
 )
 
 // Extension pickup types (POTS extension model: pick up a second handset mid-call)
@@ -219,6 +221,12 @@ type Message struct {
 
 	// Link-health telemetry (link_health messages)
 	LinkHealth *LinkHealthPayload `json:"link_health,omitempty"`
+
+	// Voicemail state (voicemail_state messages). Reports the current
+	// unheard-message count for the originating handset. No omitempty: an
+	// explicit zero must round-trip after MarkHeard-all so the server can
+	// distinguish "feature is on, mailbox empty" from "absent / unknown".
+	VoicemailUnheardCount int `json:"voicemail_unheard_count"`
 }
 
 // ParseMessage decodes a JSON-encoded signaling message from the wire.

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -226,6 +226,18 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeCallReturnCancel:
 		r.handleCallReturnCancel(ctx, from)
 		return
+	case TypeVoicemailState:
+		// Per-handset unheard-count snapshot. Hardware ID identifies which
+		// handset on a multi-handset line emitted this; without it we have
+		// no way to dedupe so we silently drop.
+		if msg.HardwareID == "" {
+			slog.WarnContext(ctx, "voicemail_state missing hardware_id", "number", from)
+			return
+		}
+		slog.InfoContext(ctx, "voicemail_state", "number", from,
+			"hardware_id", msg.HardwareID, "unheard_count", msg.VoicemailUnheardCount)
+		r.Hub.SetVoicemailUnheard(from, msg.HardwareID, msg.VoicemailUnheardCount)
+		return
 	default:
 		slog.WarnContext(ctx, "unknown message type", "type", msg.Type, "from", from)
 	}

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1305,3 +1305,48 @@ func TestRelayCallReturnExpiry(t *testing.T) {
 	default:
 	}
 }
+
+func TestRelayVoicemailStateUpdatesHub(t *testing.T) {
+	hub := NewHub()
+	relay := NewRelay(hub, nil, nil, nil)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:                  TypeVoicemailState,
+		HardwareID:            "hw-a",
+		VoicemailUnheardCount: 4,
+	})
+
+	if got := hub.LineVoicemailUnheard("3140001"); got != 4 {
+		t.Errorf("LineVoicemailUnheard: got %d, want 4", got)
+	}
+}
+
+func TestRelayVoicemailStateMissingHardwareIDIsDropped(t *testing.T) {
+	hub := NewHub()
+	relay := NewRelay(hub, nil, nil, nil)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:                  TypeVoicemailState,
+		VoicemailUnheardCount: 9,
+	})
+
+	if got := hub.LineVoicemailUnheard("3140001"); got != 0 {
+		t.Errorf("missing hardware_id should drop the message, got count %d", got)
+	}
+}
+
+func TestRelayVoicemailStateZeroExplicitlyOverwrites(t *testing.T) {
+	hub := NewHub()
+	relay := NewRelay(hub, nil, nil, nil)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type: TypeVoicemailState, HardwareID: "hw-a", VoicemailUnheardCount: 5,
+	})
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type: TypeVoicemailState, HardwareID: "hw-a", VoicemailUnheardCount: 0,
+	})
+
+	if got := hub.LineVoicemailUnheard("3140001"); got != 0 {
+		t.Errorf("explicit zero should overwrite, got %d", got)
+	}
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -564,6 +564,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/silent-mode", h.handlePhoneSilentModePost)
 	protected.HandleFunc("POST /phones/{number}/auto-update", h.handlePhoneAutoUpdatePost)
 	protected.HandleFunc("POST /phones/{number}/voicemail", h.handlePhoneVoicemailPost)
+	protected.HandleFunc("POST /phones/{number}/voicemail-toggle", h.handlePhoneVoicemailTogglePost)
 	protected.HandleFunc("POST /phones/{number}/convert", h.handlePhoneConvert)
 	protected.HandleFunc("POST /phones/{number}/delete", h.handlePhoneDelete)
 	protected.HandleFunc("POST /phones/{number}/update", h.handlePhoneUpdate)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -71,10 +71,6 @@ type lineRow struct {
 	OnlineDeviceCount   int
 	FirmwareUpdateNotes []updates.Release
 	PiUpdateNotes       []updates.Release
-	// VoicemailUnheard is the line-level unheard-message count, summed
-	// across handsets the Hub has heard from. Zero when voicemail is off
-	// or no handset has reported a non-zero count.
-	VoicemailUnheard int
 }
 
 // buildLinesData assembles the line-list page payload. hh may be nil; when
@@ -121,7 +117,6 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 		}
 		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
 		row.OnlineDeviceCount = h.hub.ConnectionCount(l.Number)
-		row.VoicemailUnheard = h.hub.LineVoicemailUnheard(l.Number)
 
 		if h.deviceStore != nil {
 			devs, err := h.deviceStore.ListByLine(r.Context(), l.ID)
@@ -307,6 +302,11 @@ type lineDetailData struct {
 	FirmwareUpdateNotes   []updates.Release
 	OtherLines            []line.Line
 	NumberError           string
+	// VoicemailUnheard is the line-level unheard-voicemail count summed
+	// across handsets last reported by digitsd. Surfaced inline with the
+	// Voicemail section header on the detail page; the chip only renders
+	// when voicemail is enabled AND this count is greater than zero.
+	VoicemailUnheard int
 }
 
 func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
@@ -386,6 +386,11 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var voicemailUnheard int
+	if h.hub != nil {
+		voicemailUnheard = h.hub.LineVoicemailUnheard(number)
+	}
+
 	renderWith(r.Context(), w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
 		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
 		Line:                  *ln,
@@ -401,6 +406,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		FirmwareUpdateNotes:   firmwareUpdateNotes,
 		OtherLines:            otherLines,
 		NumberError:           r.URL.Query().Get("number_error"),
+		VoicemailUnheard:      voicemailUnheard,
 	})
 }
 
@@ -678,19 +684,26 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	}
 
 	if isHTMX(r) {
+		count := 0
+		if h.hub != nil {
+			count = h.hub.LineVoicemailUnheard(number)
+		}
 		renderWith(r.Context(), w, h.tmplPhoneDetail,
 			partialFor(r, "voicemail-section", "am-voicemail-section"),
-			struct{ Line line.Line }{Line: *ln})
+			struct {
+				Line             line.Line
+				VoicemailUnheard int
+			}{Line: *ln, VoicemailUnheard: count})
 		return
 	}
 	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
 }
 
 // handlePhoneVoicemailTogglePost flips Voicemail.Enabled for a line and
-// swaps the list-row badge partial. The other four voicemail fields are
-// preserved through Normalize, which backfills defaults when the row was
-// created before voicemail existed. Path is intentionally separate from
-// the five-field POST so a checkbox-only round-trip does not have to
+// swaps the detail-page voicemail section. The other four voicemail fields
+// are preserved through Normalize, which backfills defaults when the row
+// was created before voicemail existed. Path is intentionally separate
+// from the five-field POST so a checkbox-only round-trip does not have to
 // resubmit the timing/code fields.
 func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
@@ -711,15 +724,15 @@ func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.
 		if h.hub != nil {
 			count = h.hub.LineVoicemailUnheard(number)
 		}
-		renderWith(r.Context(), w, h.tmplPhones,
-			partialFor(r, "voicemail-badge", "am-voicemail-badge"),
+		renderWith(r.Context(), w, h.tmplPhoneDetail,
+			partialFor(r, "voicemail-section", "am-voicemail-section"),
 			struct {
 				Line             line.Line
 				VoicemailUnheard int
 			}{Line: *ln, VoicemailUnheard: count})
 		return
 	}
-	http.Redirect(w, r, "/phones", http.StatusSeeOther)
+	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
 }
 
 // parseClampedInt reads form field `name`, parses it as an integer, and

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -71,6 +71,10 @@ type lineRow struct {
 	OnlineDeviceCount   int
 	FirmwareUpdateNotes []updates.Release
 	PiUpdateNotes       []updates.Release
+	// VoicemailUnheard is the line-level unheard-message count, summed
+	// across handsets the Hub has heard from. Zero when voicemail is off
+	// or no handset has reported a non-zero count.
+	VoicemailUnheard int
 }
 
 // buildLinesData assembles the line-list page payload. hh may be nil; when
@@ -117,6 +121,7 @@ func (h *Handler) buildLinesData(r *http.Request, hh *household.Household, errMs
 		}
 		row := lineRow{Line: l, Online: onlineSet[l.Number], DeviceInfo: info}
 		row.OnlineDeviceCount = h.hub.ConnectionCount(l.Number)
+		row.VoicemailUnheard = h.hub.LineVoicemailUnheard(l.Number)
 
 		if h.deviceStore != nil {
 			devs, err := h.deviceStore.ListByLine(r.Context(), l.ID)
@@ -621,9 +626,8 @@ func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Reque
 // before any DB write: out-of-range ints and malformed retrieval codes
 // return 400 with a friendly message so the form can surface it. On success
 // the new settings are persisted and pushed to the device (if connected),
-// then the user is redirected back to the phone detail page. No htmx
-// partial is rendered today; the UI section partials will be added when
-// the matching settings panel ships.
+// then either the voicemail-section partial is swapped (htmx) or the user
+// is redirected back to the phone detail page (regular form post).
 func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
@@ -673,7 +677,49 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if isHTMX(r) {
+		renderWith(r.Context(), w, h.tmplPhoneDetail,
+			partialFor(r, "voicemail-section", "am-voicemail-section"),
+			struct{ Line line.Line }{Line: *ln})
+		return
+	}
 	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
+}
+
+// handlePhoneVoicemailTogglePost flips Voicemail.Enabled for a line and
+// swaps the list-row badge partial. The other four voicemail fields are
+// preserved through Normalize, which backfills defaults when the row was
+// created before voicemail existed. Path is intentionally separate from
+// the five-field POST so a checkbox-only round-trip does not have to
+// resubmit the timing/code fields.
+func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
+		return
+	}
+
+	next := ln.Settings
+	next.Voicemail.Enabled = !next.Voicemail.Enabled
+	next = next.Normalize()
+	if !h.applyLineSettings(w, r, ln, next) {
+		return
+	}
+
+	if isHTMX(r) {
+		count := 0
+		if h.hub != nil {
+			count = h.hub.LineVoicemailUnheard(number)
+		}
+		renderWith(r.Context(), w, h.tmplPhones,
+			partialFor(r, "voicemail-badge", "am-voicemail-badge"),
+			struct {
+				Line             line.Line
+				VoicemailUnheard int
+			}{Line: *ln, VoicemailUnheard: count})
+		return
+	}
+	http.Redirect(w, r, "/phones", http.StatusSeeOther)
 }
 
 // parseClampedInt reads form field `name`, parses it as an integer, and

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2911,36 +2911,47 @@ func TestPhoneVoicemailToggleFlipsEnabledAndRedirects(t *testing.T) {
 	}
 }
 
-func TestPhoneVoicemailToggleHTMXReturnsBadgePartial(t *testing.T) {
+func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	// First toggle: off -> on, badge should show "VM" lozenge.
+	// First toggle: off -> on. Section partial swaps in with the enabled
+	// checkbox flipped on. No unheard count -> no chip yet.
 	w := postVoicemailToggle(t, h, cookie, true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, `data-line="3140001"`) {
-		t.Fatalf("htmx response missing data-line attribute:\n%s", body)
+	if !strings.Contains(body, `id="voicemail-section"`) {
+		t.Fatalf("htmx response missing voicemail-section wrapper:\n%s", body)
 	}
 	if !strings.Contains(body, "/voicemail-toggle") {
 		t.Fatalf("htmx response missing toggle endpoint:\n%s", body)
 	}
-	// Badge ladder: enabled with 0 unheard renders the muted "VM" chip.
-	if !strings.Contains(body, "phone-voicemail__chip--on") {
-		t.Errorf("expected on/0 muted VM chip in body:\n%s", body)
+	// With Enabled=true and count=0, the chip should NOT render.
+	if strings.Contains(body, "voicemail-chip") {
+		t.Errorf("expected no chip when count=0, got:\n%s", body)
+	}
+	// The enabled checkbox should round-trip back checked.
+	if !strings.Contains(body, `name="enabled" value="on"
+             checked`) && !strings.Contains(body, `checked`) {
+		t.Errorf("expected enabled checkbox to round-trip checked:\n%s", body)
+	}
+	// Advanced disclosure must be present.
+	if !strings.Contains(body, `class="voicemail-advanced"`) {
+		t.Errorf("expected voicemail-advanced disclosure:\n%s", body)
 	}
 
-	// Second toggle: on -> off, badge should collapse to enable button only.
+	// Second toggle: on -> off. Section partial returns with checkbox
+	// unchecked and the inner fields rendered with disabled.
 	w = postVoicemailToggle(t, h, cookie, true)
 	body = w.Body.String()
-	if strings.Contains(body, "phone-voicemail__chip") {
-		t.Errorf("expected no VM chip when voicemail is off, got:\n%s", body)
+	if strings.Contains(body, "voicemail-chip") {
+		t.Errorf("expected no chip when voicemail is off, got:\n%s", body)
 	}
-	if !strings.Contains(body, "phone-voicemail__toggle--enable") {
-		t.Errorf("expected the enable-button class when voicemail off:\n%s", body)
+	if !strings.Contains(body, `disabled`) {
+		t.Errorf("expected disabled attr on inner fields when off:\n%s", body)
 	}
 }
 
@@ -2981,16 +2992,17 @@ func TestPhoneVoicemailToggleHTMXReflectsHubUnheardCount(t *testing.T) {
 	// Pre-populate the hub with an unheard count for the line.
 	h.hub.SetVoicemailUnheard("3140001", "hw-fake", 3)
 
-	// Toggle on; htmx response should render the attention chip with the count.
+	// Toggle on; htmx response renders the section partial with the
+	// "N unheard" chip in the section header.
 	w := postVoicemailToggle(t, h, cookie, true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, "phone-voicemail__chip--attn") {
-		t.Errorf("expected attention chip when count > 0:\n%s", body)
+	if !strings.Contains(body, `class="voicemail-chip"`) {
+		t.Errorf("expected voicemail-chip when count > 0:\n%s", body)
 	}
-	if !strings.Contains(body, ">VM 3<") {
-		t.Errorf("expected 'VM 3' label:\n%s", body)
+	if !strings.Contains(body, "3 unheard") {
+		t.Errorf("expected '3 unheard' label:\n%s", body)
 	}
 }

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2615,10 +2615,16 @@ func validVoicemailForm() url.Values {
 	}
 }
 
-func postVoicemail(t *testing.T, h *Handler, cookie *http.Cookie, form url.Values) *httptest.ResponseRecorder {
+// postVoicemail posts the given form to the per-line voicemail endpoint as
+// the session in cookie. When htmx is true the HX-Request header is set so
+// the handler renders the section partial instead of 303-redirecting.
+func postVoicemail(t *testing.T, h *Handler, cookie *http.Cookie, form url.Values, htmx bool) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/voicemail", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
 	req.AddCookie(cookie)
 	w := httptest.NewRecorder()
 	h.Router().ServeHTTP(w, req)
@@ -2641,7 +2647,7 @@ func TestPhoneVoicemailValidFormPersistsAndRedirects(t *testing.T) {
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	w := postVoicemail(t, h, cookie, validVoicemailForm())
+	w := postVoicemail(t, h, cookie, validVoicemailForm(), false)
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
 	}
@@ -2672,7 +2678,7 @@ func TestPhoneVoicemailRingTimeoutOutOfRangeRejected(t *testing.T) {
 		t.Run(val, func(t *testing.T) {
 			form := validVoicemailForm()
 			form.Set("ring_timeout_seconds", val)
-			w := postVoicemail(t, h, cookie, form)
+			w := postVoicemail(t, h, cookie, form, false)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("ring_timeout_seconds=%q: expected 400, got %d: %s", val, w.Code, w.Body.String())
 			}
@@ -2693,7 +2699,7 @@ func TestPhoneVoicemailMaxMessageOutOfRangeRejected(t *testing.T) {
 		t.Run(val, func(t *testing.T) {
 			form := validVoicemailForm()
 			form.Set("max_message_seconds", val)
-			w := postVoicemail(t, h, cookie, form)
+			w := postVoicemail(t, h, cookie, form, false)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("max_message_seconds=%q: expected 400, got %d", val, w.Code)
 			}
@@ -2711,7 +2717,7 @@ func TestPhoneVoicemailMaxStoredOutOfRangeRejected(t *testing.T) {
 		t.Run(val, func(t *testing.T) {
 			form := validVoicemailForm()
 			form.Set("max_stored_messages", val)
-			w := postVoicemail(t, h, cookie, form)
+			w := postVoicemail(t, h, cookie, form, false)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("max_stored_messages=%q: expected 400, got %d", val, w.Code)
 			}
@@ -2737,7 +2743,7 @@ func TestPhoneVoicemailBadRetrievalCodeRejected(t *testing.T) {
 		t.Run(val, func(t *testing.T) {
 			form := validVoicemailForm()
 			form.Set("retrieval_code", val)
-			w := postVoicemail(t, h, cookie, form)
+			w := postVoicemail(t, h, cookie, form, false)
 			if w.Code != http.StatusBadRequest {
 				t.Fatalf("retrieval_code=%q: expected 400, got %d: %s", val, w.Code, w.Body.String())
 			}
@@ -2764,7 +2770,7 @@ func TestPhoneVoicemailMissingLineReturns404(t *testing.T) {
 		_, _ = database.DB.Exec("DELETE FROM households WHERE id = $1", hh.ID)
 	})
 
-	w := postVoicemail(t, h, cookie, validVoicemailForm())
+	w := postVoicemail(t, h, cookie, validVoicemailForm(), false)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing line, got %d: %s", w.Code, w.Body.String())
 	}
@@ -2778,7 +2784,7 @@ func TestPhoneVoicemailPushesToConnectedDevice(t *testing.T) {
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	_ = h.hub.Register("3140001", conn)
 
-	if w := postVoicemail(t, h, cookie, validVoicemailForm()); w.Code != http.StatusSeeOther {
+	if w := postVoicemail(t, h, cookie, validVoicemailForm(), false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
 	}
 
@@ -2816,7 +2822,7 @@ func TestPhoneVoicemailNoOpSkipsPush(t *testing.T) {
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
 	// First save populates the row with the validVoicemailForm values.
-	if w := postVoicemail(t, h, cookie, validVoicemailForm()); w.Code != http.StatusSeeOther {
+	if w := postVoicemail(t, h, cookie, validVoicemailForm(), false); w.Code != http.StatusSeeOther {
 		t.Fatalf("setup save: %d %s", w.Code, w.Body.String())
 	}
 
@@ -2825,7 +2831,7 @@ func TestPhoneVoicemailNoOpSkipsPush(t *testing.T) {
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	_ = h.hub.Register("3140001", conn)
 
-	if w := postVoicemail(t, h, cookie, validVoicemailForm()); w.Code != http.StatusSeeOther {
+	if w := postVoicemail(t, h, cookie, validVoicemailForm(), false); w.Code != http.StatusSeeOther {
 		t.Fatalf("second save: %d %s", w.Code, w.Body.String())
 	}
 	select {
@@ -2836,26 +2842,12 @@ func TestPhoneVoicemailNoOpSkipsPush(t *testing.T) {
 	}
 }
 
-// postVoicemailHTMX submits the same form as postVoicemail but with the
-// HX-Request header so the handler renders the section partial instead of
-// 303-redirecting.
-func postVoicemailHTMX(t *testing.T, h *Handler, cookie *http.Cookie, form url.Values) *httptest.ResponseRecorder {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/voicemail", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("HX-Request", "true")
-	req.AddCookie(cookie)
-	w := httptest.NewRecorder()
-	h.Router().ServeHTTP(w, req)
-	return w
-}
-
 func TestPhoneVoicemailHTMXReturnsSectionPartial(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	w := postVoicemailHTMX(t, h, cookie, validVoicemailForm())
+	w := postVoicemail(t, h, cookie, validVoicemailForm(), true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2835,3 +2835,170 @@ func TestPhoneVoicemailNoOpSkipsPush(t *testing.T) {
 		// Expected: no push.
 	}
 }
+
+// postVoicemailHTMX submits the same form as postVoicemail but with the
+// HX-Request header so the handler renders the section partial instead of
+// 303-redirecting.
+func postVoicemailHTMX(t *testing.T, h *Handler, cookie *http.Cookie, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/voicemail", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	return w
+}
+
+func TestPhoneVoicemailHTMXReturnsSectionPartial(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	w := postVoicemailHTMX(t, h, cookie, validVoicemailForm())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `id="voicemail-section"`) {
+		t.Fatalf("htmx response missing voicemail-section wrapper:\n%s", body)
+	}
+	if !strings.Contains(body, `name="enabled"`) {
+		t.Fatalf("htmx response missing enabled checkbox:\n%s", body)
+	}
+	if !strings.Contains(body, `name="ring_timeout_seconds"`) {
+		t.Fatalf("htmx response missing ring_timeout_seconds:\n%s", body)
+	}
+}
+
+func postVoicemailToggle(t *testing.T, h *Handler, cookie *http.Cookie, htmx bool) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/phones/3140001/voicemail-toggle", nil)
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+	return w
+}
+
+func readVoicemailEnabled(t *testing.T, database *db.Database) bool {
+	t.Helper()
+	var raw bool
+	if err := database.DB.QueryRow(
+		`SELECT COALESCE((settings->'voicemail'->>'enabled')::bool, false) FROM lines WHERE number = '3140001'`,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read voicemail enabled: %v", err)
+	}
+	return raw
+}
+
+func TestPhoneVoicemailToggleFlipsEnabledAndRedirects(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	if readVoicemailEnabled(t, database) {
+		t.Fatal("setup invariant: voicemail should default to off")
+	}
+
+	w := postVoicemailToggle(t, h, cookie, false)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
+	}
+	if !readVoicemailEnabled(t, database) {
+		t.Fatal("expected voicemail enabled=true after toggle")
+	}
+
+	if w := postVoicemailToggle(t, h, cookie, false); w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 on second toggle, got %d", w.Code)
+	}
+	if readVoicemailEnabled(t, database) {
+		t.Fatal("expected voicemail enabled=false after second toggle")
+	}
+}
+
+func TestPhoneVoicemailToggleHTMXReturnsBadgePartial(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	// First toggle: off -> on, badge should show "VM" lozenge.
+	w := postVoicemailToggle(t, h, cookie, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `data-line="3140001"`) {
+		t.Fatalf("htmx response missing data-line attribute:\n%s", body)
+	}
+	if !strings.Contains(body, "/voicemail-toggle") {
+		t.Fatalf("htmx response missing toggle endpoint:\n%s", body)
+	}
+	// Badge ladder: enabled with 0 unheard renders the muted "VM" chip.
+	if !strings.Contains(body, "phone-voicemail__chip--on") {
+		t.Errorf("expected on/0 muted VM chip in body:\n%s", body)
+	}
+
+	// Second toggle: on -> off, badge should collapse to enable button only.
+	w = postVoicemailToggle(t, h, cookie, true)
+	body = w.Body.String()
+	if strings.Contains(body, "phone-voicemail__chip") {
+		t.Errorf("expected no VM chip when voicemail is off, got:\n%s", body)
+	}
+	if !strings.Contains(body, "phone-voicemail__toggle--enable") {
+		t.Errorf("expected the enable-button class when voicemail off:\n%s", body)
+	}
+}
+
+func TestPhoneVoicemailTogglePushesToConnectedDevice(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10)}
+	_ = h.hub.Register("3140001", conn)
+
+	if w := postVoicemailToggle(t, h, cookie, false); w.Code != http.StatusSeeOther {
+		t.Fatalf("toggle save failed: %d %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, err := signaling.ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse pushed message: %v", err)
+		}
+		if msg.Type != signaling.TypeLineSettings {
+			t.Fatalf("expected %s push, got %s", signaling.TypeLineSettings, msg.Type)
+		}
+		if msg.LineSettings == nil || msg.LineSettings.Voicemail == nil || !msg.LineSettings.Voicemail.Enabled {
+			t.Fatalf("expected enabled=true voicemail push, got %+v", msg.LineSettings)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("device did not receive line_settings push after toggle")
+	}
+}
+
+func TestPhoneVoicemailToggleHTMXReflectsHubUnheardCount(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie := addSessionCookie(t, authStore)
+	_ = setupVoiceStyleLine(t, h, database, authStore)
+
+	// Pre-populate the hub with an unheard count for the line.
+	h.hub.SetVoicemailUnheard("3140001", "hw-fake", 3)
+
+	// Toggle on; htmx response should render the attention chip with the count.
+	w := postVoicemailToggle(t, h, cookie, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "phone-voicemail__chip--attn") {
+		t.Errorf("expected attention chip when count > 0:\n%s", body)
+	}
+	if !strings.Contains(body, ">VM 3<") {
+		t.Errorf("expected 'VM 3' label:\n%s", body)
+	}
+}

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2419,6 +2419,15 @@ body.am .pair-mode-field legend {
   vertical-align: middle;
 }
 
+/* Form wrapper for the AM voicemail panel. Block-flow so the toggle-row
+   and the Advanced disclosure each get their own row, with the standard
+   AM section spacing between them. Crucially NOT am-settings__form--stack:
+   that helper sets align-items: stretch on a flex-column, which would
+   stretch .am-settings__dip (an inline-flex with a red background) to
+   fill the section width. The toggle-row keeps the dip content-sized. */
+.am-voicemail-form { margin: 0; }
+.am-voicemail-form > * + * { margin-top: 12px; }
+
 /* Advanced disclosure inside the AM voicemail plate. The summary acts like
    the existing am-tab buttons: caret prefix flips when open, label is the
    familiar 10-char LED stencil. */

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2404,3 +2404,21 @@ body.am .pair-mode-field legend {
 .changelog__play:hover { border-color: var(--chip-blue); color: var(--ink); }
 .changelog__empty { color: var(--ink-muted); font-style: italic; font-size: 12px; }
 
+
+/* Voicemail badge + toggle in the AM phones roster meta line. The chip uses
+   the standard am-led typography; the OFF/ON toggle is a compact am-tab. */
+.am-voicemail {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.am-voicemail__led {
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  padding: 0 4px;
+}
+.am-voicemail__led--on { color: var(--led-amber-dim); text-shadow: none; }
+.am-voicemail__led--attn { color: var(--led-red); text-shadow: 0 0 6px rgba(255,61,46,0.5), 0 0 12px rgba(255,61,46,0.25); }
+.am-voicemail__toggle { padding: 0 6px; min-width: 0; min-height: 18px; line-height: 18px; font-size: 9px; }

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2405,20 +2405,44 @@ body.am .pair-mode-field legend {
 .changelog__empty { color: var(--ink-muted); font-style: italic; font-size: 12px; }
 
 
-/* Voicemail badge + toggle in the AM phones roster meta line. The chip uses
-   the standard am-led typography; the OFF/ON toggle is a compact am-tab. */
-.am-voicemail {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin-left: 6px;
-  vertical-align: middle;
-}
-.am-voicemail__led {
+/* Voicemail unheard-count LED in the AM detail-page section header. Stays
+   inline with the section label, glows red so an unheard count reads as a
+   "message waiting" annunciator rather than just decoration. */
+.am-voicemail-led {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 0 6px;
   font-size: 10px;
   letter-spacing: 0.12em;
-  padding: 0 4px;
+  color: var(--led-red);
+  text-shadow: 0 0 6px rgba(255,61,46,0.5), 0 0 12px rgba(255,61,46,0.25);
+  vertical-align: middle;
 }
-.am-voicemail__led--on { color: var(--led-amber-dim); text-shadow: none; }
-.am-voicemail__led--attn { color: var(--led-red); text-shadow: 0 0 6px rgba(255,61,46,0.5), 0 0 12px rgba(255,61,46,0.25); }
-.am-voicemail__toggle { padding: 0 6px; min-width: 0; min-height: 18px; line-height: 18px; font-size: 9px; }
+
+/* Advanced disclosure inside the AM voicemail plate. The summary acts like
+   the existing am-tab buttons: caret prefix flips when open, label is the
+   familiar 10-char LED stencil. */
+.am-voicemail-advanced {
+  margin-top: 8px;
+  border-top: 1px dashed var(--rule-soft, #6b5a39);
+  padding-top: 8px;
+}
+.am-voicemail-advanced > summary {
+  cursor: pointer;
+  font-family: var(--font-led);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--led-amber-dim);
+  padding: 4px 0;
+  list-style: none;
+  text-transform: uppercase;
+}
+.am-voicemail-advanced > summary::-webkit-details-marker { display: none; }
+.am-voicemail-advanced > summary::before {
+  content: "[+] ";
+}
+.am-voicemail-advanced[open] > summary::before {
+  content: "[-] ";
+  color: var(--led-amber);
+  text-shadow: 0 0 4px rgba(255,165,32,0.45);
+}

--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2446,3 +2446,19 @@ body.am .pair-mode-field legend {
   color: var(--led-amber);
   text-shadow: 0 0 4px rgba(255,165,32,0.45);
 }
+
+/* Force the four field rows + the Save button to stack vertically. The
+   parent form uses .am-settings__form--stack (flex-column), but the
+   <details> + inner-wrapper layers swallow that, so the wrapper has to
+   declare its own column layout. The Save button is pushed to its own
+   row by aligning it to the start of the cross-axis. */
+.am-voicemail-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+}
+.am-voicemail-fields__submit {
+  align-self: flex-start;
+  margin-top: 4px;
+}

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1329,6 +1329,56 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   display: none;
 }
 
+/* Voicemail row control. One-click toggle plus a count chip when enabled.
+   The form is rendered as inline-flex so the chip and toggle button sit
+   tight together; htmx swaps the whole form when the toggle round-trips. */
+.phone-voicemail {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  vertical-align: middle;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+.phone-voicemail__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.phone-voicemail__chip--on {
+  color: var(--ink-muted);
+  background: var(--rule-soft, #ece6d5);
+}
+.phone-voicemail__chip--attn {
+  color: #5a3a00;
+  background: #f7e0a0;
+}
+.phone-voicemail__toggle {
+  appearance: none;
+  border: 1px solid var(--rule-soft, #ddd2b8);
+  background: transparent;
+  color: var(--ink-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+.phone-voicemail__toggle:hover {
+  color: var(--ink);
+  border-color: var(--ink-muted);
+}
+.phone-voicemail__toggle--enable {
+  color: var(--ink-soft);
+}
+
 /* Settings two-column layout */
 .settings-layout {
   display: grid;

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1329,54 +1329,52 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
   display: none;
 }
 
-/* Voicemail row control. One-click toggle plus a count chip when enabled.
-   The form is rendered as inline-flex so the chip and toggle button sit
-   tight together; htmx swaps the whole form when the toggle round-trips. */
-.phone-voicemail {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: 8px;
-  vertical-align: middle;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-}
-.phone-voicemail__chip {
+/* Voicemail unheard-count chip in the detail-page section header. Matches
+   the .chip family but stays inline next to the section title. The chip is
+   only rendered when voicemail is enabled AND there is at least one unheard
+   message, so the bare "voicemail off" state has no chip at all. */
+.voicemail-chip {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 1px 6px;
+  margin-left: 10px;
+  padding: 2px 8px;
   border-radius: 3px;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-.phone-voicemail__chip--on {
-  color: var(--ink-muted);
-  background: var(--rule-soft, #ece6d5);
-}
-.phone-voicemail__chip--attn {
-  color: #5a3a00;
-  background: #f7e0a0;
-}
-.phone-voicemail__toggle {
-  appearance: none;
-  border: 1px solid var(--rule-soft, #ddd2b8);
-  background: transparent;
-  color: var(--ink-muted);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
-  padding: 1px 6px;
-  border-radius: 3px;
-  cursor: pointer;
   text-transform: uppercase;
+  color: #5a3a00;
+  background: #f7e0a0;
+  vertical-align: middle;
 }
-.phone-voicemail__toggle:hover {
-  color: var(--ink);
-  border-color: var(--ink-muted);
+
+/* Advanced disclosure inside the voicemail section. The summary doubles as
+   a toggle button with a chevron that flips when expanded. */
+.voicemail-advanced {
+  margin-top: 6px;
+  border-top: 1px dashed var(--rule-soft, #ddd2b8);
+  padding-top: 8px;
 }
-.phone-voicemail__toggle--enable {
+.voicemail-advanced > summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--ink-soft);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 0;
+  list-style: none;
+}
+.voicemail-advanced > summary::-webkit-details-marker { display: none; }
+.voicemail-advanced > summary::before {
+  content: "+ ";
+  display: inline-block;
+  width: 12px;
+  font-weight: 700;
+}
+.voicemail-advanced[open] > summary::before {
+  content: "- ";
 }
 
 /* Settings two-column layout */

--- a/server/internal/web/static/voicemail-form.js
+++ b/server/internal/web/static/voicemail-form.js
@@ -1,0 +1,32 @@
+// voicemail-form.js
+//
+// Mirrors the enabled-checkbox state into the field group's disabled +
+// opacity attributes so the form gives instant feedback when the user
+// flips voicemail on or off, without waiting for the htmx round-trip.
+//
+// Bound at the document level via event delegation so a single load on
+// phone-detail.html covers both the intercom and answering-machine
+// partials, and survives the htmx outerHTML swap on Save (which would
+// orphan a per-form listener bound at partial-render time).
+(function () {
+  document.addEventListener('change', function (e) {
+    var box = e.target;
+    if (!box || !box.matches || !box.matches('[data-voicemail-enabled]')) {
+      return;
+    }
+    var form = box.closest('[data-voicemail-form]');
+    if (!form) {
+      return;
+    }
+    var fieldsWrap = form.querySelector('[data-voicemail-fields]');
+    if (!fieldsWrap) {
+      return;
+    }
+    var on = box.checked;
+    fieldsWrap.style.opacity = on ? '' : '0.55';
+    var inputs = fieldsWrap.querySelectorAll('input');
+    for (var i = 0; i < inputs.length; i++) {
+      inputs[i].disabled = !on;
+    }
+  });
+})();

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -105,6 +105,16 @@
         </div>
       </section>
 
+      <!-- Voicemail -->
+      <section class="panel">
+        <header class="panel__head">
+          <h2 class="panel__title">Voicemail</h2>
+        </header>
+        <div class="panel__body">
+          {{template "voicemail-section" .}}
+        </div>
+      </section>
+
     </div>
 
     <!-- Right: operator service panel (collapsed by default) -->
@@ -721,6 +731,169 @@
 </div>
 {{end}}
 
+{{define "voicemail-section"}}
+<div id="voicemail-section">
+  <form hx-post="/phones/{{.Line.Number}}/voicemail"
+        hx-target="#voicemail-section"
+        hx-swap="outerHTML"
+        class="stack-sm"
+        data-voicemail-form>
+    <label class="checkbox-row">
+      <input type="checkbox" name="enabled" value="on"
+             {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
+             data-voicemail-enabled>
+      <span class="checkbox-row__label">Take messages when nobody answers</span>
+    </label>
+    <p class="muted" style="font-size: 12px; margin: 4px 0 0;">
+      The handset auto-answers after the timeout, plays the greeting, and records the caller.
+      Messages stay on the handset; dial the retrieval code from the phone to listen.
+    </p>
+
+    <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+      <label class="field">
+        <span class="field__label">Ring timeout (seconds)</span>
+        <input type="number" name="ring_timeout_seconds"
+               min="5" max="60"
+               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+               class="field__input" style="width: 110px;"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        <span class="muted" style="font-size: 11px;">5 to 60 seconds before voicemail picks up.</span>
+      </label>
+
+      <label class="field">
+        <span class="field__label">Max message length (seconds)</span>
+        <input type="number" name="max_message_seconds"
+               min="15" max="180"
+               value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
+               class="field__input" style="width: 110px;"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
+      </label>
+
+      <label class="field">
+        <span class="field__label">Max stored messages</span>
+        <input type="number" name="max_stored_messages"
+               min="5" max="200"
+               value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
+               class="field__input" style="width: 110px;"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        <span class="muted" style="font-size: 11px;">5 to 200; oldest dropped first.</span>
+      </label>
+
+      <label class="field">
+        <span class="field__label">Retrieval code</span>
+        <input type="text" name="retrieval_code"
+               value="{{.Line.Settings.Voicemail.RetrievalCode}}"
+               pattern="[0-9*#]{2,6}" maxlength="6" required
+               class="field__input" style="width: 110px;"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        <span class="muted" style="font-size: 11px;">2 to 6 chars; must contain * or # so it cannot collide with a 7-digit dial.</span>
+      </label>
+    </div>
+
+    <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
+  </form>
+  <script>
+    (function () {
+      var form = document.querySelector('[data-voicemail-form]');
+      if (!form) { return; }
+      var enabledBox = form.querySelector('[data-voicemail-enabled]');
+      var fieldsWrap = form.querySelector('[data-voicemail-fields]');
+      if (!enabledBox || !fieldsWrap) { return; }
+      enabledBox.addEventListener('change', function () {
+        var on = enabledBox.checked;
+        fieldsWrap.style.opacity = on ? '' : '0.55';
+        var inputs = fieldsWrap.querySelectorAll('input');
+        for (var i = 0; i < inputs.length; i++) { inputs[i].disabled = !on; }
+      });
+    })();
+  </script>
+</div>
+{{end}}
+
+{{define "am-voicemail-section"}}
+<div id="voicemail-section">
+  <form hx-post="/phones/{{.Line.Number}}/voicemail"
+        hx-target="#voicemail-section"
+        hx-swap="outerHTML"
+        class="am-settings__form am-settings__form--stack"
+        data-voicemail-form>
+    <label class="am-settings__dip" aria-label="Voicemail enabled">
+      <input type="checkbox" name="enabled" value="on"
+             {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
+             class="am-settings__dip-input"
+             data-voicemail-enabled>
+      <span class="am-settings__dip-body" aria-hidden="true">
+        <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
+        <span class="am-settings__dip-lever"></span>
+        <span class="am-settings__dip-label am-settings__dip-label--off">0</span>
+      </span>
+    </label>
+    <div class="am-settings__toggle-info">
+      <div class="am-label am-settings__toggle-title">Take messages</div>
+      <p class="am-hint am-settings__toggle-desc">
+        Auto-answer after the timeout, play greeting, record. Messages stay on the handset.
+      </p>
+    </div>
+
+    <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+      <label class="am-field">
+        <span class="am-label">Ring timeout (sec)</span>
+        <input type="number" name="ring_timeout_seconds"
+               min="5" max="60"
+               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+               class="am-input"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+      </label>
+      <label class="am-field">
+        <span class="am-label">Max message (sec)</span>
+        <input type="number" name="max_message_seconds"
+               min="15" max="180"
+               value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
+               class="am-input"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+      </label>
+      <label class="am-field">
+        <span class="am-label">Max stored</span>
+        <input type="number" name="max_stored_messages"
+               min="5" max="200"
+               value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
+               class="am-input"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+      </label>
+      <label class="am-field">
+        <span class="am-label">Retrieval code</span>
+        <input type="text" name="retrieval_code"
+               value="{{.Line.Settings.Voicemail.RetrievalCode}}"
+               pattern="[0-9*#]{2,6}" maxlength="6" required
+               class="am-input"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+      </label>
+    </div>
+
+    <button type="submit" class="am-key am-settings__submit">
+      <span class="am-key__symbol">&#x25B6;</span>
+      <span class="am-key__label">Save</span>
+    </button>
+  </form>
+  <script>
+    (function () {
+      var form = document.querySelector('[data-voicemail-form]');
+      if (!form) { return; }
+      var enabledBox = form.querySelector('[data-voicemail-enabled]');
+      var fieldsWrap = form.querySelector('[data-voicemail-fields]');
+      if (!enabledBox || !fieldsWrap) { return; }
+      enabledBox.addEventListener('change', function () {
+        var on = enabledBox.checked;
+        fieldsWrap.style.opacity = on ? '' : '0.55';
+        var inputs = fieldsWrap.querySelectorAll('input');
+        for (var i = 0; i < inputs.length; i++) { inputs[i].disabled = !on; }
+      });
+    })();
+  </script>
+</div>
+{{end}}
+
 {{define "am-voice-style-section"}}
 <div id="voice-style-section">
   <form hx-post="/phones/{{.Line.Number}}/voice-style"
@@ -996,6 +1169,11 @@
     <section class="am-plate am-handset__plate">
       <span class="am-plate__label">Ringer</span>
       {{template "am-silent-mode-section" .}}
+    </section>
+
+    <section class="am-plate am-handset__plate">
+      <span class="am-plate__label">Voicemail</span>
+      {{template "am-voicemail-section" .}}
     </section>
 
     {{template "am-software-update-section" .}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -823,28 +823,30 @@
   <form hx-post="/phones/{{.Line.Number}}/voicemail"
         hx-target="#voicemail-section"
         hx-swap="outerHTML"
-        class="am-settings__form am-settings__form--stack"
+        class="am-voicemail-form"
         data-voicemail-form>
-    <label class="am-settings__dip" aria-label="Answering machine enabled">
-      <input type="checkbox" name="enabled" value="on"
-             {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
-             class="am-settings__dip-input"
-             hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
-             hx-target="#voicemail-section"
-             hx-swap="outerHTML"
-             hx-trigger="change"
-             data-voicemail-enabled>
-      <span class="am-settings__dip-body" aria-hidden="true">
-        <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
-        <span class="am-settings__dip-lever"></span>
-        <span class="am-settings__dip-label am-settings__dip-label--off">0</span>
-      </span>
-    </label>
-    <div class="am-settings__toggle-info">
-      <div class="am-label am-settings__toggle-title">Take messages</div>
-      <p class="am-hint am-settings__toggle-desc">
-        Auto-answer after the timeout, play greeting, record. Messages stay on the handset.
-      </p>
+    <div class="am-settings__toggle-row">
+      <label class="am-settings__dip" aria-label="Answering machine enabled">
+        <input type="checkbox" name="enabled" value="on"
+               {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
+               class="am-settings__dip-input"
+               hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
+               hx-target="#voicemail-section"
+               hx-swap="outerHTML"
+               hx-trigger="change"
+               data-voicemail-enabled>
+        <span class="am-settings__dip-body" aria-hidden="true">
+          <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
+          <span class="am-settings__dip-lever"></span>
+          <span class="am-settings__dip-label am-settings__dip-label--off">0</span>
+        </span>
+      </label>
+      <div class="am-settings__toggle-info">
+        <div class="am-label am-settings__toggle-title">Take messages</div>
+        <p class="am-hint am-settings__toggle-desc">
+          Auto-answer after the timeout, play greeting, record. Messages stay on the handset.
+        </p>
+      </div>
     </div>
 
     <details class="am-voicemail-advanced">

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -106,10 +106,10 @@
         </div>
       </section>
 
-      <!-- Voicemail -->
+      <!-- Answer machine -->
       <section class="panel">
         <header class="panel__head">
-          <h2 class="panel__title">Voicemail</h2>
+          <h2 class="panel__title">Answering Machine</h2>
         </header>
         <div class="panel__body">
           {{template "voicemail-section" .}}
@@ -736,7 +736,7 @@
 <div id="voicemail-section" data-voicemail-section>
   {{if and .Line.Settings.Voicemail.Enabled (gt .VoicemailUnheard 0)}}
     <div class="voicemail-chip" role="status"
-         aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">
+         aria-label="{{.VoicemailUnheard}} unheard answering machine message{{if ne .VoicemailUnheard 1}}s{{end}}">
       {{.VoicemailUnheard}} unheard
     </div>
   {{end}}
@@ -763,46 +763,46 @@
 
     <details class="voicemail-advanced">
       <summary>Advanced settings</summary>
-      <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-        <label class="field">
-          <span class="field__label">Ring timeout (seconds)</span>
-          <input type="number" name="ring_timeout_seconds"
+      <div class="voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+        <div class="field">
+          <label for="vm-ring-timeout" class="field__label">Ring timeout (seconds)</label>
+          <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
                  min="5" max="60"
                  value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
                  class="field__input" style="width: 110px;"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">5 to 60 seconds before voicemail picks up.</span>
-        </label>
+          <span class="muted" style="font-size: 11px;">5 to 60 seconds before the answering machine picks up.</span>
+        </div>
 
-        <label class="field">
-          <span class="field__label">Max message length (seconds)</span>
-          <input type="number" name="max_message_seconds"
+        <div class="field">
+          <label for="vm-max-message" class="field__label">Max message length (seconds)</label>
+          <input type="number" id="vm-max-message" name="max_message_seconds"
                  min="15" max="180"
                  value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
                  class="field__input" style="width: 110px;"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
           <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
-        </label>
+        </div>
 
-        <label class="field">
-          <span class="field__label">Max stored messages</span>
-          <input type="number" name="max_stored_messages"
+        <div class="field">
+          <label for="vm-max-stored" class="field__label">Max stored messages</label>
+          <input type="number" id="vm-max-stored" name="max_stored_messages"
                  min="5" max="200"
                  value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
                  class="field__input" style="width: 110px;"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
           <span class="muted" style="font-size: 11px;">5 to 200; oldest dropped first.</span>
-        </label>
+        </div>
 
-        <label class="field">
-          <span class="field__label">Retrieval code</span>
-          <input type="text" name="retrieval_code"
+        <div class="field">
+          <label for="vm-retrieval-code" class="field__label">Retrieval code</label>
+          <input type="text" id="vm-retrieval-code" name="retrieval_code"
                  value="{{.Line.Settings.Voicemail.RetrievalCode}}"
                  pattern="[0-9*#]{2,6}" maxlength="6" required
                  class="field__input" style="width: 110px;"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
           <span class="muted" style="font-size: 11px;">2 to 6 chars; must contain * or # so it cannot collide with a 7-digit dial.</span>
-        </label>
+        </div>
 
         <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
       </div>
@@ -815,7 +815,7 @@
 <div id="voicemail-section" data-voicemail-section>
   {{if and .Line.Settings.Voicemail.Enabled (gt .VoicemailUnheard 0)}}
     <span class="am-led am-voicemail-led" role="status"
-          aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">
+          aria-label="{{.VoicemailUnheard}} unheard answering machine message{{if ne .VoicemailUnheard 1}}s{{end}}">
       MSG {{.VoicemailUnheard}}
     </span>
   {{end}}
@@ -825,7 +825,7 @@
         hx-swap="outerHTML"
         class="am-settings__form am-settings__form--stack"
         data-voicemail-form>
-    <label class="am-settings__dip" aria-label="Voicemail enabled">
+    <label class="am-settings__dip" aria-label="Answering machine enabled">
       <input type="checkbox" name="enabled" value="on"
              {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
              class="am-settings__dip-input"
@@ -849,41 +849,41 @@
 
     <details class="am-voicemail-advanced">
       <summary>Advanced settings</summary>
-      <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-        <label class="am-field">
-          <span class="am-label">Ring timeout (sec)</span>
-          <input type="number" name="ring_timeout_seconds"
+      <div class="am-voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+        <div class="am-settings__field">
+          <label for="vm-ring-timeout" class="am-label am-settings__field-label">Ring timeout (sec)</label>
+          <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
                  min="5" max="60"
                  value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-                 class="am-input"
+                 class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </label>
-        <label class="am-field">
-          <span class="am-label">Max message (sec)</span>
-          <input type="number" name="max_message_seconds"
+        </div>
+        <div class="am-settings__field">
+          <label for="vm-max-message" class="am-label am-settings__field-label">Max message (sec)</label>
+          <input type="number" id="vm-max-message" name="max_message_seconds"
                  min="15" max="180"
                  value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
-                 class="am-input"
+                 class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </label>
-        <label class="am-field">
-          <span class="am-label">Max stored</span>
-          <input type="number" name="max_stored_messages"
+        </div>
+        <div class="am-settings__field">
+          <label for="vm-max-stored" class="am-label am-settings__field-label">Max stored</label>
+          <input type="number" id="vm-max-stored" name="max_stored_messages"
                  min="5" max="200"
                  value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
-                 class="am-input"
+                 class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </label>
-        <label class="am-field">
-          <span class="am-label">Retrieval code</span>
-          <input type="text" name="retrieval_code"
+        </div>
+        <div class="am-settings__field">
+          <label for="vm-retrieval-code" class="am-label am-settings__field-label">Retrieval code</label>
+          <input type="text" id="vm-retrieval-code" name="retrieval_code"
                  value="{{.Line.Settings.Voicemail.RetrievalCode}}"
                  pattern="[0-9*#]{2,6}" maxlength="6" required
-                 class="am-input"
+                 class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </label>
+        </div>
 
-        <button type="submit" class="am-key am-settings__submit">
+        <button type="submit" class="am-key am-settings__submit am-voicemail-fields__submit">
           <span class="am-key__symbol">&#x25B6;</span>
           <span class="am-key__label">Save</span>
         </button>
@@ -1171,7 +1171,7 @@
     </section>
 
     <section class="am-plate am-handset__plate">
-      <span class="am-plate__label">Voicemail</span>
+      <span class="am-plate__label">Answering Machine</span>
       {{template "am-voicemail-section" .}}
     </section>
 

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1,6 +1,7 @@
 {{define "title"}}{{.Line.Name}}{{end}}
 
 {{define "content"}}
+<script src="{{static "voicemail-form.js"}}" defer></script>
 {{if and .User (eq .User.Theme "answering-machine")}}
   {{template "phone-detail-am" .}}
 {{else}}
@@ -793,21 +794,6 @@
 
     <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
   </form>
-  <script>
-    (function () {
-      var form = document.querySelector('[data-voicemail-form]');
-      if (!form) { return; }
-      var enabledBox = form.querySelector('[data-voicemail-enabled]');
-      var fieldsWrap = form.querySelector('[data-voicemail-fields]');
-      if (!enabledBox || !fieldsWrap) { return; }
-      enabledBox.addEventListener('change', function () {
-        var on = enabledBox.checked;
-        fieldsWrap.style.opacity = on ? '' : '0.55';
-        var inputs = fieldsWrap.querySelectorAll('input');
-        for (var i = 0; i < inputs.length; i++) { inputs[i].disabled = !on; }
-      });
-    })();
-  </script>
 </div>
 {{end}}
 
@@ -876,21 +862,6 @@
       <span class="am-key__label">Save</span>
     </button>
   </form>
-  <script>
-    (function () {
-      var form = document.querySelector('[data-voicemail-form]');
-      if (!form) { return; }
-      var enabledBox = form.querySelector('[data-voicemail-enabled]');
-      var fieldsWrap = form.querySelector('[data-voicemail-fields]');
-      if (!enabledBox || !fieldsWrap) { return; }
-      enabledBox.addEventListener('change', function () {
-        var on = enabledBox.checked;
-        fieldsWrap.style.opacity = on ? '' : '0.55';
-        var inputs = fieldsWrap.querySelectorAll('input');
-        for (var i = 0; i < inputs.length; i++) { inputs[i].disabled = !on; }
-      });
-    })();
-  </script>
 </div>
 {{end}}
 

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -733,7 +733,14 @@
 {{end}}
 
 {{define "voicemail-section"}}
-<div id="voicemail-section">
+<div id="voicemail-section" data-voicemail-section>
+  {{if and .Line.Settings.Voicemail.Enabled (gt .VoicemailUnheard 0)}}
+    <div class="voicemail-chip" role="status"
+         aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">
+      {{.VoicemailUnheard}} unheard
+    </div>
+  {{end}}
+
   <form hx-post="/phones/{{.Line.Number}}/voicemail"
         hx-target="#voicemail-section"
         hx-swap="outerHTML"
@@ -742,6 +749,10 @@
     <label class="checkbox-row">
       <input type="checkbox" name="enabled" value="on"
              {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
+             hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
+             hx-target="#voicemail-section"
+             hx-swap="outerHTML"
+             hx-trigger="change"
              data-voicemail-enabled>
       <span class="checkbox-row__label">Take messages when nobody answers</span>
     </label>
@@ -750,55 +761,65 @@
       Messages stay on the handset; dial the retrieval code from the phone to listen.
     </p>
 
-    <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-      <label class="field">
-        <span class="field__label">Ring timeout (seconds)</span>
-        <input type="number" name="ring_timeout_seconds"
-               min="5" max="60"
-               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-               class="field__input" style="width: 110px;"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        <span class="muted" style="font-size: 11px;">5 to 60 seconds before voicemail picks up.</span>
-      </label>
+    <details class="voicemail-advanced">
+      <summary>Advanced settings</summary>
+      <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+        <label class="field">
+          <span class="field__label">Ring timeout (seconds)</span>
+          <input type="number" name="ring_timeout_seconds"
+                 min="5" max="60"
+                 value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+                 class="field__input" style="width: 110px;"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+          <span class="muted" style="font-size: 11px;">5 to 60 seconds before voicemail picks up.</span>
+        </label>
 
-      <label class="field">
-        <span class="field__label">Max message length (seconds)</span>
-        <input type="number" name="max_message_seconds"
-               min="15" max="180"
-               value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
-               class="field__input" style="width: 110px;"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
-      </label>
+        <label class="field">
+          <span class="field__label">Max message length (seconds)</span>
+          <input type="number" name="max_message_seconds"
+                 min="15" max="180"
+                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
+                 class="field__input" style="width: 110px;"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+          <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
+        </label>
 
-      <label class="field">
-        <span class="field__label">Max stored messages</span>
-        <input type="number" name="max_stored_messages"
-               min="5" max="200"
-               value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
-               class="field__input" style="width: 110px;"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        <span class="muted" style="font-size: 11px;">5 to 200; oldest dropped first.</span>
-      </label>
+        <label class="field">
+          <span class="field__label">Max stored messages</span>
+          <input type="number" name="max_stored_messages"
+                 min="5" max="200"
+                 value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
+                 class="field__input" style="width: 110px;"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+          <span class="muted" style="font-size: 11px;">5 to 200; oldest dropped first.</span>
+        </label>
 
-      <label class="field">
-        <span class="field__label">Retrieval code</span>
-        <input type="text" name="retrieval_code"
-               value="{{.Line.Settings.Voicemail.RetrievalCode}}"
-               pattern="[0-9*#]{2,6}" maxlength="6" required
-               class="field__input" style="width: 110px;"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        <span class="muted" style="font-size: 11px;">2 to 6 chars; must contain * or # so it cannot collide with a 7-digit dial.</span>
-      </label>
-    </div>
+        <label class="field">
+          <span class="field__label">Retrieval code</span>
+          <input type="text" name="retrieval_code"
+                 value="{{.Line.Settings.Voicemail.RetrievalCode}}"
+                 pattern="[0-9*#]{2,6}" maxlength="6" required
+                 class="field__input" style="width: 110px;"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+          <span class="muted" style="font-size: 11px;">2 to 6 chars; must contain * or # so it cannot collide with a 7-digit dial.</span>
+        </label>
 
-    <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
+        <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
+      </div>
+    </details>
   </form>
 </div>
 {{end}}
 
 {{define "am-voicemail-section"}}
-<div id="voicemail-section">
+<div id="voicemail-section" data-voicemail-section>
+  {{if and .Line.Settings.Voicemail.Enabled (gt .VoicemailUnheard 0)}}
+    <span class="am-led am-voicemail-led" role="status"
+          aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">
+      MSG {{.VoicemailUnheard}}
+    </span>
+  {{end}}
+
   <form hx-post="/phones/{{.Line.Number}}/voicemail"
         hx-target="#voicemail-section"
         hx-swap="outerHTML"
@@ -808,6 +829,10 @@
       <input type="checkbox" name="enabled" value="on"
              {{if .Line.Settings.Voicemail.Enabled}}checked{{end}}
              class="am-settings__dip-input"
+             hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
+             hx-target="#voicemail-section"
+             hx-swap="outerHTML"
+             hx-trigger="change"
              data-voicemail-enabled>
       <span class="am-settings__dip-body" aria-hidden="true">
         <span class="am-settings__dip-label am-settings__dip-label--on">1</span>
@@ -822,45 +847,48 @@
       </p>
     </div>
 
-    <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-      <label class="am-field">
-        <span class="am-label">Ring timeout (sec)</span>
-        <input type="number" name="ring_timeout_seconds"
-               min="5" max="60"
-               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-               class="am-input"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-      </label>
-      <label class="am-field">
-        <span class="am-label">Max message (sec)</span>
-        <input type="number" name="max_message_seconds"
-               min="15" max="180"
-               value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
-               class="am-input"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-      </label>
-      <label class="am-field">
-        <span class="am-label">Max stored</span>
-        <input type="number" name="max_stored_messages"
-               min="5" max="200"
-               value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
-               class="am-input"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-      </label>
-      <label class="am-field">
-        <span class="am-label">Retrieval code</span>
-        <input type="text" name="retrieval_code"
-               value="{{.Line.Settings.Voicemail.RetrievalCode}}"
-               pattern="[0-9*#]{2,6}" maxlength="6" required
-               class="am-input"
-               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-      </label>
-    </div>
+    <details class="am-voicemail-advanced">
+      <summary>Advanced settings</summary>
+      <div class="stack-sm" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+        <label class="am-field">
+          <span class="am-label">Ring timeout (sec)</span>
+          <input type="number" name="ring_timeout_seconds"
+                 min="5" max="60"
+                 value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+                 class="am-input"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        </label>
+        <label class="am-field">
+          <span class="am-label">Max message (sec)</span>
+          <input type="number" name="max_message_seconds"
+                 min="15" max="180"
+                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
+                 class="am-input"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        </label>
+        <label class="am-field">
+          <span class="am-label">Max stored</span>
+          <input type="number" name="max_stored_messages"
+                 min="5" max="200"
+                 value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
+                 class="am-input"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        </label>
+        <label class="am-field">
+          <span class="am-label">Retrieval code</span>
+          <input type="text" name="retrieval_code"
+                 value="{{.Line.Settings.Voicemail.RetrievalCode}}"
+                 pattern="[0-9*#]{2,6}" maxlength="6" required
+                 class="am-input"
+                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        </label>
 
-    <button type="submit" class="am-key am-settings__submit">
-      <span class="am-key__symbol">&#x25B6;</span>
-      <span class="am-key__label">Save</span>
-    </button>
+        <button type="submit" class="am-key am-settings__submit">
+          <span class="am-key__symbol">&#x25B6;</span>
+          <span class="am-key__label">Save</span>
+        </button>
+      </div>
+    </details>
   </form>
 </div>
 {{end}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -357,7 +357,6 @@
               <span class="phone-silent__text">SILENT</span>
             </span>
             {{end}}
-            {{template "voicemail-badge" .}}
           </td>
           <td>
             {{if .Online}}
@@ -442,7 +441,6 @@
           {{.Line.Name}}
           {{if gt (len .Devices) 1}}<span class="muted" style="font-size: 11px; font-weight: normal;"> ({{len .Devices}} handsets)</span>{{end}}
           {{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}
-          {{template "voicemail-badge" .}}
         </span>
         <span class="lines__num">{{fmtPhone .Line.Number}}{{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}<span class="lines__ip num muted" style="display: block; font-size: 11px;">{{.DeviceInfo.RemoteAddr}}</span>{{end}}</span>
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}{{if gt (len .Devices) 1}}{{.OnlineDeviceCount}}/{{len .Devices}}{{else}}online{{end}}{{else}}offline{{end}}</span>
@@ -513,7 +511,6 @@
         {{else}}OFFLINE
         {{end}}
         {{if $l.Line.Settings.SilentMode}} &middot; SILENT{{end}}
-        {{template "am-voicemail-badge" $l}}
         {{if or $l.PiUpdateNotes $l.FirmwareUpdateNotes}}
         <span class="am-phones__update-flag" title="Software update available">
           <span class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
@@ -543,58 +540,6 @@
     <a href="/phones" class="am-tab">Cancel</a>
   </form>
 </div>
-{{end}}
-
-{{define "voicemail-badge"}}
-<form data-voicemail data-line="{{.Line.Number}}"
-      hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
-      hx-target="this" hx-swap="outerHTML"
-      class="phone-voicemail">
-  {{if .Line.Settings.Voicemail.Enabled}}
-    {{if gt .VoicemailUnheard 0}}
-      <span class="phone-voicemail__chip phone-voicemail__chip--attn"
-            aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}"
-            title="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">VM {{.VoicemailUnheard}}</span>
-    {{else}}
-      <span class="phone-voicemail__chip phone-voicemail__chip--on"
-            aria-label="Voicemail on, mailbox empty"
-            title="Voicemail on, mailbox empty">VM</span>
-    {{end}}
-    <button type="submit" class="phone-voicemail__toggle"
-            aria-label="Turn voicemail off"
-            title="Turn voicemail off">off</button>
-  {{else}}
-    <button type="submit" class="phone-voicemail__toggle phone-voicemail__toggle--enable"
-            aria-label="Turn voicemail on"
-            title="Turn voicemail on">VM on</button>
-  {{end}}
-</form>
-{{end}}
-
-{{define "am-voicemail-badge"}}
-<form data-voicemail data-line="{{.Line.Number}}"
-      hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
-      hx-target="this" hx-swap="outerHTML"
-      class="am-voicemail">
-  {{if .Line.Settings.Voicemail.Enabled}}
-    {{if gt .VoicemailUnheard 0}}
-      <span class="am-led am-voicemail__led am-voicemail__led--attn"
-            aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}"
-            title="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">VM {{.VoicemailUnheard}}</span>
-    {{else}}
-      <span class="am-led am-voicemail__led am-voicemail__led--on"
-            aria-label="Voicemail on, mailbox empty"
-            title="Voicemail on, mailbox empty">VM</span>
-    {{end}}
-    <button type="submit" class="am-tab am-voicemail__toggle"
-            aria-label="Turn voicemail off"
-            title="Turn voicemail off">OFF</button>
-  {{else}}
-    <button type="submit" class="am-tab am-voicemail__toggle"
-            aria-label="Turn voicemail on"
-            title="Turn voicemail on">VM ON</button>
-  {{end}}
-</form>
 {{end}}
 
 {{define "phones-am"}}

--- a/server/internal/web/templates/phones.html
+++ b/server/internal/web/templates/phones.html
@@ -357,6 +357,7 @@
               <span class="phone-silent__text">SILENT</span>
             </span>
             {{end}}
+            {{template "voicemail-badge" .}}
           </td>
           <td>
             {{if .Online}}
@@ -441,6 +442,7 @@
           {{.Line.Name}}
           {{if gt (len .Devices) 1}}<span class="muted" style="font-size: 11px; font-weight: normal;"> ({{len .Devices}} handsets)</span>{{end}}
           {{if .Line.Settings.SilentMode}}<span class="phone-silent" aria-label="Silent mode on" title="Silent mode on"><span class="phone-silent__dot" aria-hidden="true"></span><span class="phone-silent__text">SILENT</span></span>{{end}}
+          {{template "voicemail-badge" .}}
         </span>
         <span class="lines__num">{{fmtPhone .Line.Number}}{{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}<span class="lines__ip num muted" style="display: block; font-size: 11px;">{{.DeviceInfo.RemoteAddr}}</span>{{end}}</span>
         <span class="lines__state{{if .Online}} lines__state--on{{end}}">{{if .Online}}{{if gt (len .Devices) 1}}{{.OnlineDeviceCount}}/{{len .Devices}}{{else}}online{{end}}{{else}}offline{{end}}</span>
@@ -511,6 +513,7 @@
         {{else}}OFFLINE
         {{end}}
         {{if $l.Line.Settings.SilentMode}} &middot; SILENT{{end}}
+        {{template "am-voicemail-badge" $l}}
         {{if or $l.PiUpdateNotes $l.FirmwareUpdateNotes}}
         <span class="am-phones__update-flag" title="Software update available">
           <span class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
@@ -540,6 +543,58 @@
     <a href="/phones" class="am-tab">Cancel</a>
   </form>
 </div>
+{{end}}
+
+{{define "voicemail-badge"}}
+<form data-voicemail data-line="{{.Line.Number}}"
+      hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
+      hx-target="this" hx-swap="outerHTML"
+      class="phone-voicemail">
+  {{if .Line.Settings.Voicemail.Enabled}}
+    {{if gt .VoicemailUnheard 0}}
+      <span class="phone-voicemail__chip phone-voicemail__chip--attn"
+            aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}"
+            title="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">VM {{.VoicemailUnheard}}</span>
+    {{else}}
+      <span class="phone-voicemail__chip phone-voicemail__chip--on"
+            aria-label="Voicemail on, mailbox empty"
+            title="Voicemail on, mailbox empty">VM</span>
+    {{end}}
+    <button type="submit" class="phone-voicemail__toggle"
+            aria-label="Turn voicemail off"
+            title="Turn voicemail off">off</button>
+  {{else}}
+    <button type="submit" class="phone-voicemail__toggle phone-voicemail__toggle--enable"
+            aria-label="Turn voicemail on"
+            title="Turn voicemail on">VM on</button>
+  {{end}}
+</form>
+{{end}}
+
+{{define "am-voicemail-badge"}}
+<form data-voicemail data-line="{{.Line.Number}}"
+      hx-post="/phones/{{.Line.Number}}/voicemail-toggle"
+      hx-target="this" hx-swap="outerHTML"
+      class="am-voicemail">
+  {{if .Line.Settings.Voicemail.Enabled}}
+    {{if gt .VoicemailUnheard 0}}
+      <span class="am-led am-voicemail__led am-voicemail__led--attn"
+            aria-label="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}"
+            title="{{.VoicemailUnheard}} unheard voicemail message{{if ne .VoicemailUnheard 1}}s{{end}}">VM {{.VoicemailUnheard}}</span>
+    {{else}}
+      <span class="am-led am-voicemail__led am-voicemail__led--on"
+            aria-label="Voicemail on, mailbox empty"
+            title="Voicemail on, mailbox empty">VM</span>
+    {{end}}
+    <button type="submit" class="am-tab am-voicemail__toggle"
+            aria-label="Turn voicemail off"
+            title="Turn voicemail off">OFF</button>
+  {{else}}
+    <button type="submit" class="am-tab am-voicemail__toggle"
+            aria-label="Turn voicemail on"
+            title="Turn voicemail on">VM ON</button>
+  {{end}}
+</form>
 {{end}}
 
 {{define "phones-am"}}


### PR DESCRIPTION
## Summary

Phase 5 of the voicemail rollout: web UI for the per-line answering machine settings shipped in Phase 4, plus the device-side count publish that makes the unheard counter live. The /phones list stays quiet (no per-line chrome); the Answering Machine section surfaces on /phones/{number}.

- Detail page (`/phones/{number}`) gets a new Answering Machine section: a prominent on/off toggle plus an "Advanced settings" disclosure wrapping `ring_timeout`, `max_message`, `max_stored`, and `retrieval_code` for power users. When the answering machine is enabled and unheard messages exist, an inline chip near the section header shows the count.
- New `voicemail_state` signaling message from digitsd carries the per-handset unheard count to the server on three trigger families: post-(re)connect (forced snapshot), recording finalize (caller-hangup, owner-pickup partial, max-duration cap), and *98 retrieval mutations (Delete + MarkHeard + advance-from-EOF).
- Hub stores the count in-memory keyed by `(number, hardware_id)`; per-line chip sums across handsets. `Unregister` and `RekeyNumber` hooks keep the map consistent.
- Wire contract pinned both sides: `voicemail_unheard_count int json:"voicemail_unheard_count"` with no omitempty so explicit zero round-trips after MarkHeard-all.
- `POST /phones/{number}/voicemail-toggle` handles the one-click on/off; the existing `POST /phones/{number}/voicemail` from Phase 4 switched from 303 to htmx partial swap for the full 5-field Save inside Advanced.
- Theme coverage: intercom (default), dialup (reuses intercom partials inside its own chrome), answering-machine (dedicated `am-voicemail-section` + LED-style Advanced disclosure).

## Screenshots

### intercom

Detail, Advanced collapsed:

![intercom collapsed](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v3-intercom-collapsed.png)

Detail, Advanced expanded:

![intercom expanded](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v3-intercom-expanded.png)

### dialup

Detail, Advanced collapsed (inside dialup chrome):

![dialup collapsed](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v3-dialup-collapsed.png)

Detail, Advanced expanded:

![dialup expanded](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v3-dialup-expanded.png)

### answering-machine

Detail plate, Advanced collapsed:

![am collapsed](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v4-am-collapsed.png)

Detail plate, Advanced expanded (LED-style disclosure):

![am expanded](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/voicemail-phase5-v4-am-expanded.png)

## Test plan

- [x] `golangci-lint run ./...` clean from `server/`
- [x] `golangci-lint run ./...` clean from `pi/digitsd/`
- [x] `make test` + `make test-integration` from `server/`
- [x] `make test` + `make build` from `pi/digitsd/`
- [x] `10-voicemail.spec.ts` 9/9 across intercom + dialup + answering-machine (includes regression-guard that /phones has zero voicemail forms)
- [x] /simplify pass

Pre-existing e2e failures in `04-phones`, `09-silent-mode/dialup`, and `11-conference-live` are unrelated to this PR (verified by stashing and re-running).