### PR TITLE
refactor(server): idiomatic time.Duration for release TTL, consistent config defaults

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -36,8 +36,8 @@ import (
 	"github.com/justinlindh/digits/server/internal/web"
 )
 
-// releaseCacheTTL is the release index cache lifetime, in seconds.
-const releaseCacheTTL = 5 * 60
+// releaseCacheTTL is the release index cache lifetime.
+const releaseCacheTTL = 5 * time.Minute
 
 func main() {
 	logging.Setup()

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -55,11 +55,12 @@ type Config struct {
 // present in the environment retain their defaults (e.g. Addr ":8443").
 func Load() *Config {
 	c := &Config{
-		Addr:        ":8443",
-		MetricsAddr: ":9091",
-		SMTPPort:    "587",
-		SMTPFrom:    "noreply@digits.family",
-		BaseURL:     "https://app.digits.family",
+		Addr:              ":8443",
+		MetricsAddr:       ":9091",
+		SMTPPort:          "587",
+		SMTPFrom:          "noreply@digits.family",
+		BaseURL:           "https://app.digits.family",
+		WSRateLimitPerMin: 30,
 	}
 	StringEnv("SIGNALD_ADDR", &c.Addr)
 	StringEnv("SIGNALD_METRICS_ADDR", &c.MetricsAddr)
@@ -89,7 +90,6 @@ func Load() *Config {
 	// Redis
 	StringEnv("REDIS_URL", &c.RedisURL)
 	// Rate limits
-	c.WSRateLimitPerMin = 30
 	IntEnv("SIGNALD_WS_RATE_LIMIT", &c.WSRateLimitPerMin)
 	// Release index
 	OneEnv("TEST_FAKE_UPDATES", &c.FakeUpdates)

--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -55,15 +55,15 @@ type GitHubReleases struct {
 }
 
 // NewGitHubReleases creates a GitHubReleases that polls the given repo.
-// It fetches immediately in the background and refreshes every ttlSeconds.
-func NewGitHubReleases(ctx context.Context, owner, repo, token string, ttlSeconds int, onChange func(piLatest, fwLatest string)) *GitHubReleases {
+// It fetches immediately in the background and refreshes every ttl.
+func NewGitHubReleases(ctx context.Context, owner, repo, token string, ttl time.Duration, onChange func(piLatest, fwLatest string)) *GitHubReleases {
 	g := &GitHubReleases{
 		owner:    owner,
 		repo:     repo,
 		apiBase:  "https://api.github.com",
 		token:    token,
 		client:   &http.Client{Timeout: 15 * time.Second},
-		ttl:      time.Duration(ttlSeconds) * time.Second,
+		ttl:      ttl,
 		OnChange: onChange,
 	}
 	go g.poll(ctx)


### PR DESCRIPTION
## Code quality audit: server/

Audit of the `server/` folder for cleanliness, idiomaticity, and consistency. Two findings addressed.

**Before grade: 84/100**
**After grade: 87/100**

The codebase is well-architected overall: clean package boundaries, correct concurrency, comprehensive test coverage (90 test files to 77 source files), security-conscious design, and solid observability. The changes below address the two concrete idiomaticity issues found.

---

## Changes

### `NewGitHubReleases`: `ttlSeconds int` to `ttl time.Duration`

The constructor accepted a bare integer in seconds (`ttlSeconds int`) and immediately converted it with `time.Duration(ttlSeconds) * time.Second`. Go's convention is to accept `time.Duration` directly; the conversion is a code smell that obscures the unit at the call site.

- `internal/updates/github.go`: parameter renamed and retyped; internal assignment simplified to `ttl: ttl`
- `cmd/signald/main.go`: `releaseCacheTTL` constant changed from `5 * 60` (with a "in seconds" comment) to `5 * time.Minute`

### `WSRateLimitPerMin` default moved into struct literal

In `config.Load()`, all defaults (`Addr`, `MetricsAddr`, `SMTPPort`, etc.) are initialized in the `&Config{...}` struct literal. `WSRateLimitPerMin: 30` was instead set as a separate body assignment after the env-var override calls had already started. Moving it into the literal makes the pattern consistent and groups all defaults in one place. Behavior is identical: the literal runs before the `IntEnv` override call.

---

## What was not changed

The rest of the codebase did not have findings worth addressing:

- Role constants (`roleHost`/`roleAdded` in `calls`, `RoleHost`/`RoleAdded` in `signaling`) are duplicated because the packages cannot import each other. YAGNI.
- `callStateSnapshot()` uses `sync.Mutex` to read a pointer set once at startup. Correct, and concurrency is low enough that a `sync.RWMutex` upgrade has no practical benefit. YAGNI.
- `ratelimit.New` starts a goroutine that runs for the process lifetime. Intentional and documented.

## Test plan

- `go build ./...`: passes
- `go test ./...`: all 21 packages pass

---
_Generated by [Claude Code](https://claude.ai/code/session_016ftiifMthfVq1RwWN6d5BW)_