### PR TITLE
docs: sync V3 spec docs with the fabbed board

### DIFF
--- a/hardware/pcb/v3/CHANGES_FROM_V2.md
+++ b/hardware/pcb/v3/CHANGES_FROM_V2.md
@@ -56,7 +56,7 @@ V3 adds `SW2`, a 6 mm momentary tact switch (OMRON B3F-1002, LCSC C87036) betwee
 V3 adds two on-board indicator LEDs:
 
 - `D2` (red, 0603, LCSC C2286) on +5V through `R12` = 300 Ω (LCSC C25102).
-- `D3` (yellow-green KENTO KT-0603YG, 0603, LCSC C2289) on +3V3 through `R13` = 120 Ω (LCSC C25752). R13 is sized so the +3V3 indicator reliably lights at ~10 mA.
+- `D3` (yellow-green KENTO KT-0603YG, 0603, LCSC C2289) on +3V3 through `R13` = 120 Ω (LCSC C25079). R13 is sized so the +3V3 indicator reliably lights at ~10 mA.
 
 ## Handset and LED connector pin assignments
 
@@ -94,7 +94,7 @@ V3 gives the connectors semantic reference designators, consistent across schema
 | J6 | LED | Indicator LED to the phone housing |
 | J4 | KEYPAD | 7-pin keypad matrix |
 | J7 | BELL | Bell H-bridge output (BELL_A / BELL_B) |
-| J1 | Pi Zero W 2 | 40-pin Pi header |
+| J1 | PI_ZERO_W1 | 40-pin Pi header |
 | J9 | (removed) | Old mic-kill loop, folded into SW1 |
 
 ## Component-side flip

--- a/hardware/pcb/v3/COMPONENTS.md
+++ b/hardware/pcb/v3/COMPONENTS.md
@@ -126,7 +126,7 @@ The off-board signal connectors are SMD JST ZH (1.5mm pitch). The Pi header is a
 
 | Ref | Part | Package | LCSC | Connects | Purpose |
 |-----|------|---------|------|----------|---------|
-| Pi Zero W 2 | 2x20 Female Header 2.54mm | THT, body on F.Cu side | C2977589 | Pi Zero 2 W GPIO | The main interconnect between the carrier board and the Raspberry Pi. Carries: UART (Pi GPIO14/15 serial to RP2040), SWD (Pi GPIO24/25 for firmware flashing), I2S (codec data), I2C (codec control), GPCLK0 (Pi GPIO4 optional MCLK), CODEC_RESET (Pi GPIO22), +5V power to the Pi (pins 2/4), and GND. Female socket to mate with the Pi's male 2x20 pin header. |
+| PI_ZERO_W1 | 2x20 Female Header 2.54mm | THT, body on F.Cu side | C2977589 | Pi Zero 2 W GPIO | The main interconnect between the carrier board and the Raspberry Pi. Carries: UART (Pi GPIO14/15 serial to RP2040), SWD (Pi GPIO24/25 for firmware flashing), I2S (codec data), I2C (codec control), GPCLK0 (Pi GPIO4 optional MCLK), CODEC_RESET (Pi GPIO22), +5V power to the Pi (pins 2/4), and GND. Female socket to mate with the Pi's male 2x20 pin header. |
 | KEYPAD | JST ZH 7-pin SMD | JST_ZH_B7B-ZR-SM4-TF | C265294 | KP_COL0-2, KP_ROW0-3 | Keypad connector. Connects to the phone's 4x3 button matrix. Four row lines (KP_ROW0-3) are scanned as outputs by the RP2040; three column lines (KP_COL0-2) are read as inputs to detect which button is pressed. |
 | LED | JST ZH 2-pin SMD | JST_ZH_B2B-ZR-SM4-TF | C265284 | pin1 GND, pin2 LED_A | LED connector. Drives an indicator LED in the phone housing through R1 (220 ohm current limiter). The RP2040 controls the LED via GPIO16 (LED_OUT). Pin 1/2 polarity matches the stock phone LED cable directly. |
 | BELL | JST ZH 2-pin SMD (carrying screw-terminal labels in schematic) | JST_ZH_B2B-ZR-SM4-TF | C265284 | BELL_A, BELL_B | Bell/ringer output. Connects to the phone's mechanical bell mechanism. The DRV8871 (U2) drives this bidirectionally from the VBOOST rail to make the bell hammer oscillate. |
