### PR TITLE
refactor(digitsd): default Registration to enabled

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -858,14 +858,14 @@ func recoveryRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *s
 	})
 
 	regs := []subsystem.Registration{
-		{Module: subsystem.NewMountsModule(), Required: true, Enabled: true},
-		{Module: subsystem.NewKernModsModule(), Deps: []string{"mounts"}, Required: true, Enabled: true},
-		{Module: gpclk0, Deps: []string{"kernel-modules"}, Required: false, Enabled: true},
-		{Module: serial, Deps: []string{"kernel-modules"}, Required: false, Enabled: true},
-		{Module: subsystem.NewWiFiAPModule(subsystem.WiFiAPConfig{SSID: "Digits-Recovery"}), Deps: []string{"kernel-modules"}, Required: true, Enabled: true},
-		{Module: audio, Deps: []string{"gpclk0", "serial"}, Required: false, Enabled: true},
-		{Module: web, Required: true, Enabled: true},
-		{Module: subsystem.NewReaperModule(), Required: true, Enabled: true},
+		{Module: subsystem.NewMountsModule(), Required: true},
+		{Module: subsystem.NewKernModsModule(), Deps: []string{"mounts"}, Required: true},
+		{Module: gpclk0, Deps: []string{"kernel-modules"}},
+		{Module: serial, Deps: []string{"kernel-modules"}},
+		{Module: subsystem.NewWiFiAPModule(subsystem.WiFiAPConfig{SSID: "Digits-Recovery"}), Deps: []string{"kernel-modules"}, Required: true},
+		{Module: audio, Deps: []string{"gpclk0", "serial"}},
+		{Module: web, Required: true},
+		{Module: subsystem.NewReaperModule(), Required: true},
 	}
 	return regs, web, serial, audio
 }
@@ -885,11 +885,11 @@ func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subs
 	})
 
 	regs := []subsystem.Registration{
-		{Module: gpclk0, Required: true, Enabled: true},
-		{Module: serial, Deps: []string{"gpclk0"}, Required: false, Enabled: true},
-		{Module: audio, Deps: []string{"gpclk0"}, Required: false, Enabled: true},
-		{Module: wifiAP, Required: false, Enabled: false},
-		{Module: web, Required: true, Enabled: true},
+		{Module: gpclk0, Required: true},
+		{Module: serial, Deps: []string{"gpclk0"}},
+		{Module: audio, Deps: []string{"gpclk0"}},
+		{Module: wifiAP, Disabled: true},
+		{Module: web, Required: true},
 	}
 	return regs, web, serial, audio, wifiAP
 }

--- a/pi/digitsd/internal/subsystem/manager.go
+++ b/pi/digitsd/internal/subsystem/manager.go
@@ -26,8 +26,8 @@ type Manager struct {
 	states map[string]*NamedStatus
 }
 
-// NewManager creates a Manager. Enabled modules start as StatePending;
-// disabled modules start as StateDisabled.
+// NewManager creates a Manager. Enabled (default) modules start as
+// StatePending; explicitly Disabled modules start as StateDisabled.
 func NewManager(regs []Registration) *Manager {
 	states := make(map[string]*NamedStatus, len(regs))
 	for _, r := range regs {
@@ -35,10 +35,10 @@ func NewManager(regs []Registration) *Manager {
 			Name:     r.Module.Name(),
 			Required: r.Required,
 		}
-		if r.Enabled {
-			s.State = StatePending
-		} else {
+		if r.Disabled {
 			s.State = StateDisabled
+		} else {
+			s.State = StatePending
 		}
 		states[r.Module.Name()] = s
 	}
@@ -192,7 +192,7 @@ func topoLayers(regs []Registration) ([][]Registration, error) {
 	// Build index of enabled modules by name.
 	enabled := make(map[string]bool, len(regs))
 	for _, r := range regs {
-		if r.Enabled {
+		if !r.Disabled {
 			enabled[r.Module.Name()] = true
 		}
 	}
@@ -202,7 +202,7 @@ func topoLayers(regs []Registration) ([][]Registration, error) {
 	deps := make(map[string][]string, len(regs)) // name -> list of enabled names that must finish first
 
 	for _, r := range regs {
-		if !r.Enabled {
+		if r.Disabled {
 			continue
 		}
 		name := r.Module.Name()
@@ -222,7 +222,7 @@ func topoLayers(regs []Registration) ([][]Registration, error) {
 	// Collect enabled regs by name for layer construction.
 	regByName := make(map[string]Registration, len(regs))
 	for _, r := range regs {
-		if r.Enabled {
+		if !r.Disabled {
 			regByName[r.Module.Name()] = r
 		}
 	}

--- a/pi/digitsd/internal/subsystem/manager_test.go
+++ b/pi/digitsd/internal/subsystem/manager_test.go
@@ -75,7 +75,7 @@ func assertLayerContains(t *testing.T, layer []Registration, names ...string) {
 }
 
 func reg(m Module, deps []string, required, enabled bool) Registration {
-	return Registration{Module: m, Deps: deps, Required: required, Enabled: enabled}
+	return Registration{Module: m, Deps: deps, Required: required, Disabled: !enabled}
 }
 
 func stub(name string) *stubModule {

--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -54,9 +54,13 @@ func IsReady(m Module) bool {
 	return m.Status().State == StateReady
 }
 
+// Registration declares a module and how the Manager should treat it.
+// The zero value is the common case: enabled, not required, no deps. Set
+// Disabled to register a module that the Manager should skip but still report
+// in status snapshots (used for modules managed externally, e.g. by systemd).
 type Registration struct {
 	Module   Module
 	Deps     []string
 	Required bool
-	Enabled  bool
+	Disabled bool
 }


### PR DESCRIPTION
## Summary

Of the 13 `subsystem.Registration` entries in `cmd/digitsd/main.go`, 12 spelled out `Enabled: true`. The one entry whose enabled state actually carried information (setup-mode `wifiAP`, where the `digits-dnsmasq-ap` systemd unit owns the interface) was visually buried in the boilerplate.

Flip the field to `Disabled` so the zero value is the common case:

- `Registration` struct: rename `Enabled` → `Disabled`, zero = enabled.
- `subsystem.Manager`: flip the two call sites in `NewManager` and `topoLayers`.
- `cmd/digitsd/main.go`: drop the redundant `Enabled: true` entries; the setup `wifiAP` becomes `Disabled: true` and now stands out at a glance.
- `manager_test.go`: keep the test helper's `(required, enabled bool)` signature stable and invert internally so the call sites in the tests are unchanged.

No behavior change. State transitions, status snapshots, and topo-sort all keep their existing semantics.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` in `pi/digitsd/` (subsystem tests cover the Disabled path)
- [x] `golangci-lint run ./...` clean