### PR TITLE
perf(ci): disable actions/setup-go remote cache

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
-          cache-dependency-path: server/go.sum
+          cache: false
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
-          cache-dependency-path: pi/digitsd/go.sum
+          cache: false
       - name: Install C dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev libopusfile-dev
       - uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/pi-ci.yml
+++ b/.github/workflows/pi-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
-          cache-dependency-path: pi/digitsd/go.sum
+          cache: false
       - name: Install C dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev libopusfile-dev
       - name: Populate embed tree

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
-          cache-dependency-path: server/go.sum
+          cache: false
 
       - name: Build
         working-directory: server

--- a/.github/workflows/server-integration.yml
+++ b/.github/workflows/server-integration.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
-          cache-dependency-path: server/go.sum
+          cache: false
 
       - name: Integration tests
         working-directory: server


### PR DESCRIPTION
## Summary

- Disable the GitHub Actions remote cache in all `actions/setup-go` steps (`cache: false`)
- Self-hosted runners have persistent Go build and module caches via hostPath volumes, making the remote cache redundant
- Eliminates ~90s of overhead per job (21s download + 71s upload to GitHub's cache servers)

## Test plan

- [ ] Verify setup-go step completes in <5s (no download/upload)
- [ ] Verify integration tests still pass (Go modules resolve from local cache or proxy.golang.org)