### PR TITLE
docs: sync voicemail docs with removed settings and cap-at-9 change

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ These are dialed from dial tone (not prefixed with `*#`), matching the original 
 |------|--------|---------|
 | `*96` | Audition greeting | Plays your current outgoing greeting through the earpiece, so you can hear what callers hear. |
 | `*97` | Record greeting | Records a custom outgoing greeting after the tone. |
-| `*98` | Listen to messages | Plays your messages oldest first, then any saved (already heard) messages. During playback: `7` deletes, `9` saves, `#` skips, `*` replays. The retrieval code is configurable; `*98` is the default. |
+| `*98` | Listen to messages | Plays your messages oldest first, then any saved (already heard) messages. During playback: `7` deletes, `9` saves, `#` skips, `*` replays. |
 | `*99` | Delete greeting | Removes your custom greeting and restores the default. |
 
 When a call rings unanswered past the configured timeout, the phone answers it, plays your greeting, and records the caller's message. The handset microphone is muted while recording, so a caller never hears your room. See the [voicemail guide](docs/voicemail-guide.md) for using and configuring it, or [Voicemail](docs/voicemail.md) for the engineering reference: FSM, on-disk storage format, signaling, and configuration.

--- a/docs/voicemail-guide.md
+++ b/docs/voicemail-guide.md
@@ -101,24 +101,17 @@ machine on for that line, untick it to turn it off. The change saves as soon as
 you click; there is no separate save button for the toggle. With voicemail off,
 the phone simply rings and never auto-answers.
 
-### The settings form
+### The ring timeout
 
-Open the advanced settings block in the voicemail section to edit three fields.
-Change what you need, then submit the form to save.
+The voicemail section has a ring timeout field: how many seconds a call rings
+before the answering machine picks up. Change it, then submit the form to save.
+The allowed range is 5 to 60 seconds.
 
-| Field | What it controls | Allowed range |
-|-------|------------------|---------------|
-| Ring timeout | How many seconds a call rings before the answering machine picks up | 5 to 60 seconds |
-| Max stored messages | How many messages the phone keeps before the oldest is dropped | 5 to 200 |
-| Retrieval code | The code you dial on the phone to listen to messages | 2 to 6 characters, digits and `*` and `#` only, must include at least one `*` or `#` |
+If you enter a number outside that range, the app rejects the form with a
+message explaining the limit; nothing is saved until the value is valid.
 
-If you enter a number outside its range, or a retrieval code that breaks the
-rules, the app rejects the form with a message explaining the limit; nothing is
-saved until the values are valid. A retrieval code cannot be all digits, so it
-can never be mistaken for a real phone number.
-
-When voicemail is disabled, the three fields are dimmed and locked. Turn
-voicemail on to edit them.
+When voicemail is disabled, the ring timeout field is dimmed and locked. Turn
+voicemail on to edit it.
 
 ### The unheard-messages badge
 
@@ -129,10 +122,9 @@ clear messages on the handset.
 
 ### When settings take effect
 
-The on/off toggle, ring timeout, and retrieval code apply on the phone's next
-incoming call. The storage cap applies after the phone restarts. If you edit
-settings while the phone is offline, the phone picks them up the next time it
-connects.
+The on/off toggle and ring timeout apply on the phone's next incoming call. If
+you edit settings while the phone is offline, the phone picks them up the next
+time it connects.
 
 ## Limits and edge cases
 
@@ -141,13 +133,12 @@ connects.
   a caller still talking when the cap is reached hears a beep and the recording
   is saved. The cap is fixed and not configurable.
 - **Greeting length.** A custom greeting can be up to 60 seconds.
