### PR TITLE
refactor(digitsd): replace SendRing(bool) with StartRing/StopRing

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -281,8 +281,12 @@ func (d *daemonCallbacks) OncePlaying() bool {
 	return d.mixer.OncePlaying()
 }
 
-func (d *daemonCallbacks) SendRing(start bool) {
-	d.serial.Ring(start)
+func (d *daemonCallbacks) StartRing() {
+	d.serial.Ring(true)
+}
+
+func (d *daemonCallbacks) StopRing() {
+	d.serial.Ring(false)
 }
 
 func (d *daemonCallbacks) SendRingPattern(id int) {

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -87,7 +87,8 @@ var defaultTiming = controllerTiming{
 type Callbacks interface {
 	SendTone(name string)       // Play a tone (use one of the Tone* constants)
 	OncePlaying() bool          // Reports whether a one-shot tone (e.g. intercept) is still playing
-	SendRing(start bool)        // Send RING:START or RING:STOP
+	StartRing()                 // Start the ringer (emits RING:START)
+	StopRing()                  // Stop the ringer (emits RING:STOP)
 	SendLED(mode string)        // Send LED:<mode> (use one of the LED* constants)
 	EnableFlashDetection()      // Enable Pico hook-flash detection on the connected call
 	InitiateCall(number string) error // Start outgoing WebRTC call
@@ -134,7 +135,7 @@ type Controller struct {
 	digits         string
 	ownNumber      string
 	contactChecker ContactChecker
-	silentMode     bool // when true, onSignalRing suppresses SendRing(true)
+	silentMode     bool // when true, onSignalRing suppresses StartRing
 	// treatmentGen is incremented each time runPermanentSignalTreatment starts.
 	// The spawned goroutine captures the value and aborts on mismatch, so a
 	// hook-flap that re-enters off-hook treatment within ~4 min won't let the
@@ -210,7 +211,7 @@ func (c *Controller) SetSilentMode(silent bool) {
 	}
 	c.silentMode = silent
 	if silent && c.state == StateRINGING {
-		c.cb.SendRing(false)
+		c.cb.StopRing()
 	}
 }
 
@@ -405,7 +406,7 @@ func (c *Controller) onHookOff() {
 			number := c.callReturnTarget
 			c.callReturnRinging = false
 			c.callReturnTarget = ""
-			c.cb.SendRing(false)
+			c.cb.StopRing()
 			c.cb.SendTone(ToneStop)
 			c.cb.SendLED(LEDOn)
 			slog.Info("phone: callback pickup, auto-dialing", "target", number)
@@ -415,7 +416,7 @@ func (c *Controller) onHookOff() {
 		} else {
 			// Incoming: answer the call; activePeer was set when the ring arrived.
 			c.state = StateCONNECTED
-			c.cb.SendRing(false)
+			c.cb.StopRing()
 			c.cb.SendTone(ToneStop)
 			c.cb.SendLED(LEDOn)
 			c.cb.EnableFlashDetection()
@@ -477,7 +478,7 @@ func (c *Controller) onHookOn() {
 	c.confID = ""
 	c.isConfHost = false
 	c.cb.SendTone(ToneStop)
-	c.cb.SendRing(false)
+	c.cb.StopRing()
 	c.cb.SendLED(LEDOff)
 	if wasConnectedOrCalling || inConferenceFlow {
 		c.cb.HangupCall()
@@ -762,7 +763,7 @@ func (c *Controller) onSignalRing() {
 	}
 	c.state = StateRINGING
 	if !c.silentMode {
-		c.cb.SendRing(true)
+		c.cb.StartRing()
 	}
 	c.cb.SendLED(LEDBlink)
 	enabled, timeout := c.cb.VoicemailEnabled()
@@ -788,7 +789,7 @@ func (c *Controller) ringTimeoutWatcher(gen uint64, d time.Duration) {
 		return
 	}
 	c.state = StateVOICEMAIL_GREETING
-	c.cb.SendRing(false)
+	c.cb.StopRing()
 	c.cb.SendTone(ToneStop)
 	c.mu.Unlock()
 	c.cb.VoicemailAutoAnswer()
@@ -822,7 +823,7 @@ func (c *Controller) onSignalHangup(sender string) {
 		c.state = StateIDLE
 		c.callReturnRinging = false
 		c.callReturnTarget = ""
-		c.cb.SendRing(false)
+		c.cb.StopRing()
 		c.cb.SendLED(LEDOff)
 	case StateVOICEMAIL_GREETING, StateVOICEMAIL_RECORDING:
 		slog.Info("phone: caller hung up during voicemail")
@@ -1143,7 +1144,7 @@ func (c *Controller) HandleConferenceEnd(confID, reason string) {
 	default:
 		c.state = StateIDLE
 		c.cb.SendTone(ToneStop)
-		c.cb.SendRing(false)
+		c.cb.StopRing()
 		c.cb.SendLED(LEDOff)
 	}
 }

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -56,10 +56,15 @@ func (m *mockCallbacks) SendTone(name string) {
 	m.tones = append(m.tones, name)
 }
 func (m *mockCallbacks) OncePlaying() bool { return false }
-func (m *mockCallbacks) SendRing(start bool) {
+func (m *mockCallbacks) StartRing() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.rings = append(m.rings, start)
+	m.rings = append(m.rings, true)
+}
+func (m *mockCallbacks) StopRing() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rings = append(m.rings, false)
 }
 func (m *mockCallbacks) SendLED(mode string) {
 	m.mu.Lock()
@@ -525,7 +530,7 @@ func TestController_IncomingCallFlow(t *testing.T) {
 		t.Fatalf("expected RINGING, got %s", c.State())
 	}
 	if len(cb.Rings()) == 0 || cb.Rings()[0] != true {
-		t.Error("expected SendRing(true)")
+		t.Error("expected StartRing")
 	}
 	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
 		t.Error("expected SendLED(BLINK)")
@@ -542,7 +547,7 @@ func TestController_IncomingCallFlow(t *testing.T) {
 	// Ring should have been stopped
 	lastRing := cb.Rings()[len(cb.Rings())-1]
 	if lastRing != false {
-		t.Error("expected SendRing(false) when answering")
+		t.Error("expected StopRing when answering")
 	}
 
 	// Remote hangs up — enters REMOTE_HANGUP (off-hook warning sequence)
@@ -783,7 +788,7 @@ func TestController_CallerHangupDuringRing(t *testing.T) {
 	// Ring must have been stopped
 	lastRing := cb.Rings()[len(cb.Rings())-1]
 	if lastRing != false {
-		t.Error("expected SendRing(false) when caller hangs up during ring")
+		t.Error("expected StopRing when caller hangs up during ring")
 	}
 	lastLED := cb.LEDs()[len(cb.LEDs())-1]
 	if lastLED != "OFF" {
@@ -873,7 +878,7 @@ func TestController_IncomingWhileBusy(t *testing.T) {
 	}
 	// No new ring callbacks
 	if len(cb.Rings()) != ringsBefore {
-		t.Error("expected no SendRing call when ring arrives during CONNECTED")
+		t.Error("expected no ring call when ring arrives during CONNECTED")
 	}
 }
 
@@ -1781,7 +1786,7 @@ func TestController_IncomingRingSilentModeSuppressesBell(t *testing.T) {
 	}
 	for _, r := range cb.Rings() {
 		if r == true {
-			t.Error("expected no SendRing(true) while silent")
+			t.Error("expected no StartRing while silent")
 		}
 	}
 	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
@@ -1801,7 +1806,7 @@ func TestController_IncomingRingSilentOffBehavesNormally(t *testing.T) {
 		t.Fatalf("state: got %s", c.State())
 	}
 	if len(cb.Rings()) == 0 || cb.Rings()[0] != true {
-		t.Errorf("expected SendRing(true), got %v", cb.Rings())
+		t.Errorf("expected StartRing, got %v", cb.Rings())
 	}
 	if len(cb.LEDs()) == 0 || cb.LEDs()[0] != "BLINK" {
 		t.Errorf("expected SendLED(BLINK), got %v", cb.LEDs())
@@ -1814,7 +1819,7 @@ func TestController_SetSilentModeOnDuringRingStopsBell(t *testing.T) {
 	cb := &mockCallbacks{}
 	c := newTestController(cb, "")
 
-	c.HandleSignal("ring", "") // state RINGING, SendRing(true), SendLED("BLINK")
+	c.HandleSignal("ring", "") // state RINGING, StartRing, SendLED("BLINK")
 	if c.State() != StateRINGING {
 		t.Fatalf("precondition: state %s != RINGING", c.State())
 	}
@@ -1823,7 +1828,7 @@ func TestController_SetSilentModeOnDuringRingStopsBell(t *testing.T) {
 
 	last := cb.Rings()[len(cb.Rings())-1]
 	if last != false {
-		t.Errorf("expected SendRing(false) after silent=true mid-ring, got %v", cb.Rings())
+		t.Errorf("expected StopRing after silent=true mid-ring, got %v", cb.Rings())
 	}
 	if c.State() != StateRINGING {
 		t.Errorf("state changed unexpectedly: %s (should stay RINGING)", c.State())
@@ -1841,13 +1846,13 @@ func TestController_SetSilentModeOffDuringRingDoesNotStartBell(t *testing.T) {
 	c := newTestController(cb, "")
 	c.SetSilentMode(true)
 
-	c.HandleSignal("ring", "") // silent: no SendRing(true), only LED:BLINK
+	c.HandleSignal("ring", "") // silent: no StartRing, only LED:BLINK
 	ringsBefore := len(cb.Rings())
 
 	c.SetSilentMode(false)
 
 	if len(cb.Rings()) != ringsBefore {
-		t.Errorf("unexpected SendRing call on silent=false mid-ring: %v", cb.Rings())
+		t.Errorf("unexpected ring call on silent=false mid-ring: %v", cb.Rings())
 	}
 }
 


### PR DESCRIPTION
## Motivation

`Callbacks.SendRing(start bool)` was boolean-blind at its call sites. Of the eight calls in `controller.go`, seven were `SendRing(false)`, where the meaning of the bare literal depends on the reader recalling that `false` means "stop ringing." The interface comment (`// Send RING:START or RING:STOP`) existed precisely to paper over that ambiguity.

## Change

Split the single two-valued method into two intent-named methods:

- `SendRing(true)` becomes `StartRing()`
- `SendRing(false)` becomes `StopRing()`

The controller now expresses what it wants (start/stop the ringer) rather than passing a wire flag. The `RING:START` / `RING:STOP` encoding stays where it belongs, in `SerialPort.Ring(bool)`, so the wire protocol and the commands sent to the Pico are byte-for-byte unchanged.

## Scope

This touches the `Callbacks` interface, its one production implementation (`daemonCallbacks`), the test mock, and the eight call sites. The mock keeps recording transitions into its existing `rings []bool` slice, so every existing assertion is preserved; only the method names and a few test message strings change. No behavior change: `refactor`, not `feat`/`fix`.

## Test plan

- [x] `go build ./...` (digitsd)
- [x] `go test ./...` (digitsd) including the phone FSM suite
- [x] `golangci-lint run ./...` (digitsd) clean
