### PR TITLE
docs(digitsd): correct stale voicemail-settings comments

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -469,10 +469,11 @@ func (d *daemonCallbacks) publishVoicemailStateInitial() {
 // replacement of the Voicemail sub-blob; per-field diffing for log granularity
 // happens at the call site before this helper runs.
 //
-// Live consumption: Enabled, RingTimeout and RetrievalCode are read per ring
-// or per dial, so they take effect on the next inbound call without any
-// further wiring. MaxStoredMessages is baked into the voicemail.Store opened
-// at boot, so a change to it takes effect on the next daemon restart.
+// Live consumption: both fields, Enabled and RingTimeout, are read per ring,
+// so they take effect on the next inbound call without any further wiring.
+// The storage cap and retrieval code are no longer pushed; they are fixed
+// config.VoicemailMaxStoredMessages and config.VoicemailRetrievalCode
+// constants and never flow through this helper.
 func (d *daemonCallbacks) setVoicemailConfig(vm config.Voicemail) error {
 	d.mu.Lock()
 	d.cfg.Voicemail = vm

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -109,7 +109,7 @@ type Callbacks interface {
 	VoicemailEnterPlayback()                                      // *98: enter retrieval playback; daemon opens first unheard and streams to mixer
 	VoicemailExitPlayback()                                       // hook-on during playback; daemon tears down player + mixer source
 	VoicemailKey(digit string)                                    // DTMF key during playback (7=delete, 9=mark heard, #=skip, *=replay)
-	VoicemailRetrievalCode() string                               // configured retrieval code (default "*98")
+	VoicemailRetrievalCode() string                               // fixed retrieval code ("*98")
 }
 
 // ContactChecker determines whether a number is in the local contact list.


### PR DESCRIPTION
## Summary

Cross-PR holistic review caught two code comments in `digitsd` describing voicemail behavior that a merged PR changed. Each PR was reviewed on its own; the docs-sync PR that followed only touched markdown.

**Motivated by (last 24h):**
- #603 `docs: sync voicemail docs with removed settings and cap-at-9 change`

#603 was itself a holistic doc-sync for #601 (`feat(server,digitsd): remove max-stored-messages and retrieval-code settings`). It synced `docs/voicemail.md`, `docs/voicemail-guide.md`, and `README.md` to the removal, but stopped at markdown and left two stale code comments behind.

## What was stale

#601 removed `max-stored-messages` and `retrieval-code` as per-line settings. They are now fixed `config.VoicemailMaxStoredMessages` (50) and `config.VoicemailRetrievalCode` (`*98`) constants, and the pushed `config.Voicemail` struct carries only `Enabled` and `RingTimeout`. But:

- `pi/digitsd/cmd/digitsd/main.go`: the `setVoicemailConfig` doc comment still described `RetrievalCode` and `MaxStoredMessages` as part of the pushed `Voicemail` sub-blob, including a "takes effect on the next daemon restart" note for a field that no longer flows through the helper at all.
- `pi/digitsd/internal/phone/controller.go`: the `VoicemailRetrievalCode()` interface comment still called the value the "configured retrieval code (default `*98`)", implying per-line configurability. The implementation comment in `voicemail.go` already correctly calls it "hardcoded".

## Changes

- `main.go`: `setVoicemailConfig` comment now states both pushed fields (`Enabled`, `RingTimeout`) are read live per ring, and that the storage cap and retrieval code are fixed constants that never flow through the helper.
- `controller.go`: interface comment now reads `fixed retrieval code ("*98")`.

Comment-only; no behavior change.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass for `pi/digitsd` (verified locally; comment-only)
