### PR TITLE
chore(digitsd): add lint and vet make targets

### DIFF
--- a/pi/digitsd/Makefile
+++ b/pi/digitsd/Makefile
@@ -23,7 +23,7 @@ MIXER_STATE_SRC   = $(REPO_ROOT)/pi/mixer-state
 # runtime). None of these should be extracted at runtime by digitsd.
 OVERLAY_EXCLUDE = boot etc/fstab.fragment usr/local/bin/ro-root usr/local/bin/rw-root etc/sudoers.d/digits-updater etc/digits-pcb-rev
 
-.PHONY: build build-local builder deploy run test clean embed clean-embed
+.PHONY: build build-local builder deploy run test vet lint clean embed clean-embed
 
 embed: clean-embed
 	@mkdir -p $(EMBED_DIR)/rootfs $(EMBED_DIR)/data $(EMBED_DIR)/mixer
@@ -64,6 +64,12 @@ run: deploy
 
 test:
 	go test ./...
+
+vet:
+	go vet ./...
+
+lint:
+	golangci-lint run ./...
 
 clean: clean-embed
 	rm -rf bin/


### PR DESCRIPTION
## What

Add `vet` (`go vet ./...`) and `lint` (`golangci-lint run ./...`) targets to `pi/digitsd/Makefile`, mirroring the ones `server/Makefile` already exposes.

## Why (cross-PR coherence)

This came out of a holistic read across the last day's merges, not a single-PR review.

- **#627** added `make lint` and `make vet` to `server/Makefile`, explicitly to back the CLAUDE.md rule: "Run `golangci-lint run ./...` from each module directory before pushing Go changes."
- **#624** cleaned up `pi/digitsd` config defaults in the same audit pass, but the digitsd Makefile was left with only a plain `make test`.

The result was drift: the documented lint workflow became one command in `server/` and ad-hoc in `pi/digitsd/`, even though CLAUDE.md says "each module directory." This brings the two primary Go modules back to parity.

The target forms are intentionally plain, matching digitsd's existing `make test` (`go test ./...`) and exactly what the `lint-digitsd` CI job in `.github/workflows/golangci-lint.yml` already runs.

## Test plan

Verified in `pi/digitsd/` with the C deps the CI job installs (`libasound2-dev libopus-dev libopusfile-dev`) and golangci-lint v2.11:

- [x] `make vet` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] `go build ./...` passes