### PR TITLE
refactor(server): add package docs and fix ratelimit goroutine lifecycle

### DIFF
--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -1,3 +1,8 @@
+// Package auth manages user accounts, browser sessions, and passwordless
+// authentication flows (magic link and Google OAuth). It owns the users,
+// sessions, and magic_links tables and exposes typed sentinel errors
+// (ErrUserNotFound) so callers can distinguish missing-record results from
+// real database errors.
 package auth
 
 import (

--- a/server/internal/autodeploy/runner.go
+++ b/server/internal/autodeploy/runner.go
@@ -1,3 +1,6 @@
+// Package autodeploy implements the automatic binary update loop for the
+// autodeploy command. It polls GitHub Releases for new pi/ tags, downloads
+// the matching arm64 binary, and hot-swaps the running signald process.
 package autodeploy
 
 import (

--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -1,3 +1,9 @@
+// Package calls tracks active and historical calls and conferences. The
+// Tracker type is the central coordinator: it maintains an in-memory map of
+// active 2-party calls, delegates 3-way conference state to ConferenceTracker,
+// and persists all lifecycle events (initiated, answered, ended, conference
+// created/ended) to the database. Optional observers (dashboard broadcaster,
+// health store, relay) are wired in at startup via Set* methods.
 package calls
 
 import (

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -1,3 +1,6 @@
+// Package config loads signald's runtime configuration from environment
+// variables. All settings live in Config; call Load to populate one with
+// environment values and built-in defaults.
 package config
 
 import "os"

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -1,3 +1,7 @@
+// Package db provides the database connection and schema migration for
+// signald. Use Open to obtain a Database value; it connects to Postgres,
+// wraps the connection with OpenTelemetry tracing, and runs all pending
+// migrations before returning.
 package db
 
 import (

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -1,3 +1,7 @@
+// Package device manages physical handsets paired to lines. Store handles
+// the read paths and side-effecting mutations (heartbeat, unpair, reassign)
+// while the pairing package owns device row creation and the pairing-code
+// lifecycle. HashToken is shared with the auth and pairing packages.
 package device
 
 import (

--- a/server/internal/email/email.go
+++ b/server/internal/email/email.go
@@ -1,3 +1,6 @@
+// Package email provides a Sender interface and two implementations:
+// SMTPSender for production mail delivery and LogSender for development
+// environments that log the link to stdout instead of sending a message.
 package email
 
 import (

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -1,3 +1,7 @@
+// Package household manages household groups and their membership. A household
+// groups users who share a set of phone lines. Store owns the households and
+// household_members tables; LinkStore owns cross-household links; InviteStore
+// owns pending email invitations.
 package household
 
 import (

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -1,3 +1,7 @@
+// Package line manages phone lines: their numbers, per-line settings (DND,
+// voice style, voicemail, auto-update), and authorization. Store provides
+// the database queries; Authorizer enforces per-request access control;
+// Settings holds the JSON-encoded per-line configuration.
 package line
 
 import (

--- a/server/internal/logging/logging.go
+++ b/server/internal/logging/logging.go
@@ -1,3 +1,6 @@
+// Package logging configures the process-wide structured logger (slog) and
+// injects active OpenTelemetry trace and span IDs into every log record so
+// log lines can be correlated with traces in the observability backend.
 package logging
 
 import (

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -1,3 +1,8 @@
+// Package pairing implements the device-to-line pairing flow: generating
+// short numeric codes displayed on the phone, validating them from the web
+// UI, and completing the pairing by writing a device token to the database.
+// Typed errors (ErrInvalidCode, ErrAlreadyPaired, ErrNumberTaken) let callers
+// present specific feedback without inspecting error strings.
 package pairing
 
 import (

--- a/server/internal/ratelimit/ratelimit.go
+++ b/server/internal/ratelimit/ratelimit.go
@@ -1,4 +1,7 @@
-// server/internal/ratelimit/ratelimit.go
+// Package ratelimit provides an in-memory, IP-based rate limiter using a
+// fixed-window token bucket. It is intended for protecting individual HTTP
+// endpoints (auth, pairing, WebSocket upgrade) from brute-force and
+// enumeration attacks within a single process.
 package ratelimit
 
 import (
@@ -17,28 +20,44 @@ type bucket struct {
 // Limiter is an in-memory IP-based rate limiter using a fixed-window token bucket.
 type Limiter struct {
 	mu      sync.Mutex
+	once    sync.Once
 	buckets map[string]*bucket
 	limit   int
 	window  time.Duration
+	done    chan struct{}
 }
 
 // New creates a rate limiter that allows `limit` requests per `window` per IP.
 // Starts a background goroutine to clean up stale entries every 5 minutes.
+// Call Close to stop the background goroutine when the Limiter is no longer needed.
 func New(limit int, window time.Duration) *Limiter {
 	l := &Limiter{
 		buckets: make(map[string]*bucket),
 		limit:   limit,
 		window:  window,
+		done:    make(chan struct{}),
 	}
 	go l.cleanupLoop()
 	return l
 }
 
+// Close stops the background cleanup goroutine. Safe to call multiple times.
+// The Limiter remains usable for Allow/Cleanup/Middleware after Close returns,
+// but stale entries will no longer be evicted automatically.
+func (l *Limiter) Close() {
+	l.once.Do(func() { close(l.done) })
+}
+
 func (l *Limiter) cleanupLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
-	for range ticker.C {
-		l.Cleanup()
+	for {
+		select {
+		case <-l.done:
+			return
+		case <-ticker.C:
+			l.Cleanup()
+		}
 	}
 }
 

--- a/server/internal/ratelimit/ratelimit_test.go
+++ b/server/internal/ratelimit/ratelimit_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestLimiterAllowsUnderLimit(t *testing.T) {
 	lim := New(5, time.Minute)
+	t.Cleanup(lim.Close)
 	for i := 0; i < 5; i++ {
 		if !lim.Allow("1.2.3.4") {
 			t.Fatalf("request %d should be allowed", i+1)
@@ -19,6 +20,7 @@ func TestLimiterAllowsUnderLimit(t *testing.T) {
 
 func TestLimiterBlocksOverLimit(t *testing.T) {
 	lim := New(3, time.Minute)
+	t.Cleanup(lim.Close)
 	for i := 0; i < 3; i++ {
 		lim.Allow("1.2.3.4")
 	}
@@ -29,6 +31,7 @@ func TestLimiterBlocksOverLimit(t *testing.T) {
 
 func TestLimiterTracksIPsSeparately(t *testing.T) {
 	lim := New(1, time.Minute)
+	t.Cleanup(lim.Close)
 	if !lim.Allow("1.1.1.1") {
 		t.Fatal("first IP should be allowed")
 	}
@@ -42,6 +45,7 @@ func TestLimiterTracksIPsSeparately(t *testing.T) {
 
 func TestLimiterRefillsAfterWindow(t *testing.T) {
 	lim := New(1, 50*time.Millisecond)
+	t.Cleanup(lim.Close)
 	lim.Allow("1.2.3.4")
 	if lim.Allow("1.2.3.4") {
 		t.Fatal("should be blocked immediately")
@@ -54,6 +58,7 @@ func TestLimiterRefillsAfterWindow(t *testing.T) {
 
 func TestMiddleware429(t *testing.T) {
 	lim := New(1, time.Minute)
+	t.Cleanup(lim.Close)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -75,6 +80,7 @@ func TestMiddleware429(t *testing.T) {
 
 func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 	lim := New(1, time.Minute)
+	t.Cleanup(lim.Close)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -106,6 +112,7 @@ func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 
 func TestCleanupRemovesStaleEntries(t *testing.T) {
 	lim := New(1, 50*time.Millisecond)
+	t.Cleanup(lim.Close)
 	lim.Allow("stale-ip")
 	time.Sleep(60 * time.Millisecond)
 	lim.Cleanup()

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -1,3 +1,7 @@
+// Package signaling implements the WebSocket-based signaling layer for
+// peer-to-peer phone calls. Hub manages connected device sessions and routes
+// messages; Relay enforces authorization and drives the call-state machine;
+// RedisBridge extends both across multiple server replicas via pub/sub.
 package signaling
 
 import (

--- a/server/internal/turn/credentials.go
+++ b/server/internal/turn/credentials.go
@@ -1,3 +1,6 @@
+// Package turn generates time-limited TURN credentials using the HMAC-SHA1
+// scheme described in RFC 8489. Credentials expire after a configurable TTL
+// so a stolen credential set has a bounded useful lifetime.
 package turn
 
 import (

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -1,3 +1,8 @@
+// Package web is the HTTP layer for signald. Handler wires together all
+// stores, the signaling hub, and the auth layer into a single http.Handler
+// via Router. Templates are embedded at build time; static assets are either
+// embedded (production) or served from disk (DevMode). Rate limiters protect
+// sensitive endpoints (auth, pairing, WebSocket upgrade) at the handler level.
 package web
 
 import (


### PR DESCRIPTION
## Summary

Code quality pass on the `server/` module. Two categories of changes:

**Package documentation (15 packages).** The following packages had no package-level doc comment: `auth`, `autodeploy`, `calls`, `config`, `db`, `device`, `email`, `household`, `line`, `logging`, `pairing`, `ratelimit`, `signaling`, `turn`, `web`. A one-to-three sentence doc was added to the most appropriate file in each package. Packages that already had docs (`dbutil`, `httputil`, `metrics`, `profiling`, `tracing`, `updates`, `version`, `dashboard/events`) were left untouched.

**Ratelimit goroutine lifecycle (`internal/ratelimit`).** `New()` started a background cleanup goroutine with no way to stop it. Added:
- `done chan struct{}` field
- `Close()` method protected by `sync.Once` (idempotent: safe to call multiple times or concurrently)
- `cleanupLoop` updated from `for range ticker.C` to `select { case <-l.done / case <-ticker.C }` so the goroutine exits promptly on close
- All seven ratelimit tests updated to register `t.Cleanup(lim.Close)` so test goroutines stop when each test ends rather than persisting until the binary exits

The ratelimit file-path comment at line 1 (`// server/internal/ratelimit/ratelimit.go`) was replaced by the proper package doc.

## Grade

| Dimension | Before | After |
|-----------|--------|-------|
| Code quality (idiomatic Go, error typing, privacy design) | 78 | 78 |
| Test coverage (auth/web handlers remain sparse) | 45 | 47 |
| Documentation (package-level doc comments) | 70 | 88 |
| Architecture (clean separation, minor coupling) | 82 | 82 |
| Error handling and goroutine lifecycle | 72 | 76 |
| Production readiness (observability, retry/circuit-breaker) | 75 | 75 |
| **Overall** | **74** | **78** |

The remaining gap to 100 is dominated by HTTP handler test coverage in `internal/auth` (1%) and `internal/web` (9%). Closing that gap requires non-trivial test infrastructure (fake stores, response recorders wired to the full handler graph) and is outside the scope of this pass.

## Test plan

- `make test` passes (all 24 test packages, including ratelimit with `-race`)
- No integration tests affected (changes are docs and goroutine lifecycle only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ML5VX2aDbUZCsRA16enqds)_