### PR TITLE
fix(digitsd): start voicemail recording after the greeting, not at connect

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -149,6 +149,15 @@ type daemonCallbacks struct {
 	recorderMu        sync.Mutex
 	voicemailWebRTCCh chan []int16
 
+	// voicemailRecordArmed gates the OnRemoteTrack tee into the recorder.
+	// The remote track reaches its live phase right after the call
+	// connects, well before the outgoing greeting and prompt beep finish,
+	// so appending from that point would prepend the whole greeting
+	// duration of caller-side silence to every message. The greeting
+	// goroutine sets this true at the moment it transitions into the
+	// recording state, so the recorder only ever sees the actual message.
+	voicemailRecordArmed atomic.Bool
+
 	// Greeting recording (separate from message recording above). Active
 	// only between *97 entry and either # / hook-on / max-duration. Lives
 	// under its own mutex so it doesn't contend with the message recorder

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -221,6 +221,11 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 	webrtcCh := make(chan []int16, 8)
 	d.voicemailWebRTCCh = webrtcCh
 
+	// Recording stays disarmed until the greeting and beep finish. The
+	// remote track goes live well before then, so an early tee would
+	// prepend the greeting duration of caller-side silence to the message.
+	d.voicemailRecordArmed.Store(false)
+
 	d.peerMgr.OnRemoteTrack = func(track *webrtc.TrackRemote) {
 		go func() {
 			defer recoverGoroutine("voicemail-record")
@@ -272,10 +277,10 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 				}
 			}
 
-			// Phase 3: live. Each packet is decoded for the PCM channel AND
-			// the raw payload is teed into the recorder. On atCap, finalize
-			// under recorderMu and trigger the controller-side hangup via
-			// VoicemailRecordEnded.
+			// Phase 3: live. Each packet is decoded for the PCM channel AND,
+			// once recording is armed, the raw payload is teed into the
+			// recorder. On atCap, finalize under recorderMu and trigger the
+			// controller-side hangup via VoicemailRecordEnded.
 			for {
 				pkt, _, err := track.ReadRTP()
 				if err != nil {
@@ -289,10 +294,14 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 					continue
 				}
 
+				// Tee into the recorder only once the greeting goroutine has
+				// armed recording. Before that the live track carries the
+				// caller listening to the greeting; appending it would prepend
+				// the greeting duration of silence to the stored message.
 				d.recorderMu.Lock()
 				rec := d.recorder
 				d.recorderMu.Unlock()
-				if rec != nil {
+				if rec != nil && d.voicemailRecordArmed.Load() {
 					atCap, err := rec.AppendFrame(pkt.Payload)
 					if err != nil {
 						slog.Warn("voicemail: append frame failed", "caller", caller, "error", err)
@@ -399,6 +408,11 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 		time.Sleep(500 * time.Millisecond)
 		if ctrl.State() == phone.StateVOICEMAIL_GREETING {
 			pipeline.SetMuted(true)
+			// Arm the recorder tee now: the beep has finished, so the next
+			// caller frames are the actual message. Anything the remote
+			// track delivered earlier (the caller listening to the greeting)
+			// was decoded but not recorded.
+			d.voicemailRecordArmed.Store(true)
 			ctrl.SetVoicemailRecording()
 		}
 	}()

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -294,11 +294,16 @@ func (d *daemonCallbacks) HangupCall() {
 	var finalizedVoicemail bool
 	d.recorderMu.Lock()
 	if d.recorder != nil {
-		if _, err := d.recorder.Finalize(); err != nil {
+		msg, err := d.recorder.Finalize()
+		if err != nil {
 			slog.Error("hangup: voicemail finalize failed", "error", err)
 		}
 		d.recorder = nil
-		finalizedVoicemail = true
+		// A zero-frame recording (the caller hung up during the greeting,
+		// before the recorder was armed) is discarded by Finalize and
+		// returns a zero Message: nothing landed, so the unheard count did
+		// not move and the LED does not need re-emitting.
+		finalizedVoicemail = msg.ID != 0
 	}
 	d.recorderMu.Unlock()
 


### PR DESCRIPTION
## Summary

Hardware testing found a large delay during `*98` voicemail retrieval between a message starting and the caller's audio actually playing. The root cause is on the recording side, not playback.

In `VoicemailAutoAnswer`, the `OnRemoteTrack` handler reaches its live phase right after the call connects and from there teed every caller frame into the recorder. But the recorder is opened before the outgoing greeting plays, and a separate goroutine runs a 500ms lead-in, the greeting, a 500ms beep, and a 500ms tail before transitioning into the recording state. So every stored message was front-loaded with the entire greeting duration of the caller silently listening, followed by the actual message. On `*98` playback that silence is what plays between the message announcement and the caller's first words. With a custom greeting (up to 60s) it was also consuming most of the 90s message cap.

## Fix

- Add a `voicemailRecordArmed` atomic flag. The Phase 3 tee into the recorder is gated on it.
- The greeting goroutine sets it true at the exact point it transitions into the recording state, right where the mic is muted (after the beep). Recording now starts when the caller starts speaking.
- Frames the live track delivered before arming are still decoded, to keep the Opus decoder state and the pickup PCM channel in sync. They are simply not recorded.
- A caller who hangs up during the greeting now appends zero frames. `Recorder.Finalize` already discards a zero-frame recording, so that path stops saving junk silent voicemails. `HangupCall` now sets its `finalizedVoicemail` flag from the finalized message ID, so a discarded zero-frame recording no longer triggers a spurious message-waiting LED re-emit.

The fix mirrors the existing `SetMuted(true)` gating, which is already called at the same transition point.

## Test plan

- [x] `make build` (Docker cross-compile) passes
- [x] full `pi/digitsd` test suite passes (`go test ./...`)
- [x] `golangci-lint run` clean
- [ ] hardware: leave a voicemail, dial `*98`, confirm the recording starts at the caller's first words with no greeting-length silence

## Notes on testing

The bug lives in the timing between the `OnRemoteTrack` goroutine and the greeting goroutine, driven by a pion `webrtc.TrackRemote`. There is no fake-track harness in the daemon test suite and building one is disproportionate to a four-line gate. The recorder behavior the fix relies on, a zero-frame `Finalize` discarding the recording, is already covered by `TestEmptyRecordingDiscarded`. Hardware verification covers the integration.