### PR TITLE
fix(server): correct stale DefaultVoicemail doc comment

### DIFF
--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -73,8 +73,8 @@ type Settings struct {
 }
 
 // DefaultVoicemail returns the voicemail configuration a newly created line
-// starts with: disabled, with classic answering-machine defaults so that the
-// first time a household toggles it on, the behavior matches expectations.
+// starts with: enabled, with classic answering-machine defaults so a new line
+// records messages out of the box without the household having to opt in.
 func DefaultVoicemail() Voicemail {
 	return Voicemail{
 		Enabled:            true,


### PR DESCRIPTION
## What

`DefaultVoicemail()` in `server/internal/line/settings.go` had a doc comment claiming a newly created line starts with voicemail **disabled**. The struct it returns sets `Enabled: true`. Voicemail has defaulted to enabled since #569.

This corrects the comment to match the actual behavior. No code change, no behavior change.

## Testing

`golangci-lint run ./internal/line/...` from `server/`: 0 issues.