### PR TITLE
refactor(server): consolidate shared web helpers and expand config test coverage

### DIFF
--- a/server/internal/autodeploy/runner.go
+++ b/server/internal/autodeploy/runner.go
@@ -29,6 +29,7 @@ type Runner interface {
 // ExecRunner is the production Runner that delegates to os/exec.
 type ExecRunner struct{}
 
+// NewExecRunner returns an ExecRunner ready for use.
 func NewExecRunner() *ExecRunner { return &ExecRunner{} }
 
 func (ExecRunner) Run(ctx context.Context, spec RunSpec) error {

--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -65,6 +65,7 @@ type ConferenceTracker struct {
 	state       *ConfState
 }
 
+// NewConferenceTracker returns a ConferenceTracker with empty state.
 func NewConferenceTracker() *ConferenceTracker {
 	return &ConferenceTracker{
 		active:      make(map[uuid.UUID]*Conference),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -128,3 +128,33 @@ func TestLoadDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadEnvOverrides(t *testing.T) {
+	t.Setenv("SIGNALD_ADDR", ":9000")
+	t.Setenv("DATABASE_URL", "postgres://localhost/testdb")
+	t.Setenv("SIGNALD_TURN_ENABLED", "true")
+	t.Setenv("REDIS_URL", "redis://localhost:6379")
+	t.Setenv("SIGNALD_WS_RATE_LIMIT", "60")
+	t.Setenv("DEV_MODE", "true")
+
+	c := Load()
+
+	if c.Addr != ":9000" {
+		t.Errorf("Addr: got %q, want %q", c.Addr, ":9000")
+	}
+	if c.DatabaseURL != "postgres://localhost/testdb" {
+		t.Errorf("DatabaseURL: got %q, want %q", c.DatabaseURL, "postgres://localhost/testdb")
+	}
+	if !c.TURNEnabled {
+		t.Error("TURNEnabled: expected true")
+	}
+	if c.RedisURL != "redis://localhost:6379" {
+		t.Errorf("RedisURL: got %q, want %q", c.RedisURL, "redis://localhost:6379")
+	}
+	if c.WSRateLimitPerMin != 60 {
+		t.Errorf("WSRateLimitPerMin: got %d, want 60", c.WSRateLimitPerMin)
+	}
+	if !c.DevMode {
+		t.Error("DevMode: expected true")
+	}
+}

--- a/server/internal/email/email.go
+++ b/server/internal/email/email.go
@@ -97,6 +97,7 @@ func (s *NoopSender) Send(to, subject, htmlBody string) error {
 // Bodies can be long; only the subject and recipient are logged.
 type LogSender struct{}
 
+// NewLogSender returns a LogSender that writes to the structured logger.
 func NewLogSender() *LogSender {
 	return &LogSender{}
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -1,14 +1,12 @@
 package web
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/line"
 )
 
 type dashboardData struct {
@@ -192,69 +190,6 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	renderWith(r.Context(), w, h.tmplDashboard, layoutFor(r), data)
-}
-
-// buildLinkedFamilies fetches the list of linked households and their lines
-// for the given householdID. Returns an empty slice if householdID is empty or
-// the lookup fails.
-func (h *Handler) buildLinkedFamilies(ctx context.Context, householdID string) []linkedFamilyRow {
-	if householdID == "" || h.linkStore == nil {
-		return nil
-	}
-	activeLinks, err := h.linkStore.GetLinkedHouseholds(ctx, householdID)
-	if err != nil {
-		slog.ErrorContext(ctx, "buildLinkedFamilies: get linked households failed", "err", err)
-		return nil
-	}
-	otherIDs := make([]string, 0, len(activeLinks))
-	for _, l := range activeLinks {
-		otherID := l.HouseholdAID
-		if otherID == householdID && l.HouseholdBID != nil {
-			otherID = *l.HouseholdBID
-		}
-		otherIDs = append(otherIDs, otherID)
-	}
-	linesByHousehold, err := h.lineStore.ListByHouseholds(ctx, otherIDs)
-	if err != nil {
-		slog.ErrorContext(ctx, "buildLinkedFamilies: batch list lines failed", "err", err)
-	}
-	var families []linkedFamilyRow
-	for i, l := range activeLinks {
-		otherID := otherIDs[i]
-		otherName := otherID
-		if other, err := h.householdStore.GetByID(ctx, otherID); err == nil {
-			otherName = other.Name
-		}
-		families = append(families, linkedFamilyRow{
-			ID:         l.ID,
-			Name:       otherName,
-			Lines:      linesByHousehold[otherID],
-			Status:     l.Status,
-			AcceptedAt: l.AcceptedAt,
-		})
-	}
-	return families
-}
-
-// buildLinkedLineIndex flattens a slice of linkedFamilyRow into a map from
-// line number to "FamilyName · LineName" for fast peer-name resolution.
-func buildLinkedLineIndex(families []linkedFamilyRow) map[string]string {
-	index := make(map[string]string)
-	for _, f := range families {
-		for _, l := range f.Lines {
-			index[l.Number] = f.Name + " · " + l.Name
-		}
-	}
-	return index
-}
-
-// resolvePeerName returns the friendly name for a peer number using the linked
-// line index, falling back to fmtPhone formatting.
-func resolvePeerName(number string, linkedLines map[string]string) string {
-	if name, ok := linkedLines[number]; ok {
-		return name
-	}
-	return line.FormatNumber(number)
 }
 
 func countOnline(lines []lineRow) int {

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/justinlindh/digits/server/internal/auth"
@@ -488,4 +489,77 @@ func partialFor(r *http.Request, intercom, am string) string {
 		return am
 	}
 	return intercom
+}
+
+// linkedFamilyRow holds the display data for one linked household and its lines.
+// Used by the dashboard, links, and link-health handlers to render linked-family
+// information without repeated store round-trips.
+type linkedFamilyRow struct {
+	ID         string
+	Name       string
+	Lines      []line.Line
+	Status     string
+	AcceptedAt *time.Time
+}
+
+// buildLinkedFamilies fetches the list of linked households and their lines
+// for the given householdID. Returns nil if householdID is empty or the lookup fails.
+func (h *Handler) buildLinkedFamilies(ctx context.Context, householdID string) []linkedFamilyRow {
+	if householdID == "" || h.linkStore == nil {
+		return nil
+	}
+	activeLinks, err := h.linkStore.GetLinkedHouseholds(ctx, householdID)
+	if err != nil {
+		slog.ErrorContext(ctx, "buildLinkedFamilies: get linked households failed", "err", err)
+		return nil
+	}
+	otherIDs := make([]string, 0, len(activeLinks))
+	for _, l := range activeLinks {
+		otherID := l.HouseholdAID
+		if otherID == householdID && l.HouseholdBID != nil {
+			otherID = *l.HouseholdBID
+		}
+		otherIDs = append(otherIDs, otherID)
+	}
+	linesByHousehold, err := h.lineStore.ListByHouseholds(ctx, otherIDs)
+	if err != nil {
+		slog.ErrorContext(ctx, "buildLinkedFamilies: batch list lines failed", "err", err)
+	}
+	var families []linkedFamilyRow
+	for i, l := range activeLinks {
+		otherID := otherIDs[i]
+		otherName := otherID
+		if other, err := h.householdStore.GetByID(ctx, otherID); err == nil {
+			otherName = other.Name
+		}
+		families = append(families, linkedFamilyRow{
+			ID:         l.ID,
+			Name:       otherName,
+			Lines:      linesByHousehold[otherID],
+			Status:     l.Status,
+			AcceptedAt: l.AcceptedAt,
+		})
+	}
+	return families
+}
+
+// buildLinkedLineIndex flattens a slice of linkedFamilyRow into a map from
+// line number to "FamilyName · LineName" for fast peer-name resolution.
+func buildLinkedLineIndex(families []linkedFamilyRow) map[string]string {
+	index := make(map[string]string)
+	for _, f := range families {
+		for _, l := range f.Lines {
+			index[l.Number] = f.Name + " · " + l.Name
+		}
+	}
+	return index
+}
+
+// resolvePeerName returns the friendly name for a peer number using the linked
+// line index, falling back to fmtPhone formatting.
+func resolvePeerName(number string, linkedLines map[string]string) string {
+	if name, ok := linkedLines[number]; ok {
+		return name
+	}
+	return line.FormatNumber(number)
 }

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/server/internal/auth"
-	"github.com/justinlindh/digits/server/internal/line"
 )
 
 type linksData struct {
@@ -21,14 +20,6 @@ type linksData struct {
 	Canceled       bool
 	Conflicts      string
 	Error          string
-}
-
-type linkedFamilyRow struct {
-	ID         string
-	Name       string
-	Lines      []line.Line
-	Status     string
-	AcceptedAt *time.Time
 }
 
 type linkRow struct {


### PR DESCRIPTION
## Before / after grade

| | Score |
|---|---|
| Before | 82 / 100 |
| After | 88 / 100 |

## What was graded

The `server/` directory across all Go packages: idiomatic usage, dead code, project layout, test coverage, and lint hygiene.

## Findings addressed

### 1. Shared helpers defined in wrong files (organization)

`buildLinkedFamilies`, `buildLinkedLineIndex`, and `resolvePeerName` were defined in `handler_dashboard.go` but called from five other handler files (`handler_links.go`, `handler_linkhealth.go`, `handler_conference_linkhealth.go`, `handler_dashboard_stream.go`, `handler_helpers.go`). `linkedFamilyRow` was defined in `handler_links.go` but used by four other files including `handler_dashboard.go`.

Both definitions belong in `handler_helpers.go`, which is the established home for cross-handler utilities in the web package. The origin files (`handler_dashboard.go`, `handler_links.go`) now only contain logic specific to their respective pages.

Dropped the now-unused `context` and `line` imports from `handler_dashboard.go` and the `line` import from `handler_links.go`.

### 2. Missing godoc on exported constructors

Three exported constructors lacked documentation comments:

- `autodeploy.NewExecRunner()`
- `calls.NewConferenceTracker()`
- `email.NewLogSender()`

### 3. `config.Load()` not directly tested

The `config` package had good tests for the env-helper functions (`StringEnv`, `BoolEnv`, `OneEnv`, `IntEnv`) but no test exercised `Load()` with environment variable overrides. `TestLoadEnvOverrides` covers the wiring from env vars through to the returned `Config` fields.

## What was skipped (YAGNI)

- `db/` package has no unit tests: migrations are covered by integration tests; adding a mock-DB unit test for schema SQL would be testing the SQL syntax, not behavior.
- Inline HTML in `handleAPIActiveCalls` HTMX path: a two-line fragment with escaped values; extracting it to a template adds indirection with no safety gain since the values are already `HTMLEscapeString`-wrapped.
- `handler_phones.go` at 1015 lines: large but coherent; all functions belong to the phones page domain and share internal helpers. Splitting it would scatter related logic without a clear package boundary to cut along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGhBpHuWLfpMQTeHF3DiXJ)_