### PR TITLE
refactor(server): drop the dead typed signaling-error metric API

### DIFF
--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -182,19 +182,11 @@ func (r *Registry) RegisterCallsGauge(read func() float64) {
 		read)
 }
 
-// ObserveSignalingError records one signaling error in the named category.
-// The category MUST be one of the SignalingErrorCategory constants; passing
-// arbitrary strings here is a code smell and risks accidental PII leakage,
-// so callers should always use the exported constants.
-func (r *Registry) ObserveSignalingError(category SignalingErrorCategory) {
-	r.SignalingErrors.WithLabelValues(string(category)).Inc()
-}
-
 // validErrorCategories enumerates the closed set of categories accepted by
-// ObserveSignalingErrorCategory. The string form is used because the
-// signaling package cannot import this package without a cycle. Any value
-// not in the set is dropped to "other" rather than rejected so a caller
-// bug can't silently exfiltrate the offending string into a label.
+// ObserveSignalingError. The string form is used because the signaling
+// package cannot import this package without a cycle. Any value not in the
+// set is dropped to "other" rather than rejected so a caller bug can't
+// silently exfiltrate the offending string into a label.
 var validErrorCategories = map[string]struct{}{
 	string(ErrTURNAllocFailed): {},
 	string(ErrICETimeout):      {},
@@ -205,11 +197,12 @@ var validErrorCategories = map[string]struct{}{
 	string(ErrRelayDelivery):   {},
 }
 
-// ObserveSignalingErrorCategory accepts a string category from a caller
-// that cannot import the typed constants (e.g. internal/signaling, which
-// would form an import cycle). Unknown categories collapse to "other" so a
-// future caller can never smuggle a free-form string into a label value.
-func (r *Registry) ObserveSignalingErrorCategory(category string) {
+// ObserveSignalingError records one signaling error, partitioned by category.
+// The category is a plain string because the sole caller (internal/signaling)
+// cannot import the typed SignalingErrorCategory constants without forming an
+// import cycle. Unknown categories collapse to "other" so a future caller can
+// never smuggle a free-form string into a label value.
+func (r *Registry) ObserveSignalingError(category string) {
 	if _, ok := validErrorCategories[category]; !ok {
 		category = "other"
 	}

--- a/server/internal/metrics/metrics_test.go
+++ b/server/internal/metrics/metrics_test.go
@@ -165,15 +165,31 @@ func TestActiveDeviceAndCallGauges(t *testing.T) {
 
 func TestObserveSignalingError(t *testing.T) {
 	r := New("test", "abc123")
-	r.ObserveSignalingError(ErrTURNAllocFailed)
-	r.ObserveSignalingError(ErrTURNAllocFailed)
-	r.ObserveSignalingError(ErrICETimeout)
+	r.ObserveSignalingError(string(ErrTURNAllocFailed))
+	r.ObserveSignalingError(string(ErrTURNAllocFailed))
+	r.ObserveSignalingError(string(ErrICETimeout))
 
 	if got := testutil.ToFloat64(r.SignalingErrors.WithLabelValues("turn_alloc_failed")); got != 2 {
 		t.Errorf("turn_alloc_failed counter = %v, want 2", got)
 	}
 	if got := testutil.ToFloat64(r.SignalingErrors.WithLabelValues("ice_timeout")); got != 1 {
 		t.Errorf("ice_timeout counter = %v, want 1", got)
+	}
+}
+
+// A category outside the closed set must collapse to "other" rather than land
+// in a label of its own, so a caller bug can never write a free-form string
+// (and any PII it might carry) into the signaling_errors_total label.
+func TestObserveSignalingErrorUnknownCollapsesToOther(t *testing.T) {
+	r := New("test", "abc123")
+	r.ObserveSignalingError("3145551234")
+	r.ObserveSignalingError("not-a-category")
+
+	if got := testutil.ToFloat64(r.SignalingErrors.WithLabelValues("other")); got != 2 {
+		t.Errorf("other counter = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(r.SignalingErrors.WithLabelValues("3145551234")); got != 0 {
+		t.Errorf("unknown category leaked into its own label: got %v, want 0", got)
 	}
 }
 
@@ -194,7 +210,7 @@ func TestPromhttpExportsExpectedMetrics(t *testing.T) {
 	// at least one labelled child has been observed.
 	r.HTTPRequestsTotal.WithLabelValues("/api/status", "GET", "200").Inc()
 	r.HTTPRequestDuration.WithLabelValues("/api/status", "GET", "200").Observe(0.012)
-	r.ObserveSignalingError(ErrTURNAllocFailed)
+	r.ObserveSignalingError(string(ErrTURNAllocFailed))
 
 	srv := httptest.NewServer(promhttp.HandlerFor(r.Reg, promhttp.HandlerOpts{Registry: r.Reg}))
 	defer srv.Close()

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -63,7 +63,7 @@ type HealthRecorder interface {
 // strings on this surface so the relay package stays independent; the
 // metrics package validates them by exposing only a fixed set of constants.
 type SignalingErrorObserver interface {
-	ObserveSignalingErrorCategory(category string)
+	ObserveSignalingError(category string)
 }
 
 // activeExtension tracks a device that picked up an extension phone during
@@ -113,7 +113,7 @@ type Relay struct {
 // only one place to look when reviewing what categories the relay emits.
 func (r *Relay) observeError(category string) {
 	if r.Errors != nil {
-		r.Errors.ObserveSignalingErrorCategory(category)
+		r.Errors.ObserveSignalingError(category)
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1051,15 +1051,15 @@ func TestHandleLinkHealth_2WayPath_UnchangedBehavior(t *testing.T) {
 	}
 }
 
-// fakeErrorObserver records every category passed to ObserveSignalingError-
-// Category. Tests assert against the slice rather than a counter so the
-// order of observations is also verifiable; ordering matters when we want
-// to confirm the relay's first error wins instead of doubling up.
+// fakeErrorObserver records every category passed to ObserveSignalingError.
+// Tests assert against the slice rather than a counter so the order of
+// observations is also verifiable; ordering matters when we want to confirm
+// the relay's first error wins instead of doubling up.
 type fakeErrorObserver struct {
 	seen []string
 }
 
-func (f *fakeErrorObserver) ObserveSignalingErrorCategory(category string) {
+func (f *fakeErrorObserver) ObserveSignalingError(category string) {
 	f.seen = append(f.seen, category)
 }
 


### PR DESCRIPTION
## Motivation

`metrics.Registry` carried two methods that both incremented `signaling_errors_total`:

- `ObserveSignalingError(category SignalingErrorCategory)` (typed)
- `ObserveSignalingErrorCategory(category string)` (string)

The typed one was dead and could never gain a production caller. The only emitter, `internal/signaling`, cannot import the typed `SignalingErrorCategory` constants without forming an import cycle, which is the entire reason the string variant exists. The typed method stayed alive solely because its own unit test called it, and its doc comment instructed callers to "always use the exported constants" that no real caller is able to reach. That is a type-safety facade with nothing behind it.

## Change

- Delete the dead typed `ObserveSignalingError(SignalingErrorCategory)` method.
- Rename the surviving `ObserveSignalingErrorCategory(string)` to `ObserveSignalingError(string)`, dropping the `Category` suffix that only existed to avoid colliding with the now-removed method. Updates the `SignalingErrorObserver` interface in `internal/signaling`, its call site, and the test fake.
- Keep the closed `SignalingErrorCategory` type and its constants: they remain the single source of truth for `validErrorCategories`, the allow-list the surviving method checks against.
- Add a test for the unknown-category collapse to `"other"`. That privacy-relevant path lived only on the real registry (the relay tests use a fake observer), so it was previously unexercised.

## Why this scope

One coherent idea: collapse the duplicate observe API down to the one method that is actually reachable, and give it the name the suffix was working around. No metric names, labels, or values change, so this is a `refactor`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`