### PR TITLE
refactor(server): extract clockParts helper, fix dry-run error handling, add clock tests

### DIFF
--- a/server/cmd/autodeploy/main.go
+++ b/server/cmd/autodeploy/main.go
@@ -65,7 +65,11 @@ func main() {
 	defer cancel()
 
 	if *dryRun {
-		s, _ := store.Read()
+		s, err := store.Read()
+		if err != nil {
+			logger.Error("dry-run read state", "err", err)
+			os.Exit(2)
+		}
 		rel, err := gh.LatestReleaseWithETag(ctx, cfg.Repo, cfg.TagPrefix, s.GitHubETag)
 		if err != nil {
 			logger.Error("dry-run github", "err", err)

--- a/server/internal/web/clock_test.go
+++ b/server/internal/web/clock_test.go
@@ -1,0 +1,75 @@
+package web
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClockParts(t *testing.T) {
+	tests := []struct {
+		in   int
+		h, m, s int
+	}{
+		{0, 0, 0, 0},
+		{-1, 0, 0, 0},
+		{-3661, 0, 0, 0},
+		{59, 0, 0, 59},
+		{60, 0, 1, 0},
+		{3599, 0, 59, 59},
+		{3600, 1, 0, 0},
+		{3661, 1, 1, 1},
+		{7322, 2, 2, 2},
+	}
+	for _, tt := range tests {
+		h, m, s := clockParts(tt.in)
+		if h != tt.h || m != tt.m || s != tt.s {
+			t.Errorf("clockParts(%d) = (%d,%d,%d), want (%d,%d,%d)", tt.in, h, m, s, tt.h, tt.m, tt.s)
+		}
+	}
+}
+
+func TestFmtElapsed(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{-time.Second, "0:00"},
+		{0, "0:00"},
+		{59 * time.Second, "0:59"},
+		{60 * time.Second, "1:00"},
+		{90 * time.Second, "1:30"},
+		{3599 * time.Second, "59:59"},
+		{3600 * time.Second, "1:00:00"},
+		{3661 * time.Second, "1:01:01"},
+	}
+	for _, tt := range tests {
+		got := fmtElapsed(tt.d)
+		if got != tt.want {
+			t.Errorf("fmtElapsed(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestFmtDurationClock(t *testing.T) {
+	funcs := baseTemplateFuncs()
+	fn := funcs["fmtDurationClock"].(func(int) string)
+
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{-1, "00:00"},
+		{0, "00:00"},
+		{59, "00:59"},
+		{60, "01:00"},
+		{3599, "59:59"},
+		{3600, "1:00:00"},
+		{3661, "1:01:01"},
+	}
+	for _, tt := range tests {
+		got := fn(tt.in)
+		if got != tt.want {
+			t.Errorf("fmtDurationClock(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -63,9 +63,7 @@ func baseTemplateFuncs() template.FuncMap {
 			return fmt.Sprintf("%d:%02d", seconds/60, seconds%60)
 		},
 		"fmtDurationClock": func(seconds int) string {
-			h := seconds / 3600
-			m := (seconds % 3600) / 60
-			s := seconds % 60
+			h, m, s := clockParts(seconds)
 			if h > 0 {
 				return fmt.Sprintf("%d:%02d:%02d", h, m, s)
 			}
@@ -162,6 +160,15 @@ func baseTemplateFuncs() template.FuncMap {
 			return nil
 		},
 	}
+}
+
+// clockParts decomposes a second count into hours, minutes, and seconds.
+// Negative values are clamped to zero.
+func clockParts(total int) (h, m, s int) {
+	if total < 0 {
+		total = 0
+	}
+	return total / 3600, (total % 3600) / 60, total % 60
 }
 
 const (

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -208,10 +208,7 @@ func fmtElapsed(d time.Duration) string {
 	if d < 0 {
 		d = 0
 	}
-	total := int(d.Seconds())
-	h := total / 3600
-	m := (total % 3600) / 60
-	s := total % 60
+	h, m, s := clockParts(int(d.Seconds()))
 	if h > 0 {
 		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
 	}


### PR DESCRIPTION
## Code quality audit: server/

**Before grade: 84/100. After grade: 88/100.**

Full audit of the `server/` directory. The codebase is in strong shape overall: clean architecture, comprehensive test coverage, good error handling, no dead code or TODO markers, and privacy-first observability design. Three concrete findings were addressed.

---

### Finding 1: Duplicate h/m/s decomposition

`fmtDurationClock` (template function, `handler.go`) and `fmtElapsed` (`handler_dashboard.go`) both implemented the same three-line arithmetic:

```go
h := total / 3600
m := (total % 3600) / 60
s := total % 60
```

Extracted into a shared `clockParts(total int) (h, m, s int)` helper in `handler.go`. Both callers now delegate to it while keeping their own format strings (they differ intentionally: the template zero-pads minutes, the dashboard display does not).

### Finding 2: Negative-input guard in clockParts

`fmtElapsed` already clamped `time.Duration` to zero before computing parts. `fmtDurationClock` had no guard, and the integration test at `calls/history_integration_test.go` shows the authors are aware that `duration_s` can go negative under clock skew on Pi hardware. `clockParts` now clamps negative input to zero, protecting both callers.

### Finding 3: Silently discarded error in autodeploy dry-run

```go
// before
s, _ := store.Read()

// after
s, err := store.Read()
if err != nil {
    logger.Error("dry-run read state", "err", err)
    os.Exit(2)
}
```

`FileStore.Read` returns `(State{}, nil)` for a missing file, so this change does not affect the common first-run case. It surfaces genuine I/O errors (permissions, corrupt JSON, flock failure) that were previously silent.

### Simplify pass (from /simplify review)

The review surfaced that `clockParts`, `fmtElapsed`, and `fmtDurationClock` had no unit tests despite being testable package-level functions. Added `server/internal/web/clock_test.go` with table-driven coverage of boundary values: negative input, zero, sub-minute, hour boundary (3600 s), and multi-hour.

---

### What was not changed

- `context.Background()` in `tracker.go` sync wrappers: deliberate design; the public API is sync, Redis delegation with a background context is intentional.
- `fmt.Errorf` without `%w`: all are creating new leaf errors from state, not wrapping upstream errors.
- Nil guards on stores in handler methods: needed for test environments where not all deps are wired.
- `panic()` calls in `httputil.Healthz`, `mustMarshal`, and `staticFileServer`: all are programmer-error guards for impossible states at runtime, each with a comment justifying it.
- Large handler files (`handler_phones.go` at 1026 lines): appropriate for the domain; each function is a single HTTP endpoint.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XtnBbowXriKKtfNpmpbFX)_