### PR TITLE
refactor(digitsd): move audio test helpers into test files

### DIFF
--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -96,12 +96,6 @@ func (p *Pipeline) SetVoiceStyle(style string) {
 	}
 }
 
-// loadCharacter is a test helper. Returns the current character chain (may
-// be nil).
-func (p *Pipeline) loadCharacter() *BiquadChain {
-	return p.character.Load()
-}
-
 // SetMuted toggles the outbound mic mute. When true, outbound PCM frames are
 // replaced with zero-samples. With Opus DTX enabled on the encoder, the
 // receiving end renders low-level comfort noise, matching 90s POTS silent
@@ -208,20 +202,6 @@ func (p *Pipeline) nextBeepFrame(frameSize int) []int16 {
 		p.beepBuf.Store(nil)
 	}
 	return frame
-}
-
-// drainBeepFrames is a test helper that consumes all remaining beep frames of
-// the given size.
-func (p *Pipeline) drainBeepFrames(frameSize int) [][]int16 {
-	var frames [][]int16
-	for {
-		frame := p.nextBeepFrame(frameSize)
-		if frame == nil {
-			break
-		}
-		frames = append(frames, frame)
-	}
-	return frames
 }
 
 // Start opens the ALSA capture device and begins the capture goroutine.

--- a/pi/digitsd/internal/audio/pipeline_beep_test.go
+++ b/pi/digitsd/internal/audio/pipeline_beep_test.go
@@ -5,6 +5,19 @@ import (
 	"time"
 )
 
+// drainBeepFrames consumes all remaining beep frames of the given size.
+func (p *Pipeline) drainBeepFrames(frameSize int) [][]int16 {
+	var frames [][]int16
+	for {
+		frame := p.nextBeepFrame(frameSize)
+		if frame == nil {
+			break
+		}
+		frames = append(frames, frame)
+	}
+	return frames
+}
+
 func TestPlayGreetingBeep_ReplacesFrames(t *testing.T) {
 	cfg := DefaultPipelineConfig()
 	p := NewPipeline(cfg)

--- a/pi/digitsd/internal/audio/pipeline_live_test.go
+++ b/pi/digitsd/internal/audio/pipeline_live_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 )
 
+// loadCharacter returns the current character chain (may be nil).
+func (p *Pipeline) loadCharacter() *BiquadChain {
+	return p.character.Load()
+}
+
 func TestSetVoiceStyleTogglesCharacterChain(t *testing.T) {
 	p := NewPipeline(DefaultPipelineConfig())
 


### PR DESCRIPTION
## Summary

`Pipeline.loadCharacter` and `Pipeline.drainBeepFrames` lived in `pipeline.go` but existed only to support unit tests: both were already documented as test helpers, and a reachability scan confirms neither is called from any production path.

This moves each helper into the `_test.go` file that uses it:

- `loadCharacter` -> `pipeline_live_test.go` (its only caller)
- `drainBeepFrames` -> `pipeline_beep_test.go` (its only caller)

Methods defined in a package's `_test.go` files attach to the type just like production methods, so the tests are unchanged. The win is that `pipeline.go` now contains only production code, and the helpers can no longer be reached outside tests.

Mirrors the earlier "move test-only HealthStore helpers into the test file" cleanup (#605).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `deadcode -test ./...` reports no unreachable functions