### PR TITLE
refactor(server): pull r.ParseForm + 400 boilerplate into helper

### DIFF
--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -425,6 +425,16 @@ func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string, lineN
 	return false
 }
 
+// parseForm calls r.ParseForm and writes a 400 on failure. Returns true on
+// success so callers can guard with `if !parseForm(w, r) { return }`.
+func parseForm(w http.ResponseWriter, r *http.Request) bool {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
 func jsonError(ctx context.Context, w http.ResponseWriter, msg string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -110,8 +110,7 @@ func (h *Handler) handleLinksAcceptPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	code := strings.TrimSpace(strings.ToUpper(r.FormValue("code")))

--- a/server/internal/web/handler_onboard.go
+++ b/server/internal/web/handler_onboard.go
@@ -35,8 +35,7 @@ func (h *Handler) handleOnboardPost(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	name := strings.TrimSpace(r.FormValue("name"))

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -179,8 +179,7 @@ func (h *Handler) handlePhonesPost(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	number := line.StripNumber(strings.TrimSpace(r.FormValue("number")))
@@ -217,8 +216,7 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	code := strings.TrimSpace(r.FormValue("code"))
@@ -435,8 +433,7 @@ func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	name, err := validateLineName(r.FormValue("name"))
@@ -495,8 +492,7 @@ func (h *Handler) handlePhoneNameEditGet(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	raw := r.FormValue("name")
@@ -526,8 +522,7 @@ func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) {
 	oldNumber := r.PathValue("number")
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	newNumber := line.StripNumber(r.FormValue("number"))
@@ -586,8 +581,7 @@ func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	raw := strings.TrimSpace(r.FormValue("voice_style"))
@@ -601,8 +595,7 @@ func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	silent := strings.TrimSpace(r.FormValue("silent_mode")) == "on"
@@ -612,8 +605,7 @@ func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	autoUpdate := strings.TrimSpace(r.FormValue("auto_update")) == "on"
@@ -630,8 +622,7 @@ func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Reque
 // then either the voicemail-section partial is swapped (htmx) or the user
 // is redirected back to the phone detail page (regular form post).
 func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 
@@ -791,8 +782,7 @@ func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	targetPi := strings.TrimSpace(r.FormValue("target_pi_version"))
@@ -858,8 +848,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	mode := strings.TrimSpace(r.FormValue("mode"))
@@ -933,8 +922,7 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneConvert(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -66,8 +66,7 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
@@ -96,8 +95,7 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	_, hh, ok := h.requireHouseholdAdmin(w, r)
@@ -136,8 +134,7 @@ func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	tz := strings.TrimSpace(r.FormValue("timezone"))
@@ -161,8 +158,7 @@ func (h *Handler) handleUserPrefPost(w http.ResponseWriter, r *http.Request, fie
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	value := r.FormValue(field)
@@ -197,8 +193,7 @@ func (h *Handler) handleHouseholdInvitePost(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	inviteEmail := strings.TrimSpace(strings.ToLower(r.FormValue("email")))
@@ -355,8 +350,7 @@ func (h *Handler) handleHouseholdSwitchPost(w http.ResponseWriter, r *http.Reque
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	householdID := r.FormValue("household_id")

--- a/server/internal/web/handler_welcome.go
+++ b/server/internal/web/handler_welcome.go
@@ -38,8 +38,7 @@ func (h *Handler) handleWelcomePost(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "bad request", http.StatusBadRequest)
+	if !parseForm(w, r) {
 		return
 	}
 	theme := auth.Theme(r.FormValue("theme"))


### PR DESCRIPTION
## Summary

21 handlers in `internal/web` were running the same 4-line guard:

```go
if err := r.ParseForm(); err != nil {
    http.Error(w, "bad request", http.StatusBadRequest)
    return
}
```

Hoist it into `parseForm(w, r) bool` in `handler_helpers.go`, mirroring the `requireHouseholdAdmin(w, r) (_, _, ok bool)` pattern already established there. Each call site collapses to one guard line, and a future change to bad-request handling becomes a one-touch edit instead of 21.

Behavior is unchanged: same 400 status, same `"bad request"` body. The conference-kick endpoint (`handler_conference_linkhealth.go`) keeps its distinct `"bad form"` message and stays inline; sweeping it in would be a behavior change.

Net: 11 lines removed.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` in `server/`
- [x] `golangci-lint run ./...` clean