### PR TITLE
refactor(digitsd): drop the phantom StateDegraded subsystem state

### DIFF
--- a/pi/digitsd/internal/subsystem/manager.go
+++ b/pi/digitsd/internal/subsystem/manager.go
@@ -169,20 +169,17 @@ func (m *Manager) logSummary(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var ready, total, degraded int
+	var ready, total int
 	for _, s := range m.states {
 		if s.State == StateDisabled {
 			continue
 		}
 		total++
-		switch s.State {
-		case StateReady:
+		if s.State == StateReady {
 			ready++
-		case StateDegraded:
-			degraded++
 		}
 	}
-	slog.InfoContext(ctx, "subsystem: init complete", "ready", ready, "total", total, "degraded", degraded)
+	slog.InfoContext(ctx, "subsystem: init complete", "ready", ready, "total", total)
 }
 
 // topoLayers sorts regs into dependency-ordered layers using Kahn's algorithm.

--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -12,7 +12,6 @@ const (
 	StateInitializing
 	StateReady
 	StateFailed
-	StateDegraded
 	StateDisabled
 )
 
@@ -26,8 +25,6 @@ func (s State) String() string {
 		return "ready"
 	case StateFailed:
 		return "failed"
-	case StateDegraded:
-		return "degraded"
 	case StateDisabled:
 		return "disabled"
 	default:

--- a/pi/digitsd/internal/subsystem/module_test.go
+++ b/pi/digitsd/internal/subsystem/module_test.go
@@ -11,7 +11,6 @@ func TestModuleStatusString(t *testing.T) {
 		{StateInitializing, "initializing"},
 		{StateReady, "ready"},
 		{StateFailed, "failed"},
-		{StateDegraded, "degraded"},
 		{StateDisabled, "disabled"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What

`StateDegraded` was a subsystem state that no module ever produces. Every `Module.Status()` implementation (web, serial, mounts, reaper, wifiap, audio, kernmods, gpclk0) only ever sets Pending, Initializing, Ready, Failed, or Disabled. `StateDegraded` existed purely as:

- an enum constant in `module.go`,
- a `String()` case returning the degraded label,
- a `degraded` counter in `Manager.logSummary` that was therefore structurally always 0.

The init-complete startup log emitted `degraded=0` on every boot, forever, conveying nothing.

## Change

- Remove the `StateDegraded` constant and its `String()` case.
- Drop the dead `degraded` accumulator in `logSummary`; the now single-case switch collapses to an `if`, and the log reports just `ready` and `total`.
- Remove the corresponding `module_test.go` table row.

The state values are in-memory only (recomputed each boot) and exposed solely on the local `/status` debug JSON; no consumer in the tree maps them by number, so shifting the `StateDisabled` ordinal is safe.

Genuine degraded-health reporting would be a feature with a real code path; this was just unreachable scaffold.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass in `pi/digitsd`.
