### PR TITLE
refactor(server): drop bool arg from WithFlushDisabled

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -161,10 +161,12 @@ func run(ctx context.Context) error {
 	tracker.SetDashboardEvents(dashEvents)
 
 	// Link-health store with its own lifecycle; flusher runs until ctx is cancelled.
-	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled(cfg.LinkHealthFlushDisabled))
+	var healthOpts []calls.HealthStoreOption
 	if cfg.LinkHealthFlushDisabled {
+		healthOpts = append(healthOpts, calls.WithFlushDisabled())
 		slog.Warn("link-health flusher disabled via SIGNALD_LINK_HEALTH_FLUSH_DISABLED")
 	}
+	healthStore := calls.NewHealthStore(database, healthOpts...)
 	tracker.SetHealthStore(healthStore)
 
 	healthDone := make(chan struct{})

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -131,8 +131,8 @@ type HealthStoreOption func(*HealthStore)
 // and final shutdown flush. Ingest (Record/Init/Evict) and in-memory
 // reads (Latest/Window) remain fully operational. Intended for DB
 // maintenance windows; the in-memory rings still bound memory usage.
-func WithFlushDisabled(disabled bool) HealthStoreOption {
-	return func(s *HealthStore) { s.flushDisabled = disabled }
+func WithFlushDisabled() HealthStoreOption {
+	return func(s *HealthStore) { s.flushDisabled = true }
 }
 
 // NewHealthStore creates a HealthStore. Pass a nil database to operate in

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -190,7 +190,7 @@ func TestHealthStoreFlushDisabledOption(t *testing.T) {
 	// attempting any DB writes. Since NewHealthStore(nil, ...) is also
 	// a valid construction (nil DB), use that to avoid needing a DB
 	// in this unit test.
-	s := NewHealthStore(nil, WithFlushDisabled(true))
+	s := NewHealthStore(nil, WithFlushDisabled())
 	if !s.flushDisabled {
 		t.Fatal("expected flushDisabled == true")
 	}

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -130,7 +130,7 @@ func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	deviceStore := device.NewStore(database)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
-	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled(true))
+	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled())
 	tracker.SetHealthStore(healthStore)
 	dashEvents := events.New()
 	hub.SetDashboardEvents(dashEvents)


### PR DESCRIPTION
## Summary

`WithFlushDisabled(disabled bool)` is the worst kind of functional option:

- `WithFlushDisabled(false)` is meaningless (identical to omitting the option).
- `WithFlushDisabled(cfg.LinkHealthFlushDisabled)` hides the conditional inside an option that may then be a no-op setter, which is exactly what `signald/main.go` was doing.

This switches to the standard no-argument form: calling `WithFlushDisabled()` is always meaningful, and the conditional moves up to the caller, where the existing warn-log already lived. Tests that previously passed `true` now just call it with no args.

## Test plan

- [x] `go build ./...` (server)
- [x] `go test ./...` (server)
- [x] `go vet ./...` (server)
