### PR TITLE
feat(server,digitsd): remove max-stored-messages and retrieval-code settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,12 @@ Always include `--env-file .env.prod`. A bare `docker compose up` creates a sepa
 
 **Commits.** Conventional commit format with required scope. PR titles must use this format (they become the squash commit message on merge); individual commits on feature branches don't need to. Valid scopes: `pi`, `digitsd`, `firmware`, `server`, `image`, `docs`, `ci`.
 
+Type selection matters for release automation. `feat` and `fix` trigger releases; `refactor` does not. The deciding question: **does the user or the device see a difference?** If yes, it is `feat` (adding/removing behavior) or `fix` (correcting behavior), never `refactor`. Removing a UI field, dropping a wire protocol field, changing a default: all user-visible, all `feat`. `refactor` is strictly for internal restructuring where the external contract is unchanged.
+
 ```
 fix(server): handle NULL line_id in device lookup
 feat(digitsd): add volume service code
+feat(server): remove the max-message-duration setting
 docs: update wiring notes
 ```
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1641,7 +1641,7 @@ func main() {
 		vmDir := filepath.Join(filepath.Dir(*configPath), "voicemail")
 		var err error
 		vmStore, err = voicemail.Open(vmDir, voicemail.Options{
-			MaxMessages: cfg.Voicemail.MaxStoredMessages,
+			MaxMessages: config.VoicemailMaxStoredMessages,
 		})
 		if err != nil {
 			slog.Error("voicemail store open failed", "dir", vmDir, "error", err)
@@ -2477,10 +2477,8 @@ func main() {
 
 				if vm := msg.LineSettings.Voicemail; vm != nil {
 					target := config.Voicemail{
-						Enabled:           vm.Enabled,
-						RingTimeout:       time.Duration(vm.RingTimeoutSeconds) * time.Second,
-						MaxStoredMessages: vm.MaxStoredMessages,
-						RetrievalCode:     vm.RetrievalCode,
+						Enabled:     vm.Enabled,
+						RingTimeout: time.Duration(vm.RingTimeoutSeconds) * time.Second,
 					}
 					cb.mu.Lock()
 					current := cb.cfg.Voicemail
@@ -2492,12 +2490,6 @@ func main() {
 						}
 						if target.RingTimeout != current.RingTimeout {
 							slog.Info("line_settings applied", "voicemail_ring_timeout", target.RingTimeout)
-						}
-						if target.MaxStoredMessages != current.MaxStoredMessages {
-							slog.Info("line_settings applied", "voicemail_max_stored_messages", target.MaxStoredMessages)
-						}
-						if target.RetrievalCode != current.RetrievalCode {
-							slog.Info("line_settings applied", "voicemail_retrieval_code", target.RetrievalCode)
 						}
 						if err := cb.setVoicemailConfig(target); err != nil {
 							slog.Warn("line_settings: voicemail save failed", "err", err)

--- a/pi/digitsd/cmd/digitsd/main_test.go
+++ b/pi/digitsd/cmd/digitsd/main_test.go
@@ -332,10 +332,8 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 	}
 	// Defaults at startup.
 	wantDefault := config.Voicemail{
-		Enabled:           true,
-		RingTimeout:       20 * time.Second,
-		MaxStoredMessages: 50,
-		RetrievalCode:     "*98",
+		Enabled:     true,
+		RingTimeout: 20 * time.Second,
 	}
 	if cfg.Voicemail != wantDefault {
 		t.Fatalf("unexpected default voicemail config: %+v", cfg.Voicemail)
@@ -343,10 +341,8 @@ func TestSetVoicemailConfig_PersistsToDisk(t *testing.T) {
 
 	d := &daemonCallbacks{cfg: cfg}
 	target := config.Voicemail{
-		Enabled:           true,
-		RingTimeout:       25 * time.Second,
-		MaxStoredMessages: 40,
-		RetrievalCode:     "*97",
+		Enabled:     true,
+		RingTimeout: 25 * time.Second,
 	}
 	if err := d.setVoicemailConfig(target); err != nil {
 		t.Fatalf("setVoicemailConfig: %v", err)
@@ -532,20 +528,14 @@ func TestLineSettingsVoicemailConversion(t *testing.T) {
 	wire := &sigclient.Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		MaxStoredMessages:  25,
-		RetrievalCode:      "*98",
 	}
 	got := config.Voicemail{
-		Enabled:           wire.Enabled,
-		RingTimeout:       time.Duration(wire.RingTimeoutSeconds) * time.Second,
-		MaxStoredMessages: wire.MaxStoredMessages,
-		RetrievalCode:     wire.RetrievalCode,
+		Enabled:     wire.Enabled,
+		RingTimeout: time.Duration(wire.RingTimeoutSeconds) * time.Second,
 	}
 	want := config.Voicemail{
-		Enabled:           true,
-		RingTimeout:       30 * time.Second,
-		MaxStoredMessages: 25,
-		RetrievalCode:     "*98",
+		Enabled:     true,
+		RingTimeout: 30 * time.Second,
 	}
 	if got != want {
 		t.Errorf("voicemail wire->config: got %+v, want %+v", got, want)

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/codec"
+	"github.com/justinlindh/digits/pi/digitsd/internal/config"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	"github.com/justinlindh/digits/pi/digitsd/internal/voicemail"
@@ -783,13 +784,10 @@ func (d *daemonCallbacks) VoicemailDeleteGreeting() {
 	}
 }
 
-// VoicemailRetrievalCode reports the configured retrieval code (default "*98")
-// that the controller uses to intercept the dial-collection state and enter
-// VOICEMAIL_PLAYBACK. Read under d.mu so a future config-reload path is safe.
+// VoicemailRetrievalCode returns the hardcoded retrieval code that the
+// controller uses to intercept dial-collection and enter VOICEMAIL_PLAYBACK.
 func (d *daemonCallbacks) VoicemailRetrievalCode() string {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	return d.cfg.Voicemail.RetrievalCode
+	return config.VoicemailRetrievalCode
 }
 
 // VoicemailEnterPlayback opens the first unheard message and streams it to

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -20,6 +20,12 @@ const (
 	VoiceStyleModern = "modern"
 )
 
+// Voicemail constants that are no longer server-configurable.
+const (
+	VoicemailMaxStoredMessages = 50
+	VoicemailRetrievalCode     = "*98"
+)
+
 // WiFiFallback configures the wifi auto-fallback supervisor.
 type WiFiFallback struct {
 	Enabled           bool          `json:"enabled"`
@@ -41,13 +47,6 @@ type Voicemail struct {
 	// digitsd auto-answers and starts recording. Mirrors a 4-ring delay on
 	// classic answering machines (~20s on 5Hz cadence).
 	RingTimeout time.Duration `json:"ring_timeout"`
-
-	// MaxStoredMessages caps the on-disk archive. Oldest messages are evicted
-	// FIFO once the cap is exceeded.
-	MaxStoredMessages int `json:"max_stored_messages"`
-
-	// RetrievalCode is the digit sequence dialed off-hook to enter playback.
-	RetrievalCode string `json:"retrieval_code"`
 }
 
 // Config holds digitsd runtime configuration loaded from a JSON file.
@@ -120,10 +119,8 @@ func defaultWiFiFallback() WiFiFallback {
 // source of truth used by Default() and the Load path.
 func defaultVoicemail() Voicemail {
 	return Voicemail{
-		Enabled:           true,
-		RingTimeout:       20 * time.Second,
-		MaxStoredMessages: 50,
-		RetrievalCode:     "*98",
+		Enabled:     true,
+		RingTimeout: 20 * time.Second,
 	}
 }
 

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -153,10 +153,8 @@ type LineSettings struct {
 // Field-name gotcha: durations cross the wire as integer seconds. The
 // receiver converts to time.Duration when writing to config.
 type Voicemail struct {
-	Enabled            bool   `json:"enabled"`
-	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxStoredMessages  int    `json:"max_stored_messages"`
-	RetrievalCode      string `json:"retrieval_code"`
+	Enabled            bool `json:"enabled"`
+	RingTimeoutSeconds int  `json:"ring_timeout_seconds"`
 }
 
 // ConferenceMemberInfo describes one participant in a conference call.

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -314,8 +314,6 @@ func TestLineSettingsVoicemailRoundTrip(t *testing.T) {
 			Voicemail: &Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 25,
-				MaxStoredMessages:  40,
-				RetrievalCode:      "*98",
 			},
 		},
 	}
@@ -329,8 +327,6 @@ func TestLineSettingsVoicemailRoundTrip(t *testing.T) {
 		`"voicemail":`,
 		`"enabled":true`,
 		`"ring_timeout_seconds":25`,
-		`"max_stored_messages":40`,
-		`"retrieval_code":"*98"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf("expected %q in JSON, got: %s", want, s)
@@ -411,6 +407,8 @@ func TestVoicemailStateZeroNotOmitted(t *testing.T) {
 func TestLineSettingsVoicemailZeroValuesParse(t *testing.T) {
 	// Server may push enabled=false with zero ints; receiver must accept it
 	// as an authoritative full-replacement payload, not silently drop fields.
+	// The raw JSON includes legacy fields (max_stored_messages, retrieval_code)
+	// that are no longer on the struct; they must be silently ignored.
 	raw := []byte(`{"type":"line_settings","line_settings":{"voicemail":{"enabled":false,"ring_timeout_seconds":0,"max_stored_messages":0,"retrieval_code":""}}}`)
 	msg, err := ParseMessage(raw)
 	if err != nil {
@@ -420,8 +418,7 @@ func TestLineSettingsVoicemailZeroValuesParse(t *testing.T) {
 		t.Fatalf("expected non-nil voicemail block, got %+v", msg.LineSettings)
 	}
 	vm := msg.LineSettings.Voicemail
-	if vm.Enabled || vm.RingTimeoutSeconds != 0 ||
-		vm.MaxStoredMessages != 0 || vm.RetrievalCode != "" {
+	if vm.Enabled || vm.RingTimeoutSeconds != 0 {
 		t.Errorf("zero-value parse mismatch: %+v", *vm)
 	}
 }

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -1,62 +1,29 @@
-/**
- * 10-voicemail.spec.ts -- Detail-page voicemail panel: enable toggle, the
- * "Advanced settings" disclosure, and the ring timeout Save flow.
- * The list-page no longer surfaces voicemail; that direction was pulled per
- * owner feedback.
- *
- * Tests:
- *   - Detail page renders the panel with the enable checkbox + Advanced disclosure.
- *   - Enabling voicemail via the checkbox round-trips state through the toggle endpoint.
- *   - Expanding Advanced reveals the ring timeout field.
- *   - Saving valid Advanced values persists across reload.
- *   - All three themes render their respective surface (intercom, dialup, am).
- *
- * Skips when the test household has no paired phones.
- */
+import { test, expect, Page, APIRequestContext } from '@playwright/test';
 
-import { test, expect, Page } from '@playwright/test';
-import { isServerUp, setTheme } from './helpers';
-
-test.beforeEach(async ({ page }, testInfo) => {
-  const up = await isServerUp();
-  testInfo.skip(!up, 'Dev server not running');
-});
-
-function isAuthOrOnboard(url: string) {
-  return url.includes('/auth/login') || url.includes('/onboard');
+async function setTheme(request: APIRequestContext, theme: string) {
+  const resp = await request.post('/settings/theme', {
+    form: { theme },
+  });
+  if (!resp.ok()) throw new Error(`setTheme ${theme}: ${resp.status()}`);
 }
 
 async function firstPhoneHref(page: Page): Promise<string | null> {
   await page.goto('/phones');
-  if (isAuthOrOnboard(page.url())) {
-    return null;
-  }
-  const link = page.locator('a[href^="/phones/"]:not([href="/phones"])').first();
-  if ((await link.count()) === 0) {
-    return null;
-  }
-  return await link.getAttribute('href');
+  const link = page.locator('a[href^="/phones/"]').first();
+  if (!(await link.isVisible())) return null;
+  return (await link.getAttribute('href'))!;
 }
 
 async function readEnabledOnDetail(page: Page): Promise<boolean> {
-  const checkbox = page.locator('#voicemail-section input[name="enabled"]').first();
-  await expect(checkbox).toBeVisible();
-  return await checkbox.isChecked();
+  return page.locator('#voicemail-section input[name="enabled"]').isChecked();
 }
 
-/**
- * Click the enable checkbox and wait for the toggle endpoint round-trip.
- * The checkbox has hx-post + hx-trigger=change, so a click triggers the swap
- * of the whole voicemail section.
- */
 async function clickEnableCheckbox(page: Page) {
-  const checkbox = page.locator('#voicemail-section input[name="enabled"]').first();
-  await expect(checkbox).toBeVisible();
-  const wait = page.waitForResponse(
+  const cb = page.locator('#voicemail-section input[name="enabled"]');
+  await cb.click();
+  await page.waitForResponse(
     (r) => r.url().includes('/voicemail-toggle') && r.request().method() === 'POST',
   );
-  await checkbox.click();
-  await wait;
 }
 
 test.describe('Voicemail (intercom theme)', () => {
@@ -64,7 +31,7 @@ test.describe('Voicemail (intercom theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('detail page renders panel with enable checkbox + Advanced disclosure', async ({ page }) => {
+  test('detail page renders voicemail section with enable checkbox and ring timeout', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -74,27 +41,15 @@ test.describe('Voicemail (intercom theme)', () => {
 
     await expect(page.locator('h2.panel__title', { hasText: /answering machine/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
-
-    // Advanced should be collapsed by default; the detail fields are hidden until expanded.
-    const ringField = page.locator('#voicemail-section input[name="ring_timeout_seconds"]');
-    await expect(ringField).not.toBeVisible();
-  });
-
-  test('expanding Advanced reveals ring timeout field', async ({ page }) => {
-    const href = await firstPhoneHref(page);
-    if (!href) {
-      test.skip(true, 'No phones registered');
-      return;
-    }
-    await page.goto(href);
-
-    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
+
     // Removed fields must not be present.
     await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toHaveCount(0);
     await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toHaveCount(0);
     await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toHaveCount(0);
+
+    // No accordion wrapper.
+    await expect(page.locator('#voicemail-section details')).toHaveCount(0);
   });
 
   test('checkbox toggle swaps section partial and persists', async ({ page }) => {
@@ -123,7 +78,7 @@ test.describe('Voicemail (intercom theme)', () => {
     await clickEnableCheckbox(page);
   });
 
-  test('saving valid Advanced values persists across reload', async ({ page }) => {
+  test('saving ring timeout persists across reload', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -131,13 +86,11 @@ test.describe('Voicemail (intercom theme)', () => {
     }
     await page.goto(href);
 
-    // Make sure voicemail is on so the inner fields aren't disabled.
+    // Make sure voicemail is on so the fields aren't disabled.
     if (!(await readEnabledOnDetail(page))) {
       await clickEnableCheckbox(page);
     }
 
-    // Expand Advanced and edit.
-    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
 
     const wait = page.waitForResponse(
@@ -147,9 +100,8 @@ test.describe('Voicemail (intercom theme)', () => {
     const resp = await wait;
     expect(resp.status()).toBe(200);
 
-    // Reload, expand, confirm fields stuck.
+    // Reload, confirm value stuck.
     await page.goto(href);
-    await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(
       page.locator('#voicemail-section input[name="ring_timeout_seconds"]'),
     ).toHaveValue('30');
@@ -159,8 +111,6 @@ test.describe('Voicemail (intercom theme)', () => {
   });
 
   test('list page does NOT show a voicemail badge', async ({ page }) => {
-    // Regression guard: the list-row voicemail UI was removed per owner
-    // direction. If a future hand re-adds the badge, this test fails.
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -185,7 +135,7 @@ test.describe('Voicemail (dialup theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('detail page renders the panel under dialup chrome', async ({ page }) => {
+  test('detail page renders voicemail section under dialup chrome', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -195,7 +145,8 @@ test.describe('Voicemail (dialup theme)', () => {
 
     await expect(page.locator('#voicemail-section')).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section details.voicemail-advanced')).toBeVisible();
+    await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section details')).toHaveCount(0);
   });
 });
 
@@ -212,7 +163,7 @@ test.describe('Voicemail (answering-machine theme)', () => {
     await setTheme(page.request, 'intercom').catch(() => undefined);
   });
 
-  test('AM detail page renders the voicemail plate with AM-styled disclosure', async ({ page }) => {
+  test('AM detail page renders voicemail controls inline', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -222,10 +173,7 @@ test.describe('Voicemail (answering-machine theme)', () => {
 
     await expect(page.locator('.am-plate__label', { hasText: /answering machine/i })).toBeVisible();
     await expect(page.locator('#voicemail-section input[name="enabled"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section details.am-voicemail-advanced')).toBeVisible();
-
-    // Expand and confirm AM-styled fields show.
-    await page.locator('#voicemail-section details.am-voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
+    await expect(page.locator('#voicemail-section details')).toHaveCount(0);
   });
 });

--- a/server/e2e/tests/10-voicemail.spec.ts
+++ b/server/e2e/tests/10-voicemail.spec.ts
@@ -1,15 +1,14 @@
 /**
  * 10-voicemail.spec.ts -- Detail-page voicemail panel: enable toggle, the
- * "Advanced settings" disclosure, the unheard-count chip, and the 5-field
- * Save flow. The list-page no longer surfaces voicemail; that direction was
- * pulled per owner feedback.
+ * "Advanced settings" disclosure, and the ring timeout Save flow.
+ * The list-page no longer surfaces voicemail; that direction was pulled per
+ * owner feedback.
  *
  * Tests:
  *   - Detail page renders the panel with the enable checkbox + Advanced disclosure.
  *   - Enabling voicemail via the checkbox round-trips state through the toggle endpoint.
- *   - Expanding Advanced reveals the 4 numeric/code fields.
+ *   - Expanding Advanced reveals the ring timeout field.
  *   - Saving valid Advanced values persists across reload.
- *   - Bad retrieval code is rejected (400).
  *   - All three themes render their respective surface (intercom, dialup, am).
  *
  * Skips when the test household has no paired phones.
@@ -82,7 +81,7 @@ test.describe('Voicemail (intercom theme)', () => {
     await expect(ringField).not.toBeVisible();
   });
 
-  test('expanding Advanced reveals all detail fields', async ({ page }) => {
+  test('expanding Advanced reveals ring timeout field', async ({ page }) => {
     const href = await firstPhoneHref(page);
     if (!href) {
       test.skip(true, 'No phones registered');
@@ -92,9 +91,9 @@ test.describe('Voicemail (intercom theme)', () => {
 
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
-    // The per-message recording cap is fixed in digitsd, so no field for it.
+    // Removed fields must not be present.
+    await expect(page.locator('#voicemail-section input[name="max_stored_messages"]')).toHaveCount(0);
+    await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toHaveCount(0);
     await expect(page.locator('#voicemail-section input[name="max_message_seconds"]')).toHaveCount(0);
   });
 
@@ -140,8 +139,6 @@ test.describe('Voicemail (intercom theme)', () => {
     // Expand Advanced and edit.
     await page.locator('#voicemail-section details.voicemail-advanced > summary').click();
     await page.locator('#voicemail-section input[name="ring_timeout_seconds"]').fill('30');
-    await page.locator('#voicemail-section input[name="max_stored_messages"]').fill('25');
-    await page.locator('#voicemail-section input[name="retrieval_code"]').fill('*99');
 
     const wait = page.waitForResponse(
       (r) => r.url().endsWith('/voicemail') && r.request().method() === 'POST',
@@ -156,37 +153,9 @@ test.describe('Voicemail (intercom theme)', () => {
     await expect(
       page.locator('#voicemail-section input[name="ring_timeout_seconds"]'),
     ).toHaveValue('30');
-    await expect(
-      page.locator('#voicemail-section input[name="retrieval_code"]'),
-    ).toHaveValue('*99');
 
     // Cleanup: voicemail off.
     await clickEnableCheckbox(page);
-  });
-
-  test('bad retrieval code is rejected with 400', async ({ page }) => {
-    const href = await firstPhoneHref(page);
-    if (!href) {
-      test.skip(true, 'No phones registered');
-      return;
-    }
-    await page.goto(href);
-
-    // Bypass HTML5 client-side validation and exercise the server-side guard.
-    // "12345" is digits-only (no * or #), which the handler rejects to avoid
-    // a 7-digit-dial collision.
-    const number = href.split('/').pop() as string;
-    const resp = await page.request.post(`/phones/${number}/voicemail`, {
-      form: {
-        enabled: 'on',
-        ring_timeout_seconds: '20',
-        max_stored_messages: '50',
-        retrieval_code: '12345',
-      },
-      maxRedirects: 0,
-    });
-    expect(resp.status()).toBe(400);
-    expect(await resp.text()).toMatch(/retrieval_code/i);
   });
 
   test('list page does NOT show a voicemail badge', async ({ page }) => {
@@ -258,6 +227,5 @@ test.describe('Voicemail (answering-machine theme)', () => {
     // Expand and confirm AM-styled fields show.
     await page.locator('#voicemail-section details.am-voicemail-advanced > summary').click();
     await expect(page.locator('#voicemail-section input[name="ring_timeout_seconds"]')).toBeVisible();
-    await expect(page.locator('#voicemail-section input[name="retrieval_code"]')).toBeVisible();
   });
 });

--- a/server/internal/line/settings.go
+++ b/server/internal/line/settings.go
@@ -1,66 +1,30 @@
 package line
 
-import (
-	"regexp"
-	"strings"
-)
-
 // Voice style identifiers persisted in line.Settings and on the wire.
 const (
 	VoiceStyleCopper = "copper"
 	VoiceStyleModern = "modern"
 )
 
-// Voicemail field clamp bounds and default retrieval code. Kept as package
-// constants so the handler validation, Normalize(), and tests reference the
-// same numbers.
+// Voicemail ring timeout bounds.
 const (
 	VoicemailRingTimeoutMin = 5
 	VoicemailRingTimeoutMax = 60
-	VoicemailMaxStoredMin   = 5
-	VoicemailMaxStoredMax   = 200
 
 	DefaultVoicemailRingTimeoutSeconds = 20
-	DefaultVoicemailMaxStoredMessages  = 50
-	DefaultVoicemailRetrievalCode      = "*98"
 )
 
-// retrievalCodeFormatRegex pins the charset and length of a voicemail
-// retrieval code. The trailing semantic check (must contain * or #) is
-// done with strings.ContainsAny so a plain numeric prefix like "1234"
-// can't shadow a 7-digit dial; that check lives in IsValidRetrievalCode.
-var retrievalCodeFormatRegex = regexp.MustCompile(`^[0-9*#]{2,6}$`)
-
-// IsValidRetrievalCode reports whether code passes both the format regex
-// and the must-contain-star-or-hash rule. Exported so the HTTP handler and
-// Normalize() can share one definition.
-func IsValidRetrievalCode(code string) bool {
-	return retrievalCodeFormatRegex.MatchString(code) && strings.ContainsAny(code, "*#")
-}
-
 // Voicemail is the per-line voicemail (answering-machine) configuration.
-// Wire field names match what the digitsd receiver expects. The integer
-// time fields use seconds on the wire; the daemon converts to time.Duration
-// when applying to its internal config.
-//
-// Inner fields deliberately omit omitempty to match the wire contract: a
-// stored row carries every field literally so a future read can tell
-// "Enabled was explicitly false" apart from "field was absent". Empty /
-// out-of-range values are still healed by Normalize on read.
+// Only Enabled and RingTimeoutSeconds are user-configurable; max stored
+// messages and retrieval code are constants in digitsd.
 type Voicemail struct {
-	Enabled            bool   `json:"enabled"`
-	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxStoredMessages  int    `json:"max_stored_messages"`
-	RetrievalCode      string `json:"retrieval_code"`
+	Enabled            bool `json:"enabled"`
+	RingTimeoutSeconds int  `json:"ring_timeout_seconds"`
 }
 
 // Settings holds per-line configuration that a household owner can change in
 // the web UI. Stored as a single JSONB column on the lines table so new
 // fields can be added without schema changes.
-//
-// Voicemail intentionally has no omitempty: encoding/json's omitempty has
-// no effect on value-typed structs anyway, and dropping it documents the
-// "always carry the full block" contract.
 type Settings struct {
 	VoiceStyle string    `json:"voice_style,omitempty"`
 	SilentMode bool      `json:"silent_mode,omitempty"`
@@ -69,14 +33,12 @@ type Settings struct {
 }
 
 // DefaultVoicemail returns the voicemail configuration a newly created line
-// starts with: enabled, with classic answering-machine defaults so a new line
-// records messages out of the box without the household having to opt in.
+// starts with: enabled, with a 20-second ring timeout so a new line records
+// messages out of the box without the household having to opt in.
 func DefaultVoicemail() Voicemail {
 	return Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: DefaultVoicemailRingTimeoutSeconds,
-		MaxStoredMessages:  DefaultVoicemailMaxStoredMessages,
-		RetrievalCode:      DefaultVoicemailRetrievalCode,
 	}
 }
 
@@ -99,35 +61,20 @@ func (v Voicemail) Merge(patch Voicemail) Voicemail {
 	if patch.RingTimeoutSeconds != 0 {
 		v.RingTimeoutSeconds = patch.RingTimeoutSeconds
 	}
-	if patch.MaxStoredMessages != 0 {
-		v.MaxStoredMessages = patch.MaxStoredMessages
-	}
-	if patch.RetrievalCode != "" {
-		v.RetrievalCode = patch.RetrievalCode
-	}
 	return v
 }
 
 // Normalize substitutes the default value for any field that is zero or out
-// of the allowed range. Defense in depth so corrupt on-disk data can never
-// propagate to the daemon (which would, for instance, never pick up if
-// RingTimeoutSeconds is zero).
+// of the allowed range.
 func (v Voicemail) Normalize() Voicemail {
 	if v.RingTimeoutSeconds < VoicemailRingTimeoutMin || v.RingTimeoutSeconds > VoicemailRingTimeoutMax {
 		v.RingTimeoutSeconds = DefaultVoicemailRingTimeoutSeconds
-	}
-	if v.MaxStoredMessages < VoicemailMaxStoredMin || v.MaxStoredMessages > VoicemailMaxStoredMax {
-		v.MaxStoredMessages = DefaultVoicemailMaxStoredMessages
-	}
-	if !IsValidRetrievalCode(v.RetrievalCode) {
-		v.RetrievalCode = DefaultVoicemailRetrievalCode
 	}
 	return v
 }
 
 // Merge layers a patch on top of s, overwriting only the fields the patch
-// actually sets. This is how we apply a DB-loaded settings JSON on top of
-// the defaults: missing fields keep their default value.
+// actually sets.
 func (s Settings) Merge(patch Settings) Settings {
 	if patch.VoiceStyle != "" {
 		s.VoiceStyle = patch.VoiceStyle
@@ -139,7 +86,6 @@ func (s Settings) Merge(patch Settings) Settings {
 }
 
 // Normalize rewrites any fields that hold an unknown value to their default.
-// Use this after unmarshaling untrusted input to avoid propagating garbage.
 func (s Settings) Normalize() Settings {
 	switch s.VoiceStyle {
 	case VoiceStyleCopper, VoiceStyleModern:

--- a/server/internal/line/settings_test.go
+++ b/server/internal/line/settings_test.go
@@ -163,19 +163,13 @@ func TestSettingsMergeAutoUpdateFromPatch(t *testing.T) {
 	}
 }
 
-func TestDefaultVoicemailMatchesPhaseOneSpec(t *testing.T) {
+func TestDefaultVoicemailMatchesSpec(t *testing.T) {
 	v := DefaultVoicemail()
 	if !v.Enabled {
 		t.Errorf("Enabled default: got false, want true")
 	}
 	if v.RingTimeoutSeconds != 20 {
 		t.Errorf("RingTimeoutSeconds default: got %d, want 20", v.RingTimeoutSeconds)
-	}
-	if v.MaxStoredMessages != 50 {
-		t.Errorf("MaxStoredMessages default: got %d, want 50", v.MaxStoredMessages)
-	}
-	if v.RetrievalCode != "*98" {
-		t.Errorf("RetrievalCode default: got %q, want %q", v.RetrievalCode, "*98")
 	}
 }
 
@@ -192,8 +186,6 @@ func TestSettingsJSONRoundTripVoicemail(t *testing.T) {
 		Voicemail: Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 30,
-			MaxStoredMessages:  75,
-			RetrievalCode:      "#42",
 		},
 	}
 	b, err := json.Marshal(in)
@@ -214,8 +206,6 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	patch := Settings{Voicemail: Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		// MaxStoredMessages, RetrievalCode unset (zero)
-		// should keep defaults from base.
 	}}
 	merged := base.Merge(patch)
 	if !merged.Voicemail.Enabled {
@@ -223,14 +213,6 @@ func TestSettingsMergeVoicemailLayersOnDefaults(t *testing.T) {
 	}
 	if merged.Voicemail.RingTimeoutSeconds != 30 {
 		t.Errorf("RingTimeoutSeconds: got %d, want 30", merged.Voicemail.RingTimeoutSeconds)
-	}
-	if merged.Voicemail.MaxStoredMessages != DefaultVoicemailMaxStoredMessages {
-		t.Errorf("MaxStoredMessages: got %d, want default %d",
-			merged.Voicemail.MaxStoredMessages, DefaultVoicemailMaxStoredMessages)
-	}
-	if merged.Voicemail.RetrievalCode != DefaultVoicemailRetrievalCode {
-		t.Errorf("RetrievalCode: got %q, want default %q",
-			merged.Voicemail.RetrievalCode, DefaultVoicemailRetrievalCode)
 	}
 }
 
@@ -242,12 +224,10 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 	}{
 		{
 			name: "zero values get defaults",
-			in:   Voicemail{Enabled: true, RetrievalCode: "*98"},
+			in:   Voicemail{Enabled: true},
 			want: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 20,
-				MaxStoredMessages:  50,
-				RetrievalCode:      "*98",
 			},
 		},
 		{
@@ -255,14 +235,10 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 1,
-				MaxStoredMessages:  10,
-				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 20, // 1 < min(5) → default
-				MaxStoredMessages:  10,
-				RetrievalCode:      "*99",
+				RingTimeoutSeconds: 20, // 1 < min(5) -> default
 			},
 		},
 		{
@@ -270,29 +246,21 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 			in: Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 600,
-				MaxStoredMessages:  10,
-				RetrievalCode:      "*99",
 			},
 			want: Voicemail{
 				Enabled:            true,
-				RingTimeoutSeconds: 20, // 600 > max(60) → default
-				MaxStoredMessages:  10,
-				RetrievalCode:      "*99",
+				RingTimeoutSeconds: 20, // 600 > max(60) -> default
 			},
 		},
 		{
-			name: "below-min max stored reset",
+			name: "valid ring timeout preserved",
 			in: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxStoredMessages:  2,
-				RetrievalCode:      "*98",
 			},
 			want: Voicemail{
 				Enabled:            false,
 				RingTimeoutSeconds: 30,
-				MaxStoredMessages:  50, // 2 < min(5) → default
-				RetrievalCode:      "*98",
 			},
 		},
 	}
@@ -306,60 +274,10 @@ func TestSettingsNormalizeClampsOutOfRangeInts(t *testing.T) {
 	}
 }
 
-func TestSettingsNormalizeRetrievalCodeFallback(t *testing.T) {
-	cases := map[string]string{
-		"":         "*98",      // empty
-		"1234567":  "*98",      // too long
-		"a":        "*98",      // bad chars
-		"123":      "*98",      // digits only, no * or #
-		"12345":    "*98",      // digits only, no * or # (would shadow 7-digit dialing)
-		"*98":      "*98",      // valid: star prefix
-		"#42":      "#42",      // valid: hash prefix
-		"1#":       "1#",       // valid: hash with digit
-		"*123":     "*123",     // valid: longer with star
-		"##":       "##",       // valid: shortest acceptable
-		"123#":     "123#",     // valid: trailing hash
-	}
-	for in, want := range cases {
-		got := (Voicemail{
-			RingTimeoutSeconds: 20,
-			MaxStoredMessages:  50,
-			RetrievalCode:      in,
-		}).Normalize().RetrievalCode
-		if got != want {
-			t.Errorf("Normalize(%q).RetrievalCode = %q, want %q", in, got, want)
-		}
-	}
-}
-
-func TestIsValidRetrievalCode(t *testing.T) {
-	valid := []string{"*98", "#42", "*123", "##", "1#", "*0", "1234*", "*1234"}
-	for _, code := range valid {
-		if !IsValidRetrievalCode(code) {
-			t.Errorf("IsValidRetrievalCode(%q) = false, want true", code)
-		}
-	}
-	invalid := []string{
-		"",        // empty
-		"1",       // too short
-		"1234567", // too long
-		"abc",     // bad chars
-		"*",       // 1-char, too short
-		"123",     // no * or #
-		"12345",   // no * or #
-		"1 2",     // space
-	}
-	for _, code := range invalid {
-		if IsValidRetrievalCode(code) {
-			t.Errorf("IsValidRetrievalCode(%q) = true, want false", code)
-		}
-	}
-}
-
 func TestSettingsScanFromEmptyJSONAppliesDefaults(t *testing.T) {
 	// Mirrors what store.scanSettings does for a fresh row. Merge is
 	// authoritative on booleans, so Enabled (JSON zero = false) overwrites
-	// the default true. Normalize backfills numeric/string defaults but
+	// the default true. Normalize backfills numeric defaults but
 	// does not force-enable voicemail.
 	var patch Settings
 	if err := json.Unmarshal([]byte(`{}`), &patch); err != nil {
@@ -373,10 +291,11 @@ func TestSettingsScanFromEmptyJSONAppliesDefaults(t *testing.T) {
 	}
 }
 
-func TestSettingsUnmarshalIgnoresVestigialMaxMessageKey(t *testing.T) {
-	// Rows written before max_message_seconds was removed still carry the
-	// key in their JSONB. encoding/json drops unknown keys silently, so the
-	// surviving fields must still decode and survive Merge + Normalize.
+func TestSettingsUnmarshalIgnoresVestigialKeys(t *testing.T) {
+	// Rows written before max_stored_messages and retrieval_code were removed
+	// still carry those keys in their JSONB. encoding/json drops unknown keys
+	// silently, so the surviving fields must still decode and survive
+	// Merge + Normalize.
 	raw := []byte(`{
 		"voice_style": "modern",
 		"voicemail": {
@@ -395,8 +314,6 @@ func TestSettingsUnmarshalIgnoresVestigialMaxMessageKey(t *testing.T) {
 	want := Voicemail{
 		Enabled:            true,
 		RingTimeoutSeconds: 30,
-		MaxStoredMessages:  75,
-		RetrievalCode:      "#42",
 	}
 	if merged.Voicemail != want {
 		t.Errorf("legacy row decode: got %+v, want %+v", merged.Voicemail, want)

--- a/server/internal/signaling/linesettings_test.go
+++ b/server/internal/signaling/linesettings_test.go
@@ -40,8 +40,6 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 			Voicemail: &Voicemail{
 				Enabled:            true,
 				RingTimeoutSeconds: 30,
-				MaxStoredMessages:  75,
-				RetrievalCode:      "#42",
 			},
 		},
 	}
@@ -55,17 +53,16 @@ func TestLineSettingsVoicemailJSONRoundTrip(t *testing.T) {
 		`"voicemail":`,
 		`"enabled":true`,
 		`"ring_timeout_seconds":30`,
-		`"max_stored_messages":75`,
-		`"retrieval_code":"#42"`,
 	} {
 		if !strings.Contains(wire, key) {
 			t.Errorf("wire missing %q in %s", key, wire)
 		}
 	}
-	// The per-message recording cap is fixed in digitsd, not configured
-	// per line, so no max-duration key may ride the wire.
-	if strings.Contains(wire, "max_message_seconds") {
-		t.Errorf("wire must not carry max_message_seconds, got %s", wire)
+	// Removed fields must not ride the wire.
+	for _, banned := range []string{"max_message_seconds", "max_stored_messages", "retrieval_code"} {
+		if strings.Contains(wire, banned) {
+			t.Errorf("wire must not carry %q, got %s", banned, wire)
+		}
 	}
 	got, err := ParseMessage(b)
 	if err != nil {
@@ -101,9 +98,7 @@ func TestLineSettingsVoicemailOmittedWhenNil(t *testing.T) {
 // inner Voicemail fields have no omitempty: a non-nil pointer to a
 // zero-value Voicemail must serialize every key with its zero value so
 // the daemon can distinguish "server didn't set this" (nil outer) from
-// "server set this to zero" (outer present with explicit zero). Regresses
-// against a future hand that tries to re-add omitempty to "tidy up" the
-// wire.
+// "server set this to zero" (outer present with explicit zero).
 func TestLineSettingsVoicemailZeroValuesRoundTrip(t *testing.T) {
 	in := &Message{
 		Type: TypeLineSettings,
@@ -120,8 +115,6 @@ func TestLineSettingsVoicemailZeroValuesRoundTrip(t *testing.T) {
 	for _, key := range []string{
 		`"enabled":false`,
 		`"ring_timeout_seconds":0`,
-		`"max_stored_messages":0`,
-		`"retrieval_code":""`,
 	} {
 		if !strings.Contains(wire, key) {
 			t.Errorf("expected zero-value %q in wire, got %s", key, wire)

--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -19,15 +19,10 @@ func NewLineStoreAdapter(s *line.Store) LineStore {
 }
 
 // VoicemailFromLine projects a line.Voicemail into its wire representation.
-// Adding a new voicemail field requires updating this helper and the matching
-// receiver in pi/digitsd/internal/signal; collapsing the per-callsite field-
-// copy into one place keeps the wire contract from drifting silently.
 func VoicemailFromLine(v line.Voicemail) *Voicemail {
 	return &Voicemail{
 		Enabled:            v.Enabled,
 		RingTimeoutSeconds: v.RingTimeoutSeconds,
-		MaxStoredMessages:  v.MaxStoredMessages,
-		RetrievalCode:      v.RetrievalCode,
 	}
 }
 

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -95,14 +95,10 @@ type LineSettings struct {
 //
 // Field names mirror the daemon config keys exactly. The daemon's local
 // config holds RingTimeout as a time.Duration; the wire uses integer seconds
-// and the daemon converts on receipt. The per-message recording cap is not
-// configurable: digitsd enforces a fixed 10-minute limit, so no max-duration
-// field rides the wire.
+// and the daemon converts on receipt.
 type Voicemail struct {
-	Enabled            bool   `json:"enabled"`
-	RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-	MaxStoredMessages  int    `json:"max_stored_messages"`
-	RetrievalCode      string `json:"retrieval_code"`
+	Enabled            bool `json:"enabled"`
+	RingTimeoutSeconds int  `json:"ring_timeout_seconds"`
 }
 
 // ConferenceMemberInfo describes one participant in a conference call.

--- a/server/internal/signaling/relay_linesettings_test.go
+++ b/server/internal/signaling/relay_linesettings_test.go
@@ -135,8 +135,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		Voicemail: &Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxStoredMessages:  40,
-			RetrievalCode:      "*97",
 		},
 	})
 	relay := NewRelay(hub, nil, nil, store)
@@ -162,8 +160,6 @@ func TestOnRegisteredPushesVoicemail(t *testing.T) {
 		want := Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxStoredMessages:  40,
-			RetrievalCode:      "*97",
 		}
 		if got != want {
 			t.Errorf("Voicemail: got %+v, want %+v", got, want)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -641,18 +641,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	maxStored, ok := parseClampedInt(w, r, "max_stored_messages",
-		line.VoicemailMaxStoredMin, line.VoicemailMaxStoredMax)
-	if !ok {
-		return
-	}
-	code := strings.TrimSpace(r.FormValue("retrieval_code"))
-	if !line.IsValidRetrievalCode(code) {
-		http.Error(w,
-			"retrieval_code must be 2 to 6 characters of digits, *, or # and must contain at least one * or #",
-			http.StatusBadRequest)
-		return
-	}
 
 	number := r.PathValue("number")
 	ln := h.requireLineOwnership(w, r, number)
@@ -664,8 +652,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	next.Voicemail = line.Voicemail{
 		Enabled:            enabled,
 		RingTimeoutSeconds: ring,
-		MaxStoredMessages:  maxStored,
-		RetrievalCode:      code,
 	}
 	next = next.Normalize()
 	if !h.applyLineSettings(w, r, ln, next) {

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2609,8 +2609,6 @@ func validVoicemailForm() url.Values {
 	return url.Values{
 		"enabled":              {"on"},
 		"ring_timeout_seconds": {"25"},
-		"max_stored_messages":  {"30"},
-		"retrieval_code":       {"*97"},
 	}
 }
 
@@ -2657,17 +2655,16 @@ func TestPhoneVoicemailValidFormPersistsAndRedirects(t *testing.T) {
 	for _, want := range []string{
 		`"enabled": true`,
 		`"ring_timeout_seconds": 25`,
-		`"max_stored_messages": 30`,
-		`"retrieval_code": "*97"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("voicemail JSONB missing %q in %s", want, got)
 		}
 	}
-	// The configurable per-message cap is gone: a new write must not
-	// reintroduce the vestigial key.
-	if strings.Contains(got, "max_message_seconds") {
-		t.Errorf("voicemail JSONB should not carry max_message_seconds, got %s", got)
+	// Removed fields must not reappear in new writes.
+	for _, banned := range []string{"max_message_seconds", "max_stored_messages", "retrieval_code"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("voicemail JSONB should not carry %q, got %s", banned, got)
+		}
 	}
 }
 
@@ -2692,52 +2689,6 @@ func TestPhoneVoicemailRingTimeoutOutOfRangeRejected(t *testing.T) {
 	}
 }
 
-func TestPhoneVoicemailMaxStoredOutOfRangeRejected(t *testing.T) {
-	h, database, authStore := setupHandler(t)
-	cookie := addSessionCookie(t, authStore)
-	_ = setupVoiceStyleLine(t, h, database, authStore)
-
-	cases := []string{"0", "4", "201", "9999", ""}
-	for _, val := range cases {
-		t.Run(val, func(t *testing.T) {
-			form := validVoicemailForm()
-			form.Set("max_stored_messages", val)
-			w := postVoicemail(t, h, cookie, form, false)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("max_stored_messages=%q: expected 400, got %d", val, w.Code)
-			}
-		})
-	}
-}
-
-func TestPhoneVoicemailBadRetrievalCodeRejected(t *testing.T) {
-	h, database, authStore := setupHandler(t)
-	cookie := addSessionCookie(t, authStore)
-	_ = setupVoiceStyleLine(t, h, database, authStore)
-
-	cases := []string{
-		"",        // empty
-		"1",       // too short
-		"1234567", // too long
-		"abc",     // bad chars
-		"123",     // no * or #, ambiguous with 7-digit dialing
-		"12345",   // no * or #
-		"* 98",    // space
-	}
-	for _, val := range cases {
-		t.Run(val, func(t *testing.T) {
-			form := validVoicemailForm()
-			form.Set("retrieval_code", val)
-			w := postVoicemail(t, h, cookie, form, false)
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("retrieval_code=%q: expected 400, got %d: %s", val, w.Code, w.Body.String())
-			}
-			if !strings.Contains(w.Body.String(), "retrieval_code") {
-				t.Errorf("400 body should name the field, got %q", w.Body.String())
-			}
-		})
-	}
-}
 
 func TestPhoneVoicemailMissingLineReturns404(t *testing.T) {
 	h, database, authStore := setupHandler(t)
@@ -2789,8 +2740,6 @@ func TestPhoneVoicemailPushesToConnectedDevice(t *testing.T) {
 		want := signaling.Voicemail{
 			Enabled:            true,
 			RingTimeoutSeconds: 25,
-			MaxStoredMessages:  30,
-			RetrievalCode:      "*97",
 		}
 		if got != want {
 			t.Errorf("Voicemail push: got %+v, want %+v", got, want)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2861,10 +2861,6 @@ func TestPhoneVoicemailToggleHTMXReturnsSectionPartial(t *testing.T) {
 	if !strings.Contains(body, "/voicemail-toggle") {
 		t.Fatalf("htmx response missing toggle endpoint:\n%s", body)
 	}
-	// Advanced disclosure must be present.
-	if !strings.Contains(body, `class="voicemail-advanced"`) {
-		t.Errorf("expected voicemail-advanced disclosure:\n%s", body)
-	}
 	// After toggling off, fields should be disabled.
 	if !strings.Contains(body, `disabled`) {
 		t.Errorf("expected disabled attr on inner fields when off:\n%s", body)

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -754,42 +754,19 @@
       Messages stay on the handset; dial the retrieval code from the phone to listen.
     </p>
 
-    <details class="voicemail-advanced">
-      <summary>Advanced settings</summary>
-      <div class="voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-        <div class="field">
-          <label for="vm-ring-timeout" class="field__label">Ring timeout (seconds)</label>
-          <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
-                 min="5" max="60"
-                 value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-                 class="field__input" style="width: 110px;"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">5 to 60 seconds before the answering machine picks up.</span>
-        </div>
-
-        <div class="field">
-          <label for="vm-max-stored" class="field__label">Max stored messages</label>
-          <input type="number" id="vm-max-stored" name="max_stored_messages"
-                 min="5" max="200"
-                 value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
-                 class="field__input" style="width: 110px;"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">5 to 200; oldest dropped first.</span>
-        </div>
-
-        <div class="field">
-          <label for="vm-retrieval-code" class="field__label">Retrieval code</label>
-          <input type="text" id="vm-retrieval-code" name="retrieval_code"
-                 value="{{.Line.Settings.Voicemail.RetrievalCode}}"
-                 pattern="[0-9*#]{2,6}" maxlength="6" required
-                 class="field__input" style="width: 110px;"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-          <span class="muted" style="font-size: 11px;">2 to 6 chars; must contain * or # so it cannot collide with a 7-digit dial.</span>
-        </div>
-
-        <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
+    <div class="voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+      <div class="field">
+        <label for="vm-ring-timeout" class="field__label">Ring timeout (seconds)</label>
+        <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
+               min="5" max="60"
+               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+               class="field__input" style="width: 110px;"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
+        <span class="muted" style="font-size: 11px;">5 to 60 seconds before the answering machine picks up.</span>
       </div>
-    </details>
+
+      <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 6px;">Save</button>
+    </div>
   </form>
 </div>
 {{end}}
@@ -825,40 +802,21 @@
       </div>
     </div>
 
-    <details class="am-voicemail-advanced">
-      <summary>Advanced settings</summary>
-      <div class="am-voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
-        <div class="am-settings__field">
-          <label for="vm-ring-timeout" class="am-label am-settings__field-label">Ring timeout (sec)</label>
-          <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
-                 min="5" max="60"
-                 value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
-                 class="am-settings__input"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </div>
-        <div class="am-settings__field">
-          <label for="vm-max-stored" class="am-label am-settings__field-label">Max stored</label>
-          <input type="number" id="vm-max-stored" name="max_stored_messages"
-                 min="5" max="200"
-                 value="{{.Line.Settings.Voicemail.MaxStoredMessages}}"
-                 class="am-settings__input"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </div>
-        <div class="am-settings__field">
-          <label for="vm-retrieval-code" class="am-label am-settings__field-label">Retrieval code</label>
-          <input type="text" id="vm-retrieval-code" name="retrieval_code"
-                 value="{{.Line.Settings.Voicemail.RetrievalCode}}"
-                 pattern="[0-9*#]{2,6}" maxlength="6" required
-                 class="am-settings__input"
-                 {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
-        </div>
-
-        <button type="submit" class="am-key am-settings__submit am-voicemail-fields__submit">
-          <span class="am-key__symbol">&#x25B6;</span>
-          <span class="am-key__label">Save</span>
-        </button>
+    <div class="am-voicemail-fields" data-voicemail-fields {{if not .Line.Settings.Voicemail.Enabled}}style="opacity: 0.55;"{{end}}>
+      <div class="am-settings__field">
+        <label for="vm-ring-timeout" class="am-label am-settings__field-label">Ring timeout (sec)</label>
+        <input type="number" id="vm-ring-timeout" name="ring_timeout_seconds"
+               min="5" max="60"
+               value="{{.Line.Settings.Voicemail.RingTimeoutSeconds}}"
+               class="am-settings__input"
+               {{if not .Line.Settings.Voicemail.Enabled}}disabled{{end}}>
       </div>
-    </details>
+
+      <button type="submit" class="am-key am-settings__submit am-voicemail-fields__submit">
+        <span class="am-key__symbol">&#x25B6;</span>
+        <span class="am-key__label">Save</span>
+      </button>
+    </div>
   </form>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

- Remove `max_stored_messages` and `retrieval_code` as user-configurable voicemail settings across the full stack (server, wire protocol, digitsd)
- Hardcode as constants in digitsd: 50 messages, `*98` retrieval code
- Remove the "Advanced settings" accordion from the phone detail page; ring timeout is now a simple inline field
- Add commit-type selection guidance to CLAUDE.md so user-visible changes use `feat`/`fix` (prevents the silent-no-release bug that left PR #596 stuck on main)

## What was wrong

These settings existed because they were easy to implement, not because anyone would ever change them. Nobody configures a message cap or customizes `*98`. They cluttered the UI, inflated the testing surface, and confused users.

Additionally, PR #596 (the earlier max-message-duration removal) used `refactor(server):` as its commit type. Since semantic-release only triggers on `feat`/`fix`/`perf`, that change has been sitting on main unreleased. This PR includes CLAUDE.md guidance to prevent that class of bug.

## Backward compatibility

- Legacy JSONB rows in `lines.settings` still carry `max_stored_messages` and `retrieval_code` keys. `encoding/json` silently drops unknown keys on decode. No migration needed.
- Legacy `config.json` files on devices still carry the keys. Same: silently ignored on load.
- Old servers that still push these fields on the wire (during rollout gap): digitsd silently ignores the unknown JSON keys.

## Test plan

- [x] `go build ./...` clean (server + digitsd)
- [x] `go test ./...` passes (server + digitsd)
- [x] `golangci-lint run ./...` 0 issues (server + digitsd)
- [ ] e2e: voicemail toggle and ring timeout still work in all themes
- [ ] Verify phone detail page no longer shows max stored / retrieval code fields