### PR TITLE
refactor(server): centralize link-health linked-index resolution

### DIFF
--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -58,10 +58,7 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	var linkedIndex map[string]string
-	if primaryHH != nil {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
-	}
+	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
 
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
@@ -170,10 +167,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 		return
 	}
 
-	var linkedIndex map[string]string
-	if primaryHH != nil {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
-	}
+	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
 
 	// Subscribe FIRST so samples arriving between the initial snapshot and
 	// the select loop are buffered rather than silently dropped.
@@ -271,10 +265,7 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	}
 	user := auth.UserFromContext(r.Context())
 
-	var linkedIndex map[string]string
-	if primaryHH != nil {
-		linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
-	}
+	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
 	_, isHostHH := ownedLines[conf.Host]

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -555,6 +555,17 @@ func buildLinkedLineIndex(families []linkedFamilyRow) map[string]string {
 	return index
 }
 
+// linkedIndexForHousehold builds the linked-line display-name index for the
+// caller's primary household, or returns nil when hh is nil (the caller owns
+// no household). The link-health endpoints share this so the "resolve once per
+// request" rule lives in one place.
+func (h *Handler) linkedIndexForHousehold(ctx context.Context, hh *household.Household) map[string]string {
+	if hh == nil {
+		return nil
+	}
+	return buildLinkedLineIndex(h.buildLinkedFamilies(ctx, hh.ID))
+}
+
 // resolvePeerName returns the friendly name for a peer number using the linked
 // line index, falling back to fmtPhone formatting.
 func resolvePeerName(number string, linkedLines map[string]string) string {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -73,11 +73,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	// Linked-household names are shown for peers that the user already sees in
 	// their call log; the underlying auth check does not grant read access to
 	// calls the user was not part of.
-	var linkedIndex map[string]string
-	if primaryHH != nil {
-		linkedFamilies := h.buildLinkedFamilies(r.Context(), primaryHH.ID)
-		linkedIndex = buildLinkedLineIndex(linkedFamilies)
-	}
+	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
 
 	resp := LinkHealthResp{CallID: call.ID, StartedAt: call.StartedAt}
 	callerEndpoint, err := h.buildLinkHealthEndpoint(r.Context(), call.ID, call.Caller, linkedIndex, ownedLines)


### PR DESCRIPTION
## Motivation

Four link-health endpoints each inlined the same block to turn the caller's primary household into a linked-line display-name index:

```go
var linkedIndex map[string]string
if primaryHH != nil {
    linkedIndex = buildLinkedLineIndex(h.buildLinkedFamilies(r.Context(), primaryHH.ID))
}
```

It appears verbatim three times in `handler_conference_linkhealth.go` (JSON, SSE stream, live detail) and as a near-identical variant in `handler_linkhealth.go` (call detail). The nil-check guards a real invariant (`primaryHH` is nil when the caller owns no household), so the duplication isn't obvious boilerplate: it's an easy place for the four copies to drift.

## Change

Add one helper next to its dependencies in `handler_helpers.go`:

```go
func (h *Handler) linkedIndexForHousehold(ctx context.Context, hh *household.Household) map[string]string {
    if hh == nil {
        return nil
    }
    return buildLinkedLineIndex(h.buildLinkedFamilies(ctx, hh.ID))
}
```

and replace all four sites with a single call. Net `-17/+15`, but the win is structural: the nil-household contract now lives in one place.

## Scope

Deliberately leaves `linkedIndexForCall` (the SSE call-stream helper) alone: it derives the index from `ownedLines` rather than a `*household.Household`, so it isn't the same call shape and folding it in would muddy both. This PR only unifies the four sites that already share an identical input.

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `server/`.