-- **Storage cap.** The phone keeps up to 50 messages by default. When the box
-  is full and a new message arrives, the oldest message is deleted to make
-  room. Listen to and clear your messages so you do not lose old ones to new
-  ones.
-- **Lots of messages.** If you have ten or more unheard messages, the phone
-  stops counting them out one by one and just tells you that you have many
-  messages. The exact number is not read aloud past nine.
+- **Storage cap.** The phone keeps up to 50 messages. When the box is full and
+  a new message arrives, the oldest message is deleted to make room. Listen to
+  and clear your messages so you do not lose old ones to new ones.
+- **Lots of messages.** If you have more than nine unheard messages, the phone
+  announces the count as "nine"; it does not read an exact number aloud past
+  nine.
 - **Ring time.** A call has to ring for the configured timeout (20 seconds by
   default) before the answering machine picks up. Setting the timeout to zero
   turns auto-answer off; the phone just keeps ringing.
@@ -163,10 +154,6 @@ takes effect on the next incoming call.
 did not finish cleanly the phone falls back to the standard greeting. Dial
 `*97` and record it again, and wait for the "Greeting saved" confirmation
 before hanging up.
-
-**I changed the storage cap and nothing changed.** The storage cap is read
-when the phone starts up, so a change to it takes effect after the phone
-restarts. The on/off toggle, ring timeout, and retrieval code apply right away.
 
 **The message-waiting light is pulsing but `*98` says no messages.** The slow
 pulse tracks unheard messages. If you saved or deleted everything, the light

--- a/docs/voicemail.md
+++ b/docs/voicemail.md
@@ -241,12 +241,13 @@ in `internal/assets/embed/data/tones/`:
 | `vm_new_message.wav` | "new message" (singular) |
 | `vm_new_messages.wav` | "new messages" (plural) |
 | `vm_no_messages.wav` | "You have no messages" |
-| `vm_lost_count.wav` | A self-contained "many messages" phrase for counts of 10 or more |
+| `vm_no_new_messages.wav` | "You have no new messages", played before saved review when `*98` is dialed with no unheard messages |
 | `vm_message_deleted.wav` | "Message deleted" |
 | `vm_message_saved.wav` | "Message saved" |
 | `vm_message.wav` | "Message" (composed with a digit clip for the per-message announcement) |
 | `vm_saved_message.wav` | "saved message" (singular) |
 | `vm_saved_messages.wav` | "saved messages" (plural) |
+| `vm_saved_next.wav` | "Saved messages are next", played when retrieval crosses from the new-message phase into saved review |
 | `vm_end_of_messages.wav` | "End of messages" |
 | `vm_playback_controls.wav` | The spoken playback-controls prompt, played once per `*98` session |
 | `vm_record_greeting.wav` | The greeting-recording prompt, including how to finish ("press pound when finished, or hang up") |
@@ -263,10 +264,10 @@ feature.
 phrase from individual clips:
 
 - `count <= 0`: play `vm_no_messages` alone.
-- `count >= 10`: play `vm_lost_count` alone. The system does not read out
-  counts of ten or more digit by digit; one phrase covers the whole range.
-- otherwise: play the sequence `vm_you_have`, `spoken_<count>`, then
-  `vm_new_message` for one or `vm_new_messages` for more than one.
+- otherwise: play the sequence `vm_you_have`, `spoken_<min(count, 9)>`, then
+  `vm_new_message` for one or `vm_new_messages` for more than one. The spoken
+  count is capped at nine: there is no digit clip for a larger number, so a
+  mailbox with ten or more unheard messages is announced as "nine".
 
 **Composing "Message N".** During a `*98` retrieval session that holds two or
 more messages, `announceMessageNumber(number)` plays a spoken "Message N"
