### PR TITLE
refactor(digitsd): drop write-only FrameMs/OpusBitrate from PipelineConfig

### DIFF
--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -10,11 +10,9 @@ import (
 
 // PipelineConfig holds configuration for the audio pipeline.
 type PipelineConfig struct {
-	SampleRate  int
-	FrameMs     int
-	OpusBitrate int
-	MicChannel  int  // 0=left, 1=right. Both codecs route mic to left channel.
-	Denoise     bool
+	SampleRate int
+	MicChannel int // 0=left, 1=right. Both codecs route mic to left channel.
+	Denoise    bool
 	// Bandpass enables the POTS telephony bandpass + mains notch comb on
 	// the capture path, applied BEFORE the denoiser. See NewPOTSChain for
 	// the exact filter topology.
@@ -28,11 +26,9 @@ type PipelineConfig struct {
 // DefaultPipelineConfig returns sensible defaults for both codec types.
 func DefaultPipelineConfig() PipelineConfig {
 	return PipelineConfig{
-		SampleRate:  48000,
-		FrameMs:     20,
-		OpusBitrate: 24000,
-		MicChannel:  0, // Both codecs route mic to left channel
-		Denoise:     true,
+		SampleRate: 48000,
+		MicChannel: 0, // Both codecs route mic to left channel
+		Denoise:    true,
 		// Bandpass off by default: RNNoise alone handles both the 60 Hz
 		// mains hum and the broadband preamp hiss on the prototype phones
 		// cleanly. A fixed biquad chain in front of RNNoise only distorts
@@ -52,7 +48,7 @@ func DefaultPipelineConfig() PipelineConfig {
 type Pipeline struct {
 	cfg       PipelineConfig
 	capture   *Capture
-	filters   *BiquadChain // pre-denoise bandpass (optional)
+	filters   *BiquadChain                // pre-denoise bandpass (optional)
 	character atomic.Pointer[BiquadChain] // post-denoise POTS character, swappable live
 	denoiser  *Denoiser
 	muted     atomic.Bool
@@ -129,7 +125,7 @@ func SynthGreetingBeep(sampleRate int, d time.Duration) []int16 {
 	}
 
 	const freq = 1000.0
-	const amplitude = 10000.0 // ~30% of int16 max
+	const amplitude = 10000.0            // ~30% of int16 max
 	fadeSamples := sampleRate * 5 / 1000 // 5ms fade
 
 	buf := make([]int16, totalSamples)

--- a/pi/digitsd/internal/audio/pipeline_beep_test.go
+++ b/pi/digitsd/internal/audio/pipeline_beep_test.go
@@ -22,7 +22,7 @@ func TestPlayGreetingBeep_ReplacesFrames(t *testing.T) {
 	cfg := DefaultPipelineConfig()
 	p := NewPipeline(cfg)
 
-	frameSize := cfg.SampleRate * cfg.FrameMs / 1000 // 960
+	frameSize := cfg.SampleRate / 50 // 20ms frames (960 at 48kHz)
 
 	p.PlayGreetingBeep(40 * time.Millisecond) // 2 frames at 20ms each
 
@@ -54,7 +54,7 @@ func TestPlayGreetingBeep_FadeEnvelope(t *testing.T) {
 
 	p.PlayGreetingBeep(100 * time.Millisecond) // 5 frames
 
-	frameSize := cfg.SampleRate * cfg.FrameMs / 1000
+	frameSize := cfg.SampleRate / 50 // 20ms frames (960 at 48kHz)
 	frames := p.drainBeepFrames(frameSize)
 	if len(frames) == 0 {
 		t.Fatal("no beep frames")
@@ -82,7 +82,7 @@ func TestPlayGreetingSamples_ReplacesFrames(t *testing.T) {
 	cfg := DefaultPipelineConfig()
 	p := NewPipeline(cfg)
 
-	frameSize := cfg.SampleRate * cfg.FrameMs / 1000 // 960
+	frameSize := cfg.SampleRate / 50 // 20ms frames (960 at 48kHz)
 
 	// Two frames of distinctive samples.
 	samples := make([]int16, frameSize*2)
@@ -123,7 +123,7 @@ func TestPlayGreetingSamples_EmptyIsNoop(t *testing.T) {
 	p.PlayGreetingSamples(nil)
 	p.PlayGreetingSamples([]int16{})
 
-	frameSize := cfg.SampleRate * cfg.FrameMs / 1000
+	frameSize := cfg.SampleRate / 50 // 20ms frames (960 at 48kHz)
 	frames := p.drainBeepFrames(frameSize)
 	if len(frames) != 0 {
 		t.Errorf("expected 0 frames after no-op call, got %d", len(frames))

--- a/pi/digitsd/internal/audio/pipeline_test.go
+++ b/pi/digitsd/internal/audio/pipeline_test.go
@@ -42,12 +42,6 @@ func TestPipelineConfig(t *testing.T) {
 	if cfg.SampleRate != 48000 {
 		t.Errorf("SampleRate: got %d, want 48000", cfg.SampleRate)
 	}
-	if cfg.FrameMs != 20 {
-		t.Errorf("FrameMs: got %d, want 20", cfg.FrameMs)
-	}
-	if cfg.OpusBitrate != 24000 {
-		t.Errorf("OpusBitrate: got %d, want 24000", cfg.OpusBitrate)
-	}
 	if cfg.MicChannel != 0 {
 		t.Errorf("MicChannel: got %d, want 0", cfg.MicChannel)
 	}


### PR DESCRIPTION
## What

`PipelineConfig.FrameMs` and `PipelineConfig.OpusBitrate` were set in `DefaultPipelineConfig` but never read by any production code. Both daemon pipeline constructors (`newPipeline` in `cmd/digitsd/webrtc.go` and the capture loop in `main.go`) build the config from the defaults and only override `Character`; nothing consults either field. The only reads are in the audio package's own tests.

They also actively mislead, which is the real reason to remove them rather than leave them:

- `OpusBitrate: 24000` reads like it configures the Opus encoder, but each `PeerManager` hardcodes `codec.NewEncoder(48000, 1, 24000)` in `internal/webrtc/peer.go`. Changing the config field does nothing.
- `FrameMs: 20` reads like it controls framing, but the actual frame size comes from the ALSA capture period (`len(stereo)/2` in `captureLoop`), not from this field.

A maintainer who tried to retune the bitrate or frame size via the config would be left wondering why nothing changed.

## Change

- Remove both fields from `PipelineConfig` and their assignments in `DefaultPipelineConfig`.
- Drop the two now-dead assertions in `TestPipelineConfig`.
- The beep tests derived a 20 ms frame size as `cfg.SampleRate * cfg.FrameMs / 1000`; they now compute it directly from the sample rate as `cfg.SampleRate / 50` (still 960 at 48 kHz).

No production behavior changes: the removed fields had no readers.

## Test plan

- `go build ./...`, `go test ./...`, `golangci-lint run ./...`, `gofmt -l` all clean in `pi/digitsd`.
