### PR TITLE
refactor(server): drop the fake SignalingErrorCategory type for a plain allow-list

### DIFF
--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -44,22 +44,6 @@ import (
 
 const serviceName = "signald"
 
-// SignalingErrorCategory is a closed set of categories for the
-// signaling_errors_total counter. The list is intentionally small and
-// product-defined: adding a new category is a code change, never a runtime
-// label, so an attacker cannot smuggle PII into a label value.
-type SignalingErrorCategory string
-
-const (
-	ErrTURNAllocFailed SignalingErrorCategory = "turn_alloc_failed"
-	ErrICETimeout      SignalingErrorCategory = "ice_timeout"
-	ErrPeerUnreachable SignalingErrorCategory = "peer_unreachable"
-	ErrCallSetupFailed SignalingErrorCategory = "call_setup_failed"
-	ErrAuthFailed      SignalingErrorCategory = "auth_failed"
-	ErrInvalidMessage  SignalingErrorCategory = "invalid_message"
-	ErrRelayDelivery   SignalingErrorCategory = "relay_delivery"
-)
-
 // Registry bundles a Prometheus registry, the metrics registered into it,
 // and any GaugeFuncs that read live state. Keep one Registry per process.
 type Registry struct {
@@ -182,26 +166,27 @@ func (r *Registry) RegisterCallsGauge(read func() float64) {
 		read)
 }
 
-// validErrorCategories enumerates the closed set of categories accepted by
-// ObserveSignalingError. The string form is used because the signaling
-// package cannot import this package without a cycle. Any value not in the
-// set is dropped to "other" rather than rejected so a caller bug can't
-// silently exfiltrate the offending string into a label.
+// validErrorCategories is the closed, product-defined set of categories
+// accepted by ObserveSignalingError. The set is intentionally small: adding a
+// category is a code change here, never a runtime label, so a caller can never
+// smuggle a free-form string (or any PII it might carry) into a label value.
+// Any value not in the set collapses to "other" rather than being rejected so
+// a caller bug can't silently exfiltrate the offending string into a label.
 var validErrorCategories = map[string]struct{}{
-	string(ErrTURNAllocFailed): {},
-	string(ErrICETimeout):      {},
-	string(ErrPeerUnreachable): {},
-	string(ErrCallSetupFailed): {},
-	string(ErrAuthFailed):      {},
-	string(ErrInvalidMessage):  {},
-	string(ErrRelayDelivery):   {},
+	"turn_alloc_failed": {},
+	"ice_timeout":       {},
+	"peer_unreachable":  {},
+	"call_setup_failed": {},
+	"auth_failed":       {},
+	"invalid_message":   {},
+	"relay_delivery":    {},
 }
 
 // ObserveSignalingError records one signaling error, partitioned by category.
 // The category is a plain string because the sole caller (internal/signaling)
-// cannot import the typed SignalingErrorCategory constants without forming an
-// import cycle. Unknown categories collapse to "other" so a future caller can
-// never smuggle a free-form string into a label value.
+// cannot import this package without forming an import cycle, so it reports
+// categories as string literals. Unknown categories collapse to "other" so a
+// caller can never smuggle a free-form string into a label value.
 func (r *Registry) ObserveSignalingError(category string) {
 	if _, ok := validErrorCategories[category]; !ok {
 		category = "other"

--- a/server/internal/metrics/metrics_test.go
+++ b/server/internal/metrics/metrics_test.go
@@ -165,9 +165,9 @@ func TestActiveDeviceAndCallGauges(t *testing.T) {
 
 func TestObserveSignalingError(t *testing.T) {
 	r := New("test", "abc123")
-	r.ObserveSignalingError(string(ErrTURNAllocFailed))
-	r.ObserveSignalingError(string(ErrTURNAllocFailed))
-	r.ObserveSignalingError(string(ErrICETimeout))
+	r.ObserveSignalingError("turn_alloc_failed")
+	r.ObserveSignalingError("turn_alloc_failed")
+	r.ObserveSignalingError("ice_timeout")
 
 	if got := testutil.ToFloat64(r.SignalingErrors.WithLabelValues("turn_alloc_failed")); got != 2 {
 		t.Errorf("turn_alloc_failed counter = %v, want 2", got)
@@ -210,7 +210,7 @@ func TestPromhttpExportsExpectedMetrics(t *testing.T) {
 	// at least one labelled child has been observed.
 	r.HTTPRequestsTotal.WithLabelValues("/api/status", "GET", "200").Inc()
 	r.HTTPRequestDuration.WithLabelValues("/api/status", "GET", "200").Observe(0.012)
-	r.ObserveSignalingError(string(ErrTURNAllocFailed))
+	r.ObserveSignalingError("turn_alloc_failed")
 
 	srv := httptest.NewServer(promhttp.HandlerFor(r.Reg, promhttp.HandlerOpts{Registry: r.Reg}))
 	defer srv.Close()

--- a/server/internal/tracing/tracing.go
+++ b/server/internal/tracing/tracing.go
@@ -21,7 +21,7 @@
 //     service.instance.id (the pod / container hostname), deployment
 //     environment, plus the static cluster=homelab label.
 //   - Span events for signaling errors using the closed-set category
-//     identifiers from internal/metrics.SignalingErrorCategory.
+//     identifiers accepted by internal/metrics.ObserveSignalingError.
 //   - Relay signaling spans: message type, internal line numbers
 //     (signaling.from, signaling.to), and call_id. These are opaque
 //     internal identifiers, not real telephone numbers or PII. They


### PR DESCRIPTION
## Motivation

`internal/metrics` defined a `SignalingErrorCategory` string type plus seven typed constants (`ErrTURNAllocFailed`, `ErrICETimeout`, ...). They looked like the canonical, type-safe definition of the signaling-error category set, but no value is ever held as the type:

- The sole emitter, `internal/signaling/relay.go`, reports categories as raw string literals (`r.observeError("peer_unreachable")` etc.), not via the constants.
- The constants were only ever immediately `string()`-converted: once to build the `validErrorCategories` allow-list, and a few times in `metrics_test.go`.

So the type bought zero safety and actively misled the reader into thinking the emitter and the validator shared a typed contract. They don't.

## Change

- Delete the `SignalingErrorCategory` type and its seven constants.
- Rebuild `validErrorCategories` as a plain `map[string]struct{}` keyed by string literals.
- Reword the doc comments (here and the `internal/tracing` reference) that pointed at the typed constants.
- Update `metrics_test.go` to pass the category strings directly.

## Why this scope

The accepted category set, the unknown-category collapse to `"other"`, and every emitted metric are byte-for-byte unchanged, so this is a pure `refactor`. I deliberately did not touch *which* categories exist (e.g. `turn_alloc_failed`/`ice_timeout` are never emitted today): that is a separate product decision about the metric's label space, not part of removing the fake typing. Keeping it out keeps this PR to one coherent idea.

## Test plan

- `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `server/`.
- No behavior change: the allow-list and `"other"` collapse are exercised unchanged by the existing `TestObserveSignalingError*` tests.