### PR TITLE
refactor(server): drop the dead single-device DeviceInfo accessors

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -600,16 +600,6 @@ type DeviceInfoSnapshot struct {
 	DevMode bool `json:"-"`
 }
 
-// DeviceInfo returns version info for the first connected device on a line.
-// Returns nil if no device is online.
-func (h *Hub) DeviceInfo(number string) *DeviceInfoSnapshot {
-	all := h.AllDeviceInfo(number)
-	if len(all) == 0 {
-		return nil
-	}
-	return &all[0]
-}
-
 // AllDeviceInfo returns version info for all connected devices on a line.
 func (h *Hub) AllDeviceInfo(number string) []DeviceInfoSnapshot {
 	h.mu.RLock()

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -99,22 +99,23 @@ func TestDeviceInfoIncludesRemoteAddr(t *testing.T) {
 	}
 	_ = hub.Register("3140001", conn)
 
-	info := hub.DeviceInfo("3140001")
-	if info == nil {
-		t.Fatal("DeviceInfo returned nil for registered conn")
+	all := hub.AllDeviceInfo("3140001")
+	if len(all) == 0 {
+		t.Fatal("AllDeviceInfo returned no devices for registered conn")
 	}
+	info := all[0]
 	if info.RemoteAddr != "192.168.1.42" {
-		t.Errorf("DeviceInfo.RemoteAddr = %q, want %q", info.RemoteAddr, "192.168.1.42")
+		t.Errorf("RemoteAddr = %q, want %q", info.RemoteAddr, "192.168.1.42")
 	}
 	if info.PiVersion != "1.2.3" {
-		t.Errorf("DeviceInfo.PiVersion = %q, want %q", info.PiVersion, "1.2.3")
+		t.Errorf("PiVersion = %q, want %q", info.PiVersion, "1.2.3")
 	}
 }
 
-func TestDeviceInfoNilWhenOffline(t *testing.T) {
+func TestAllDeviceInfoEmptyWhenOffline(t *testing.T) {
 	hub := NewHub()
-	if got := hub.DeviceInfo("3140002"); got != nil {
-		t.Errorf("DeviceInfo for unregistered number = %+v, want nil", got)
+	if got := hub.AllDeviceInfo("3140002"); len(got) != 0 {
+		t.Errorf("AllDeviceInfo for unregistered number = %+v, want empty", got)
 	}
 }
 
@@ -126,10 +127,11 @@ func TestRegisterOverwritesRemoteAddrOnReconnect(t *testing.T) {
 	second := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-003", RemoteAddr: "192.168.1.99"}
 	_ = hub.Register("3140003", second)
 
-	info := hub.DeviceInfo("3140003")
-	if info == nil {
-		t.Fatal("expected DeviceInfo after reconnect")
+	all := hub.AllDeviceInfo("3140003")
+	if len(all) == 0 {
+		t.Fatal("expected device info after reconnect")
 	}
+	info := all[0]
 	if info.RemoteAddr != "192.168.1.99" {
 		t.Errorf("RemoteAddr after reconnect = %q, want %q", info.RemoteAddr, "192.168.1.99")
 	}

--- a/server/internal/signaling/state_redis.go
+++ b/server/internal/signaling/state_redis.go
@@ -124,14 +124,6 @@ func (s *DeviceState) OnlineNumbers(ctx context.Context) []string {
 	return numbers
 }
 
-func (s *DeviceState) DeviceInfo(ctx context.Context, number string) *DeviceInfoSnapshot {
-	all := s.AllDeviceInfo(ctx, number)
-	if len(all) == 0 {
-		return nil
-	}
-	return &all[0]
-}
-
 func (s *DeviceState) AllDeviceInfo(ctx context.Context, number string) []DeviceInfoSnapshot {
 	setKey := lineDevicesPrefix + number
 	hwIDs, err := s.client.SMembers(ctx, setKey).Result()

--- a/server/internal/signaling/state_redis_integration_test.go
+++ b/server/internal/signaling/state_redis_integration_test.go
@@ -47,10 +47,11 @@ func TestDeviceStateIntegrationTwoPods(t *testing.T) {
 		t.Fatal("pod B should see device as online")
 	}
 
-	info := dsB.DeviceInfo(ctx, "test-5551234")
-	if info == nil {
+	all := dsB.AllDeviceInfo(ctx, "test-5551234")
+	if len(all) == 0 {
 		t.Fatal("pod B should see device info")
 	}
+	info := all[0]
 	if info.PiVersion != "2.0.0" {
 		t.Errorf("PiVersion = %q, want %q", info.PiVersion, "2.0.0")
 	}

--- a/server/internal/signaling/state_redis_test.go
+++ b/server/internal/signaling/state_redis_test.go
@@ -94,10 +94,11 @@ func TestDeviceStateDeviceInfo(t *testing.T) {
 		RemoteAddr:      "10.0.0.5",
 	})
 
-	info := ds.DeviceInfo(ctx, "5551234")
-	if info == nil {
-		t.Fatal("expected non-nil DeviceInfoSnapshot")
+	all := ds.AllDeviceInfo(ctx, "5551234")
+	if len(all) == 0 {
+		t.Fatal("expected a DeviceInfoSnapshot")
 	}
+	info := all[0]
 	if info.PiVersion != "1.2.0" {
 		t.Errorf("PiVersion = %q, want %q", info.PiVersion, "1.2.0")
 	}
@@ -119,9 +120,8 @@ func TestDeviceStateDeviceInfoOffline(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	info := ds.DeviceInfo(ctx, "5559999")
-	if info != nil {
-		t.Fatalf("expected nil for offline device, got %+v", info)
+	if got := ds.AllDeviceInfo(ctx, "5559999"); len(got) != 0 {
+		t.Fatalf("expected no devices for offline number, got %+v", got)
 	}
 }
 
@@ -141,10 +141,11 @@ func TestDeviceStateUpdateDeviceInfo(t *testing.T) {
 		RemoteAddr: "192.168.1.50",
 	})
 
-	info := ds.DeviceInfo(ctx, "5551234")
-	if info == nil {
-		t.Fatal("expected non-nil DeviceInfoSnapshot")
+	all := ds.AllDeviceInfo(ctx, "5551234")
+	if len(all) == 0 {
+		t.Fatal("expected a DeviceInfoSnapshot")
 	}
+	info := all[0]
 	if info.PiVersion != "1.1.0" {
 		t.Errorf("PiVersion = %q, want %q", info.PiVersion, "1.1.0")
 	}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1865,9 +1865,9 @@ func runDeviceInfoAndCaptureAddr(t *testing.T, srv *httptest.Server, hub *signal
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		info := hub.DeviceInfo(number)
-		if info != nil && info.PiVersion == "1.0.0" {
-			return info.RemoteAddr
+		all := hub.AllDeviceInfo(number)
+		if len(all) > 0 && all[0].PiVersion == "1.0.0" {
+			return all[0].RemoteAddr
 		}
 		time.Sleep(2 * time.Millisecond)
 	}


### PR DESCRIPTION
## What

`Hub.DeviceInfo(number)` and `DeviceState.DeviceInfo(ctx, number)` returned the first connected device on a line by delegating to `AllDeviceInfo` and taking `[0]`. They had **zero production callers**: every real path uses `AllDeviceInfo`.

- `handler_phones.go`, `handler_changelog.go`, `handler_helpers.go` all iterate `AllDeviceInfo`.
- A line routinely has multiple handsets, so the first device is an arbitrary fiction, not a meaningful one.

The singular methods were therefore a two-layer dead delegation chain (`Hub.DeviceInfo` -> `DeviceState.DeviceInfo` -> `AllDeviceInfo`) reachable only from tests, plus a footgun inviting future callers to pin behavior to an arbitrary device. Linters miss it because the symbols are exported.

## Change

- Delete both `DeviceInfo` methods.
- Convert the tests that used them (`hub_test.go`, `state_redis_test.go`, `state_redis_integration_test.go`, `handler_test.go`) to assert against `AllDeviceInfo` directly: take the first element when a device is expected, or check the slice is empty when offline. Coverage of remote-addr capture, version surfacing, and reconnect-overwrite is preserved.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass in `server`.
- `go vet -tags=integration ./...` passes (the converted integration test compiles).
