### PR TITLE
docs: add V3 to the root README hardware revision table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Each phone is a gutted vintage desk phone with two processors inside: an RP2040 
 
 | Component | Role |
 |-----------|------|
-| **RP2040** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. V0/V1 use a Pico H module; V2 has the RP2040 onboard. |
+| **RP2040** (firmware, C) | Real-time phone I/O: keypad matrix, hook switch, bell driver, DTMF/tone generation, status LED. Communicates with the Pi over UART. V0/V1 use a Pico H module; V2/V3 have the RP2040 onboard. |
 | **Pi Zero 2 W** (digitsd, Go) | VoIP daemon: WebRTC media, Opus codec, DTLS-SRTP, signaling client, call state machine, Wi-Fi setup, OTA updates. |
-| **Audio codec** | Mic input and earpiece output. Codec Zero HAT (DA7212) on V0/V1, onboard TLV320AIC3104 on V2. |
+| **Audio codec** | Mic input and earpiece output. Codec Zero HAT (DA7212) on V0/V1, onboard TLV320AIC3104 on V2/V3. |
 | **Signaling server** (Go) | WebSocket relay for SDP/ICE exchange, PostgreSQL persistence, device pairing, household management, web dashboard. |
 
 Calls are peer-to-peer WebRTC sessions between two phones (or three, for party-line calls). The server brokers the signaling handshake but never handles media.
@@ -62,19 +62,22 @@ See [Architecture deep-dive](docs/architecture/overview.md) for the full call pa
 
 ## Hardware
 
-Three hardware iterations, each a different build strategy:
+Four hardware iterations, each a different build strategy:
 
 | Rev | Construction | Audio | Ringer | Status |
 |-----|-------------|-------|--------|--------|
 | [V0](docs/build/components.md) | Perfboard, off-the-shelf modules | Codec Zero HAT (DA7212) | L298N + step-up transformer | Done, documented end-to-end |
 | [V1](hardware/pcb/v1/) | Hand-assembled PCB, Pico H module | Codec Zero HAT (DA7212) | L298N + step-up transformer | Fabricated, has [errata](hardware/pcb/v1/ERRATA.md) |
 | [V2](hardware/pcb/v2/) | Contract-assembled (JLCPCB), onboard RP2040 | Onboard TLV320AIC3104 | Onboard DRV8871 | Deployed, ~10 units in use |
+| [V3](hardware/pcb/v3/) | Contract-assembled (JLCPCB), onboard RP2040 | Onboard TLV320AIC3104 | Onboard DRV8871 + XL6019 boost | In progress, see [changes](hardware/pcb/v3/CHANGES_FROM_V2.md) |
 
 **V1** is a bench-build target: single-sided, mostly through-hole, hand-solderable. External modules handle audio (Codec Zero HAT) and bell ringing (L298N H-bridge plus a step-up transformer).
 
 **V2** is a fab-service target: onboard RP2040, audio codec (TLV320AIC3104, 32-pin QFN), and ringer driver (DRV8871). Arrives pre-assembled from JLCPCB. Not practical to hand-solder.
 
-Schematics, PCB layouts, Gerbers, and BOMs are in [`hardware/pcb/`](hardware/pcb/). All designed in KiCad. The firmware abstracts board differences at runtime, so the same binary runs on V1 and V2.
+**V3** is a major spin of V2: +5 V input (the 12 V buck stage is gone), an on-board XL6019 boost converter making ~37 V to ring the bell in place of the external step-up transformer, a single DPDT cradle switch for hook sense and series mic-kill, an SW2 BOOTSEL button, power indicator LEDs, components flipped to face up, and J8/LED pinouts matched to the stock donor-phone cables. Like V2, it arrives pre-assembled from JLCPCB.
+
+Schematics, PCB layouts, Gerbers, and BOMs are in [`hardware/pcb/`](hardware/pcb/). All designed in KiCad. The firmware abstracts board differences at runtime, so the same binary runs on V1, V2, and V3.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

PR #626 shipped the V3 carrier PCB and updated `hardware/pcb/README.md` (revision table + the "Pick V2 (really V3 once it ships)" line) and `docs/architecture/unified-firmware.md` (V3 references). It did not touch the repo root `README.md`, which still listed only V0/V1/V2. This adds the parallel V3 entries there so the top-level hardware overview matches the per-board docs.

## Changes

`README.md`:
- Hardware revision table: new `V3` row (contract-assembled JLCPCB, onboard RP2040, onboard TLV320AIC3104, `DRV8871 + XL6019 boost` ringer, "In progress" linking to `hardware/pcb/v3/CHANGES_FROM_V2.md`). Intro updated from "Three hardware iterations" to "Four".
- New `**V3**` build-strategy paragraph mirroring the existing V1/V2 ones: +5 V input (12 V buck stage removed), on-board XL6019 ~37 V boost replacing the external step-up transformer, single DPDT cradle switch for hook sense plus series mic-kill, SW2 BOOTSEL button, power indicator LEDs, components flipped to face up, J8/LED pinouts matched to the stock donor-phone cables.
- RP2040 architecture line: `V2/V3 have the RP2040 onboard`.
- Audio-codec architecture line: `onboard TLV320AIC3104 on V2/V3`.
- Firmware-portability line: `the same binary runs on V1, V2, and V3`.

## Scope notes

- `hardware/pcb/README.md`, `hardware/pcb/v3/README.md`, and `docs/architecture/unified-firmware.md` already carry their V3 entries from #626, so they are untouched here.
- `docs/build/components.md`, `wiring.md`, and `hardware-kill-switch.md` document the V0 perfboard build specifically and do not enumerate per-revision PCBs, so no V3 entry applies.
- The user-facing build guide at `digits.family/build` is hosted in a separate site repo (this repo only references it by URL). Its V3 page is out of reach here and still needs a V3 update there.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the V3 row, the V3 paragraph, and the V3 links resolve to `hardware/pcb/v3/`.