### PR TITLE
fix(digitsd): bound voicemail dial-tone drain, drop stale tone_busy comment

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -1082,21 +1082,20 @@ func (d *daemonCallbacks) voicemailAdvanceFromEOF(sess *voicemailPlaybackSession
 }
 
 // voicemailExitToDialtoneAsync resets the FSM to DIALTONE and re-arms the
-// dial tone after any queued one-shot tone (e.g. a tone_busy ack) has
-// finished playing. The drain is required because PlayOnce mixes one-shot
-// audio over any active loop, so starting the dial-tone loop while a busy
-// beep is still in the queue would play them simultaneously.
+// dial tone after any queued one-shot tone (e.g. a spoken end-of-messages
+// announcement) has finished playing. The drain is required because
+// PlayOnce mixes one-shot audio over any active loop, so starting the
+// dial-tone loop while a clip is still in the queue would play them
+// simultaneously. waitForOnceComplete bounds the wait so a stalled mixer
+// cannot wedge the goroutine forever.
 //
 // Spawned with `go` by callers that hold c.mu (VoicemailEnterPlayback) so
 // the inner ResetToDialtone does not recurse on the controller mutex.
 // Callers already running in a controller-spawned goroutine (VoicemailKey,
-// the playback EOF path) invoke it synchronously: the drain blocks for at
-// most the longest queued one-shot, currently ~1s for tone_busy.
+// the playback EOF path) invoke it synchronously.
 func (d *daemonCallbacks) voicemailExitToDialtoneAsync() {
 	defer recoverGoroutine("voicemail-exit-to-dialtone")
-	for d.mixer.OncePlaying() {
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForOnceComplete(d.mixer, 10*time.Second)
 	d.ctrl.ResetToDialtone()
 	d.SendTone(phone.ToneDial)
 	d.evaluateLED()


### PR DESCRIPTION
## What

`voicemailExitToDialtoneAsync` drained the mixer's one-shot queue with an inline, unbounded loop:

```go
for d.mixer.OncePlaying() {
    time.Sleep(50 * time.Millisecond)
}
```

This commit routes the drain through the existing `waitForOnceComplete` helper (`voice_prompt.go`), which performs the same 50ms poll but bounds it with a timeout so a stalled mixer cannot wedge the goroutine forever. It also rewrites the stale doc comment.

## Why (cross-PR drift caught in holistic review)

This is a coherence gap that single-PR review missed across the voicemail phase sequence:

- **#564** introduced `voicemailExitToDialtoneAsync` as a plain `ResetToDialtone` + `SendTone`.
- **#566** added the inline `for OncePlaying { sleep }` drain so a `tone_busy` ack could not overlap the dial-tone loop. The drain was written inline and unbounded, even though `waitForOnceComplete` (already used by `recovery.go` and `setup.go`) does exactly this with a timeout ceiling.
- **#574** replaced every `mixer.PlayOnce("tone_busy")` in the voicemail exit paths with spoken announcement clips played through `playAnnouncementSequence`, and that helper itself uses `waitForOnceComplete` with a 10s bound, with a comment explaining the wedge risk. The exit paths no longer queue `tone_busy` at all.

After #574, `voicemailExitToDialtoneAsync` was the odd one out: an unbounded drain loop where the rest of the file uses the bounded helper, plus a doc comment that still cited `tone_busy` ("the drain blocks for at most the longest queued one-shot, currently ~1s for tone_busy") that no longer reflects the code. `grep` confirms `tone_busy` now appears only in that comment.

## Test plan

- [x] `go build ./...` (pi/digitsd)
- [x] `go test ./...` (pi/digitsd) all packages pass
- [x] `go vet ./cmd/digitsd/...` clean

No behavior change beyond converting an unbounded wait into a bounded one; no new imports.