### PR TITLE
refactor(digitsd): stop threading the unused wifiAP handle through setup

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -862,7 +862,7 @@ func recoveryRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *s
 	return regs, web, serial, audio
 }
 
-func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subsystem.SerialModule, *subsystem.AudioModule, *subsystem.WiFiAPModule) {
+func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subsystem.SerialModule, *subsystem.AudioModule) {
 	web := subsystem.NewWebModule()
 	gpclk0 := subsystem.NewGPCLK0Module()
 	serial := subsystem.NewSerialModule(subsystem.SerialConfig{Device: *serialDev, Baud: 115200})
@@ -883,7 +883,7 @@ func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subs
 		{Module: wifiAP, Disabled: true},
 		{Module: web, Required: true},
 	}
-	return regs, web, serial, audio, wifiAP
+	return regs, web, serial, audio
 }
 
 func main() {
@@ -930,7 +930,7 @@ func main() {
 		// Crash log to /data survives reboots for post-mortem.
 		setupCrashLog("/data/digits/crash.log")
 
-		regs, web, serial, audioMod, wifiAP := setupRegistrations()
+		regs, web, serial, audioMod := setupRegistrations()
 		mgr := subsystem.NewManager(regs)
 		web.SetLogPath("/tmp/setup.log")
 		web.SetManager(mgr)
@@ -939,7 +939,7 @@ func main() {
 			slog.Error("setup init failed", "error", err)
 			os.Exit(1)
 		}
-		runSetupMode(web, serial, audioMod, wifiAP)
+		runSetupMode(web, serial, audioMod)
 		return
 	}
 

--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -30,7 +30,7 @@ func setupVoiceLoop(serial *subsystem.SerialModule, audioMod *subsystem.AudioMod
 	voicePromptLoop(events, mixer, cfg)
 }
 
-func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audio *subsystem.AudioModule, wifiAP *subsystem.WiFiAPModule) {
+func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audio *subsystem.AudioModule) {
 
 	// Clear boot counter so repeated setup boots don't trigger recovery.
 	if err := bootcount.Clear(bootcount.DefaultPath); err != nil {


### PR DESCRIPTION
## Motivation

In setup mode the `*subsystem.WiFiAPModule` handle was carried through three places but never used:

1. `setupRegistrations()` returned it as a fifth value.
2. `main()` destructured it into a local `wifiAP`.
3. That local was passed into `runSetupMode(..., wifiAP)`, whose body never reads the parameter.

The access point in setup mode is actually run by `digits-dnsmasq-ap.service` (systemd), not by this module. The module is registered as `{Module: wifiAP, Disabled: true}` purely so it appears in status snapshots. So the handle had no consumer: it was premature flexibility spread across a function boundary and an awkward five-value return signature.

## Change

- Drop `*subsystem.WiFiAPModule` from `setupRegistrations`'s return tuple (five values back to four).
- Drop the matching destructure in `main()`.
- Drop the unused `wifiAP` parameter from `runSetupMode`.

The `Registration{Module: wifiAP, Disabled: true}` entry is left exactly as-is, so the module is still constructed and registered (disabled). Module wiring, the manager's view, and status output are unchanged.

## Test plan

- `go build ./...`, `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` all pass in `pi/digitsd/`.
- No behavior change: the handle was never read, and the disabled registration is identical.