@@ -141,7 +141,7 @@ The off-board signal connectors are SMD JST ZH (1.5mm pitch). The Pi header is a
 | D2 | Red LED | 0603 | C2286 | +5V via R12, /LED12V_K | Power indicator on the +5V rail. The net `/LED12V_K` is a legacy label; it sits on +5V on this revision. |
 | D3 | Yellow-green LED (KENTO KT-0603YG) | 0603 | C2289 | +3V3 via R13, /LED3V3_K | Power indicator on the +3V3 rail. |
 | R12 | 300 ohm | 0402 | C25102 | D2 cathode (/LED12V_K) -> GND | Current limit for D2. |
-| R13 | 120 ohm | 0402 | C25752 | D3 cathode (/LED3V3_K) -> GND | Current limit for D3, sized so the +3V3 indicator reliably lights at ~10mA. |
+| R13 | 120 ohm | 0402 | C25079 | D3 cathode (/LED3V3_K) -> GND | Current limit for D3, sized so the +3V3 indicator reliably lights at ~10mA. |
 
 SW1 has no LCSC part assigned in the schematic: it is the custom hand-placed DPDT cradle switch (footprint SW_DPDT_Hook_24.2x17.1mm).
 

--- a/hardware/pcb/v3/NET_TOPOLOGY.md
+++ b/hardware/pcb/v3/NET_TOPOLOGY.md
@@ -27,7 +27,7 @@ All component references, values, footprints, and placements are fixed by the ph
 | `U7` | XC6206P182MR | Codec +1V8 LDO | SOT-23 |
 | `U10` | XL6019E1 | +5V to ~37V bell boost | TO-263-5 |
 | `Y1` | ABM8-272-T3 (12 MHz) | RP2040 crystal, per RP2040 DS sec 2.16.1.1 | Crystal_SMD_3225-4Pin |
-| `Pi Zero W 2` | Conn_02x20_Odd_Even | Raspberry Pi 40-pin header | PinHeader 2x20 2.54 mm |
+| `PI_ZERO_W1` | Conn_02x20_Odd_Even | Raspberry Pi 40-pin header | PinHeader 2x20 2.54 mm |
 | `PWR` | VIN_BARREL_PIGTAIL | +5 V power input | JST XH B2B-XH-A 2.5 mm |
 | `KEYPAD` | Conn_01x07 | Keypad flex ribbon | JST ZH B7B-ZR-SM4-TF |
 | `LED` | Conn_01x02 | Status LED | JST ZH B2B-ZR-SM4-TF |
@@ -160,9 +160,9 @@ Two on-board LEDs confirm the two main rails are up. Both are wired anode-to-rai
 
 `/LED12V_K` is a legacy net label carried over from the 12 V era; on v3 the D2 anode is on +5 V. The net name is cosmetic and does not change the connectivity.
 
-## Raspberry Pi 40-pin header (`Pi Zero W 2`)
+## Raspberry Pi 40-pin header (`PI_ZERO_W1`)
 
-The reference designator is `Pi Zero W 2`; it is the standard Raspberry Pi 40-pin header. Pi pin numbering matches the physical pinout. It is not rotated or mirrored in the schematic.
+The reference designator is `PI_ZERO_W1`; it is the standard Raspberry Pi 40-pin header. Pi pin numbering matches the physical pinout. It is not rotated or mirrored in the schematic.
 
 | Pin | Pi function | Net | Notes |
 |---|---|---|---|

