### PR TITLE
refactor(digitsd): drop the constant expectedState param from playRejectSequence

### DIFF
--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -411,7 +411,7 @@ func (c *Controller) onHookOff() {
 			slog.Info("phone: callback pickup, auto-dialing", "target", number)
 			c.state = StateCALLING
 			c.initiateCallAfterDelay(number, StateCALLING, "phone: callback auto-dial failed",
-				func() { c.playRejectSequence(StateCALLING) })
+				func() { c.playRejectSequence() })
 		} else {
 			// Incoming: answer the call; activePeer was set when the ring arrived.
 			c.state = StateCONNECTED
@@ -598,7 +598,7 @@ func (c *Controller) onKey(digit string) {
 			slog.Info("phone: CALL_RETURN -> CALLING", "number", number)
 			c.state = StateCALLING
 			c.initiateCallAfterDelay(number, StateCALLING, "phone: call return failed, server unreachable",
-				func() { c.playRejectSequence(StateCALLING) })
+				func() { c.playRejectSequence() })
 		}
 	case StateADD_DIALTONE:
 		// First key during add-dial: stop the second dial tone, start collecting.
@@ -648,12 +648,12 @@ func (c *Controller) onDial(number string) {
 		slog.Info("phone: number not in contacts, rejecting", "number", number)
 		c.state = StateCALLING
 		c.cb.SendTone(ToneRingback)
-		go c.playRejectSequence(StateCALLING)
+		go c.playRejectSequence()
 		return
 	}
 	c.state = StateCALLING
 	c.initiateCallAfterDelay(number, StateCALLING, "phone: call failed, server unreachable",
-		func() { c.playRejectSequence(StateCALLING) })
+		func() { c.playRejectSequence() })
 }
 
 // initiateCallAfterDelay simulates the PSTN call-setup pause and then starts
@@ -683,13 +683,13 @@ func (c *Controller) initiateCallAfterDelay(number string, expectedState State, 
 
 // playRejectSequence plays the POTS intercept sequence: ringback is already
 // playing from the caller, so wait 3s (simulates connection attempt), then
-// SIT tones + busy. Runs without holding the controller lock and checks
-// expectedState before each step so a hang-up aborts cleanly.
-func (c *Controller) playRejectSequence(expectedState State) {
+// SIT tones + busy. Runs without holding the controller lock and checks the
+// call is still in StateCALLING before each step so a hang-up aborts cleanly.
+func (c *Controller) playRejectSequence() {
 	checkState := func() bool {
 		c.mu.Lock()
 		defer c.mu.Unlock()
-		return c.state == expectedState
+		return c.state == StateCALLING
 	}
 
 	time.Sleep(c.timing.RejectWait)


### PR DESCRIPTION
## Motivation

`playRejectSequence(expectedState State)` used its `expectedState` parameter in exactly one place: the `checkState` closure that aborts the intercept sequence if the caller hangs up (`c.state == expectedState`). Every one of the four call sites passes `StateCALLING`:

- `onHookOff` callback auto-dial failure
- `onKey` CALL_RETURN failure
- `onDial` not-in-contacts rejection
- `onDial` call-setup failure

No other value is reachable. The lookalike add-call reject path in `dialThirdParty` does not call this helper at all: it has its own bespoke closure keyed on `StateADD_CALLING`/`StateADD_INTERCEPT`. So the parameter advertised a flexibility that does not exist and forced a reader to scan every call site to confirm `StateCALLING` was the only state in play.

## Change

- Inline `StateCALLING` directly in the `checkState` closure.
- Drop the `expectedState` parameter and update the four call sites.
- Update the doc comment to name the concrete state.

## Test plan

- `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `pi/digitsd/`.
- No behavior change: `StateCALLING` was already the only value passed, so the gating logic is identical.