### PR TITLE
feat(digitsd): fix the voicemail message cap at 10 minutes, drop the setting

### DIFF
--- a/docs/voicemail-guide.md
+++ b/docs/voicemail-guide.md
@@ -103,13 +103,12 @@ the phone simply rings and never auto-answers.
 
 ### The settings form
 
-Open the advanced settings block in the voicemail section to edit four fields.
+Open the advanced settings block in the voicemail section to edit three fields.
 Change what you need, then submit the form to save.
 
 | Field | What it controls | Allowed range |
 |-------|------------------|---------------|
 | Ring timeout | How many seconds a call rings before the answering machine picks up | 5 to 60 seconds |
-| Max message | The longest a single caller message can be | 15 to 180 seconds |
 | Max stored messages | How many messages the phone keeps before the oldest is dropped | 5 to 200 |
 | Retrieval code | The code you dial on the phone to listen to messages | 2 to 6 characters, digits and `*` and `#` only, must include at least one `*` or `#` |
 
@@ -118,7 +117,7 @@ rules, the app rejects the form with a message explaining the limit; nothing is
 saved until the values are valid. A retrieval code cannot be all digits, so it
 can never be mistaken for a real phone number.
 
-When voicemail is disabled, the four fields are dimmed and locked. Turn
+When voicemail is disabled, the three fields are dimmed and locked. Turn
 voicemail on to edit them.
 
 ### The unheard-messages badge
@@ -131,14 +130,16 @@ clear messages on the handset.
 ### When settings take effect
 
 The on/off toggle, ring timeout, and retrieval code apply on the phone's next
-incoming call. The max message length and storage cap apply after the phone
-restarts. If you edit settings while the phone is offline, the phone picks them
-up the next time it connects.
+incoming call. The storage cap applies after the phone restarts. If you edit
+settings while the phone is offline, the phone picks them up the next time it
+connects.
 
 ## Limits and edge cases
 
-- **Message length.** Each message can be up to 90 seconds by default. When a
-  caller reaches the limit, recording stops and the message is saved.
+- **Message length.** A message ends when the caller hangs up. As a backstop
+  for a caller who never hangs up, a single recording is capped at 10 minutes;
+  a caller still talking when the cap is reached hears a beep and the recording
+  is saved. The cap is fixed and not configurable.
 - **Greeting length.** A custom greeting can be up to 60 seconds.
 - **Storage cap.** The phone keeps up to 50 messages by default. When the box
   is full and a new message arrives, the oldest message is deleted to make
@@ -163,10 +164,9 @@ did not finish cleanly the phone falls back to the standard greeting. Dial
 `*97` and record it again, and wait for the "Greeting saved" confirmation
 before hanging up.
 
-**I changed the message limit or storage cap and nothing changed.** The
-maximum message length and the storage cap are read when the phone starts up.
-A change to either takes effect after the phone restarts. The on/off toggle,
-ring timeout, and retrieval code apply right away.
+**I changed the storage cap and nothing changed.** The storage cap is read
+when the phone starts up, so a change to it takes effect after the phone
+restarts. The on/off toggle, ring timeout, and retrieval code apply right away.
 
 **The message-waiting light is pulsing but `*98` says no messages.** The slow
 pulse tracks unheard messages. If you saved or deleted everything, the light

--- a/docs/voicemail.md
+++ b/docs/voicemail.md
@@ -140,8 +140,12 @@ begins at the caller's first word, with no leading greeting-duration silence. A
 caller who hangs up while the greeting is still playing leaves no message at
 all, because the recorder was never armed.
 
-When the recorder reports it has hit the message-duration cap, the daemon
-finalizes the recording and calls `VoicemailRecordEnded()`.
+A message normally ends when the caller hangs up. As a backstop for a caller
+who never does, a single recording is capped at a fixed 10 minutes. The cap is
+not configurable. When the recorder reports it has hit the cap, the daemon
+finalizes the recording, plays the prompt beep to the caller through the
+outbound path (so a runaway recording is not cut to silent dead air), then
+calls `VoicemailRecordEnded()` to hang up.
 
 **Microphone mute is a security property.** The caller must never hear the
 callee's environment while leaving a message. The capture pipeline
