### PR TITLE
docs: refresh voicemail docs for the answering-machine iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ On the hardware side, I am not an electrical engineer. I learned KiCad, read dat
 - [Architecture](docs/architecture/overview.md)
 - [Party Line](docs/architecture/party-line.md)
 - [Voicemail](docs/voicemail.md)
+- [User guide](docs/user-guide.md)
 - [Voicemail guide](docs/voicemail-guide.md)
 - [Self-hosting](docs/hosting/self-hosting.md)
 - [Load testing](docs/hosting/load-testing.md)

--- a/README.md
+++ b/README.md
@@ -157,15 +157,16 @@ Hidden codes entered on the keypad while the handset is off-hook.
 
 These are dialed from dial tone (not prefixed with `*#`), matching the original 1990s POTS behavior.
 
-### Voicemail (*98 / *97 / *99)
+### Voicemail (*96 / *97 / *98 / *99)
 
 | Code | Action | Details |
 |------|--------|---------|
-| `*98` | Listen to messages | Plays your messages oldest first. During playback: `7` deletes, `9` saves, `#` skips, `*` replays. The retrieval code is configurable; `*98` is the default. |
+| `*96` | Audition greeting | Plays your current outgoing greeting through the earpiece, so you can hear what callers hear. |
 | `*97` | Record greeting | Records a custom outgoing greeting after the tone. |
+| `*98` | Listen to messages | Plays your messages oldest first, then any saved (already heard) messages. During playback: `7` deletes, `9` saves, `#` skips, `*` replays. The retrieval code is configurable; `*98` is the default. |
 | `*99` | Delete greeting | Removes your custom greeting and restores the default. |
 
-When a call rings unanswered past the configured timeout, the phone answers it, plays your greeting, and records the caller's message. The handset microphone is muted while recording, so a caller never hears your room. See [Voicemail](docs/voicemail.md) for the FSM, on-disk storage format, signaling, and configuration.
+When a call rings unanswered past the configured timeout, the phone answers it, plays your greeting, and records the caller's message. The handset microphone is muted while recording, so a caller never hears your room. See the [voicemail guide](docs/voicemail-guide.md) for using and configuring it, or [Voicemail](docs/voicemail.md) for the engineering reference: FSM, on-disk storage format, signaling, and configuration.
 
 ### Confirmation feedback
 
@@ -229,6 +230,7 @@ On the hardware side, I am not an electrical engineer. I learned KiCad, read dat
 - [Architecture](docs/architecture/overview.md)
 - [Party Line](docs/architecture/party-line.md)
 - [Voicemail](docs/voicemail.md)
