### PR TITLE
refactor(server): extract shared SSE stream setup into startSSE

### DIFF
--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -165,19 +165,10 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 		return
 	}
 
-	flusher, ok := w.(http.Flusher)
+	flusher, ok := startSSE(w, r)
 	if !ok {
-		slog.ErrorContext(r.Context(), "SSE conference stream: ResponseWriter does not implement Flusher")
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
 
 	var linkedIndex map[string]string
 	if primaryHH != nil {

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -40,19 +40,10 @@ func (h *Handler) handleDashboardStream(w http.ResponseWriter, r *http.Request) 
 	}
 	hh := h.activeHousehold(r)
 
-	flusher, ok := w.(http.Flusher)
+	flusher, ok := startSSE(w, r)
 	if !ok {
-		slog.ErrorContext(r.Context(), "dashboard SSE: ResponseWriter does not implement Flusher")
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
 
 	if err := h.writeDashStatus(w, flusher, r, hh); err != nil {
 		return

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -168,19 +168,10 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	flusher, ok := w.(http.Flusher)
+	flusher, ok := startSSE(w, r)
 	if !ok {
-		slog.ErrorContext(r.Context(), "SSE stream: ResponseWriter does not implement Flusher")
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
 
 	// Compute the linked-families index once at subscribe time. It can't
 	// change mid-call (household membership changes don't retroactively
@@ -221,6 +212,27 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 			flusher.Flush()
 		}
 	}
+}
+
+// startSSE asserts that w supports flushing, writes the standard
+// Server-Sent Events response headers, and flushes them so the client sees
+// the stream open immediately. On success it returns the flusher with
+// ok=true; on failure it has already written a 500 response and the caller
+// must return without writing further.
+func startSSE(w http.ResponseWriter, r *http.Request) (http.Flusher, bool) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		slog.ErrorContext(r.Context(), "SSE: ResponseWriter does not implement Flusher")
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return nil, false
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+	return flusher, true
 }
 
 // writeSSE emits one SSE event frame: "event: <name>\ndata: <data>\n\n".


### PR DESCRIPTION
## What

Three SSE handlers (`handleCallLinkHealthStream`, `handleConferenceLinkHealthStream`, `handleDashboardStream`) each opened with the same boilerplate: assert the `ResponseWriter` is an `http.Flusher`, write the four standard `text/event-stream` headers, `WriteHeader(200)`, and an initial `Flush()`. The blocks were byte-identical apart from the log message string.

## Change

Added one `startSSE(w, r) (http.Flusher, bool)` helper next to the existing `writeSSE` primitive in `handler_linkhealth.go`. Each handler now calls it and bails on `ok == false` (the helper has already written the 500 response).

- `handler_linkhealth.go`: add `startSSE`; call it in `handleCallLinkHealthStream`.
- `handler_conference_linkhealth.go`: call `startSSE` in `handleConferenceLinkHealthStream`.
- `handler_dashboard_stream.go`: call `startSSE` in `handleDashboardStream`.

Net: 3 copies of a 13-line block collapsed to one definition plus three 3-line call sites. The per-handler log prefix ("SSE stream" / "SSE conference stream" / "dashboard SSE") is dropped in favor of a single generic message; the missing-`Flusher` case is a server/runtime misconfiguration, not stream-specific, so the prefix carried no diagnostic value.

## Testing

- `go build ./...` clean
- `go test ./...` passes
- `golangci-lint run ./...`: 0 issues
