### PR TITLE
refactor(digitsd): replace bool-arg serial Ring/FlashEnabled with intent methods

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -282,11 +282,11 @@ func (d *daemonCallbacks) OncePlaying() bool {
 }
 
 func (d *daemonCallbacks) StartRing() {
-	d.serial.Ring(true)
+	d.serial.StartRing()
 }
 
 func (d *daemonCallbacks) StopRing() {
-	d.serial.Ring(false)
+	d.serial.StopRing()
 }
 
 func (d *daemonCallbacks) SendRingPattern(id int) {
@@ -313,7 +313,7 @@ func (d *daemonCallbacks) NotifyCallConnected() {
 }
 
 func (d *daemonCallbacks) EnableFlashDetection() {
-	d.serial.FlashEnabled(true)
+	d.serial.EnableFlashDetection()
 }
 
 func (d *daemonCallbacks) OnCallReturn() {
@@ -810,7 +810,7 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 // hardware states were active.
 func resetPicoHardware(sp *phone.SerialPort) {
 	slog.Info("pico: clearing residual hardware state on startup")
-	sp.Ring(false)
+	sp.StopRing()
 	sp.LED("UNLOCK")
 }
 

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -324,7 +324,7 @@ func (d *daemonCallbacks) HangupCall() {
 
 	// Call is tearing down. Drop the Pico into instant-hangup mode so any
 	// subsequent idle hook press doesn't sit behind the flash window.
-	d.serial.FlashEnabled(false)
+	d.serial.DisableFlashDetection()
 
 	d.pendingOffer = ""
 	d.pendingCaller = ""

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -189,13 +189,14 @@ func (sp *SerialPort) DroppedLines() int64 {
 	return sp.droppedLines.Load()
 }
 
-// Ring sends RING:START or RING:STOP to the Pico.
-func (sp *SerialPort) Ring(start bool) {
-	if start {
-		sp.SendFire("RING:START")
-	} else {
-		sp.SendFire("RING:STOP")
-	}
+// StartRing sends RING:START to the Pico to begin ringing.
+func (sp *SerialPort) StartRing() {
+	sp.SendFire("RING:START")
+}
+
+// StopRing sends RING:STOP to the Pico to stop ringing.
+func (sp *SerialPort) StopRing() {
+	sp.SendFire("RING:STOP")
 }
 
 // RingPattern sends RING:PATTERN:<id> to the Pico for distinctive ring cadences.
@@ -244,15 +245,17 @@ func (sp *SerialPort) CallConnected() {
 	sp.SendFire("CALL:CONNECTED")
 }
 
-// FlashEnabled toggles flash-window detection on the Pico. When disabled,
-// hangup is instantaneous; when enabled the Pico waits up to 600ms after on-hook
-// to distinguish a flash from a hangup. Pi enables it only while in a call.
-func (sp *SerialPort) FlashEnabled(enabled bool) {
-	if enabled {
-		sp.SendFire("HOOK:FLASH:ON")
-	} else {
-		sp.SendFire("HOOK:FLASH:OFF")
-	}
+// EnableFlashDetection opens the flash-detection window on the Pico: after
+// on-hook it waits up to 600ms to distinguish a flash from a hangup. The Pi
+// enables this only while in a call.
+func (sp *SerialPort) EnableFlashDetection() {
+	sp.SendFire("HOOK:FLASH:ON")
+}
+
+// DisableFlashDetection closes the flash-detection window so the Pico treats
+// on-hook as an instantaneous hangup.
+func (sp *SerialPort) DisableFlashDetection() {
+	sp.SendFire("HOOK:FLASH:OFF")
 }
 
 // Close stops the reader and closes the port.

--- a/pi/digitsd/internal/phone/serial_test.go
+++ b/pi/digitsd/internal/phone/serial_test.go
@@ -12,7 +12,8 @@ func TestSerialPortInterface(t *testing.T) {
 		SendCommand(string, time.Duration) (string, error)
 		SendFire(string)
 		Ping() error
-		Ring(bool)
+		StartRing()
+		StopRing()
 		LED(string)
 		AddMonitor(chan string) func()
 		Close() error


### PR DESCRIPTION
## Motivation

`SerialPort.Ring(bool)` and `SerialPort.FlashEnabled(bool)` each took a boolean and branched on it to send one of two fixed wire commands (`RING:START`/`RING:STOP`, `HOOK:FLASH:ON`/`HOOK:FLASH:OFF`). This is the same boolean-state-flag wart that #633 removed at the `Callbacks` layer (`SendRing(bool)` to `StartRing`/`StopRing`).

The `Callbacks` layer already exposes intent-named `StartRing`/`StopRing`/`EnableFlashDetection`, so every call bounced an intent through a boolean only to have the serial layer expand it back into a constant string. The boolean carried no information the two methods don't.

## Change

- `SerialPort.Ring(bool)` becomes `StartRing()` / `StopRing()`.
- `SerialPort.FlashEnabled(bool)` becomes `EnableFlashDetection()` / `DisableFlashDetection()`.
- Updated the four call sites in `cmd/digitsd` (`StartRing`/`StopRing`/`EnableFlashDetection` callbacks, `resetPicoHardware`, and the WebRTC teardown) plus the compile-time interface assertion in `serial_test.go`.

Each method now reads as the command it sends, and the boolean round-trip across the callbacks-to-serial boundary is gone.

## Scope

Kept to the two methods that purely select between two constant commands. `SetFlashEnabled(bool)` is left alone: its boolean is a genuine config value (whether the Pi forwards `HOOK:FLASH` events at all), not a two-command selector. `RingPattern(id int)` is unrelated and untouched.

## Test plan

- [x] `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass in `pi/digitsd`
- [x] Wire protocol unchanged (same `RING:*` / `HOOK:FLASH:*` strings), so firmware behavior is identical