@@ -346,10 +347,8 @@ type Settings struct {
 }
 
 type Voicemail struct {
-    Enabled            bool   `json:"enabled"`
-    RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-    MaxStoredMessages  int    `json:"max_stored_messages"`
-    RetrievalCode      string `json:"retrieval_code"`
+    Enabled            bool `json:"enabled"`
+    RingTimeoutSeconds int  `json:"ring_timeout_seconds"`
 }
 ```
 
@@ -357,8 +356,7 @@ The inner `Voicemail` fields deliberately omit `omitempty` so a stored row
 carries every field literally; a later read can tell "Enabled was explicitly
 false" apart from "field absent". Time fields are integer seconds in storage
 and on the wire. `line.DefaultVoicemail()` is what a new line starts with:
-`Enabled: true`, ring timeout 20 s, max stored 50, retrieval
-code `*98`. `CreateLine` seeds the `settings` column with
+`Enabled: true`, ring timeout 20 s. `CreateLine` seeds the `settings` column with
 `DefaultSettings().Normalize()` so the non-zero `enabled` default survives the
 DB round trip.
 
@@ -377,12 +375,11 @@ Bounds are package constants in `line/settings.go`, shared by the HTTP handler,
 | Field | Min | Max | Out-of-range heals to |
 |-------|-----|-----|-----------------------|
 | `ring_timeout_seconds` | 5 | 60 | 20 |
-| `max_stored_messages` | 5 | 200 | 50 |
 
-The retrieval code must match `^[0-9*#]{2,6}$` (2 to 6 characters, only digits,
-`*`, and `#`) and must contain at least one `*` or `#`. A purely numeric code
-is rejected so it cannot shadow a real 7-digit dial. An invalid code heals to
-`*98`.
+Ring timeout is the only validated field. The message-storage cap and the
+retrieval code are no longer per-line settings: they are fixed in `digitsd` as
+the `VoicemailMaxStoredMessages` (50) and `VoicemailRetrievalCode` (`*98`)
+constants in `internal/config/config.go`.
 
 ### Endpoints
 
@@ -390,19 +387,17 @@ Both endpoints are POST, registered on the authenticated mux in
 `web/handler.go`, and ownership-checked with `requireLineOwnership` (an auth
 failure returns 404, not 403).
 
