### PR TITLE
refactor(server): move test-only HealthStore helpers into the test file

### DIFF
--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -209,22 +209,6 @@ func (s *HealthStore) windowSession(key SessionKey, from, peer string) []Sample 
 	return out
 }
 
-// latestSession returns the most recent sample for a single session edge or nil.
-func (s *HealthStore) latestSession(key SessionKey, from, peer string) *Sample {
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		return nil
-	}
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	if r := sr.byEndpoint[endpointKey{From: from, Peer: peer}]; r != nil {
-		return r.latest()
-	}
-	return nil
-}
-
 // evictSession drops all in-memory state for a session. Broadcasts EndedKind
 // to every live subscriber and closes their channels. Idempotent.
 func (s *HealthStore) evictSession(key SessionKey) {
@@ -306,30 +290,6 @@ func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
 	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample)
 }
 
-// latest returns the most recent samples for caller and callee on a 2-party
-// call, captured under a single lock so the two values are consistent. nil
-// pointers if no sample has been recorded for that endpoint yet. nil/nil if
-// the call is unknown. Test-only; production reads use Window/Readback.
-func (s *HealthStore) latest(callID int64, caller, callee string) (*Sample, *Sample) {
-	key := SessionKey{CallID: callID}
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		return nil, nil
-	}
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	var a, b *Sample
-	if r := sr.byEndpoint[endpointKey{From: caller}]; r != nil {
-		a = r.latest()
-	}
-	if r := sr.byEndpoint[endpointKey{From: callee}]; r != nil {
-		b = r.latest()
-	}
-	return a, b
-}
-
 // Window returns a copy of the retained sample ring for an endpoint, oldest
 // first. Returns an empty slice if the call or endpoint is unknown.
 func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
@@ -363,12 +323,6 @@ func (s *HealthStore) RecordEdge(confID uuid.UUID, from, peer string, sample Sam
 // edge, oldest first. Empty if unknown.
 func (s *HealthStore) WindowEdge(confID uuid.UUID, from, peer string) []Sample {
 	return s.windowSession(SessionKey{ConfID: confID}, from, peer)
-}
-
-// latestEdge returns the most recent sample for a conference edge or nil.
-// Test-only; production reads use WindowEdge/ReadbackEdge.
-func (s *HealthStore) latestEdge(confID uuid.UUID, from, peer string) *Sample {
-	return s.latestSession(SessionKey{ConfID: confID}, from, peer)
 }
 
 // EvictConference drops in-memory state for a conference and broadcasts

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -14,6 +14,51 @@ func sample(ts int64, loss float32) Sample {
 	return Sample{TS: time.Unix(0, ts*int64(time.Millisecond)), LossPct: &l}
 }
 
+// latestSession returns the most recent sample for a single session edge or nil.
+func (s *HealthStore) latestSession(key SessionKey, from, peer string) *Sample {
+	s.mu.Lock()
+	sr, ok := s.sessions[key]
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	if r := sr.byEndpoint[endpointKey{From: from, Peer: peer}]; r != nil {
+		return r.latest()
+	}
+	return nil
+}
+
+// latest returns the most recent samples for caller and callee on a 2-party
+// call, captured under a single lock so the two values are consistent. nil
+// pointers if no sample has been recorded for that endpoint yet. nil/nil if
+// the call is unknown.
+func (s *HealthStore) latest(callID int64, caller, callee string) (*Sample, *Sample) {
+	key := SessionKey{CallID: callID}
+	s.mu.Lock()
+	sr, ok := s.sessions[key]
+	s.mu.Unlock()
+	if !ok {
+		return nil, nil
+	}
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	var a, b *Sample
+	if r := sr.byEndpoint[endpointKey{From: caller}]; r != nil {
+		a = r.latest()
+	}
+	if r := sr.byEndpoint[endpointKey{From: callee}]; r != nil {
+		b = r.latest()
+	}
+	return a, b
+}
+
+// latestEdge returns the most recent sample for a conference edge or nil.
+func (s *HealthStore) latestEdge(confID uuid.UUID, from, peer string) *Sample {
+	return s.latestSession(SessionKey{ConfID: confID}, from, peer)
+}
+
 func TestHealthStoreRecordAndLatest(t *testing.T) {
 	s := NewHealthStore(nil) // nil DB => flusher disabled (flusher not implemented in T3 but constructor must accept nil cleanly)
 	s.Init(1)


### PR DESCRIPTION
## Summary

`HealthStore.latestSession`, `HealthStore.latest`, and `HealthStore.latestEdge` are unexported helpers used only by `linkhealth_test.go`. Their doc comments already stated they are test-only ("production reads use Window/Readback"). Keeping them in `linkhealth.go` put test scaffolding in production source and left them flagged as unreachable by deadcode analysis.

This moves the three functions verbatim into `linkhealth_test.go`, next to the `sample` helper and the tests that call them. They reference unexported fields (`mu`, `sessions`, `byEndpoint`), which is fine in a same-package `_test.go` file. The redundant "test-only" notes were trimmed since the file location now says it. No behavior change: production code never called these.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
