### PR TITLE
refactor(server): use strconv for type conversions, add security middleware tests

### DIFF
--- a/server/internal/calls/history_cursor.go
+++ b/server/internal/calls/history_cursor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -69,7 +70,7 @@ func CursorForEntry(e HistoryEntry) HistoryCursor {
 	c := HistoryCursor{Time: e.SortTime, Kind: e.Kind}
 	switch e.Kind {
 	case HistoryEntryCall:
-		c.ID = fmt.Sprintf("%d", e.Call.ID)
+		c.ID = strconv.FormatInt(e.Call.ID, 10)
 	case HistoryEntryConference:
 		c.ID = e.Conference.ID.String()
 	}

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -336,7 +337,7 @@ func (s *Store) SetAllSilentByHousehold(ctx context.Context, householdID string,
 		 SET settings = jsonb_set(COALESCE(settings, '{}'), '{silent_mode}', $1::jsonb),
 		     updated_at = NOW()
 		 WHERE household_id = $2`,
-		fmt.Sprintf("%t", silent), householdID,
+		strconv.FormatBool(silent), householdID,
 	)
 	if err != nil {
 		return fmt.Errorf("set all silent by household: %w", err)

--- a/server/internal/web/middleware_test.go
+++ b/server/internal/web/middleware_test.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsGateExempt(t *testing.T) {
+	cases := []struct {
+		path  string
+		extra []string
+		want  bool
+	}{
+		{"/auth/login", nil, true},
+		{"/auth/magic/abc", nil, true},
+		{"/auth", nil, false}, // exact "/auth" has no trailing slash; not exempt
+		{"/api/status", nil, true},
+		{"/api/dashboard/stream", nil, true},
+		{"/api", nil, false}, // exact "/api" has no trailing slash; not exempt
+		{"/ws", nil, true},
+		{"/ws/", nil, true},
+		{"/ws/room/abc", nil, true},
+		{"/", nil, false},
+		{"/phones", nil, false},
+		{"/settings", nil, false},
+		{"/calls", nil, false},
+		{"/welcome", []string{"/welcome"}, true},
+		{"/onboard", []string{"/welcome", "/onboard"}, true},
+		{"/welcome", []string{"/onboard"}, false},
+		{"/phones/5551234", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			got := isGateExempt(tc.path, tc.extra...)
+			if got != tc.want {
+				t.Errorf("isGateExempt(%q, %v) = %v, want %v", tc.path, tc.extra, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCSRFOriginCheck(t *testing.T) {
+	const baseURL = "https://app.digits.family"
+
+	pass := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := csrfOriginCheck(baseURL, pass)
+
+	cases := []struct {
+		name     string
+		method   string
+		origin   string
+		wantCode int
+	}{
+		{"GET no origin", http.MethodGet, "", http.StatusOK},
+		{"GET matching origin", http.MethodGet, baseURL, http.StatusOK},
+		{"GET wrong origin", http.MethodGet, "https://evil.example", http.StatusOK},
+		{"HEAD wrong origin", http.MethodHead, "https://evil.example", http.StatusOK},
+		{"OPTIONS wrong origin", http.MethodOptions, "https://evil.example", http.StatusOK},
+		{"POST matching origin", http.MethodPost, baseURL, http.StatusOK},
+		{"POST no origin", http.MethodPost, "", http.StatusOK},
+		{"POST wrong origin", http.MethodPost, "https://evil.example", http.StatusForbidden},
+		{"PUT wrong origin", http.MethodPut, "https://evil.example", http.StatusForbidden},
+		{"DELETE wrong origin", http.MethodDelete, "https://evil.example", http.StatusForbidden},
+		{"PATCH wrong origin", http.MethodPatch, "https://evil.example", http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("code=%d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestCSRFOriginCheckDisabledWithEmptyBaseURL(t *testing.T) {
+	pass := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := csrfOriginCheck("", pass)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("empty baseURL: got %d, want 200 (check disabled)", rec.Code)
+	}
+}


### PR DESCRIPTION
## Code quality review: server/

Full analysis of the `server/` folder for code cleanliness, idiomatic Go, dead code, project layout, and test coverage.

**Before grade: 88/100**
**After grade: 91/100**

---

### Grading breakdown

| Area | Score | Notes |
|------|-------|-------|
| Error handling | 95 | Proper `%w` wrapping throughout, sentinel errors, no swallowed errors |
| Resource management | 95 | All rows/connections deferred-closed, transaction rollback guard in `dbutil` |
| Code organization | 92 | Clean layering: cmd -> web -> signaling/calls -> auth/line/household -> db |
| Security | 90 | Token hashing, CSRF check, rate limiting, SMTP injection guard |
| Concurrency | 90 | Correct RWMutex usage, channel-based WS pumps, no obvious races |
| Database | 95 | Safe idempotent migrations, transactions, FK constraints |
| Modern Go idioms | 90 | `any`, `embed`, `slog`, zero `context.TODO()`, zero `interface{}` |
| Test coverage | 85 | Good unit + integration coverage; two security middleware functions had no tests |
| Documentation | 85 | Code is largely self-documenting; comments explain non-obvious invariants |

The codebase is production-quality. Two concrete improvements are made below.

---

### Changes

**1. `strconv` over `fmt.Sprintf` for simple type conversions**

Two places used `fmt.Sprintf` for single-value type conversions where the dedicated `strconv` function is the idiomatic Go choice:

- `calls/history_cursor.go`: `fmt.Sprintf("%d", e.Call.ID)` -> `strconv.FormatInt(e.Call.ID, 10)`
- `line/store.go`: `fmt.Sprintf("%t", silent)` -> `strconv.FormatBool(silent)`

Both are functionally identical (same output strings) and the change is purely idiomatic. `strconv` functions are the canonical path for single-value conversions; `fmt.Sprintf` adds format-string parsing overhead and is the idiomatic choice only when composing multiple values into a string.

**2. Unit tests for `isGateExempt` and `csrfOriginCheck`**

Both functions are security-relevant and had zero test coverage:

- `isGateExempt` controls which request paths bypass the welcome and onboarding redirect gates. A bug here could cause infinite redirect loops or allow unauthenticated access to protected pages.
- `csrfOriginCheck` is the CSRF protection middleware that rejects state-changing requests from foreign origins.

The new `middleware_test.go` covers:
- All prefix boundaries for `isGateExempt`, including the important edge cases where `/auth` and `/api` (without trailing slash) are correctly not exempt
- All HTTP methods for the CSRF check: GET/HEAD/OPTIONS pass through regardless of origin; POST/PUT/DELETE/PATCH reject non-empty mismatched origins
- The `baseURL == ""` bypass path that disables the CSRF check entirely

---

### What was audited but not changed (YAGNI)

- **Rate limiter goroutine lifecycle**: `ratelimit.New` starts a cleanup goroutine that runs for the process lifetime. The doc comment already documents this as intentional. Since the server is a long-running process and these limiters live for the same duration, adding a stop channel would be complexity with no real benefit.
- **Inline HTML in `handler_api.go`**: The active-calls HTMX endpoint writes a few lines of HTML inline. Moving them to a template partial would add indirection for no observable gain.
- **`strings.Replace` with `n=1` in `handler.go`**: Used to replace scheme prefixes in URLs. The `n=1` is intentionally explicit about replacing only the first occurrence; changing to `strings.ReplaceAll` would be less precise.
- **The 4 `panic` calls**: All are in infallible code paths (JSON marshal of fixed structs, embedded `fs.Sub`, enum exhaustiveness guard). None are reachable at runtime with correct usage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FysRF8meGDBtn8QW7AhYon)_