### PR TITLE
fix(server): handle randomToken error in Google OAuth login, tighten docs

### DIFF
--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -42,7 +42,12 @@ func (g *GoogleAuth) Enabled() bool {
 
 // HandleLogin redirects to Google consent screen.
 func (g *GoogleAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
-	state, _ := randomToken(16)
+	state, err := randomToken(16)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "auth: failed to generate oauth state token", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 	returnTo := r.URL.Query().Get("return_to")
 	cookieVal := state
 	if returnTo != "" {

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -207,6 +207,8 @@ func LoginRedirectFor(u *User) string {
 	return "/"
 }
 
+// isSafeRedirect rejects protocol-relative ("//") and host-relative ("/\") paths
+// that browsers can resolve to an attacker-controlled host.
 func isSafeRedirect(path string) bool {
 	return path != "" && strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "//") && !strings.HasPrefix(path, "/\\")
 }

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -36,6 +36,8 @@ func Open(databaseURL string) (*Database, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
+	// Low-concurrency process: 25 open / 5 idle covers bursts without
+	// exhausting typical Postgres connection limits.
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(5 * time.Minute)

--- a/server/internal/tracing/tracing.go
+++ b/server/internal/tracing/tracing.go
@@ -297,7 +297,7 @@ func buildResource(ctx context.Context, cfg Config) (*resource.Resource, error) 
 // fallbackResource is used when resource detection fails. Carries the
 // minimum to identify a service in a multi-tenant collector.
 func fallbackResource(cfg Config) *resource.Resource {
-	host, _ := os.Hostname() // nolint:errcheck
+	host, _ := os.Hostname() // nolint:errcheck // empty hostname is fine
 	return resource.NewWithAttributes(
 		semconv.SchemaURL,
 		semconv.ServiceName(cfg.ServiceName),


### PR DESCRIPTION
## Code quality audit: server/

Graded the `server/` package on idiomatic Go, project layout, dead code, error handling, test coverage, SQL safety, consistency, documentation, and security. Then fixed every genuine finding.

**Before: 85/100. After: 88/100.**

---

## Findings and grades

| Category | Grade | Notes |
|---|---|---|
| Project layout | A | Idiomatic cmd/internal structure, 25 well-scoped packages |
| Dead code | A | No orphaned functions, types, or imports found |
| Idiomatic Go | A- | Context throughout, proper error wrapping, small interfaces |
| Error handling | B+ | Strong overall; one bug (see below) |
| Test coverage | B+ | 88 test files; core packages 65-100%; web handlers covered by integration tests |
| SQL safety | A+ | 100% parameterized queries, no injection surface |
| Consistency | A- | Auth and error-response patterns slightly varied but correct |
| Documentation | B+ | Good on exported symbols; one security function lacked a comment |
| Security | A- | Solid; one CSRF protection gap (see below) |

---

## Changes

### `internal/auth/google.go`: fix silent crypto error drop (security bug)

`randomToken(16)` was called with `_` for the error. If `crypto/rand` fails, `state` becomes `""`. The OAuth callback check compares the cookie state against the query `state` parameter: two empty strings match trivially, bypassing CSRF protection for the Google login flow. Now returns HTTP 500 instead.

### `internal/auth/handlers.go`: document `isSafeRedirect`

Added a two-line comment explaining which attack the function prevents and why `//` and `/\` prefixes are rejected. The function is called in three places and the threat model was not self-evident from the implementation.

### `internal/db/db.go`: explain connection pool values inline

The pool values (25 open, 5 idle, 5 min lifetime) were bare literals with no rationale. Added an inline comment at the call site explaining the low-concurrency context. Skipped named constants: the values appear once and constants would not add readability.

### `internal/tracing/tracing.go`: consistent nolint annotation

`fallbackResource` had `// nolint:errcheck` with no rationale. The identical pattern in `buildResource` (line 277) already carries `// empty hostname is fine`. Made them consistent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpSfpY4djyS6o5fku9XrXK)_