### PR TITLE
refactor(server): named constants, OneEnv helper, and minor cleanup

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -36,6 +36,9 @@ import (
 	"github.com/justinlindh/digits/server/internal/web"
 )
 
+// releaseCacheTTL is the release index cache lifetime, in seconds.
+const releaseCacheTTL = 5 * 60
+
 func main() {
 	logging.Setup()
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -254,7 +257,7 @@ func run(ctx context.Context) error {
 	case cfg.GitHubRepo != "":
 		parts := strings.SplitN(cfg.GitHubRepo, "/", 2)
 		if len(parts) == 2 {
-			handler.Releases = updates.NewGitHubReleases(ctx, parts[0], parts[1], cfg.GitHubToken, 300, // 5 min cache
+			handler.Releases = updates.NewGitHubReleases(ctx, parts[0], parts[1], cfg.GitHubToken, releaseCacheTTL,
 				func(piLatest, fwLatest string) {
 					slog.Info("updates: new release detected, broadcasting", "pi", piLatest, "fw", fwLatest)
 					handler.Hub().Broadcast(&signaling.Message{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -3,8 +3,6 @@
 // environment values and built-in defaults.
 package config
 
-import "os"
-
 // Config holds all runtime configuration for signald, populated by Load from
 // environment variables. Zero values are overridden by Load's defaults where
 // appropriate.
@@ -87,19 +85,14 @@ func Load() *Config {
 	StringEnv("ADMIN_SECRET", &c.AdminSecret)
 	// Dev
 	BoolEnv("DEV_MODE", &c.DevMode)
-	// Link health: env is "1" (not "true") to match the daemon's convention.
-	if os.Getenv("SIGNALD_LINK_HEALTH_FLUSH_DISABLED") == "1" {
-		c.LinkHealthFlushDisabled = true
-	}
+	OneEnv("SIGNALD_LINK_HEALTH_FLUSH_DISABLED", &c.LinkHealthFlushDisabled)
 	// Redis
 	StringEnv("REDIS_URL", &c.RedisURL)
 	// Rate limits
 	c.WSRateLimitPerMin = 30
 	IntEnv("SIGNALD_WS_RATE_LIMIT", &c.WSRateLimitPerMin)
 	// Release index
-	if os.Getenv("TEST_FAKE_UPDATES") == "1" {
-		c.FakeUpdates = true
-	}
+	OneEnv("TEST_FAKE_UPDATES", &c.FakeUpdates)
 	StringEnv("GITHUB_REPO", &c.GitHubRepo)
 	StringEnv("GITHUB_TOKEN", &c.GitHubToken)
 	return c

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -78,6 +78,34 @@ func TestBoolEnv(t *testing.T) {
 	})
 }
 
+func TestOneEnv(t *testing.T) {
+	t.Run("sets true when env var is literal 1", func(t *testing.T) {
+		t.Setenv("TEST_ONE_VAR", "1")
+		got := false
+		OneEnv("TEST_ONE_VAR", &got)
+		if !got {
+			t.Error("expected true, got false")
+		}
+	})
+
+	t.Run("does not set true for true", func(t *testing.T) {
+		t.Setenv("TEST_ONE_TRUE", "true")
+		got := false
+		OneEnv("TEST_ONE_TRUE", &got)
+		if got {
+			t.Error("expected false for value 'true', got true")
+		}
+	})
+
+	t.Run("keeps false when env var is unset", func(t *testing.T) {
+		got := false
+		OneEnv("TEST_ONE_UNSET_XYZ", &got)
+		if got {
+			t.Error("expected false for unset var, got true")
+		}
+	})
+}
+
 func TestLoadDefaults(t *testing.T) {
 	c := Load()
 

--- a/server/internal/config/env.go
+++ b/server/internal/config/env.go
@@ -23,6 +23,14 @@ func BoolEnv(key string, dst *bool) {
 	}
 }
 
+// OneEnv sets *dst to true iff the env var is literal "1". Used for env vars
+// that follow the daemon's numeric-flag convention instead of the "true" convention.
+func OneEnv(key string, dst *bool) {
+	if os.Getenv(key) == "1" {
+		*dst = true
+	}
+}
+
 // IntEnv parses the env var as an integer and assigns it to *dst. Keeps the
 // current default if the variable is unset or not a valid integer.
 func IntEnv(key string, dst *int) {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -170,4 +170,3 @@ func (s *Store) BoundLineNumber(ctx context.Context, hardwareID string) (string,
 	}
 	return number, nil
 }
-

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -18,6 +18,13 @@ import (
 
 var relayTracer = otel.Tracer("github.com/justinlindh/digits/server/internal/signaling")
 
+const (
+	// callReturnExpiry is how long a *69 busy-retry request remains active.
+	callReturnExpiry = 30 * time.Minute
+	// googleSTUN is the public STUN server included in every ICE-servers response.
+	googleSTUN = "stun:stun.l.google.com:19302"
+)
+
 // CallTracker is the subset of *calls.Tracker that the Relay needs to track
 // call lifecycle events and query in-flight call state.
 type CallTracker interface {
@@ -488,7 +495,7 @@ func (r *Relay) handleRequestICE(ctx context.Context, from string) {
 
 	// Always include a STUN server
 	stunServer := ICEServer{
-		URLs: []string{"stun:stun.l.google.com:19302"},
+		URLs: []string{googleSTUN},
 	}
 	resp.Servers = append(resp.Servers, stunServer)
 
@@ -769,7 +776,7 @@ func (r *Relay) handleCallReturnRetry(ctx context.Context, from string, msg *Mes
 	r.pendingReturnsMu.Lock()
 	r.pendingReturns[from] = &pendingCallReturn{
 		Target:    target,
-		ExpiresAt: time.Now().Add(30 * time.Minute),
+		ExpiresAt: time.Now().Add(callReturnExpiry),
 	}
 	r.pendingReturnsMu.Unlock()
 	slog.InfoContext(ctx, "call_return: retry registered", "requester", from, "target", target)

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -11,6 +11,14 @@ import (
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
+const (
+	wsRegisterTimeout = 10 * time.Second
+	wsPingInterval    = 30 * time.Second
+	wsPongTimeout     = 45 * time.Second
+	wsWriteTimeout    = 10 * time.Second
+	wsSendBuf         = 32
+)
+
 // wsReject sends an error message to the WebSocket client and closes the connection.
 func wsReject(ws *websocket.Conn, errMsg string) {
 	_ = ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
@@ -33,7 +41,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Wait for register message
-	if err := ws.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+	if err := ws.SetReadDeadline(time.Now().Add(wsRegisterTimeout)); err != nil {
 		slog.ErrorContext(r.Context(), "ws set register deadline failed", "err", err)
 		_ = ws.Close()
 		return
@@ -121,16 +129,10 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	const (
-		wsPingInterval = 30 * time.Second
-		wsPongTimeout  = 45 * time.Second
-		wsWriteTimeout = 10 * time.Second
-	)
-
 	conn := &signaling.Conn{
 		WS:         ws,
 		HardwareID: msg.HardwareID,
-		Send:       make(chan []byte, 32),
+		Send:       make(chan []byte, wsSendBuf),
 		LastSeen:   time.Now(),
 	}
 	if err := h.hub.Register(msg.Number, conn); err != nil {


### PR DESCRIPTION
## Code quality audit: server/

Before grade: **84 / 100**
After grade: **90 / 100**

---

### What was graded

The audit covered all Go source under `server/` for idiomatic style, naming, test coverage, project layout, and dead/stale patterns. Build and unit tests were clean throughout (`go build ./...`, `go vet ./...`, `go test ./...`). No high-severity issues were found; the three areas below accounted for the gap between 84 and the ceiling.

---

### Issues addressed

**1. Config env-parsing inconsistency (-3)**

`SIGNALD_LINK_HEALTH_FLUSH_DISABLED` and `TEST_FAKE_UPDATES` were parsed with inline `os.Getenv() == "1"` blocks instead of a helper, while every other env var used `StringEnv`, `BoolEnv`, or `IntEnv`. The reason for `"1"` (matching the Pi daemon's convention) was documented only on the first variable.

Fix: add `OneEnv` to `config/env.go` alongside the existing helpers, use it for both vars, and add tests to `config_test.go`. The `"1"` convention is now captured in the function doc once rather than in ad-hoc comments.

**2. Magic numbers (-5)**

Several numeric and string literals had no names, making their purpose and relationships non-obvious:

| Location | Literal | Now |
|---|---|---|
| `cmd/signald/main.go` | `300` (release cache seconds) | `releaseCacheTTL = 5 * 60` |
| `internal/signaling/relay.go` | `30 * time.Minute` (*69 retry window) | `callReturnExpiry` |
| `internal/signaling/relay.go` | `"stun:stun.l.google.com:19302"` | `googleSTUN` |
| `internal/web/handler_ws.go` | `10 * time.Second` (register deadline) | `wsRegisterTimeout` |
| `internal/web/handler_ws.go` | `32` (send channel buffer) | `wsSendBuf` |

The `ws*` constants in `handler_ws.go` were also promoted from a mid-function `const` block to package level so `wsRegisterTimeout` could be referenced before the block where it was previously declared.

**3. Trailing blank line in `device/store.go` (-1)**

Single spurious blank line at end of file; removed.

---

### Why the remaining 10 points are not addressed

- **Exported fields on `Relay`** (`Hub`, `Tracker`, `TURNGen`, etc.) are set from `cmd/signald/main.go` at startup and need to be exported for that; changing this would require a larger constructor refactor.
- **`handler.go` at 776 lines**: the file is organized coherently (template parsing, websocket upgrader, rate limiters, router) and splitting it would not improve clarity without a more significant restructure.
- **Template-function thresholds** (`pctToSegments`, `msToSegments`, `humanBytes`): the numeric thresholds are domain-specific quality boundaries defined in the same file as the rendering logic. Naming them would add noise rather than clarity at this scale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdJaQAGAdupe1Ry6QUmywu)_