+- [Voicemail guide](docs/voicemail-guide.md)
 - [Self-hosting](docs/hosting/self-hosting.md)
 - [Load testing](docs/hosting/load-testing.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,13 +14,13 @@ Everything you need to build a Digits phone from scratch.
 
 - [Architecture overview](architecture/overview.md) -- system design, call path, data model, NAT traversal
 - [UART protocol](architecture/uart-protocol.md) -- Pico/Pi communication spec
-- [Voicemail](voicemail.md) -- answering machine architecture, storage format, signaling, service codes
+- [Voicemail](voicemail.md) -- answering machine engineering reference: call FSM, on-disk storage format, audio pipeline, signaling, service codes
 - [State machine](diagrams/phone-fsm.dot) -- firmware FSM ([rendered](diagrams/phone-fsm.png))
 
 ## Using Your Phone
 
 - [Quick start guide](user-guide.md) -- setup and everyday use
-- [Voicemail guide](voicemail-guide.md) -- using and configuring the answering machine
+- [Voicemail guide](voicemail-guide.md) -- using voicemail from the handset and configuring it in the web app
 
 ## Run Your Own Server
 

--- a/docs/voicemail-guide.md
+++ b/docs/voicemail-guide.md
@@ -76,7 +76,7 @@ By default, callers hear a standard Digits greeting. To record your own:
 4. Press `#` when you are done. The phone confirms with "Greeting saved".
 
 Your greeting can be up to 60 seconds long. You can also finish by hanging up,
-and the phone stops on its own at the 60 second limit; all three ways save what
+and the phone stops on its own at the 60-second limit; all three ways save what
 you recorded. Recording a new greeting replaces the previous one.
 
 To hear your greeting back, dial `*96` (see "Hearing your current greeting"
@@ -91,8 +91,8 @@ to dial tone.
 ## Configuring voicemail in the web app
 
 Voicemail settings live on the phone's detail page in the web app. From the
-phones list, open a phone to its detail page (`/phones/{number}`), then find
-the voicemail section.
+phones list, open a phone to reach its detail page, then find the voicemail
+section.
 
 ### Turning voicemail on and off
 
@@ -164,9 +164,9 @@ did not finish cleanly the phone falls back to the standard greeting. Dial
 before hanging up.
 
 **I changed the message limit or storage cap and nothing changed.** The
-maximum message length and the storage cap are read when the phone's daemon
-starts. A change to either takes effect after the phone restarts. The on/off
-toggle, ring timeout, and retrieval code apply right away.
+maximum message length and the storage cap are read when the phone starts up.
+A change to either takes effect after the phone restarts. The on/off toggle,
+ring timeout, and retrieval code apply right away.
 
 **The message-waiting light is pulsing but `*98` says no messages.** The slow
 pulse tracks unheard messages. If you saved or deleted everything, the light
@@ -175,3 +175,9 @@ clears on the next idle check. If it persists, restart the phone.
 **Messages are missing.** The phone keeps a fixed number of messages and
 deletes the oldest when full. If old messages disappeared, the box hit its cap.
 Clear messages regularly to avoid this.
+
+## How it works
+
+For how voicemail is built (the call state machine, on-disk message storage,
+audio pipeline, signaling, and service-code reference), see
+[voicemail.md](voicemail.md).

--- a/docs/voicemail-guide.md
+++ b/docs/voicemail-guide.md
@@ -28,7 +28,9 @@ means no new messages. The slow pulse is your "you have voicemail" light.
 ### Listening to your messages
 
 Lift the handset and dial `*98`. The phone tells you how many new messages you
-have, then plays them one at a time, oldest first.
+have, reads out the keypad controls, then plays the messages one at a time,
+oldest first. When you have more than one new message, the phone says "Message
+one", "Message two", and so on before each one so you can keep track.
 
 While a message is playing, the keypad controls the session:
 
@@ -36,24 +38,49 @@ While a message is playing, the keypad controls the session:
 |-----|--------------|
 | `7` | Delete this message and move to the next one. You hear "Message deleted". |
 | `9` | Save this message and move to the next one. You hear "Message saved". |
-| `#` | Skip to the next message without saving or deleting this one. |
+| `#` | Skip to the next message. The skipped message stays new, so you hear it again next time. |
 | `*` | Replay the current message from the start. |
 
-A saved message is marked as heard and is kept; a deleted message is gone for
-good. When there are no more new messages, the phone says "End of messages".
-Hang up at any time to stop.
+Letting a message play all the way to the end counts as listening to it: the
+phone marks it heard and keeps it. Pressing `9` does the same thing on demand.
+A heard message is not gone, it is kept and you can hear it again in the saved
+review (below). Only `7` deletes a message for good.
+
+### Saved messages
+
+After your new messages, if you have older messages you have already heard, the
+phone says how many saved messages you have and plays those too. You can
+delete, replay, or skip them with the same keys. If you dial `*98` and have no
+new messages but do have saved ones, the phone goes straight to the saved
+review.
+
+When there are no more messages of either kind, the phone says "End of
+messages". Hang up at any time to stop.
+
+### Hearing your current greeting
+
+To check what callers hear when they reach your voicemail, lift the handset and
+dial `*96`. The phone says "Your current answering machine greeting is...", then
+plays your active greeting: your own recording if you have made one, otherwise
+the standard Digits greeting. It then returns to dial tone. This is playback
+only; it never changes your greeting or your messages.
 
 ### Recording your own greeting
 
 By default, callers hear a standard Digits greeting. To record your own:
 
 1. Lift the handset and dial `*97`.
-2. Wait for the prompt: "Record your greeting after the tone."
+2. Wait for the prompt. It tells you to press the pound key when you are
+   finished, or hang up, and is followed by a short pause and a tone.
 3. After the tone, speak your greeting.
-4. The phone confirms with "Greeting saved".
+4. Press `#` when you are done. The phone confirms with "Greeting saved".
 
-Your greeting can be up to 60 seconds long. Recording a new greeting replaces
-the previous one.
+Your greeting can be up to 60 seconds long. You can also finish by hanging up,
+and the phone stops on its own at the 60 second limit; all three ways save what
+you recorded. Recording a new greeting replaces the previous one.
+
+To hear your greeting back, dial `*96` (see "Hearing your current greeting"
+above).
 
 ### Removing your greeting
 

--- a/docs/voicemail.md
+++ b/docs/voicemail.md
@@ -29,7 +29,7 @@ callee's Pi and nowhere else.
 
 ### FSM states
 
-The phone controller (`internal/phone/controller.go`) adds four states for
+The phone controller (`internal/phone/controller.go`) adds five states for
 voicemail:
 
 | State | Meaning |
@@ -37,6 +37,7 @@ voicemail:
 | `VOICEMAIL_GREETING` | Call auto-answered; playing the outgoing greeting, then the beep |
 | `VOICEMAIL_RECORDING` | Recording the caller's audio |
 | `VOICEMAIL_RECORD_GREETING` | The household member is recording a custom outgoing greeting (`*97`) |
+| `VOICEMAIL_PLAY_GREETING` | The household member dialed `*96`; the active outgoing greeting is auditioning through the earpiece |
 | `VOICEMAIL_PLAYBACK` | The household member dialed the retrieval code; stored messages are playing back |
 
 ### Auto-answer on ring timeout
@@ -120,9 +121,20 @@ When `VoicemailAutoAnswer()` runs, the daemon answers the WebRTC call and
 installs an `OnRemoteTrack` handler. Caller audio arrives as RTP packets and is
 handled in three phases: discard packets until the pipeline is ready (keeping
 the Opus decoder state in sync), drain the buffered backlog, then treat the
-stream as live. In the live phase each inbound packet's raw Opus payload is
-appended to the recorder with `AppendFrame(pkt.Payload)`, and the decoded PCM
-is mixed to the handset speaker so the household can hear a message being left.
+stream as live. In the live phase the decoded PCM is mixed to the handset
+speaker so the household can hear a message being left, and each inbound
+packet's raw Opus payload is appended to the recorder with
+`AppendFrame(pkt.Payload)`.
+
+**Recording starts after the greeting, not at connect.** The recorder tee is
+gated by a `voicemailRecordArmed` flag that stays false from auto-answer until
+the outgoing greeting and the prompt beep have both finished playing. The
+remote track goes live well before then (the caller is hearing the greeting),
+so before the flag is armed those frames are decoded but not appended. Arming
+the recorder at the greeting-to-recording transition means a stored message
+begins at the caller's first word, with no leading greeting-duration silence. A
+caller who hangs up while the greeting is still playing leaves no message at
+all, because the recorder was never armed.
 
 When the recorder reports it has hit the message-duration cap, the daemon
 finalizes the recording and calls `VoicemailRecordEnded()`.
@@ -156,6 +168,60 @@ asset is missing, the daemon logs a warning and proceeds with the beep only.
 After the greeting comes a 500 ms 1 kHz beep synthesized by
 `PlayGreetingBeep()`.
 
+### Greeting recording (`*97`)
+
+Dialing `*97` enters `VOICEMAIL_RECORD_GREETING` and calls
+`VoicemailRecordGreeting()`. The daemon brings up the audio pipeline in
+microphone-capture mode (no WebRTC peer), plays the `vm_record_greeting` spoken
+prompt followed by a short beep, then opens a greeting recorder and starts a
+loop that encodes captured microphone frames to Opus and appends them to
+`greeting.frames`.
+
+The prompt and beep play through the mixer into the earpiece, not the outbound
+capture path: the `*97` flow has no remote peer, so injecting the beep into
+capture would mean nobody hears it. The spoken prompt tells the user how to end
+the recording ("press pound when finished, or hang up") and is followed by a
+short pause before the beep, so the instruction lands clearly before the
+recorder goes hot. `waitForOnceComplete` gates the recording loop until the
+beep has finished, keeping the prompt and beep out of the recording itself.
+
+A greeting recording ends on any of three paths, and all three finalize and
+save the recording:
+
+- **`#` key.** `VoicemailRecordGreetingKey("#")` calls
+  `finalizeGreetingRecording()`.
+- **Duration cap.** The recorder caps at `greetingMaxDuration` (60 s); on the
+  cap the loop finalizes itself.
+- **Hang-up.** An on-hook during recording routes through the controller's
+  hang-up path, which finalizes the partial greeting.
+
+`finalizeGreetingRecording()` is idempotent: the first caller wins, renames the
+temp file over any prior `greeting.frames`, plays the `vm_greeting_saved`
+confirmation, stops the pipeline, and returns the phone to dial tone.
+
+### Greeting audition (`*96`)
+
+Dialing `*96` enters `VOICEMAIL_PLAY_GREETING` and calls
+`VoicemailPlayGreeting()`. It is a pure read-only audition of the active
+outgoing greeting: no recorder is opened and the stored greeting is never
+modified.
+
+The daemon decodes the active greeting with `decodeCustomGreeting()`, the same
+Opus-decode helper the auto-answer path uses. If a custom greeting is recorded
+it is decoded; otherwise the daemon loads the embedded default through
+`ToneSamples("voicemail_greeting")`. Either way the daemon first plays the
+`vm_current_greeting` spoken intro ("Your current answering machine greeting
+is..."), then the greeting itself, both through the mixer one-shot into the
+earpiece. When playback finishes the FSM returns to dial tone.
+
+`VoicemailPlayGreeting` runs on its own goroutine. A hook-on mid-audition
+routes through `VoicemailExitGreetingPlayback()`, which clears the one-shot
+queue with `Mixer.StopOnce()` so the audition stops at once. Completion goes
+through `Controller.FinishGreetingAudition()`, which checks the FSM state and,
+only if the audition is still active, transitions to dial tone, all under the
+controller lock so a racing hook-on cannot leave a dial tone looping against an
+on-hook handset.
+
 ### Voice prompt assets
 
 Every voicemail interaction has audible spoken feedback. The prompt WAVs live
@@ -171,10 +237,14 @@ in `internal/assets/embed/data/tones/`:
 | `vm_message_deleted.wav` | "Message deleted" |
 | `vm_message_saved.wav` | "Message saved" |
 | `vm_message.wav` | "Message" (composed with a digit clip for the per-message announcement) |
+| `vm_saved_message.wav` | "saved message" (singular) |
+| `vm_saved_messages.wav` | "saved messages" (plural) |
 | `vm_end_of_messages.wav` | "End of messages" |
-| `vm_record_greeting.wav` | "Record your greeting after the tone" |
+| `vm_playback_controls.wav` | The spoken playback-controls prompt, played once per `*98` session |
+| `vm_record_greeting.wav` | The greeting-recording prompt, including how to finish ("press pound when finished, or hang up") |
 | `vm_greeting_saved.wav` | "Greeting saved" |
 | `vm_greeting_deleted.wav` | "Greeting deleted" |
+| `vm_current_greeting.wav` | "Your current answering machine greeting is...", the `*96` audition intro |
 | `voicemail_greeting.wav` | The default outgoing greeting |
 
 The per-digit clips `spoken_0.wav` through `spoken_9.wav` live in the
@@ -202,6 +272,50 @@ message" count intro already identifies it.
 `playAnnouncementSequence()` plays the clips back to back through the mixer's
 `PlayOnce()`, waiting for each clip to finish before starting the next, with a
 30 ms silence between clips.
+
+### Retrieval playback (`*98`)
+
+Dialing the retrieval code enters `VOICEMAIL_PLAYBACK` and calls
+`VoicemailEnterPlayback()`. A retrieval session runs in two phases.
+
+**New-message phase.** The daemon counts the unheard messages, announces the
+count, plays the `vm_playback_controls` spoken prompt once, then plays the
+unheard messages oldest first. When two or more messages are present each one
+is preceded by its spoken "Message N" announcement. Playing a message through
+to its end (EOF) marks it heard: `voicemailAdvanceFromEOF()` calls
+`MarkHeard()` before opening the next message. A heard message is not deleted,
+it is retained on disk and becomes reviewable in the saved phase.
+
+**Saved-message review phase.** At session entry, before any new message is
+marked heard, the daemon snapshots the IDs of every already-heard message into
+a saved-review queue. When the new-message phase runs out, if that queue is
+non-empty the session crosses into saved review: it announces the saved count
+("You have N saved messages") and plays the heard messages in turn. If `*98` is
+dialed when there are no unheard messages but saved ones exist, the session
+enters saved review directly, playing the controls prompt on that path since
+the new-message phase never ran. A mailbox with no messages of either kind
+plays "You have no messages" and returns to dial tone.
+
+**DTMF controls.** Keypad digits during playback route to `VoicemailKey()`:
+
+- `7` deletes the current message (both files) and advances. Works in both
+  phases.
+- `9` in the new-message phase marks the current message heard and advances.
+  In saved review the message is already heard, so `9` simply advances.
+- `#` skips to the next message. In the new-message phase it leaves the heard
+  flag untouched, so a skipped message stays unheard for a later session.
+- `*` replays the current message from the start.
+
+When a new-phase key exhausts the unheard messages and saved messages exist,
+`7`, `9`, and `#` cross into saved review rather than ending the session. When
+no message of either kind remains, the session plays "End of messages" and
+returns to dial tone. Hanging up at any point ends the session immediately.
+
+The net message lifecycle: a message arrives unheard; playing it to the end or
+pressing `9` marks it heard; a heard message is kept and is reviewable through
+the saved phase; `7` deletes it outright; doing nothing keeps it. There is no
+implicit deletion from playback, only the FIFO eviction once the stored-message
+cap is exceeded.
 
 ## Server internals
 
@@ -379,21 +493,27 @@ are fixed.
 
 | Code | Action |
 |------|--------|
+| `*96` | Audition the active outgoing greeting through the earpiece. Enters `VOICEMAIL_PLAY_GREETING`, then returns to dial tone. |
 | `*97` | Record a custom outgoing greeting. Enters `VOICEMAIL_RECORD_GREETING`. |
 | `*98` | Retrieve stored messages. Enters `VOICEMAIL_PLAYBACK`. This code is the configurable `RetrievalCode`; `*98` is the default. |
 | `*99` | Delete the custom greeting and revert to the default. Returns to dial tone. |
+
+`*96`, `*97`, and `*99` are fixed; only `*98` (the `RetrievalCode`) is
+configurable. All four are gated on voicemail being enabled for the line.
 
 During message playback (`VOICEMAIL_PLAYBACK`), DTMF digits control the
 session. The controller routes them to `VoicemailKey(digit)`:
 
 | Key | Action |
 |-----|--------|
-| `7` | Delete the current message, then advance to the next unheard message. Plays "Message deleted". |
-| `9` | Save the current message (mark it heard), then advance to the next unheard message. Plays "Message saved". |
-| `#` | Skip the current message without changing its heard flag, advance past it. |
+| `7` | Delete the current message (both files), then advance. Plays "Message deleted". Works in the new-message and saved-review phases. |
+| `9` | New-message phase: mark the current message heard and advance, playing "Message saved". Saved-review phase: just advance, since the message is already heard. |
+| `#` | Skip to the next message. In the new-message phase the heard flag is left untouched, so the message stays unheard for a later session. |
 | `*` | Replay the current message from the start. |
 
-When no unheard messages remain, the session plays "End of messages" and exits
+When the new-message phase is exhausted and saved messages exist, `7`, `9`, and
+`#` cross into the saved-review phase rather than ending the session. When no
+message of either kind remains, the session plays "End of messages" and returns
 to dial tone.
 
 ## Limits and defaults

--- a/docs/voicemail.md
+++ b/docs/voicemail.md
@@ -25,6 +25,10 @@ Responsibility is split in two:
 Recorded audio is never uploaded. A caller's message exists as a file on the
 callee's Pi and nowhere else.
 
+This document is the engineering reference. For how to use voicemail from the
+handset and configure it in the web app in plain language, see the
+[voicemail guide](voicemail-guide.md).
+
 ## digitsd internals
 
 ### FSM states


### PR DESCRIPTION
## Summary

`docs/voicemail.md` and `docs/voicemail-guide.md` predated this hardware-testing iteration and had gone stale. This brings both current with everything in the pass.

- **`*97` greeting recording.** The prompt and beep play through the earpiece, the prompt instructs the user how to finish ("press pound when finished, or hang up") with a pre-beep pause, and all three end paths (`#` key, 60s cap, hang-up) finalize and save.
- **Recording timing.** The recorder is armed only after the greeting and beep finish, so stored messages carry no leading greeting-duration silence, and a caller who hangs up during the greeting leaves nothing.
- **`*98` retrieval.** Documents the two-phase session, the once-per-session spoken controls prompt, the "Message N" announcements, and the saved-message review phase with its saved-count announcement.
- **`*96` (new).** On-device audition of the active outgoing greeting through the earpiece, including the spoken intro.
- **Message lifecycle.** Play-to-EOF and `9` both mark heard and retain; `7` deletes; `#` skips and leaves unheard; doing nothing keeps the message.
- FSM state table, service code table, and voice prompt asset list updated for `VOICEMAIL_PLAY_GREETING`, `*96`, and the new prompt assets.

## Sequencing

The `*96` content reflects PR #593. This PR must not merge before #593 merges. If the `*96` hardware test changes #593, the `*96` sections here will be updated to match before this merges.

## Test plan

- [x] No em dashes
- [x] Head-state only, no future-work or historical sections
- [ ] `@claude` review