### PR TITLE
fix(digitsd): correct stale voicemail default comment

### DIFF
--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -99,7 +99,7 @@ type Config struct {
 	// WiFiFallback configures the WiFi auto-fallback supervisor.
 	WiFiFallback WiFiFallback `json:"wifi_fallback"`
 
-	// Voicemail configures the answering-machine feature. Disabled by default.
+	// Voicemail configures the answering-machine feature. Enabled by default.
 	Voicemail Voicemail `json:"voicemail"`
 
 	// path is the file the config was loaded from; used by Save.


### PR DESCRIPTION
## What

The `Config.Voicemail` field comment in `pi/digitsd/internal/config/config.go` claimed the answering-machine feature is "Disabled by default." It is not: `defaultVoicemail()` returns `Enabled: true`.

```go
// before
// Voicemail configures the answering-machine feature. Disabled by default.
// after
// Voicemail configures the answering-machine feature. Enabled by default.
```

Comment-only change. No code or behavior change.

## Why (cross-PR drift caught in holistic review)

This is a coherence gap the per-PR reviews missed across the voicemail phase sequence:

- **#569** (`feat(digitsd,server): default answering machine to enabled`) flipped the default from `false` to `true` in two places: `defaultVoicemail()` in digitsd config and `DefaultVoicemail()` in `server/internal/line/settings.go`.
- **#576** (`fix(server): correct stale DefaultVoicemail doc comment`) noticed that the server-side doc comment still said voicemail starts disabled and corrected it.
- The digitsd side carried the identical stale "Disabled by default" comment, and #576 only touched `server/`. This PR fixes the missed twin so both modules describe the shipped default consistently.

## Test plan

- [x] `go build ./internal/config/...` (pi/digitsd)
- [x] `go test ./internal/config/...` (pi/digitsd)