### PR TITLE
refactor(digitsd): drop the never-wired insecure-TLS escape hatch

### DIFF
--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -1,7 +1,6 @@
 package signal
 
 import (
-	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -20,15 +19,14 @@ const (
 
 // Client connects to a signald WebSocket server and manages message I/O.
 type Client struct {
-	url             string
-	number          string
-	hardwareID      string
-	deviceToken     string
-	conn            *websocket.Conn
-	inbox           chan *Message
-	done            chan struct{}
-	mu              sync.Mutex
-	insecureSkipTLS bool
+	url         string
+	number      string
+	hardwareID  string
+	deviceToken string
+	conn        *websocket.Conn
+	inbox       chan *Message
+	done        chan struct{}
+	mu          sync.Mutex
 }
 
 // NewClient creates a new Client. Call Connect() to establish the connection.
@@ -43,22 +41,11 @@ func NewClient(url, number, hardwareID, deviceToken string) *Client {
 	}
 }
 
-// SetInsecureSkipTLS disables TLS certificate verification (for dev/self-signed certs).
-func (c *Client) SetInsecureSkipTLS(skip bool) {
-	c.insecureSkipTLS = skip
-}
-
 // Connect dials the WebSocket URL, sends a register message, and starts
 // the readPump goroutine. On failure, the done channel is closed so that
 // callers selecting on Done() can detect the failure and retry.
 func (c *Client) Connect() error {
-	dialer := websocket.DefaultDialer
-	if c.insecureSkipTLS {
-		dialer = &websocket.Dialer{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-	}
-	conn, _, err := dialer.Dial(c.url, http.Header{})
+	conn, _, err := websocket.DefaultDialer.Dial(c.url, http.Header{})
 	if err != nil {
 		close(c.done)
 		return fmt.Errorf("signal: dial %s: %w", c.url, err)


### PR DESCRIPTION
## Motivation

`signal.Client` carried an `insecureSkipTLS` field and a `SetInsecureSkipTLS(skip bool)` setter documented as "disables TLS certificate verification (for dev/self-signed certs)". Nothing ever called the setter, anywhere in the module (including tests):

```
$ rg -n 'SetInsecureSkipTLS|insecureSkipTLS' --glob '*.go'
# only the declaration, the setter, and the field's own read inside Connect
```

Because the flag is never set, it is always `false`, which means the custom-dialer branch in `Connect()` is unreachable:

```go
dialer := websocket.DefaultDialer
if c.insecureSkipTLS {              // never true
    dialer = &websocket.Dialer{
        TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
    }
}
conn, _, err := dialer.Dial(c.url, http.Header{})
```

This is worse than ordinary dead code: it advertises a TLS-verification bypass on the daemon's connection to the signaling server that does not actually exist. A reader auditing the TLS path has to trace the field to discover the escape hatch is inert.

## Change

Remove the field, the setter, and the dead branch. `Connect()` now dials with `websocket.DefaultDialer` directly, and the `crypto/tls` import drops out. No behavior change: the daemon already always used `DefaultDialer`.

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `pi/digitsd/` (ALSA/opus dev headers installed locally so the cgo packages compile).