### PR TITLE
refactor(digitsd): drop write-only lastOKAt from WiFi fallback supervisor

### DIFF
--- a/pi/digitsd/internal/wififallback/supervisor.go
+++ b/pi/digitsd/internal/wififallback/supervisor.go
@@ -48,7 +48,6 @@ type Supervisor struct {
 	graceExpires time.Time
 	apExpires    time.Time
 	backoff      time.Duration
-	lastOKAt     time.Time
 }
 
 // NewSupervisor creates a Supervisor. If logger is nil, slog.Default() is used.
@@ -100,7 +99,6 @@ func (s *Supervisor) Tick(now time.Time) {
 
 func (s *Supervisor) tickStationOK(now time.Time, connected bool) {
 	if connected {
-		s.lastOKAt = now
 		return
 	}
 	s.transitionTo(now, StateStationDegraded, "connectivity lost")
@@ -160,7 +158,6 @@ func (s *Supervisor) transitionTo(now time.Time, next State, reason string) {
 	s.logger.Info("wifi-fallback: transition", "from", prev.String(), "to", next.String(), "reason", reason)
 	switch next {
 	case StateStationOK:
-		s.lastOKAt = now
 		s.backoff = s.cfg.GraceInitial
 	case StateStationDegraded:
 		s.graceExpires = now.Add(s.backoff)


### PR DESCRIPTION
## Motivation

The WiFi-fallback `Supervisor` carried a `lastOKAt time.Time` field. It is written in two places, on every connected `tickStationOK` and on each transition into `StateStationOK`, but never read:

```
$ grep -rn lastOKAt pi/digitsd/
supervisor.go:51:  lastOKAt     time.Time   # decl
supervisor.go:103: s.lastOKAt = now         # write
supervisor.go:163: s.lastOKAt = now         # write
```

In a state machine this is more than ordinary dead code. `lastOKAt` sits right next to `graceExpires`, `apExpires`, and `backoff`, all of which feed real transition decisions, so a maintainer touching the escalation logic reasonably assumes `lastOKAt` is a "time since last OK connectivity" input too. It isn't: nothing consults it. The field is a half-built feature that misleads anyone reading the supervisor.

## Change

Remove the field and both assignments. No behavior change: the value was never observed. Every field the struct tracks is now one the machine actually uses.

## Validation

`go build ./...`, `go test ./...` (including the wififallback suite), and `golangci-lint run ./...` all pass in `pi/digitsd/`.