--- a/hardware/pcb/v3/codec-module-spec.md
+++ b/hardware/pcb/v3/codec-module-spec.md
@@ -255,7 +255,7 @@ The checker will parse `codec.kicad_sch` and assert all of the following. Any fa
 
 ### Resolved during Phase 2 → Phase 3 transition
 
-- **Parent schematic net naming** investigated (kicad-cli netlist export of `digits-pcb.kicad_sch`). Parent uses `CODEC_BCLK`, `CODEC_WCLK`, `CODEC_DIN`, `CODEC_DOUT`, `CODEC_MCLK`, `CODEC_SDA`, `CODEC_SCL`, `CODEC_RESET` (to the Pi Zero W 2 header), plus `MIC_FROM_SW`, `EAR_P`, `EAR_N` (to the J8 handset connector; `MIC_FROM_SW` comes from SW1 pole 2, and `EAR_P`/`EAR_N` reach J8 directly). Codec sheet ports renamed to match these existing net names verbatim, so Phase 3 integration wires sheet-pin-to-existing-net with no label gymnastics.
+- **Parent schematic net naming** investigated (kicad-cli netlist export of `digits-pcb.kicad_sch`). Parent uses `CODEC_BCLK`, `CODEC_WCLK`, `CODEC_DIN`, `CODEC_DOUT`, `CODEC_MCLK`, `CODEC_SDA`, `CODEC_SCL`, `CODEC_RESET` (to the PI_ZERO_W1 header), plus `MIC_FROM_SW`, `EAR_P`, `EAR_N` (to the J8 handset connector; `MIC_FROM_SW` comes from SW1 pole 2, and `EAR_P`/`EAR_N` reach J8 directly). Codec sheet ports renamed to match these existing net names verbatim, so Phase 3 integration wires sheet-pin-to-existing-net with no label gymnastics.
 
 ## 11. References
 


### PR DESCRIPTION
## What

Align the V3 hardware spec docs with the board that was finalized for fabrication. Two designator/part references in the docs no longer matched the KiCad files and the production BOM:

- **Pi-header reference designator**: `Pi Zero W 2` -> `PI_ZERO_W1`, in `NET_TOPOLOGY.md`, `CHANGES_FROM_V2.md`, `COMPONENTS.md`, and `codec-module-spec.md`.
- **R13 LCSC part**: `C25752` -> `C25079`, in `CHANGES_FROM_V2.md` and `COMPONENTS.md`.

## Why (cross-PR coherence)

This came out of a holistic read across the last day's merges, not a single-PR review.

- **#626** introduced the V3 board and its spec docs, with the Pi header carrying a space-containing reference designator and R13 documented as `C25752`.
- **#632** finalized V3 for first fab: it renamed the Pi-header reference to `PI_ZERO_W1` (the old spaced form was being split by JLCPCB, breaking BOM/CPL designator matching so the 2x20 header silently dropped from assembly) and corrected R13 to the real 120R part `C25079`. Those edits landed in the KiCad schematic, PCB, and the production `bom.csv`, but the prose spec docs from #626 were left describing the pre-fab state.

The result was drift between the fabbed board (and its BOM) and the spec docs that describe it. The board file uses `PI_ZERO_W1` in all 21 references and `C25079` for R13 with no `C25752` anywhere; this brings the docs back in line. `C25752` is the wrong 12k part the docs had been citing as "120 Ohm", so the old value was also internally inconsistent.

## Scope

Docs only, 4 files, 8 lines. No board, BOM, or code changes: the board is already correct, this only fixes the documentation that lagged it.

## Test plan

- [x] `rg "Pi Zero W 2"` and `rg "C25752"` return zero matches repo-wide after the change
- [x] Confirmed the KiCad PCB/schematic and `production/bom.csv` use `PI_ZERO_W1` and `R13 = C25079`
