### PR TITLE
fix(digitsd): play the greeting-recording beep through the earpiece

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -497,11 +497,16 @@ func (d *daemonCallbacks) VoicemailRecordGreeting() {
 	d.greetingRecorderMu.Unlock()
 
 	// Spoken prompt ("Record your greeting after the tone") followed by the
-	// beep so the user knows the recorder is hot. 400ms tail keeps the beep
-	// out of the recording itself.
+	// beep so the user knows the recorder is hot. The *97 flow has no WebRTC
+	// peer, so the beep is played through the mixer into the earpiece rather
+	// than injected into the outbound capture path (which nobody would hear).
+	// waitForOnceComplete gates the recording goroutine until the beep has
+	// finished, keeping it out of the recording itself.
 	d.playAnnouncementSequence("vm_record_greeting")
-	pipeline.PlayGreetingBeep(300 * time.Millisecond)
-	time.Sleep(400 * time.Millisecond)
+	beep := audio.SynthGreetingBeep(48000, 300*time.Millisecond)
+	d.mixer.PlayOnceSamples(beep)
+	waitForOnceComplete(d.mixer, 10*time.Second)
+	time.Sleep(30 * time.Millisecond)
 
 	slog.Info("voicemail: recording custom greeting")
 

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -123,14 +123,15 @@ func maybeMute(frame []int16, muted bool) {
 	}
 }
 
-// PlayGreetingBeep synthesizes a 1kHz sine beep of the given duration and
-// arms it for injection into the capture loop. The beep replaces real mic
-// frames for its duration so the caller hears it in the outbound stream.
-func (p *Pipeline) PlayGreetingBeep(d time.Duration) {
-	sampleRate := p.cfg.SampleRate
+// SynthGreetingBeep synthesizes a 1kHz sine beep of the given duration at the
+// requested sample rate and returns the PCM buffer. A zero-length result means
+// the duration rounded to zero samples. Callers that need the beep on the
+// outbound capture path use PlayGreetingBeep; callers that need it in the
+// earpiece play the buffer through the mixer.
+func SynthGreetingBeep(sampleRate int, d time.Duration) []int16 {
 	totalSamples := int(d.Seconds() * float64(sampleRate))
 	if totalSamples == 0 {
-		return
+		return nil
 	}
 
 	const freq = 1000.0
@@ -152,6 +153,17 @@ func (p *Pipeline) PlayGreetingBeep(d time.Duration) {
 		buf[i] = int16(sample)
 	}
 
+	return buf
+}
+
+// PlayGreetingBeep synthesizes a 1kHz sine beep of the given duration and
+// arms it for injection into the capture loop. The beep replaces real mic
+// frames for its duration so the caller hears it in the outbound stream.
+func (p *Pipeline) PlayGreetingBeep(d time.Duration) {
+	buf := SynthGreetingBeep(p.cfg.SampleRate, d)
+	if len(buf) == 0 {
+		return
+	}
 	p.beepPos.Store(0)
 	p.beepBuf.Store(&buf)
 }


### PR DESCRIPTION
## The bug

Dialing `*97` to record a custom voicemail greeting plays the spoken prompt "Record your greeting after the tone", but the user hears no beep before recording starts. Confirmed by hardware testing.

## Root cause

`PlayGreetingBeep` arms the synthesized beep for injection into the CAPTURE loop: the beep replaces real mic frames so it travels in the OUTBOUND audio stream. That is correct for `VoicemailAutoAnswer`, where a WebRTC caller is on the other end and must hear the beep.

But the `*97` greeting-recording flow has no WebRTC peer and no local monitoring, so a beep injected into the capture/outbound path reaches nobody. The user's earpiece is fed by the mixer, not the capture path. The spoken prompt is heard in `*97` only because it plays via the mixer.

## The fix

- `pipeline.go`: the beep-synthesis body of `PlayGreetingBeep` is extracted into a new exported `SynthGreetingBeep` that returns the PCM buffer. `PlayGreetingBeep` keeps its outbound-capture behavior byte-identical (same 1kHz sine, same amplitude, same fade envelope, same zero-length guard).
- `voicemail.go` `VoicemailRecordGreeting`: synthesizes the same beep and plays it through the mixer with `PlayOnceSamples`, then waits via `waitForOnceComplete` so the beep finishes before the recording goroutine starts and is not captured. The old 400ms sleep, which compensated for the capture-path routing, is removed.
- `VoicemailAutoAnswer` is unchanged: its beep must reach the WebRTC caller via the outbound path.

This is a hardware-testing bug fix. No new audio assets: the existing beep waveform is reused.

## Verification

- `make build` (Docker cross-compile): passes
- `go test ./...`: passes
- `golangci-lint run ./...`: 0 issues