### PR TITLE
refactor(digitsd): collapse duplicate sigSender / voicemailStateSender

### DIFF
--- a/pi/digitsd/cmd/digitsd/linkhealth.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth.go
@@ -9,8 +9,10 @@ import (
 	"github.com/pion/webrtc/v4"
 )
 
-// sigSender is the minimal send surface buildMeshLinkHealthSend needs.
-// *sigclient.Client satisfies it.
+// sigSender is the minimal Send-only surface that helpers in this package
+// (link-health reporter, voicemail-state publisher) need from the signaling
+// client. *sigclient.Client satisfies it; unit tests inject capturing fakes
+// to exercise these flows without standing up a real WebSocket.
 type sigSender interface {
 	Send(*sigclient.Message) error
 }

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -390,14 +390,6 @@ func (d *daemonCallbacks) setAutoUpdateConfig(enabled bool) error {
 	return d.cfg.Save()
 }
 
-// voicemailStateSender is the minimal Send-only surface publishVoicemailStateOnce
-// needs from the signaling client. Defined as an interface so unit tests can
-// inject a capturing fake without standing up a real WebSocket. *sigclient.Client
-// satisfies it implicitly.
-type voicemailStateSender interface {
-	Send(*sigclient.Message) error
-}
-
 // publishVoicemailStateOnce reads the current unheard-message count from store
 // and sends a voicemail_state message via sender. When force is false, the
 // send is skipped if the count equals *last (dedup against repeated change
@@ -412,7 +404,7 @@ type voicemailStateSender interface {
 // On a nil store (voicemail feature disabled at boot) or any UnheardCount
 // error, no message is sent and *last is left unchanged so the next trigger
 // will retry from the same baseline.
-func publishVoicemailStateOnce(sender voicemailStateSender, store *voicemail.Store, last *int64, force bool) bool {
+func publishVoicemailStateOnce(sender sigSender, store *voicemail.Store, last *int64, force bool) bool {
 	if store == nil {
 		return false
 	}


### PR DESCRIPTION
## Summary

Two interfaces in `cmd/digitsd` had identical bodies:

```go
type sigSender interface { Send(*sigclient.Message) error }              // linkhealth.go
type voicemailStateSender interface { Send(*sigclient.Message) error }   // main.go
```

Same package, same purpose: a Send-only surface on the signaling client that production satisfies with `*sigclient.Client` and tests satisfy with a capturing fake (`recordingSig`, `fakeVoicemailStateSender`, both retained because they capture different state).

Drop `voicemailStateSender`; switch `publishVoicemailStateOnce` to `sigSender`. Expand the `sigSender` doc to acknowledge both callers so the next "I need a Send-only fake" helper picks it up instead of declaring a third copy.

No behavior change. Both existing tests keep their fakes and pass unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/digitsd/...` (covers `TestPublishVoicemailStateOnce_*` and `TestBuildMeshLinkHealthSend_StampsPeer`)
- [x] `golangci-lint run ./...` clean