### PR TITLE
refactor(server): drop the unused ratelimit Limiter.Close lifecycle

### DIFF
--- a/server/internal/ratelimit/ratelimit.go
+++ b/server/internal/ratelimit/ratelimit.go
@@ -20,44 +20,29 @@ type bucket struct {
 // Limiter is an in-memory IP-based rate limiter using a fixed-window token bucket.
 type Limiter struct {
 	mu      sync.Mutex
-	once    sync.Once
 	buckets map[string]*bucket
 	limit   int
 	window  time.Duration
-	done    chan struct{}
 }
 
 // New creates a rate limiter that allows `limit` requests per `window` per IP.
-// Starts a background goroutine to clean up stale entries every 5 minutes.
-// Call Close to stop the background goroutine when the Limiter is no longer needed.
+// It starts a background goroutine that evicts stale entries every 5 minutes
+// and runs for the lifetime of the process.
 func New(limit int, window time.Duration) *Limiter {
 	l := &Limiter{
 		buckets: make(map[string]*bucket),
 		limit:   limit,
 		window:  window,
-		done:    make(chan struct{}),
 	}
 	go l.cleanupLoop()
 	return l
 }
 
-// Close stops the background cleanup goroutine. Safe to call multiple times.
-// The Limiter remains usable for Allow/Cleanup/Middleware after Close returns,
-// but stale entries will no longer be evicted automatically.
-func (l *Limiter) Close() {
-	l.once.Do(func() { close(l.done) })
-}
-
 func (l *Limiter) cleanupLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
-	for {
-		select {
-		case <-l.done:
-			return
-		case <-ticker.C:
-			l.Cleanup()
-		}
+	for range ticker.C {
+		l.Cleanup()
 	}
 }
 

--- a/server/internal/ratelimit/ratelimit_test.go
+++ b/server/internal/ratelimit/ratelimit_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestLimiterAllowsUnderLimit(t *testing.T) {
 	lim := New(5, time.Minute)
-	t.Cleanup(lim.Close)
 	for i := 0; i < 5; i++ {
 		if !lim.Allow("1.2.3.4") {
 			t.Fatalf("request %d should be allowed", i+1)
@@ -20,7 +19,6 @@ func TestLimiterAllowsUnderLimit(t *testing.T) {
 
 func TestLimiterBlocksOverLimit(t *testing.T) {
 	lim := New(3, time.Minute)
-	t.Cleanup(lim.Close)
 	for i := 0; i < 3; i++ {
 		lim.Allow("1.2.3.4")
 	}
@@ -31,7 +29,6 @@ func TestLimiterBlocksOverLimit(t *testing.T) {
 
 func TestLimiterTracksIPsSeparately(t *testing.T) {
 	lim := New(1, time.Minute)
-	t.Cleanup(lim.Close)
 	if !lim.Allow("1.1.1.1") {
 		t.Fatal("first IP should be allowed")
 	}
@@ -45,7 +42,6 @@ func TestLimiterTracksIPsSeparately(t *testing.T) {
 
 func TestLimiterRefillsAfterWindow(t *testing.T) {
 	lim := New(1, 50*time.Millisecond)
-	t.Cleanup(lim.Close)
 	lim.Allow("1.2.3.4")
 	if lim.Allow("1.2.3.4") {
 		t.Fatal("should be blocked immediately")
@@ -58,7 +54,6 @@ func TestLimiterRefillsAfterWindow(t *testing.T) {
 
 func TestMiddleware429(t *testing.T) {
 	lim := New(1, time.Minute)
-	t.Cleanup(lim.Close)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -80,7 +75,6 @@ func TestMiddleware429(t *testing.T) {
 
 func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 	lim := New(1, time.Minute)
-	t.Cleanup(lim.Close)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -112,7 +106,6 @@ func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 
 func TestCleanupRemovesStaleEntries(t *testing.T) {
 	lim := New(1, 50*time.Millisecond)
-	t.Cleanup(lim.Close)
 	lim.Allow("stale-ip")
 	time.Sleep(60 * time.Millisecond)
 	lim.Cleanup()


### PR DESCRIPTION
## Summary

`ratelimit.Limiter` carried a full stop-the-goroutine lifecycle (`Close`, a `sync.Once`, a `done` channel, and a select-based cleanup loop) that nothing in production ever used. The six limiters wired into the web `Handler` (`handler.go:483-488`) are created once and live for the lifetime of the process; there is no `Handler` shutdown path that closes them. The only callers of `Close` were the unit tests, each via `t.Cleanup(lim.Close)`, tidying up a goroutine that sits parked on a 5-minute ticker and never even fires during a sub-second test.

So the lifecycle machinery existed only to support a teardown that production never performs.

## Change

- Remove `Close`, the `once sync.Once` field, and the `done chan struct{}` field.
- Collapse `cleanupLoop` from a `for { select { ... } }` into a plain `for range ticker.C`.
- Reword the `New` doc to say what is actually true: the cleanup goroutine runs for the lifetime of the process.
- Drop the seven `t.Cleanup(lim.Close)` calls from the tests.

Net: 4 insertions, 26 deletions. The limiter behaves identically; this only removes unused concurrency plumbing and a misleading "you can close this" API.

## Verification

- `go build ./...`, `go vet`, and `go test ./...` pass.
- `golangci-lint run ./...` reports 0 issues.
- No goroutine-leak detector is in use (no `goleak.VerifyNone`/`TestMain` guard), so removing the test teardown does not regress any leak assertion.