### PR TITLE
refactor(server): share dbutil.RowScanner across store packages

### DIFF
--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/justinlindh/digits/server/internal/dbutil"
 	"github.com/justinlindh/digits/server/internal/device"
 )
 
@@ -56,14 +57,9 @@ func NewStore(db *sql.DB) *Store {
 // SELECT/RETURNING lists and three Scan argument lists.
 const userColumns = `id, email, name, google_id, theme, theme_chosen, crt_mode, appearance, created_at, last_login_at`
 
-// rowScanner is the subset of *sql.Row / *sql.Rows that matters here.
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
 // scanUser materializes a User from any row whose columns match userColumns
 // in order.
-func scanUser(row rowScanner) (*User, error) {
+func scanUser(row dbutil.RowScanner) (*User, error) {
 	u := &User{}
 	if err := row.Scan(&u.ID, &u.Email, &u.Name, &u.GoogleID, &u.Theme, &u.ThemeChosen, &u.CRTMode, &u.Appearance, &u.CreatedAt, &u.LastLoginAt); err != nil {
 		return nil, err
@@ -182,7 +178,7 @@ const sessionColumns = `id, user_id, expires_at, created_at`
 
 // scanSession materializes a Session from any row whose columns match
 // sessionColumns in order.
-func scanSession(row rowScanner) (*Session, error) {
+func scanSession(row dbutil.RowScanner) (*Session, error) {
 	sess := &Session{}
 	if err := row.Scan(&sess.ID, &sess.UserID, &sess.ExpiresAt, &sess.CreatedAt); err != nil {
 		return nil, err

--- a/server/internal/dbutil/dbutil.go
+++ b/server/internal/dbutil/dbutil.go
@@ -9,6 +9,13 @@ import (
 	"strings"
 )
 
+// RowScanner is the subset of *sql.Row / *sql.Rows that scan-helpers depend
+// on. Defined here once so per-table scan functions across packages can share
+// the same single-row / multi-row abstraction without redeclaring it.
+type RowScanner interface {
+	Scan(dest ...any) error
+}
+
 // Placeholders returns a comma-separated string of PostgreSQL positional
 // placeholders ($1, $2, …, $n) for use in SQL IN clauses.
 func Placeholders(n int) string {

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
 const inviteTTL = 7 * 24 * time.Hour
@@ -54,7 +56,7 @@ func generateInviteToken() (string, error) {
 
 const inviteColumns = `id, household_id, email, invited_by, token, status, created_at, accepted_at, expires_at`
 
-func scanInvite(row rowScanner) (*HouseholdInvite, error) {
+func scanInvite(row dbutil.RowScanner) (*HouseholdInvite, error) {
 	inv := &HouseholdInvite{}
 	err := row.Scan(&inv.ID, &inv.HouseholdID, &inv.Email, &inv.InvitedBy,
 		&inv.Token, &inv.Status, &inv.CreatedAt, &inv.AcceptedAt, &inv.ExpiresAt)

--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
 const inviteCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -18,14 +20,9 @@ const inviteCodeLength = 8
 const linkColumns = `id, household_a_id, household_b_id, status, invite_code, invited_by,
 	accepted_by, created_at, accepted_at, revoked_at, revoked_by`
 
-// rowScanner is the subset of *sql.Row / *sql.Rows that matters here.
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
 // scanLink materializes a HouseholdLink from any row whose columns match
 // linkColumns in order.
-func scanLink(row rowScanner) (*HouseholdLink, error) {
+func scanLink(row dbutil.RowScanner) (*HouseholdLink, error) {
 	l := &HouseholdLink{}
 	if err := row.Scan(
 		&l.ID, &l.HouseholdAID, &l.HouseholdBID, &l.Status, &l.InviteCode,

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/justinlindh/digits/server/internal/db"
+	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
 // ErrNotFound is returned when a line cannot be found.
@@ -35,16 +36,10 @@ func scanSettings(raw []byte) (Settings, error) {
 
 const lineColumns = `id, number, name, household_id, settings, created_at, updated_at`
 
-// rowScanner abstracts *sql.Row and *sql.Rows so the same field list and
-// settings decode can serve both single-row and multi-row queries.
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
 // scanLine reads a single row from the lines table using lineColumns and
 // returns the materialized Line. sql.ErrNoRows is returned unwrapped so
 // callers can map it to ErrNotFound with errors.Is.
-func scanLine(s rowScanner) (Line, error) {
+func scanLine(s dbutil.RowScanner) (Line, error) {
 	var l Line
 	var settingsRaw []byte
 	if err := s.Scan(&l.ID, &l.Number, &l.Name, &l.HouseholdID, &settingsRaw, &l.CreatedAt, &l.UpdatedAt); err != nil {


### PR DESCRIPTION
## Summary

Three internal packages (auth, household, line) each declared an identical private `rowScanner interface { Scan(dest ...any) error }` so their per-table scan helpers could accept both `*sql.Row` (single-row) and `*sql.Rows` (multi-row). Move the type to `dbutil` as exported `RowScanner` and drop the three duplicate definitions.

Five scan helpers now share one abstraction:
- `auth.scanUser`, `auth.scanSession`
- `household.scanLink`, `household.scanInvite`
- `line.scanLine`

## Why

Three byte-identical interface definitions across packages is the kind of low-grade duplication that quietly drifts: one comment is updated and the others rot, or someone adds a fourth without noticing the existing three. Centralizing it in `dbutil` (which already owns `Placeholders`, `WithTx`, and other cross-package SQL helpers) puts it where the next package reaching for the same pattern will find it.

## Test plan

- [x] `go build ./...` passes from `server/`
- [x] `go test ./...` passes from `server/`
- [x] `golangci-lint run ./...` clean