### PR TITLE
fix(digitsd): stop the spurious WARN when *97 finalize races the recorder

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -604,6 +604,13 @@ func (d *daemonCallbacks) VoicemailRecordGreeting() {
 
 			atCap, err := rec.AppendFrame(payload)
 			if err != nil {
+				if errors.Is(err, voicemail.ErrRecorderClosed) {
+					// finalizeGreetingRecording closed the recorder out from
+					// under this loop (the # key, hang-up, or duration cap).
+					// The greeting is already saved; this frame just lost the
+					// race. Stop quietly instead of logging a spurious WARN.
+					return
+				}
 				slog.Warn("voicemail: greeting append failed", "error", err)
 				continue
 			}

--- a/pi/digitsd/internal/voicemail/store.go
+++ b/pi/digitsd/internal/voicemail/store.go
@@ -230,6 +230,11 @@ func (s *Store) BeginRecording() (*Recorder, error) {
 	}, nil
 }
 
+// ErrRecorderClosed is returned by Recorder.AppendFrame when the recorder has
+// already been finalized or discarded. A writer racing a finalize should treat
+// it as a clean stop, not a failure.
+var ErrRecorderClosed = errors.New("voicemail: recorder closed")
+
 // Recorder writes Opus frames for a single message.
 type Recorder struct {
 	store     *Store
@@ -250,7 +255,7 @@ func (r *Recorder) AppendFrame(payload []byte) (atCap bool, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
-		return false, errors.New("voicemail: recorder closed")
+		return false, ErrRecorderClosed
 	}
 	if len(payload) > 0xffff {
 		return false, fmt.Errorf("voicemail: opus payload too large (%d)", len(payload))


### PR DESCRIPTION
## Summary

Ending a `*97` greeting recording (the `#` key, hang-up, or the 60s duration cap) calls `finalizeGreetingRecording`, which closes the recorder. The mic-to-Opus-to-recorder goroutine can already be mid-iteration holding the recorder pointer it read a moment earlier, so its next `AppendFrame` lands on the closed recorder and the loop logged:

```
WARN voicemail: greeting append failed error="voicemail: recorder closed"
```

The greeting is finalized and saved before that stray frame runs (`custom greeting saved` logs immediately before the WARN), so it is purely cosmetic, but it printed once per greeting recording. Found by log-watch during `*96`/`*97` hardware testing.

## Change

- `internal/voicemail/store.go`: promote the bare `errors.New("voicemail: recorder closed")` to a package sentinel, `voicemail.ErrRecorderClosed`, returned from `Recorder.AppendFrame`.
- `cmd/digitsd/voicemail.go`: the greeting-record loop treats `errors.Is(err, voicemail.ErrRecorderClosed)` as a clean stop and returns quietly. Every other `AppendFrame` error keeps the existing WARN-and-continue.

Pre-existing behavior, not introduced this session and unrelated to `*96`.

## Test plan

- [x] `go test ./...` and `golangci-lint run ./...` pass
- [ ] Hardware: record a `*97` greeting, press `#`, confirm `custom greeting saved` still logs and the `recorder closed` WARN no longer appears