@@ -344,7 +348,6 @@ type Settings struct {
 type Voicemail struct {
     Enabled            bool   `json:"enabled"`
     RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-    MaxMessageSeconds  int    `json:"max_message_seconds"`
     MaxStoredMessages  int    `json:"max_stored_messages"`
     RetrievalCode      string `json:"retrieval_code"`
 }
@@ -354,7 +357,7 @@ The inner `Voicemail` fields deliberately omit `omitempty` so a stored row
 carries every field literally; a later read can tell "Enabled was explicitly
 false" apart from "field absent". Time fields are integer seconds in storage
 and on the wire. `line.DefaultVoicemail()` is what a new line starts with:
-`Enabled: true`, ring timeout 20 s, max message 90 s, max stored 50, retrieval
+`Enabled: true`, ring timeout 20 s, max stored 50, retrieval
 code `*98`. `CreateLine` seeds the `settings` column with
 `DefaultSettings().Normalize()` so the non-zero `enabled` default survives the
 DB round trip.
@@ -374,7 +377,6 @@ Bounds are package constants in `line/settings.go`, shared by the HTTP handler,
 | Field | Min | Max | Out-of-range heals to |
 |-------|-----|-----|-----------------------|
 | `ring_timeout_seconds` | 5 | 60 | 20 |
-| `max_message_seconds` | 15 | 180 | 90 |
 | `max_stored_messages` | 5 | 200 | 50 |
 
 The retrieval code must match `^[0-9*#]{2,6}$` (2 to 6 characters, only digits,
@@ -389,16 +391,16 @@ Both endpoints are POST, registered on the authenticated mux in
 failure returns 404, not 403).
 
 - `POST /phones/{number}/voicemail` (`handlePhoneVoicemailPost`) takes the full
-  form of all five settings: the `enabled` checkbox, the three integer fields
-  (`ring_timeout_seconds`, `max_message_seconds`, `max_stored_messages`), and
-  `retrieval_code`. The integers are validated with `parseClampedInt` (400 with
-  a friendly "must be an integer between MIN and MAX" message on a bad value)
-  and the code with `IsValidRetrievalCode` (400 on a malformed code), both
-  before any DB write. On success it builds the new `Voicemail`, runs
-  `Normalize()`, persists, and pushes to the device.
+  form of all four settings: the `enabled` checkbox, the two integer fields
+  (`ring_timeout_seconds`, `max_stored_messages`), and `retrieval_code`. The
+  integers are validated with `parseClampedInt` (400 with a friendly "must be
+  an integer between MIN and MAX" message on a bad value) and the code with
+  `IsValidRetrievalCode` (400 on a malformed code), both before any DB write.
+  On success it builds the new `Voicemail`, runs `Normalize()`, persists, and
+  pushes to the device.
 - `POST /phones/{number}/voicemail-toggle`
   (`handlePhoneVoicemailTogglePost`) flips `Voicemail.Enabled` only and takes no
-  body fields. The other four fields are preserved through `Normalize()`, which
+  body fields. The other three fields are preserved through `Normalize()`, which
   backfills defaults if the row predates voicemail. It is a separate path so a
   checkbox round trip does not have to resubmit the timing and code fields.
 
@@ -438,7 +440,6 @@ part of a line-settings update. The wire types are in
 type Voicemail struct {
     Enabled            bool   `json:"enabled"`
     RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-    MaxMessageSeconds  int    `json:"max_message_seconds"`
     MaxStoredMessages  int    `json:"max_stored_messages"`
     RetrievalCode      string `json:"retrieval_code"`
 }
@@ -480,9 +481,8 @@ at the same time:
 
 - `Enabled`, `RingTimeout`, and `RetrievalCode` are read live, per ring or per
   dial, so a change applies on the next inbound call with no restart.
-- `MaxStoredMessages` and `MaxMessageDuration` are baked into the
-  `voicemail.Store` when it is opened at boot, so a change to either takes
-  effect on the next daemon restart.
+- `MaxStoredMessages` is baked into the `voicemail.Store` when it is opened at
+  boot, so a change to it takes effect on the next daemon restart.
 
 In the other direction the daemon reports its unheard-message count to the
 server with a `voicemail_state` message (`TypeVoicemailState`) carrying
@@ -522,17 +522,17 @@ to dial tone.
 
 ## Limits and defaults
 
-Every configurable bound, defined in `internal/config/config.go`
-(`defaultVoicemail()`) except the greeting cap, which is fixed in
-`internal/voicemail/store.go`.
+Configurable bounds are defined in `internal/config/config.go`
+(`defaultVoicemail()`). The two recording caps are fixed constants in
+`internal/voicemail/store.go`, not configurable.
 
 | Setting | Config field | Default | Notes |
 |---------|--------------|---------|-------|
 | Voicemail enabled | `Enabled` | `true` | Read live; off at boot means the store is never opened |
 | Ring timeout before auto-answer | `RingTimeout` | 20 s | Read live; `0` disables auto-answer |
-| Max message duration | `MaxMessageDuration` | 90 s | Baked into the store at boot |
 | Max stored messages | `MaxStoredMessages` | 50 | Baked into the store at boot; FIFO eviction past the cap |
 | Retrieval code | `RetrievalCode` | `*98` | Read live |
+| Max message duration | `messageMaxDuration` | 10 min | Fixed in `store.go`, not configurable; a backstop for a caller who never hangs up |
 | Max greeting duration | `greetingMaxDuration` | 60 s | Fixed in `store.go`, not configurable |
 
 The config file is `/data/digits/config.json`. Settings pushed from the server
@@ -541,5 +541,5 @@ which need a restart.
 
 These daemon-side values are the defaults. The server clamps user-entered
 values to narrower ranges before they are pushed down (ring timeout 5 to 60 s,
-max message 15 to 180 s, max stored 5 to 200); see Validation ranges under
+max stored 5 to 200); see Validation ranges under
 Server internals.

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -471,9 +471,8 @@ func (d *daemonCallbacks) publishVoicemailStateInitial() {
 //
 // Live consumption: Enabled, RingTimeout and RetrievalCode are read per ring
 // or per dial, so they take effect on the next inbound call without any
-// further wiring. MaxStoredMessages and MaxMessageDuration are baked into the
-// voicemail.Store opened at boot, so changes to those values take effect on
-// the next daemon restart.
+// further wiring. MaxStoredMessages is baked into the voicemail.Store opened
+// at boot, so a change to it takes effect on the next daemon restart.
 func (d *daemonCallbacks) setVoicemailConfig(vm config.Voicemail) error {
 	d.mu.Lock()
 	d.cfg.Voicemail = vm
@@ -1642,8 +1641,7 @@ func main() {
 		vmDir := filepath.Join(filepath.Dir(*configPath), "voicemail")
 		var err error
 		vmStore, err = voicemail.Open(vmDir, voicemail.Options{
-			MaxMessages:        cfg.Voicemail.MaxStoredMessages,
-			MaxMessageDuration: cfg.Voicemail.MaxMessageDuration,
+			MaxMessages: cfg.Voicemail.MaxStoredMessages,
 		})
 		if err != nil {
 			slog.Error("voicemail store open failed", "dir", vmDir, "error", err)
@@ -2479,11 +2477,10 @@ func main() {
 
 				if vm := msg.LineSettings.Voicemail; vm != nil {
 					target := config.Voicemail{
-						Enabled:            vm.Enabled,
-						RingTimeout:        time.Duration(vm.RingTimeoutSeconds) * time.Second,
-						MaxMessageDuration: time.Duration(vm.MaxMessageSeconds) * time.Second,
-						MaxStoredMessages:  vm.MaxStoredMessages,
-						RetrievalCode:      vm.RetrievalCode,
+						Enabled:           vm.Enabled,
+						RingTimeout:       time.Duration(vm.RingTimeoutSeconds) * time.Second,
+						MaxStoredMessages: vm.MaxStoredMessages,
+						RetrievalCode:     vm.RetrievalCode,
 					}
 					cb.mu.Lock()
 					current := cb.cfg.Voicemail
@@ -2495,9 +2492,6 @@ func main() {
 						}
 						if target.RingTimeout != current.RingTimeout {
 							slog.Info("line_settings applied", "voicemail_ring_timeout", target.RingTimeout)
-						}
-						if target.MaxMessageDuration != current.MaxMessageDuration {
-							slog.Info("line_settings applied", "voicemail_max_message_duration", target.MaxMessageDuration)
 						}
 						if target.MaxStoredMessages != current.MaxStoredMessages {
 							slog.Info("line_settings applied", "voicemail_max_stored_messages", target.MaxStoredMessages)

--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -332,11 +332,10 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 	}
 	// Defaults at startup.
 	wantDefault := config.Voicemail{
-		Enabled:            true,
-		RingTimeout:        20 * time.Second,
-		MaxMessageDuration: 90 * time.Second,
-		MaxStoredMessages:  50,
-		RetrievalCode:      "*98",
+		Enabled:           true,
+		RingTimeout:       20 * time.Second,
+		MaxStoredMessages: 50,
+		RetrievalCode:     "*98",
 	}
 	if cfg.Voicemail != wantDefault {
 		t.Fatalf("unexpected default voicemail config: %+v", cfg.Voicemail)
@@ -344,11 +343,10 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 
 	d := &daemonCallbacks{cfg: cfg}
 	target := config.Voicemail{
-		Enabled:            true,
-		RingTimeout:        25 * time.Second,
-		MaxMessageDuration: 120 * time.Second,
-		MaxStoredMessages:  40,
-		RetrievalCode:      "*97",
+		Enabled:           true,
+		RingTimeout:       25 * time.Second,
+		MaxStoredMessages: 40,
+		RetrievalCode:     "*97",
 	}
 	if err := d.setVoicemailConfig(target); err != nil {
 		t.Fatalf("setVoicemailConfig: %v", err)
@@ -534,23 +532,20 @@ func TestLineSettingsVoicemailConversion(t *testing.T) {
 	wire := &sigclient.Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		MaxMessageSeconds:  180,
 		MaxStoredMessages:  25,
 		RetrievalCode:      "*98",
 	}
 	got := config.Voicemail{
-		Enabled:            wire.Enabled,
-		RingTimeout:        time.Duration(wire.RingTimeoutSeconds) * time.Second,
-		MaxMessageDuration: time.Duration(wire.MaxMessageSeconds) * time.Second,
-		MaxStoredMessages:  wire.MaxStoredMessages,
-		RetrievalCode:      wire.RetrievalCode,
+		Enabled:           wire.Enabled,
+		RingTimeout:       time.Duration(wire.RingTimeoutSeconds) * time.Second,
+		MaxStoredMessages: wire.MaxStoredMessages,
+		RetrievalCode:     wire.RetrievalCode,
 	}
 	want := config.Voicemail{
-		Enabled:            true,
-		RingTimeout:        30 * time.Second,
-		MaxMessageDuration: 180 * time.Second,
-		MaxStoredMessages:  25,
-		RetrievalCode:      "*98",
+		Enabled:           true,
+		RingTimeout:       30 * time.Second,
+		MaxStoredMessages: 25,
+		RetrievalCode:     "*98",
 	}
 	if got != want {
 		t.Errorf("voicemail wire->config: got %+v, want %+v", got, want)

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -364,7 +364,7 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 					if err != nil {
 						slog.Warn("voicemail: append frame failed", "caller", caller, "error", err)
 					} else if atCap {
-						slog.Info("voicemail: max duration reached", "caller", caller)
+						slog.Info("voicemail: max duration reached, beeping caller", "caller", caller)
 						d.recorderMu.Lock()
 						if d.recorder != nil {
 							if _, err := d.recorder.Finalize(); err != nil {
@@ -373,6 +373,20 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 							d.recorder = nil
 						}
 						d.recorderMu.Unlock()
+						// Beep the caller before hanging up so a runaway
+						// recording that hits the 10-minute cap is not dropped
+						// into silent dead air. The local mic is muted during
+						// recording, but PlayGreetingBeep injects into the
+						// outbound beep slot, so the caller hears it. The sleep
+						// lets the beep drain before VoicemailRecordEnded tears
+						// the call down.
+						d.mu.Lock()
+						pipeline := d.pipeline
+						d.mu.Unlock()
+						if pipeline != nil {
+							pipeline.PlayGreetingBeep(500 * time.Millisecond)
+							time.Sleep(600 * time.Millisecond)
+						}
 						go d.VoicemailRecordEnded()
 						return
 					}

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -42,10 +42,6 @@ type Voicemail struct {
 	// classic answering machines (~20s on 5Hz cadence).
 	RingTimeout time.Duration `json:"ring_timeout"`
 
-	// MaxMessageDuration caps a single recording. Once hit, the recording is
-	// finalized and the call is hung up.
-	MaxMessageDuration time.Duration `json:"max_message_duration"`
-
 	// MaxStoredMessages caps the on-disk archive. Oldest messages are evicted
 	// FIFO once the cap is exceeded.
 	MaxStoredMessages int `json:"max_stored_messages"`
@@ -124,11 +120,10 @@ func defaultWiFiFallback() WiFiFallback {
 // source of truth used by Default() and the Load path.
 func defaultVoicemail() Voicemail {
 	return Voicemail{
-		Enabled:            true,
-		RingTimeout:        20 * time.Second,
-		MaxMessageDuration: 90 * time.Second,
-		MaxStoredMessages:  50,
-		RetrievalCode:      "*98",
+		Enabled:           true,
+		RingTimeout:       20 * time.Second,
+		MaxStoredMessages: 50,
+		RetrievalCode:     "*98",
 	}
 }
 

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -155,7 +155,6 @@ type LineSettings struct {
 type Voicemail struct {
 	Enabled            bool   `json:"enabled"`
 	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxMessageSeconds  int    `json:"max_message_seconds"`
 	MaxStoredMessages  int    `json:"max_stored_messages"`
 	RetrievalCode      string `json:"retrieval_code"`
 }

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -314,7 +314,6 @@ func TestLineSettingsVoicemailRoundTrip(t *testing.T) {
 			Voicemail: &Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 25,
-				MaxMessageSeconds:  120,
 				MaxStoredMessages:  40,
 				RetrievalCode:      "*98",
 			},
@@ -330,7 +329,6 @@ func TestLineSettingsVoicemailRoundTrip(t *testing.T) {
 		`"voicemail":`,
 		`"enabled":true`,
 		`"ring_timeout_seconds":25`,
-		`"max_message_seconds":120`,
 		`"max_stored_messages":40`,
 		`"retrieval_code":"*98"`,
 	} {
@@ -413,7 +411,7 @@ func TestVoicemailStateZeroNotOmitted(t *testing.T) {
 func TestLineSettingsVoicemailZeroValuesParse(t *testing.T) {
 	// Server may push enabled=false with zero ints; receiver must accept it
 	// as an authoritative full-replacement payload, not silently drop fields.
-	raw := []byte(`{"type":"line_settings","line_settings":{"voicemail":{"enabled":false,"ring_timeout_seconds":0,"max_message_seconds":0,"max_stored_messages":0,"retrieval_code":""}}}`)
+	raw := []byte(`{"type":"line_settings","line_settings":{"voicemail":{"enabled":false,"ring_timeout_seconds":0,"max_stored_messages":0,"retrieval_code":""}}}`)
 	msg, err := ParseMessage(raw)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -422,7 +420,7 @@ func TestLineSettingsVoicemailZeroValuesParse(t *testing.T) {
 		t.Fatalf("expected non-nil voicemail block, got %+v", msg.LineSettings)
 	}
 	vm := msg.LineSettings.Voicemail
-	if vm.Enabled || vm.RingTimeoutSeconds != 0 || vm.MaxMessageSeconds != 0 ||
+	if vm.Enabled || vm.RingTimeoutSeconds != 0 ||
 		vm.MaxStoredMessages != 0 || vm.RetrievalCode != "" {
 		t.Errorf("zero-value parse mismatch: %+v", *vm)
 	}

--- a/pi/digitsd/internal/voicemail/store.go
+++ b/pi/digitsd/internal/voicemail/store.go
@@ -38,14 +38,16 @@ const greetingFile = "greeting.frames"
 // greetingMaxDuration caps how long a greeting recording can run.
 const greetingMaxDuration = 60 * time.Second
 
+// messageMaxDuration is the fixed cap on a single inbound voicemail recording.
+// It is a generous backstop for a caller who never hangs up: a normal message
+// ends when the caller hangs up, well under this. Not configurable.
+const messageMaxDuration = 10 * time.Minute
+
 // Options controls store retention.
 type Options struct {
 	// MaxMessages caps the number of stored messages. When exceeded, the
 	// oldest are deleted (FIFO). Zero disables the cap.
 	MaxMessages int
-	// MaxMessageDuration caps a single recording. Zero disables the cap;
-	// the recorder will accept frames indefinitely until Finalize.
-	MaxMessageDuration time.Duration
 	// Now is injected for tests. Defaults to time.Now.
 	Now func() time.Time
 }
@@ -226,7 +228,7 @@ func (s *Store) BeginRecording() (*Recorder, error) {
 		tmpPath:  tmpPath,
 		finalPath: framesPath,
 		file:     f,
-		maxFrames: framesForDuration(s.opts.MaxMessageDuration),
+		maxFrames: framesForDuration(messageMaxDuration),
 	}, nil
 }
 

--- a/pi/digitsd/internal/voicemail/store_test.go
+++ b/pi/digitsd/internal/voicemail/store_test.go
@@ -185,20 +185,26 @@ func TestFIFOEviction(t *testing.T) {
 	}
 }
 
-func TestMaxMessageDurationCap(t *testing.T) {
-	s := newTestStore(t, Options{MaxMessageDuration: 60 * time.Millisecond})
+func TestMessageMaxDurationCap(t *testing.T) {
+	s := newTestStore(t, Options{})
 	r, err := s.BeginRecording()
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 3 frames * 20ms = 60ms => atCap on the third.
-	for i := 0; i < 2; i++ {
-		atCap, err := r.AppendFrame([]byte{byte(i)})
+	// The message cap is the fixed messageMaxDuration constant, no longer
+	// configurable. Every frame up to the cap reports atCap=false; the
+	// cap-th frame reports true.
+	capFrames := framesForDuration(messageMaxDuration)
+	if capFrames <= 0 {
+		t.Fatalf("expected a positive frame cap, got %d", capFrames)
+	}
+	for i := 0; i < capFrames-1; i++ {
+		atCap, err := r.AppendFrame([]byte{0x01})
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("frame %d: %v", i, err)
 		}
 		if atCap {
-			t.Errorf("frame %d reported atCap early", i)
+			t.Fatalf("frame %d reported atCap before the %d-frame cap", i, capFrames)
 		}
 	}
 	atCap, err := r.AppendFrame([]byte{0xff})
@@ -206,7 +212,7 @@ func TestMaxMessageDurationCap(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !atCap {
-		t.Errorf("expected atCap=true on 3rd frame")
+		t.Errorf("expected atCap=true on the cap-th frame (%d)", capFrames)
 	}
 	if _, err := r.Finalize(); err != nil {
 		t.Fatal(err)

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -77,12 +77,12 @@ test.describe('Voicemail (intercom theme)', () => {
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
     await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
 
-    // Advanced should be collapsed by default; the 4 fields are hidden until expanded.
+    // Advanced should be collapsed by default; the detail fields are hidden until expanded.
     const ringField = page.locator('#voicemail-section input[name="ring_timeout_seconds"]');
     await expect(ringField).not.toBeVisible();
   });
 
-  test('expanding Advanced reveals all four detail fields', async ({ page }) => {
+  test('expanding Advanced reveals all detail fields', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -92,9 +92,10 @@ test.describe('Voicemail (intercom theme)', () => {
 
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
+    // The per-message recording cap is fixed in digitsd, so no field for it.
+    await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toHaveCount(0);
   });
 
   test('checkbox toggle swaps section partial and persists', async ({ page }) => {
@@ -139,7 +140,6 @@ test.describe('Voicemail (intercom theme)', () => {
     // Expand Advanced and edit.
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
-    await page.locator('#voicemail-section input[name="max_message_seconds"]').fill('100');
     await page.locator('#voicemail-section input[name="max_stored_messages"]').fill('25');
     await page.locator('#voicemail-section input[name="retrieval_code"]').fill('*99');
 
@@ -180,7 +180,6 @@ test.describe('Voicemail (intercom theme)', () => {
       form: {
         enabled: 'on',
         ring_timeout_seconds: '20',
-        max_message_seconds: '90',
         max_stored_messages: '50',
         retrieval_code: '12345',
       },

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -17,13 +17,10 @@ const (
 const (
 	VoicemailRingTimeoutMin = 5
 	VoicemailRingTimeoutMax = 60
-	VoicemailMaxMessageMin  = 15
-	VoicemailMaxMessageMax  = 180
 	VoicemailMaxStoredMin   = 5
 	VoicemailMaxStoredMax   = 200
 
 	DefaultVoicemailRingTimeoutSeconds = 20
-	DefaultVoicemailMaxMessageSeconds  = 90
 	DefaultVoicemailMaxStoredMessages  = 50
 	DefaultVoicemailRetrievalCode      = "*98"
 )
@@ -53,7 +50,6 @@ func IsValidRetrievalCode(code string) bool {
 type Voicemail struct {
 	Enabled            bool   `json:"enabled"`
 	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxMessageSeconds  int    `json:"max_message_seconds"`
 	MaxStoredMessages  int    `json:"max_stored_messages"`
 	RetrievalCode      string `json:"retrieval_code"`
 }
@@ -79,7 +75,6 @@ func DefaultVoicemail() Voicemail {
 	return Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: DefaultVoicemailRingTimeoutSeconds,
-		MaxMessageSeconds:  DefaultVoicemailMaxMessageSeconds,
 		MaxStoredMessages:  DefaultVoicemailMaxStoredMessages,
 		RetrievalCode:      DefaultVoicemailRetrievalCode,
 	}
@@ -104,9 +99,6 @@ func (v Voicemail) Merge(patch Voicemail) Voicemail {
 	if patch.RingTimeoutSeconds != 0 {
 		v.RingTimeoutSeconds = patch.RingTimeoutSeconds
 	}
-	if patch.MaxMessageSeconds != 0 {
-		v.MaxMessageSeconds = patch.MaxMessageSeconds
-	}
 	if patch.MaxStoredMessages != 0 {
 		v.MaxStoredMessages = patch.MaxStoredMessages
 	}
@@ -118,14 +110,11 @@ func (v Voicemail) Merge(patch Voicemail) Voicemail {
 
 // Normalize substitutes the default value for any field that is zero or out
 // of the allowed range. Defense in depth so corrupt on-disk data can never
-// propagate to the daemon (which would, for instance, refuse to record a
-// message if MaxMessageSeconds is zero).
+// propagate to the daemon (which would, for instance, never pick up if
+// RingTimeoutSeconds is zero).
 func (v Voicemail) Normalize() Voicemail {
 	if v.RingTimeoutSeconds < VoicemailRingTimeoutMin || v.RingTimeoutSeconds > VoicemailRingTimeoutMax {
 		v.RingTimeoutSeconds = DefaultVoicemailRingTimeoutSeconds
-	}
-	if v.MaxMessageSeconds < VoicemailMaxMessageMin || v.MaxMessageSeconds > VoicemailMaxMessageMax {
-		v.MaxMessageSeconds = DefaultVoicemailMaxMessageSeconds
 	}
 	if v.MaxStoredMessages < VoicemailMaxStoredMin || v.MaxStoredMessages > VoicemailMaxStoredMax {
 		v.MaxStoredMessages = DefaultVoicemailMaxStoredMessages

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -171,9 +171,6 @@ func TestDefaultVoicemailMatchesPhaseOneSpec(t *testing.T) {
 	if v.RingTimeoutSeconds != 20 {
 		t.Errorf("RingTimeoutSeconds default: got %d, want 20", v.RingTimeoutSeconds)
 	}
-	if v.MaxMessageSeconds != 90 {
-		t.Errorf("MaxMessageSeconds default: got %d, want 90", v.MaxMessageSeconds)
-	}
 	if v.MaxStoredMessages != 50 {
 		t.Errorf("MaxStoredMessages default: got %d, want 50", v.MaxStoredMessages)
 	}
@@ -195,7 +192,6 @@ func TestSettingsJSONRoundTripVoicemail(t *testing.T) {
 		Voicemail: Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 30,
-			MaxMessageSeconds:  120,
 			MaxStoredMessages:  75,
 			RetrievalCode:      "#42",
 		},
@@ -218,7 +214,7 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	patch := Settings{Voicemail: Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		// MaxMessageSeconds, MaxStoredMessages, RetrievalCode unset (zero)
+		// MaxStoredMessages, RetrievalCode unset (zero)
 		// should keep defaults from base.
 	}}
 	merged := base.Merge(patch)
@@ -228,9 +224,9 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	if merged.Voicemail.RingTimeoutSeconds != 30 {
 		t.Errorf("RingTimeoutSeconds: got %d, want 30", merged.Voicemail.RingTimeoutSeconds)
 	}
-	if merged.Voicemail.MaxMessageSeconds != DefaultVoicemailMaxMessageSeconds {
-		t.Errorf("MaxMessageSeconds: got %d, want default %d",
-			merged.Voicemail.MaxMessageSeconds, DefaultVoicemailMaxMessageSeconds)
+	if merged.Voicemail.MaxStoredMessages != DefaultVoicemailMaxStoredMessages {
+		t.Errorf("MaxStoredMessages: got %d, want default %d",
+			merged.Voicemail.MaxStoredMessages, DefaultVoicemailMaxStoredMessages)
 	}
 	if merged.Voicemail.RetrievalCode != DefaultVoicemailRetrievalCode {
 		t.Errorf("RetrievalCode: got %q, want default %q",
@@ -250,7 +246,6 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			want: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 20,
-				MaxMessageSeconds:  90,
 				MaxStoredMessages:  50,
 				RetrievalCode:      "*98",
 			},
@@ -260,31 +255,27 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 1,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 20, // 1 < min(5) → default
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 		},
 		{
-			name: "above-max max message reset",
+			name: "above-max ring timeout reset",
 			in: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  600,
+				RingTimeoutSeconds: 600,
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  90, // 600 > max(180) → default
+				RingTimeoutSeconds: 20, // 600 > max(60) → default
 				MaxStoredMessages:  10,
 				RetrievalCode:      "*99",
 			},
@@ -294,14 +285,12 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  2,
 				RetrievalCode:      "*98",
 			},
 			want: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  60,
 				MaxStoredMessages:  50, // 2 < min(5) → default
 				RetrievalCode:      "*98",
 			},
@@ -334,7 +323,6 @@ func TestSettingsNormalizeRetrievalCodeFallback(t *testing.T) {
 	for in, want := range cases {
 		got := (Voicemail{
 			RingTimeoutSeconds: 20,
-			MaxMessageSeconds:  90,
 			MaxStoredMessages:  50,
 			RetrievalCode:      in,
 		}).Normalize().RetrievalCode
@@ -382,5 +370,35 @@ func TestSettingsScanFromEmptyJSONAppliesDefaults(t *testing.T) {
 	want.Enabled = false
 	if merged.Voicemail != want {
 		t.Errorf("empty JSONB merge: got %+v, want %+v", merged.Voicemail, want)
+	}
+}
+
+func TestSettingsUnmarshalIgnoresVestigialMaxMessageKey(t *testing.T) {
+	// Rows written before max_message_seconds was removed still carry the
+	// key in their JSONB. encoding/json drops unknown keys silently, so the
+	// surviving fields must still decode and survive Merge + Normalize.
+	raw := []byte(`{
+		"voice_style": "modern",
+		"voicemail": {
+			"enabled": true,
+			"ring_timeout_seconds": 30,
+			"max_message_seconds": 120,
+			"max_stored_messages": 75,
+			"retrieval_code": "#42"
+		}
+	}`)
+	var patch Settings
+	if err := json.Unmarshal(raw, &patch); err != nil {
+		t.Fatalf("unmarshal legacy row: %v", err)
+	}
+	merged := DefaultSettings().Merge(patch).Normalize()
+	want := Voicemail{
+		Enabled:            true,
+		RingTimeoutSeconds: 30,
+		MaxStoredMessages:  75,
+		RetrievalCode:      "#42",
+	}
+	if merged.Voicemail != want {
+		t.Errorf("legacy row decode: got %+v, want %+v", merged.Voicemail, want)
 	}
 }

--- a/server/internal/signaling/linesettings_test.go
+++ b/server/internal/signaling/linesettings_test.go
@@ -40,7 +40,6 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 			Voicemail: &Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 30,
-				MaxMessageSeconds:  120,
 				MaxStoredMessages:  75,
 				RetrievalCode:      "#42",
 			},
@@ -56,13 +55,17 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 		`"voicemail":`,
 		`"enabled":true`,
 		`"ring_timeout_seconds":30`,
-		`"max_message_seconds":120`,
 		`"max_stored_messages":75`,
 		`"retrieval_code":"#42"`,
 	} {
 		if !strings.Contains(wire, key) {
 			t.Errorf("wire missing %q in %s", key, wire)
 		}
+	}
+	// The per-message recording cap is fixed in digitsd, not configured
+	// per line, so no max-duration key may ride the wire.
+	if strings.Contains(wire, "max_message_seconds") {
+		t.Errorf("wire must not carry max_message_seconds, got %s", wire)
 	}
 	got, err := ParseMessage(b)
 	if err != nil {
@@ -117,7 +120,6 @@ func TestLineSettingsVoicemailZeroValuesRoundTrip(t *testing.T) {
 	for _, key := range []string{
 		`"enabled":false`,
 		`"ring_timeout_seconds":0`,
-		`"max_message_seconds":0`,
 		`"max_stored_messages":0`,
 		`"retrieval_code":""`,
 	} {

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -26,7 +26,6 @@ func VoicemailFromLine(v line.Voicemail) *Voicemail {
 	return &Voicemail{
 		Enabled:            v.Enabled,
 		RingTimeoutSeconds: v.RingTimeoutSeconds,
-		MaxMessageSeconds:  v.MaxMessageSeconds,
 		MaxStoredMessages:  v.MaxStoredMessages,
 		RetrievalCode:      v.RetrievalCode,
 	}

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -94,12 +94,13 @@ type LineSettings struct {
 // its own.
 //
 // Field names mirror the daemon config keys exactly. The daemon's local
-// config holds RingTimeout/MaxMessageDuration as time.Duration; the wire
-// uses integer seconds and the daemon converts on receipt.
+// config holds RingTimeout as a time.Duration; the wire uses integer seconds
+// and the daemon converts on receipt. The per-message recording cap is not
+// configurable: digitsd enforces a fixed 10-minute limit, so no max-duration
+// field rides the wire.
 type Voicemail struct {
 	Enabled            bool   `json:"enabled"`
 	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxMessageSeconds  int    `json:"max_message_seconds"`
 	MaxStoredMessages  int    `json:"max_stored_messages"`
 	RetrievalCode      string `json:"retrieval_code"`
 }

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -135,7 +135,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		Voicemail: &Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  100,
 			MaxStoredMessages:  40,
 			RetrievalCode:      "*97",
 		},
@@ -163,7 +162,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		want := Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  100,
 			MaxStoredMessages:  40,
 			RetrievalCode:      "*97",
 		}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -623,8 +623,8 @@ func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Reque
 }
 
 // handlePhoneVoicemailPost accepts a form submission with the full voicemail
-// configuration for the line. All five fields are validated server-side
-// before any DB write: out-of-range ints and malformed retrieval codes
+// configuration for the line. Every field is validated server-side before
+// any DB write: out-of-range ints and malformed retrieval codes
 // return 400 with a friendly message so the form can surface it. On success
 // the new settings are persisted and pushed to the device (if connected),
 // then either the voicemail-section partial is swapped (htmx) or the user
@@ -638,11 +638,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	enabled := strings.TrimSpace(r.FormValue("enabled")) == "on"
 	ring, ok := parseClampedInt(w, r, "ring_timeout_seconds",
 		line.VoicemailRingTimeoutMin, line.VoicemailRingTimeoutMax)
-	if !ok {
-		return
-	}
-	maxMsg, ok := parseClampedInt(w, r, "max_message_seconds",
-		line.VoicemailMaxMessageMin, line.VoicemailMaxMessageMax)
 	if !ok {
 		return
 	}
@@ -669,7 +664,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	next.Voicemail = line.Voicemail{
 		Enabled:            enabled,
 		RingTimeoutSeconds: ring,
-		MaxMessageSeconds:  maxMsg,
 		MaxStoredMessages:  maxStored,
 		RetrievalCode:      code,
 	}
@@ -690,10 +684,10 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 }
 
 // handlePhoneVoicemailTogglePost flips Voicemail.Enabled for a line and
-// swaps the detail-page voicemail section. The other four voicemail fields
+// swaps the detail-page voicemail section. The other voicemail fields
 // are preserved through Normalize, which backfills defaults when the row
 // was created before voicemail existed. Path is intentionally separate
-// from the five-field POST so a checkbox-only round-trip does not have to
+// from the full-form POST so a checkbox-only round-trip does not have to
 // resubmit the timing/code fields.
 func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2609,7 +2609,6 @@ func validVoicemailForm() url.Values {
 	return url.Values{
 		"enabled":              {"on"},
 		"ring_timeout_seconds": {"25"},
-		"max_message_seconds":  {"60"},
 		"max_stored_messages":  {"30"},
 		"retrieval_code":       {"*97"},
 	}
@@ -2658,13 +2657,17 @@ func TestPhoneVoicemailValidFormPersistsAndRedirects(t *testing.T) {
 	for _, want := range []string{
 		`"enabled": true`,
 		`"ring_timeout_seconds": 25`,
-		`"max_message_seconds": 60`,
 		`"max_stored_messages": 30`,
 		`"retrieval_code": "*97"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("voicemail JSONB missing %q in %s", want, got)
 		}
+	}
+	// The configurable per-message cap is gone: a new write must not
+	// reintroduce the vestigial key.
+	if strings.Contains(got, "max_message_seconds") {
+		t.Errorf("voicemail JSONB should not carry max_message_seconds, got %s", got)
 	}
 }
 
@@ -2684,24 +2687,6 @@ func TestPhoneVoicemailRingTimeoutOutOfRangeRejected(t *testing.T) {
 			}
 			if !strings.Contains(w.Body.String(), "ring_timeout_seconds") {
 				t.Errorf("400 body should name the field, got %q", w.Body.String())
-			}
-		})
-	}
-}
-
-func TestPhoneVoicemailMaxMessageOutOfRangeRejected(t *testing.T) {
-	h, database, authStore := setupHandler(t)
-	cookie := addSessionCookie(t, authStore)
-	_ = setupVoiceStyleLine(t, h, database, authStore)
-
-	cases := []string{"0", "14", "181", "10000", "x"}
-	for _, val := range cases {
-		t.Run(val, func(t *testing.T) {
-			form := validVoicemailForm()
-			form.Set("max_message_seconds", val)
-			w := postVoicemail(t, h, cookie, form, false)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("max_message_seconds=%q: expected 400, got %d", val, w.Code)
 			}
 		})
 	}
@@ -2804,7 +2789,6 @@ func TestPhoneVoicemailPushesToConnectedDevice(t *testing.T) {
 		want := signaling.Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxMessageSeconds:  60,
 			MaxStoredMessages:  30,
 			RetrievalCode:      "*97",
 		}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -768,16 +768,6 @@
         </div>
 
         <div class="field">
-          <label for="vm-max-message" class="field__label">Max message length (seconds)</label>
-          <input type="number" id="vm-max-message" name="max_message_seconds"
-                 min="15" max="180"
-                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
-                 class="field__input" style="width: 110px;"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">15 to 180 seconds per recording.</span>
-        </div>
-
-        <div class="field">
           <label for="vm-max-stored" class="field__label">Max stored messages</label>
           <input type="number" id="vm-max-stored" name="max_stored_messages"
                  min="5" max="200"
@@ -843,14 +833,6 @@
           <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
                  min="5" max="60"
                  value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-                 class="am-settings__input"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </div>
-        <div class="am-settings__field">
-          <label for="vm-max-message" class="am-label am-settings__field-label">Max message (sec)</label>
-          <input type="number" id="vm-max-message" name="max_message_seconds"
-                 min="15" max="180"
-                 value="{{.Line.Settings.Voicemail.MaxMessageSeconds}}"
                  class="am-settings__input"
                  {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
         </div>


### PR DESCRIPTION
## Summary

The per-line max-message-duration voicemail setting is removed. It was pointless configurability: a message ends when the caller hangs up, and the duration cap is only a backstop for a caller who never does. A fixed, generous cap covers that without a knob nobody needs to turn.

- `internal/voicemail/store.go`: new fixed package constant `messageMaxDuration` = 10 minutes; the `Options.MaxMessageDuration` field is gone and `BeginRecording` caps the recorder at the constant, mirroring how greeting recording already uses `greetingMaxDuration`.
- `internal/config/config.go`: the `MaxMessageDuration` field is removed from the `Voicemail` config struct and from `defaultVoicemail()`.
- `internal/signal/protocol.go`: `max_message_seconds` is dropped from the wire voicemail-settings struct.
- `cmd/digitsd/main.go`: the `line_settings` receiver no longer reads or applies a max-message value; the voicemail store opens with only `MaxStoredMessages`.
- `cmd/digitsd/voicemail.go`: when an inbound recording hits the 10-minute cap, the caller now hears the prompt beep before the call is hung up, so a runaway recording is not dropped into silent dead air.
- Docs: `voicemail.md` and `voicemail-guide.md` updated for the fixed 10-minute cap and the cap beep; the configurable 15-180s language is removed.

Recording-ends-on-caller-hangup is unchanged.

## Coordination

The wire-contract change (dropping `max_message_seconds` from the `line_settings` voicemail payload) is paired with the server-side removal in task #22. `encoding/json` ignores unknown fields, so the two sides need no flag-day and can land in either order.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all pass
- [x] `TestMessageMaxDurationCap` reworked to the fixed constant
- [ ] Hardware: leave a normal voicemail, hang up, confirm it saves and ends cleanly (unchanged path)
- [ ] Hardware: a recording that runs to the cap plays a beep to the caller before the call drops