-- `POST /phones/{number}/voicemail` (`handlePhoneVoicemailPost`) takes the full
-  form of all four settings: the `enabled` checkbox, the two integer fields
-  (`ring_timeout_seconds`, `max_stored_messages`), and `retrieval_code`. The
-  integers are validated with `parseClampedInt` (400 with a friendly "must be
-  an integer between MIN and MAX" message on a bad value) and the code with
-  `IsValidRetrievalCode` (400 on a malformed code), both before any DB write.
-  On success it builds the new `Voicemail`, runs `Normalize()`, persists, and
-  pushes to the device.
+- `POST /phones/{number}/voicemail` (`handlePhoneVoicemailPost`) takes the
+  `enabled` checkbox and the `ring_timeout_seconds` integer field. The integer
+  is validated with `parseClampedInt` (400 with a friendly "must be an integer
+  between MIN and MAX" message on a bad value) before any DB write. On success
+  it builds the new `Voicemail`, runs `Normalize()`, persists, and pushes to
+  the device.
 - `POST /phones/{number}/voicemail-toggle`
   (`handlePhoneVoicemailTogglePost`) flips `Voicemail.Enabled` only and takes no
-  body fields. The other three fields are preserved through `Normalize()`, which
-  backfills defaults if the row predates voicemail. It is a separate path so a
-  checkbox round trip does not have to resubmit the timing and code fields.
+  body fields. The ring timeout is preserved through `Normalize()`, which
+  backfills the default if the row predates voicemail. It is a separate path so
+  a checkbox round trip does not have to resubmit the ring timeout.
 
 Both swap the `voicemail-section` partial back for HTMX requests
 (`am-voicemail-section` in the answering-machine theme) or send a 303 redirect
@@ -418,9 +413,8 @@ by the `voicemail-section` partial (intercom and dialup themes) or
 
 - An enabled checkbox that `hx-post`s to `/voicemail-toggle` and swaps
   `#voicemail-section`.
-- An advanced `<details>` block holding the four other fields. The whole form
-  `hx-post`s to `/voicemail`. When voicemail is disabled the field block is
-  dimmed and the inputs are `disabled`.
+- An inline ring-timeout field. The form `hx-post`s to `/voicemail`. When
+  voicemail is disabled the field is dimmed and the input is `disabled`.
 - An unheard-count badge ("N unheard" chip, or "MSG N" LED in the
   answering-machine theme) that renders only when voicemail is enabled and the
   unheard count is greater than zero.
@@ -438,10 +432,8 @@ part of a line-settings update. The wire types are in
 
 ```go
 type Voicemail struct {
-    Enabled            bool   `json:"enabled"`
-    RingTimeoutSeconds int    `json:"ring_timeout_seconds"`
-    MaxStoredMessages  int    `json:"max_stored_messages"`
-    RetrievalCode      string `json:"retrieval_code"`
+    Enabled            bool `json:"enabled"`
+    RingTimeoutSeconds int  `json:"ring_timeout_seconds"`
 }
 
 type LineSettings struct {
@@ -476,13 +468,9 @@ triggers:
   caught up. There is no server-side retry queue.
 
 The wire format uses integer seconds; the daemon converts them to
-`time.Duration` for its own `config.Voicemail`. Not every setting takes effect
-at the same time:
-
-- `Enabled`, `RingTimeout`, and `RetrievalCode` are read live, per ring or per
-  dial, so a change applies on the next inbound call with no restart.
-- `MaxStoredMessages` is baked into the `voicemail.Store` when it is opened at
-  boot, so a change to it takes effect on the next daemon restart.
+`time.Duration` for its own `config.Voicemail`. Both pushed settings, `Enabled`
+and `RingTimeout`, are read live, per ring, so a change applies on the next
+inbound call with no restart.
 
 In the other direction the daemon reports its unheard-message count to the
 server with a `voicemail_state` message (`TypeVoicemailState`) carrying
@@ -492,18 +480,16 @@ explicit `0`, so the server can tell "zero unheard" apart from "not reported".
 ## Service code reference
 
 Service codes are dialed on the phone. The mapping is defined in
-`internal/phone/controller.go`; the retrieval code is configurable and the rest
-are fixed.
+`internal/phone/controller.go`; all four codes are fixed.
 
 | Code | Action |
 |------|--------|
 | `*96` | Audition the active outgoing greeting through the earpiece. Enters `VOICEMAIL_PLAY_GREETING`, then returns to dial tone. |
 | `*97` | Record a custom outgoing greeting. Enters `VOICEMAIL_RECORD_GREETING`. |
-| `*98` | Retrieve stored messages. Enters `VOICEMAIL_PLAYBACK`. This code is the configurable `RetrievalCode`; `*98` is the default. |
+| `*98` | Retrieve stored messages. Enters `VOICEMAIL_PLAYBACK`. |
 | `*99` | Delete the custom greeting and revert to the default. Returns to dial tone. |
 
-`*96`, `*97`, and `*99` are fixed; only `*98` (the `RetrievalCode`) is
-configurable. All four are gated on voicemail being enabled for the line.
+All four codes are fixed and are gated on voicemail being enabled for the line.
 
 During message playback (`VOICEMAIL_PLAYBACK`), DTMF digits control the
 session. The controller routes them to `VoicemailKey(digit)`:
@@ -522,24 +508,24 @@ to dial tone.
 
 ## Limits and defaults
 
-Configurable bounds are defined in `internal/config/config.go`
-(`defaultVoicemail()`). The two recording caps are fixed constants in
-`internal/voicemail/store.go`, not configurable.
+The two server-pushed settings are defined in `internal/config/config.go`
+(`defaultVoicemail()`). The message-storage cap and retrieval code are fixed
+constants in the same file; the two recording caps are fixed constants in
+`internal/voicemail/store.go`.
 
-| Setting | Config field | Default | Notes |
-|---------|--------------|---------|-------|
-| Voicemail enabled | `Enabled` | `true` | Read live; off at boot means the store is never opened |
-| Ring timeout before auto-answer | `RingTimeout` | 20 s | Read live; `0` disables auto-answer |
-| Max stored messages | `MaxStoredMessages` | 50 | Baked into the store at boot; FIFO eviction past the cap |
-| Retrieval code | `RetrievalCode` | `*98` | Read live |
+| Setting | Config field or constant | Default | Notes |
+|---------|--------------------------|---------|-------|
+| Voicemail enabled | `Voicemail.Enabled` | `true` | Server-pushed; read live; off at boot means the store is never opened |
+| Ring timeout before auto-answer | `Voicemail.RingTimeout` | 20 s | Server-pushed; read live; `0` disables auto-answer |
+| Max stored messages | `VoicemailMaxStoredMessages` | 50 | Fixed constant; baked into the store at boot; FIFO eviction past the cap |
+| Retrieval code | `VoicemailRetrievalCode` | `*98` | Fixed constant |
 | Max message duration | `messageMaxDuration` | 10 min | Fixed in `store.go`, not configurable; a backstop for a caller who never hangs up |
 | Max greeting duration | `greetingMaxDuration` | 60 s | Fixed in `store.go`, not configurable |
 
 The config file is `/data/digits/config.json`. Settings pushed from the server
-update this config; see Signaling above for which take effect immediately and
-which need a restart.
+update this config and take effect on the next inbound call; see Signaling
+above.
 
-These daemon-side values are the defaults. The server clamps user-entered
-values to narrower ranges before they are pushed down (ring timeout 5 to 60 s,
-max stored 5 to 200); see Validation ranges under
+These daemon-side values are the defaults. The server clamps the user-entered
+ring timeout to 5 to 60 s before it is pushed down; see Validation ranges under
 Server internals.


### PR DESCRIPTION
## Summary

Cross-PR holistic review caught the voicemail docs describing behavior that two merged PRs changed. Each PR was reviewed on its own; nobody re-read the docs against the final shape of the feature.

**Motivated by (last 24h):**
- #601 `feat(server,digitsd): remove max-stored-messages and retrieval-code settings`
- #602 `fix(digitsd): differentiate new vs saved messages in *98 retrieval` (also removed the dead `vm_lost_count.wav` clip and caps the spoken count at 9)

## What was stale

#601 removed `max-stored-messages` and `retrieval-code` as per-line settings, hardcoding them as `digitsd` constants (`VoicemailMaxStoredMessages`, `VoicemailRetrievalCode`) and dropping the advanced-settings accordion in favor of an inline ring-timeout field. But:
- `docs/voicemail.md` still showed both fields in the `line.Voicemail` and wire `Voicemail` structs, listed `max_stored_messages` in the validation-ranges table, documented the retrieval-code regex, described the `/voicemail` endpoint as taking "all four settings", and called `*98` "the configurable `RetrievalCode`".
- `docs/voicemail-guide.md` told users to edit a three-field form and described retrieval-code validation rules.
- `README.md` claimed "the retrieval code is configurable".

#602 removed `vm_lost_count.wav` and now caps the spoken message count at nine, but `voicemail.md` still listed that clip in the asset table and described the "count of ten or more plays `vm_lost_count` alone" path. The two new clips it added (`vm_no_new_messages.wav`, `vm_saved_next.wav`) were undocumented.

## Changes

- `docs/voicemail.md`: struct definitions, validation-ranges table, endpoint description, web-UI description, signaling section, service-code reference, and limits-and-defaults table updated to reflect ring timeout as the only per-line setting and the cap/retrieval code as fixed constants. Asset table and `announceMessageCount` description updated for the cap-at-9 change and the new clips.
- `docs/voicemail-guide.md`: settings form section rewritten as a single ring-timeout field; storage-cap troubleshooting entry removed; "lots of messages" edge case corrected.
- `README.md`: dropped the "retrieval code is configurable" clause from the `*98` row.

Docs-only; no code changes.

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] No remaining references to removed settings as configurable
