### PR TITLE
feat(digitsd,server): default answering machine to enabled

### DIFF
--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -332,7 +332,7 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 	}
 	// Defaults at startup.
 	wantDefault := config.Voicemail{
-		Enabled:            false,
+		Enabled:            true,
 		RingTimeout:        20 * time.Second,
 		MaxMessageDuration: 90 * time.Second,
 		MaxStoredMessages:  50,

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -124,7 +124,7 @@ func defaultWiFiFallback() WiFiFallback {
 // source of truth used by Default() and the Load path.
 func defaultVoicemail() Voicemail {
 	return Voicemail{
-		Enabled:            false,
+		Enabled:            true,
 		RingTimeout:        20 * time.Second,
 		MaxMessageDuration: 90 * time.Second,
 		MaxStoredMessages:  50,

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -77,7 +77,7 @@ type Settings struct {
 // first time a household toggles it on, the behavior matches expectations.
 func DefaultVoicemail() Voicemail {
 	return Voicemail{
-		Enabled:            false,
+		Enabled:            true,
 		RingTimeoutSeconds: DefaultVoicemailRingTimeoutSeconds,
 		MaxMessageSeconds:  DefaultVoicemailMaxMessageSeconds,
 		MaxStoredMessages:  DefaultVoicemailMaxStoredMessages,

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -165,8 +165,8 @@ func TestSettingsMergeAutoUpdateFromPatch(t *testing.T) {
 
 func TestDefaultVoicemailMatchesPhaseOneSpec(t *testing.T) {
 	v := DefaultVoicemail()
-	if v.Enabled {
-		t.Errorf("Enabled default: got true, want false")
+	if !v.Enabled {
+		t.Errorf("Enabled default: got false, want true")
 	}
 	if v.RingTimeoutSeconds != 20 {
 		t.Errorf("RingTimeoutSeconds default: got %d, want 20", v.RingTimeoutSeconds)
@@ -369,13 +369,18 @@ func TestIsValidRetrievalCode(t *testing.T) {
 }
 
 func TestSettingsScanFromEmptyJSONAppliesDefaults(t *testing.T) {
-	// Mirrors what store.scanSettings does for a fresh row.
+	// Mirrors what store.scanSettings does for a fresh row. Merge is
+	// authoritative on booleans, so Enabled (JSON zero = false) overwrites
+	// the default true. Normalize backfills numeric/string defaults but
+	// does not force-enable voicemail.
 	var patch Settings
 	if err := json.Unmarshal([]byte(`{}`), &patch); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	merged := DefaultSettings().Merge(patch).Normalize()
-	if merged.Voicemail != DefaultVoicemail() {
-		t.Errorf("empty JSONB should leave defaults intact, got %+v", merged.Voicemail)
+	want := DefaultVoicemail()
+	want.Enabled = false
+	if merged.Voicemail != want {
+		t.Errorf("empty JSONB merge: got %+v, want %+v", merged.Voicemail, want)
 	}
 }

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -111,13 +111,19 @@ func NewStore(database *db.Database) *Store {
 	return &Store{db: database.DB}
 }
 
-// Add inserts a new line for the given household and returns it.
+// Add inserts a new line for the given household and returns it. The initial
+// settings column is seeded with DefaultSettings() so the DB round-trip
+// preserves defaults (notably voicemail.enabled) that have non-zero values.
 func (s *Store) Add(ctx context.Context, number, name, householdID string) (*Line, error) {
+	defaults, err := json.Marshal(DefaultSettings().Normalize())
+	if err != nil {
+		return nil, fmt.Errorf("marshal default settings: %w", err)
+	}
 	row := s.db.QueryRowContext(ctx,
-		`INSERT INTO lines (number, name, household_id)
-		 VALUES ($1, $2, $3)
+		`INSERT INTO lines (number, name, household_id, settings)
+		 VALUES ($1, $2, $3, $4)
 		 RETURNING `+lineColumns,
-		number, name, householdID,
+		number, name, householdID, defaults,
 	)
 	l, err := scanLine(row)
 	if err != nil {

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/dbutil"
 	"github.com/justinlindh/digits/server/internal/device"
+	"github.com/justinlindh/digits/server/internal/line"
 )
 
 const (
@@ -126,12 +128,16 @@ func (s *Store) ClaimDevice(ctx context.Context, code, lineNumber, lineName, dev
 		}
 		hardwareID = hwID
 
+		defaults, jsonErr := json.Marshal(line.DefaultSettings().Normalize())
+		if jsonErr != nil {
+			return fmt.Errorf("marshal default settings: %w", jsonErr)
+		}
 		var lineID int64
 		err = tx.QueryRowContext(ctx, `
-			INSERT INTO lines (number, name, household_id)
-			VALUES ($1, $2, $3)
+			INSERT INTO lines (number, name, household_id, settings)
+			VALUES ($1, $2, $3, $4)
 			RETURNING id
-		`, lineNumber, lineName, householdID).Scan(&lineID)
+		`, lineNumber, lineName, householdID, defaults).Scan(&lineID)
 		if err != nil {
 			if isUniqueViolation(err) {
 				return ErrNumberTaken

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2891,23 +2891,23 @@ func TestPhoneVoicemailToggleFlipsEnabledAndRedirects(t *testing.T) {
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	if readVoicemailEnabled(t, database) {
-		t.Fatal("setup invariant: voicemail should default to off")
+	if !readVoicemailEnabled(t, database) {
+		t.Fatal("setup invariant: voicemail should default to on")
 	}
 
 	w := postVoicemailToggle(t, h, cookie, false)
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("expected 303, got %d: %s", w.Code, w.Body.String())
 	}
-	if !readVoicemailEnabled(t, database) {
-		t.Fatal("expected voicemail enabled=true after toggle")
+	if readVoicemailEnabled(t, database) {
+		t.Fatal("expected voicemail enabled=false after toggle")
 	}
 
 	if w := postVoicemailToggle(t, h, cookie, false); w.Code != http.StatusSeeOther {
 		t.Fatalf("expected 303 on second toggle, got %d", w.Code)
 	}
-	if readVoicemailEnabled(t, database) {
-		t.Fatal("expected voicemail enabled=false after second toggle")
+	if !readVoicemailEnabled(t, database) {
+		t.Fatal("expected voicemail enabled=true after second toggle")
 	}
 }
 
@@ -2916,8 +2916,7 @@ func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	// First toggle: off -> on. Section partial swaps in with the enabled
-	// checkbox flipped on. No unheard count -> no chip yet.
+	// First toggle: on -> off (default is now enabled).
 	w := postVoicemailToggle(t, h, cookie, true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2928,15 +2927,6 @@ func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	}
 	if !strings.Contains(body, "/voicemail-toggle") {
 		t.Fatalf("htmx response missing toggle endpoint:\n%s", body)
-	}
-	// With Enabled=true and count=0, the chip should NOT render.
-	if strings.Contains(body, "voicemail-chip") {
-		t.Errorf("expected no chip when count=0, got:\n%s", body)
-	}
-	// The enabled checkbox should round-trip back checked.
-	if !strings.Contains(body, `name="enabled" value="on"
-             checked`) && !strings.Contains(body, `checked`) {
-		t.Errorf("expected enabled checkbox to round-trip checked:\n%s", body)
 	}
 	// Advanced disclosure must be present.
 	if !strings.Contains(body, `class="voicemail-advanced"`) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2916,7 +2916,7 @@ func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	cookie := addSessionCookie(t, authStore)
 	_ = setupVoiceStyleLine(t, h, database, authStore)
 
-	// First toggle: on -> off (default is now enabled).
+	// First toggle: on -> off (default is enabled).
 	w := postVoicemailToggle(t, h, cookie, true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
@@ -2932,16 +2932,19 @@ func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	if !strings.Contains(body, `class="voicemail-advanced"`) {
 		t.Errorf("expected voicemail-advanced disclosure:\n%s", body)
 	}
-
-	// Second toggle: on -> off. Section partial returns with checkbox
-	// unchecked and the inner fields rendered with disabled.
-	w = postVoicemailToggle(t, h, cookie, true)
-	body = w.Body.String()
+	// After toggling off, fields should be disabled.
 	if strings.Contains(body, "voicemail-chip") {
 		t.Errorf("expected no chip when voicemail is off, got:\n%s", body)
 	}
 	if !strings.Contains(body, `disabled`) {
 		t.Errorf("expected disabled attr on inner fields when off:\n%s", body)
+	}
+
+	// Second toggle: off -> on. Fields should be enabled again.
+	w = postVoicemailToggle(t, h, cookie, true)
+	body = w.Body.String()
+	if strings.Contains(body, `disabled`) {
+		t.Errorf("expected no disabled attr on inner fields when on:\n%s", body)
 	}
 }
 
@@ -2953,8 +2956,19 @@ func TestPhoneVoicemailTogglePushesToConnectedDevice(t *testing.T) {
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	_ = h.hub.Register("3140001", conn)
 
+	// Default is enabled. First toggle: on -> off. Drain the push.
 	if w := postVoicemailToggle(t, h, cookie, false); w.Code != http.StatusSeeOther {
-		t.Fatalf("toggle save failed: %d %s", w.Code, w.Body.String())
+		t.Fatalf("first toggle failed: %d %s", w.Code, w.Body.String())
+	}
+	select {
+	case <-conn.Send:
+	case <-time.After(time.Second):
+		t.Fatal("device did not receive push after first toggle")
+	}
+
+	// Second toggle: off -> on. Verify the push carries enabled=true.
+	if w := postVoicemailToggle(t, h, cookie, false); w.Code != http.StatusSeeOther {
+		t.Fatalf("second toggle failed: %d %s", w.Code, w.Body.String())
 	}
 
 	select {
@@ -2982,9 +2996,15 @@ func TestPhoneVoicemailToggleHTMXReflectsHubUnheardCount(t *testing.T) {
 	// Pre-populate the hub with an unheard count for the line.
 	h.hub.SetVoicemailUnheard("3140001", "hw-fake", 3)
 
-	// Toggle on; htmx response renders the section partial with the
-	// "N unheard" chip in the section header.
+	// Default is enabled. First toggle: on -> off.
 	w := postVoicemailToggle(t, h, cookie, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Second toggle: off -> on. The section partial should render
+	// the "N unheard" chip in the section header.
+	w = postVoicemailToggle(t, h, cookie, true)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}


### PR DESCRIPTION
## Summary

Flips the default voicemail enabled state from false to true in both the digitsd config defaults and the server-side line settings defaults. New lines and fresh device configs now have the answering machine enabled out of the box.

## Test plan

- [x] Server unit tests updated and passing
- [x] digitsd config tests passing
- [x] golangci-lint clean both modules