### PR TITLE
refactor(digitsd): unify lazy mesh-init behind ensureMesh

### DIFF
--- a/pi/digitsd/cmd/digitsd/conference.go
+++ b/pi/digitsd/cmd/digitsd/conference.go
@@ -18,6 +18,15 @@ import (
 	"github.com/pion/webrtc/v4"
 )
 
+// ensureMesh lazily creates the conference mesh manager and returns it.
+// The caller must hold d.mu.
+func (d *daemonCallbacks) ensureMesh() *owebrtc.MeshManager {
+	if d.mesh == nil {
+		d.mesh = owebrtc.NewMeshManager(owebrtc.NewICEConfig(d.iceServers))
+	}
+	return d.mesh
+}
+
 func (d *daemonCallbacks) MutePeer(phone string, muted bool) {
 	d.mu.Lock()
 	mesh := d.mesh
@@ -53,10 +62,7 @@ func (d *daemonCallbacks) MigrateToMesh(phone string) {
 		return
 	}
 
-	// Ensure the mesh exists.
-	if d.mesh == nil {
-		d.mesh = owebrtc.NewMeshManager(owebrtc.NewICEConfig(d.iceServers))
-	}
+	d.ensureMesh()
 
 	// Transfer ownership: the existing PeerManager moves into the mesh under
 	// the peer's phone key. d.peerMgr is cleared so future 2-party calls
@@ -160,11 +166,7 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 	}
 
 	d.mu.Lock()
-	if d.mesh == nil {
-		iceCfg := owebrtc.NewICEConfig(d.iceServers)
-		d.mesh = owebrtc.NewMeshManager(iceCfg)
-	}
-	mesh := d.mesh
+	mesh := d.ensureMesh()
 	confID := d.ctrl.ConferenceID()
 	sig := d.sig
 	d.mu.Unlock()
@@ -296,11 +298,7 @@ func (d *daemonCallbacks) TearDownAllMeshPeers() {
 // Returns the answer SDP. Must NOT be called with d.mu held.
 func (d *daemonCallbacks) setupMeshResponder(peer, offerSDP, confID string) (string, error) {
 	d.mu.Lock()
-	if d.mesh == nil {
-		iceCfg := owebrtc.NewICEConfig(d.iceServers)
-		d.mesh = owebrtc.NewMeshManager(iceCfg)
-	}
-	mesh := d.mesh
+	mesh := d.ensureMesh()
 	d.mu.Unlock()
 
 	pm, err := mesh.AddPeer(peer)


### PR DESCRIPTION
## Motivation

The "create the conference mesh manager on first use" block was copy-pasted three times in `conference.go`, in `MigrateToMesh`, `AddMeshPeer`, and `setupMeshResponder`. The copies had already drifted:

```go
// MigrateToMesh
if d.mesh == nil {
    d.mesh = owebrtc.NewMeshManager(owebrtc.NewICEConfig(d.iceServers))
}

// AddMeshPeer / setupMeshResponder
if d.mesh == nil {
    iceCfg := owebrtc.NewICEConfig(d.iceServers)
    d.mesh = owebrtc.NewMeshManager(iceCfg)
}
mesh := d.mesh
```

Same intent, two spellings: one inlines `NewICEConfig`, the others route it through a local. All three run under `d.mu`.

## Change

Add one helper and call it from all three sites:

```go
// ensureMesh lazily creates the conference mesh manager and returns it.
// The caller must hold d.mu.
func (d *daemonCallbacks) ensureMesh() *owebrtc.MeshManager {
    if d.mesh == nil {
        d.mesh = owebrtc.NewMeshManager(owebrtc.NewICEConfig(d.iceServers))
    }
    return d.mesh
}
```

The two sites that captured `mesh := d.mesh` now read `mesh := d.ensureMesh()`; `MigrateToMesh` (which uses `d.mesh` directly afterward) just calls `d.ensureMesh()`. No behavior change: every call site already held `d.mu` and the init expression is identical.

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `pi/digitsd/` (ALSA/opus dev headers installed locally so the cgo packages compile).