### PR TITLE
docs: drop nonexistent -insecure digitsd flag from self-hosting guide

### DIFF
--- a/docs/hosting/self-hosting.md
+++ b/docs/hosting/self-hosting.md
@@ -278,8 +278,6 @@ sudo systemctl daemon-reload
 sudo systemctl restart digitsd
 ```
 
-If your server uses a self-signed cert (dev only), add `-insecure` to skip TLS verification. Do not do this in production.
-
 ### Pairing Flow
 
 1. In the web app, complete onboarding to create a household, then add a line on `/phones`.


### PR DESCRIPTION
## Summary

`docs/hosting/self-hosting.md` told operators that if signald uses a self-signed cert they could add `-insecure` to `digitsd` to skip TLS verification. That flag does not exist. `digitsd`'s flags are `config`, `signald`, `number`, `serial`, `socket`, `tones`, `alsa-playback`, `version`, and `mode` (`pi/digitsd/cmd/digitsd/main.go`). Go's `flag` package exits with `flag provided but not defined: -insecure` on an unknown flag, so anyone following this line would have the daemon refuse to start.

## Why now (cross-PR coherence)

This is the holistic across-PR read of the daily-cleanup batch merged in the last 24h. PR #637 (`refactor(digitsd): drop the never-wired insecure-TLS escape hatch`) removed `SetInsecureSkipTLS` / `insecureSkipTLS` from `pi/digitsd/internal/signal/client.go`. That setter is the mechanism a `-insecure` flag would have driven, and it had zero callers, confirming the documented flag was never wired. #637 reviewed cleanly on its own; the stale doc is only visible when you read the removal against the self-hosting guide.

Removing the line is the coherent fix: reintroducing a TLS-bypass path is a security decision, not a documentation correction. Caddy already terminates TLS with a real Let's Encrypt cert in the documented production setup, so there is no supported self-signed bypass to point operators at.

## Scope

Docs only, one line removed. No Go module touched, so no build/test impact.

## Motivated by (last 24h)

- #637: refactor(digitsd): drop the never-wired insecure-TLS escape hatch
