### PR TITLE
refactor(server): remove the per-line voicemail max-message-duration setting

### DIFF
--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -77,12 +77,12 @@ test.describe('Voicemail (intercom theme)', () => {
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
     await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
 
-    // Advanced should be collapsed by default; the 4 fields are hidden until expanded.
+    // Advanced should be collapsed by default; the detail fields are hidden until expanded.
     const ringField = page.locator('#voicemail-section input[name="ring_timeout_seconds"]');
     await expect(ringField).not.toBeVisible();
   });
 
-  test('expanding Advanced reveals all four detail fields', async ({ page }) => {
+  test('expanding Advanced reveals all detail fields', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -92,9 +92,10 @@ test.describe('Voicemail (intercom theme)', () => {
 
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
+    // The per-message recording cap is fixed in digitsd, so no field for it.
+    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toHaveCount(0);
   });
 
   test('checkbox toggle swaps section partial and persists', async ({ page }) => {
@@ -139,7 +140,6 @@ test.describe('Voicemail (intercom theme)', () => {
     // Expand Advanced and edit.
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
-    await page.locator('#voicemail-section input[name="max_message_seconds"]').fill('100');
     await page.locator('#voicemail-section input[name="max_stored_messages"]').fill('25');
     await page.locator('#voicemail-section input[name="retrieval_code"]').fill('*99');
 
@@ -180,7 +180,6 @@ test.describe('Voicemail (intercom theme)', () => {
       form: {
         enabled: 'on',
         ring_timeout_seconds: '20',
-        max_message_seconds: '90',
         max_stored_messages: '50',
         retrieval_code: '12345',
       },

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -17,13 +17,10 @@ const (
 const (
 	VoicemailRingTimeoutMin = 5
 	VoicemailRingTimeoutMax = 60
-	VoicemailMaxMessageMin  = 15
-	VoicemailMaxMessageMax  = 180
 	VoicemailMaxStoredMin   = 5
 	VoicemailMaxStoredMax   = 200
 
 	DefaultVoicemailRingTimeoutSeconds = 20
-	DefaultVoicemailMaxMessageSeconds  = 90
 	DefaultVoicemailMaxStoredMessages  = 50
 	DefaultVoicemailRetrievalCode      = "*98"
 )
@@ -53,7 +50,6 @@ func IsValidRetrievalCode(code string) bool {
 type Voicemail struct {
 	Enabled            bool   `json:"enabled"`
 	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxMessageSeconds  int    `json:"max_message_seconds"`
 	MaxStoredMessages  int    `json:"max_stored_messages"`
 	RetrievalCode      string `json:"retrieval_code"`
 }
@@ -79,7 +75,6 @@ func DefaultVoicemail() Voicemail {
 	return Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: DefaultVoicemailRingTimeoutSeconds,
-		MaxMessageSeconds:  DefaultVoicemailMaxMessageSeconds,
 		MaxStoredMessages:  DefaultVoicemailMaxStoredMessages,
 		RetrievalCode:      DefaultVoicemailRetrievalCode,
 	}
@@ -104,9 +99,6 @@ func (v Voicemail) Merge(patch Voicemail) Voicemail {
 	if patch.RingTimeoutSeconds != 0 {
 		v.RingTimeoutSeconds = patch.RingTimeoutSeconds
 	}
-	if patch.MaxMessageSeconds != 0 {
-		v.MaxMessageSeconds = patch.MaxMessageSeconds
-	}
 	if patch.MaxStoredMessages != 0 {
 		v.MaxStoredMessages = patch.MaxStoredMessages
 	}
@@ -118,14 +110,11 @@ func (v Voicemail) Merge(patch Voicemail) Voicemail {
 
 // Normalize substitutes the default value for any field that is zero or out
 // of the allowed range. Defense in depth so corrupt on-disk data can never
-// propagate to the daemon (which would, for instance, refuse to record a
-// message if MaxMessageSeconds is zero).
+// propagate to the daemon (which would, for instance, never pick up if
+// RingTimeoutSeconds is zero).
 func (v Voicemail) Normalize() Voicemail {
 	if v.RingTimeoutSeconds < VoicemailRingTimeoutMin || v.RingTimeoutSeconds > VoicemailRingTimeoutMax {
 		v.RingTimeoutSeconds = DefaultVoicemailRingTimeoutSeconds
-	}
-	if v.MaxMessageSeconds < VoicemailMaxMessageMin || v.MaxMessageSeconds > VoicemailMaxMessageMax {
-		v.MaxMessageSeconds = DefaultVoicemailMaxMessageSeconds
 	}
 	if v.MaxStoredMessages < VoicemailMaxStoredMin || v.MaxStoredMessages > VoicemailMaxStoredMax {
 		v.MaxStoredMessages = DefaultVoicemailMaxStoredMessages

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -171,9 +171,6 @@ func TestDefaultVoicemailMatchesPhaseOneSpec(t *testing.T) {
 	if v.RingTimeoutSeconds != 20 {
 		t.Errorf("RingTimeoutSeconds default: got %d, want 20", v.RingTimeoutSeconds)
 	}
-	if v.MaxMessageSeconds != 90 {
-		t.Errorf("MaxMessageSeconds default: got %d, want 90", v.MaxMessageSeconds)
-	}
 	if v.MaxStoredMessages != 50 {
 		t.Errorf("MaxStoredMessages default: got %d, want 50", v.MaxStoredMessages)
 	}
@@ -195,7 +192,6 @@ func TestSettingsJSONRoundTripVoicemail(t *testing.T) {
 		Voicemail: Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 30,
-			MaxMessageSeconds:  120,
 			MaxStoredMessages:  75,
 			RetrievalCode:      "#42",
 		},
@@ -218,7 +214,7 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	patch := Settings{Voicemail: Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		// MaxMessageSeconds, MaxStoredMessages, RetrievalCode unset (zero)
+		// MaxStoredMessages, RetrievalCode unset (zero)
 		// should keep defaults from base.
 	}}
 	merged := base.Merge(patch)
@@ -228,9 +224,9 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	if merged.Voicemail.RingTimeoutSeconds != 30 {
 		t.Errorf("RingTimeoutSeconds: got %d, want 30", merged.Voicemail.RingTimeoutSeconds)
 	}
-	if merged.Voicemail.MaxMessageSeconds != DefaultVoicemailMaxMessageSeconds {
-		t.Errorf("MaxMessageSeconds: got %d, want default %d",
-			merged.Voicemail.MaxMessageSeconds, DefaultVoicemailMaxMessageSeconds)
+	if merged.Voicemail.MaxStoredMessages != DefaultVoicemailMaxStoredMessages {
+		t.Errorf("MaxStoredMessages: got %d, want default %d",
+			merged.Voicemail.MaxStoredMessages, DefaultVoicemailMaxStoredMessages)
 	}
 	if merged.Voicemail.RetrievalCode != DefaultVoicemailRetrievalCode {
 		t.Errorf("RetrievalCode: got %q, want default %q",
@@ -250,7 +246,6 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			want: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 20,
-				MaxMessageSeconds:  90,
 				MaxStoredMessages:  50,
 				RetrievalCode:      "*98",
 			},
@@ -260,31 +255,27 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 1,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 20, // 1 < min(5) → default
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 		},
 		{
-			name: "above-max max message reset",
+			name: "above-max ring timeout reset",
 			in: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  600,
+				RingTimeoutSeconds: 600,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  90, // 600 > max(180) → default
+				RingTimeoutSeconds: 20, // 600 > max(60) → default
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
@@ -294,14 +285,12 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  2,
 				RetrievalCode:      "*98",
 			},
 			want: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  50, // 2 < min(5) → default
 				RetrievalCode:      "*98",
 			},
@@ -334,7 +323,6 @@ func TestSettingsNormalizeRetrievalCodeFallback(t *testing.T) {
 	for in, want := range cases {
 		got := (Voicemail{
 			RingTimeoutSeconds: 20,
-			MaxMessageSeconds:  90,
 			MaxStoredMessages:  50,
 			RetrievalCode:      in,
 		}).Normalize().RetrievalCode
@@ -382,5 +370,35 @@ func TestSettingsScanFromEmptyJSONAppliesDefaults(t *testing.T) {
 	want.Enabled = false
 	if merged.Voicemail != want {
 		t.Errorf("empty JSONB merge: got %+v, want %+v", merged.Voicemail, want)
+	}
+}
+
+func TestSettingsUnmarshalIgnoresVestigialMaxMessageKey(t *testing.T) {
+	// Rows written before max_message_seconds was removed still carry the
+	// key in their JSONB. encoding/json drops unknown keys silently, so the
+	// surviving fields must still decode and survive Merge + Normalize.
+	raw := []byte(`{
+		"voice_style": "modern",
+		"voicemail": {
+			"enabled": true,
+			"ring_timeout_seconds": 30,
+			"max_message_seconds": 120,
+			"max_stored_messages": 75,
+			"retrieval_code": "#42"
+		}
+	}`)
+	var patch Settings
+	if err := json.Unmarshal(raw, &patch); err != nil {
+		t.Fatalf("unmarshal legacy row: %v", err)
+	}
+	merged := DefaultSettings().Merge(patch).Normalize()
+	want := Voicemail{
+		Enabled:            true,
+		RingTimeoutSeconds: 30,
+		MaxStoredMessages:  75,
+		RetrievalCode:      "#42",
+	}
+	if merged.Voicemail != want {
+		t.Errorf("legacy row decode: got %+v, want %+v", merged.Voicemail, want)
 	}
 }

--- a/server/internal/signaling/linesettings_test.go
+++ b/server/internal/signaling/linesettings_test.go
@@ -40,7 +40,6 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 			Voicemail: &Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  120,
 				MaxStoredMessages:  75,
 				RetrievalCode:      "#42",
 			},
@@ -56,13 +55,17 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 		`"voicemail":`,
 		`"enabled":true`,
 		`"ring_timeout_seconds":30`,
-		`"max_message_seconds":120`,
 		`"max_stored_messages":75`,
 		`"retrieval_code":"#42"`,
 	} {
 		if !strings.Contains(wire, key) {
 			t.Errorf("wire missing %q in %s", key, wire)
 		}
+	}
+	// The per-message recording cap is fixed in digitsd, not configured
+	// per line, so no max-duration key may ride the wire.
+	if strings.Contains(wire, "max_message_seconds") {
+		t.Errorf("wire must not carry max_message_seconds, got %s", wire)
 	}
 	got, err := ParseMessage(b)
 	if err != nil {
@@ -117,7 +120,6 @@ func TestLineSettingsVoicemailZeroValuesRoundTrip(t *testing.T) {
 	for _, key := range []string{
 		`"enabled":false`,
 		`"ring_timeout_seconds":0`,
-		`"max_message_seconds":0`,
 		`"max_stored_messages":0`,
 		`"retrieval_code":""`,
 	} {

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -26,7 +26,6 @@ func VoicemailFromLine(v line.Voicemail) *Voicemail {
 	return &Voicemail{
 		Enabled:            v.Enabled,
 		RingTimeoutSeconds: v.RingTimeoutSeconds,
-		MaxMessageSeconds:  v.MaxMessageSeconds,
 		MaxStoredMessages:  v.MaxStoredMessages,
 		RetrievalCode:      v.RetrievalCode,
 	}

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -94,12 +94,13 @@ type LineSettings struct {
 // its own.
 //
 // Field names mirror the daemon config keys exactly. The daemon's local
-// config holds RingTimeout/MaxMessageDuration as time.Duration; the wire
-// uses integer seconds and the daemon converts on receipt.
+// config holds RingTimeout as a time.Duration; the wire uses integer seconds
+// and the daemon converts on receipt. The per-message recording cap is not
+// configurable: digitsd enforces a fixed 10-minute limit, so no max-duration
+// field rides the wire.
 type Voicemail struct {
 	Enabled            bool   `json:"enabled"`
 	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxMessageSeconds  int    `json:"max_message_seconds"`
 	MaxStoredMessages  int    `json:"max_stored_messages"`
 	RetrievalCode      string `json:"retrieval_code"`
 }

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -135,7 +135,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		Voicemail: &Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  100,
 			MaxStoredMessages:  40,
 			RetrievalCode:      "*97",
 		},
@@ -163,7 +162,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		want := Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  100,
 			MaxStoredMessages:  40,
 			RetrievalCode:      "*97",
 		}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -623,8 +623,8 @@ func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Reque
 }
 
 // handlePhoneVoicemailPost accepts a form submission with the full voicemail
-// configuration for the line. All five fields are validated server-side
-// before any DB write: out-of-range ints and malformed retrieval codes
+// configuration for the line. Every field is validated server-side before
+// any DB write: out-of-range ints and malformed retrieval codes
 // return 400 with a friendly message so the form can surface it. On success
 // the new settings are persisted and pushed to the device (if connected),
 // then either the voicemail-section partial is swapped (htmx) or the user
@@ -638,11 +638,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	enabled := strings.TrimSpace(r.FormValue("enabled")) == "on"
 	ring, ok := parseClampedInt(w, r, "ring_timeout_seconds",
 		line.VoicemailRingTimeoutMin, line.VoicemailRingTimeoutMax)
-	if !ok {
-		return
-	}
-	maxMsg, ok := parseClampedInt(w, r, "max_message_seconds",
-		line.VoicemailMaxMessageMin, line.VoicemailMaxMessageMax)
 	if !ok {
 		return
 	}
@@ -669,7 +664,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	next.Voicemail = line.Voicemail{
 		Enabled:            enabled,
 		RingTimeoutSeconds: ring,
-		MaxMessageSeconds:  maxMsg,
 		MaxStoredMessages:  maxStored,
 		RetrievalCode:      code,
 	}
@@ -690,10 +684,10 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 }
 
 // handlePhoneVoicemailTogglePost flips Voicemail.Enabled for a line and
-// swaps the detail-page voicemail section. The other four voicemail fields
+// swaps the detail-page voicemail section. The other voicemail fields
 // are preserved through Normalize, which backfills defaults when the row
 // was created before voicemail existed. Path is intentionally separate
-// from the five-field POST so a checkbox-only round-trip does not have to
+// from the full-form POST so a checkbox-only round-trip does not have to
 // resubmit the timing/code fields.
 func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2609,7 +2609,6 @@ func validVoicemailForm() url.Values {
 	return url.Values{
 		"enabled":              {"on"},
 		"ring_timeout_seconds": {"25"},
-		"max_message_seconds":  {"60"},
 		"max_stored_messages":  {"30"},
 		"retrieval_code":       {"*97"},
 	}
@@ -2658,13 +2657,17 @@ func TestPhoneVoicemailValidFormPersistsAndRedirects(t *testing.T) {
 	for _, want := range []string{
 		`"enabled": true`,
 		`"ring_timeout_seconds": 25`,
-		`"max_message_seconds": 60`,
 		`"max_stored_messages": 30`,
 		`"retrieval_code": "*97"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("voicemail JSONB missing %q in %s", want, got)
 		}
+	}
+	// The configurable per-message cap is gone: a new write must not
+	// reintroduce the vestigial key.
+	if strings.Contains(got, "max_message_seconds") {
+		t.Errorf("voicemail JSONB should not carry max_message_seconds, got %s", got)
 	}
 }
 
@@ -2684,24 +2687,6 @@ func TestPhoneVoicemailRingTimeoutOutOfRangeRejected(t *testing.T) {
 			}
 			if !strings.Contains(w.Body.String(), "ring_timeout_seconds") {
 				t.Errorf("400 body should name the field, got %q", w.Body.String())
-			}
-		})
-	}
-}
-
-func TestPhoneVoicemailMaxMessageOutOfRangeRejected(t *testing.T) {
-	h, database, authStore := setupHandler(t)
-	cookie := addSessionCookie(t, authStore)
-	_ = setupVoiceStyleLine(t, h, database, authStore)
-
-	cases := []string{"0", "14", "181", "10000", "x"}
-	for _, val := range cases {
-		t.Run(val, func(t *testing.T) {
-			form := validVoicemailForm()
-			form.Set("max_message_seconds", val)
-			w := postVoicemail(t, h, cookie, form, false)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("max_message_seconds=%q: expected 400, got %d", val, w.Code)
 			}
 		})
 	}
@@ -2804,7 +2789,6 @@ func TestPhoneVoicemailPushesToConnectedDevice(t *testing.T) {
 		want := signaling.Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  60,
 			MaxStoredMessages:  30,
 			RetrievalCode:      "*97",
 		}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -768,16 +768,6 @@
         </div>
 
         <div class="field">
-          <label for="vm-max-message" class="field__label">Max message length (seconds)</label>
-          <input type="number" id="vm-max-message" name="max_message_seconds"
-                 min="15" max="180"
-                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
-                 class="field__input" style="width: 110px;"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
-        </div>
-
-        <div class="field">
           <label for="vm-max-stored" class="field__label">Max stored messages</label>
           <input type="number" id="vm-max-stored" name="max_stored_messages"
                  min="5" max="200"
@@ -843,14 +833,6 @@
           <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
                  min="5" max="60"
                  value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-                 class="am-settings__input"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </div>
-        <div class="am-settings__field">
-          <label for="vm-max-message" class="am-label am-settings__field-label">Max message (sec)</label>
-          <input type="number" id="vm-max-message" name="max_message_seconds"
-                 min="15" max="180"
-                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
                  class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
         </div>


### PR DESCRIPTION
## What

Removes the configurable per-line voicemail max-message-duration setting. Per owner direction, that knob was pointless configurability. The per-message recording cap becomes a fixed 10-minute limit hardcoded in digitsd, so the server no longer stores, validates, or pushes a per-line value.

This is the server side. The digitsd side (fixed `10 * time.Minute` constant, dropping the wire field) is handled separately.

## Changes

- `line.Voicemail`: drop `MaxMessageSeconds` and its constants (`DefaultVoicemailMaxMessageSeconds`, `VoicemailMaxMessageMin`, `VoicemailMaxMessageMax`) plus the `Normalize()` clamp and `Merge()` handling.
- `signaling.Voicemail` wire struct: drop the `max_message_seconds` key so the `line_settings` push no longer carries it. digitsd stops expecting it.
- Phone detail voicemail form (intercom and answering-machine templates): remove the "Max message" input. The enabled toggle, ring timeout, max stored messages, and retrieval code are unchanged.
- Voicemail settings handler (`/phones/{number}/voicemail`): drop the `max_message_seconds` parse and range validation.
- Tests updated: dropped `TestPhoneVoicemailMaxMessageOutOfRangeRejected`, adjusted the JSON round-trip and clamp tests, and added regression coverage that the wire and new JSONB writes never carry `max_message_seconds`.

## JSONB compatibility

`lines.settings` rows written before this change still carry `max_message_seconds`. `encoding/json` drops unknown keys silently, so legacy rows decode cleanly. `TestSettingsUnmarshalIgnoresVestigialMaxMessageKey` pins that behavior. No migration needed: the key is simply vestigial and gets dropped on the next write.

## Wire contract

Coordinated with the digitsd side: server stops emitting `max_message_seconds`, digitsd stops expecting it and hardcodes the 600s cap. Remaining voicemail wire fields are unchanged: `enabled`, `ring_timeout_seconds`, `max_stored_messages`, `retrieval_code`.

## Testing

- `go build ./...` clean
- `go test ./...` passes
- `golangci-lint run ./...`: 0 issues