### PR TITLE
fix(server): handle error from IsPendingForHouseholdEmail in devseed

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -191,7 +191,10 @@ func main() {
 
 	// Seed a pending user invite on the primary household
 	invStore := household.NewInviteStore(database.DB)
-	pending, _ := invStore.IsPendingForHouseholdEmail(ctx, primaryHH.ID, "pending@digits.local")
+	pending, err := invStore.IsPendingForHouseholdEmail(ctx, primaryHH.ID, "pending@digits.local")
+	if err != nil {
+		log.Fatalf("check pending invite: %v", err)
+	}
 	if !pending {
 		if _, err := invStore.CreateInvite(ctx, primaryHH.ID, "pending@digits.local", primaryUser.ID); err != nil {
 			log.Fatalf("seed pending invite: %v", err)


### PR DESCRIPTION
## Server code audit: before/after grade

**Before: 88/100. After: 89/100.**

---

### Audit methodology

All Go source files under `server/` were reviewed for:

- Code cleanliness and idiomatic Go patterns
- Stale, dead, or unreferenced code
- Project layout correctness
- Error handling consistency
- Test coverage
- Security and correctness

---

### Findings

**Fixed (this PR):**

- `cmd/devseed/main.go:194`: The return error from `IsPendingForHouseholdEmail` was silently discarded with `_`. A database failure would cause the check to behave as if no pending invite exists, letting the seeder proceed to `CreateInvite` without any diagnostic output. The variable is now checked with `log.Fatalf`, consistent with every other fallible call in `main()`.

**YAGNI-skipped (concrete reasons):**

- `internal/updates/github.go:159`: `body, _ = io.ReadAll(...)` on the error-response body. An empty string in the diagnostic log is a perfectly acceptable fallback for a non-200 response. No fix needed.
- `internal/tracing/tracing.go:277,300`: `host, _ := os.Hostname()` repeated twice with `// nolint:errcheck` comments. Deduplication would require a private helper for two identical one-liners. YAGNI.
- `cmd/signald/main.go:298-299`: Metrics `/healthz` returns `{"status":"ok"}` without a version field, while the public `/healthz` uses `httputil.Healthz(version.Version)`. These endpoints have different consumers (Prometheus/Docker vs autodeploy) and different contracts. YAGNI.
- `cmd/signald/main.go:40`: `releaseCacheTTL = 5 * 60` as a bare `int`. Changing to `time.Duration` would require updating `NewGitHubReleases`'s signature; pre-existing design decision. YAGNI.
- `internal/auth/store.go`, `internal/pairing/pairing.go`: `n, _ := res.RowsAffected()`. With `lib/pq`, `RowsAffected` never returns an error for `UPDATE`/`DELETE`. YAGNI.
- `internal/pairing` and `internal/device` have no standalone `_test.go` files. Coverage is provided by integration tests in `internal/web/e2e_pairing_test.go` and the full integration suite. YAGNI.

---

### What kept the grade from 100

The remaining 11 points reflect structural constraints rather than actionable bugs:

- No test files for `internal/pairing` and `internal/device` (-4): coverage exists at the integration layer but not as isolated unit tests.
- Minor inconsistencies noted above but YAGNI-skipped (-4).
- The `handler_api.go` htmx fragment inlines Tailwind class strings directly in Go (-2): functional, but styling is scattered rather than in templates. Refactoring would touch the e2e suite and is out of scope.
- One discarded error in devseed (-1): fixed here.

---

### Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` passes (all 24 packages)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmxwH4E6TzntNJmAgrPtLP)_