### PR TITLE
refactor(digitsd): drop always-true parameter from flash callback

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -308,8 +308,8 @@ func (d *daemonCallbacks) NotifyCallConnected() {
 	d.serial.CallConnected()
 }
 
-func (d *daemonCallbacks) SetFlashEnabled(enabled bool) {
-	d.serial.FlashEnabled(enabled)
+func (d *daemonCallbacks) EnableFlashDetection() {
+	d.serial.FlashEnabled(true)
 }
 
 func (d *daemonCallbacks) OnCallReturn() {

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -80,7 +80,7 @@ type Callbacks interface {
 	OncePlaying() bool          // Reports whether a one-shot tone (e.g. intercept) is still playing
 	SendRing(start bool)        // Send RING:START or RING:STOP
 	SendLED(mode string)        // Send LED:<mode>
-	SetFlashEnabled(enabled bool) // Enable/disable Pico hook-flash detection (off = instant hangup)
+	EnableFlashDetection()      // Enable Pico hook-flash detection on the connected call
 	InitiateCall(number string) error // Start outgoing WebRTC call
 	AnswerCall()                // Accept incoming WebRTC call
 	HangupCall()                // Tear down WebRTC call
@@ -386,14 +386,14 @@ func (c *Controller) onHookOff() {
 			c.cb.SendRing(false)
 			c.cb.SendTone(ToneStop)
 			c.cb.SendLED("ON")
-			c.cb.SetFlashEnabled(true)
+			c.cb.EnableFlashDetection()
 			c.cb.AnswerCall()
 		}
 	case StateVOICEMAIL_GREETING, StateVOICEMAIL_RECORDING:
 		c.state = StateCONNECTED
 		c.cb.SendTone(ToneStop)
 		c.cb.SendLED("ON")
-		c.cb.SetFlashEnabled(true)
+		c.cb.EnableFlashDetection()
 		c.cb.VoicemailPickup()
 	default:
 		slog.Info("phone: HOOK:OFF ignored", "state", c.state)
@@ -748,7 +748,7 @@ func (c *Controller) onSignalAnswer(sender string) {
 	case StateCALLING:
 		c.state = StateCONNECTED
 		c.cb.SendTone(ToneStop)
-		c.cb.SetFlashEnabled(true)
+		c.cb.EnableFlashDetection()
 		c.cb.NotifyCallConnected()
 	case StateADD_CALLING:
 		if sender != "" && sender != c.addingPeer {

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -26,7 +26,7 @@ type mockCallbacks struct {
 	ringPatterns       []int
 	callReturnCancels  int
 	callReturnAbandons int
-	flashEnabledLog    []bool            // each SetFlashEnabled call recorded in order
+	flashDetections    int               // EnableFlashDetection call count
 	mutedPeers         map[string]bool   // phone -> current mute state
 	torndownPeers      []string          // peers that had TearDownPeer called
 	removedMeshPeers   []string          // peers that had RemoveMeshPeer called
@@ -64,10 +64,10 @@ func (m *mockCallbacks) SendLED(mode string) {
 	defer m.mu.Unlock()
 	m.leds = append(m.leds, mode)
 }
-func (m *mockCallbacks) SetFlashEnabled(enabled bool) {
+func (m *mockCallbacks) EnableFlashDetection() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.flashEnabledLog = append(m.flashEnabledLog, enabled)
+	m.flashDetections++
 }
 func (m *mockCallbacks) InitiateCall(number string) error {
 	m.mu.Lock()


### PR DESCRIPTION
## What

`Callbacks.SetFlashEnabled(enabled bool)` in `internal/phone/controller.go` was a constant-in-practice flag. All three call sites in the controller FSM pass a literal `true`:

- `onHookOff` (incoming answer)
- `onHookOff` (voicemail pickup)
- `onSignalAnswer` (outgoing call connected)

The FSM only ever *enables* flash detection, on call connect. It never disables it through this callback. The disable path lives elsewhere: `webrtc.go` calls `serial.FlashEnabled(false)` directly on call teardown, not via `Callbacks`.

This renames the method to `EnableFlashDetection()` with no parameter, so the interface no longer implies a disable path the FSM never exercises. The daemon implementation passes `true` to `serial.FlashEnabled` directly.

## Why `refactor`, not `feat`

Device behavior is byte-for-byte identical: every former call passed `true`, and it still does. This is purely an interface-surface cleanup, so the external contract is unchanged.

## Scope

Three files: the interface declaration plus its three call sites (`controller.go`), the daemon implementation (`main.go`), and the test mock (`controller_test.go`). The mock's write-only `flashEnabledLog []bool` is replaced with a matching `flashDetections int` counter.

## Test

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass for `pi/digitsd`.