### PR TITLE
refactor(server): export ActiveCall, guard CursorForEntry default, fix nolint consistency

### DIFF
--- a/server/internal/calls/history_cursor.go
+++ b/server/internal/calls/history_cursor.go
@@ -73,6 +73,8 @@ func CursorForEntry(e HistoryEntry) HistoryCursor {
 		c.ID = strconv.FormatInt(e.Call.ID, 10)
 	case HistoryEntryConference:
 		c.ID = e.Conference.ID.String()
+	default:
+		panic(fmt.Sprintf("calls: unknown HistoryEntryKind %v", e.Kind))
 	}
 	return c
 }

--- a/server/internal/calls/state_redis.go
+++ b/server/internal/calls/state_redis.go
@@ -194,9 +194,9 @@ func (s *CallState) CanAddAsHost(ctx context.Context, number string) bool {
 	return false
 }
 
-func (s *CallState) Active(ctx context.Context) []activeCall {
+func (s *CallState) Active(ctx context.Context) []ActiveCall {
 	seen := make(map[int64]bool)
-	var calls []activeCall
+	var calls []ActiveCall
 
 	iter := s.client.Scan(ctx, 0, callKeyPrefix+"*", 100).Iterator()
 	for iter.Next(ctx) {
@@ -227,7 +227,7 @@ func (s *CallState) Active(ctx context.Context) []activeCall {
 				callee = number
 			}
 
-			calls = append(calls, activeCall{
+			calls = append(calls, ActiveCall{
 				ID:        e.ID,
 				Caller:    caller,
 				Callee:    callee,

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -41,7 +41,9 @@ type Call struct {
 	ForceEndedBy            *string // UUID of user who force-ended, nil if peer-initiated
 }
 
-type activeCall struct {
+// ActiveCall is a snapshot of an in-flight 2-party call. It is returned by
+// Tracker.Active and CallState.Active for use by metrics and dashboard handlers.
+type ActiveCall struct {
 	ID        int64
 	Caller    string
 	Callee    string
@@ -77,7 +79,7 @@ type callEndObserver interface {
 type Tracker struct {
 	db          *db.Database
 	mu          sync.Mutex
-	active      map[string]*activeCall // "caller→callee" → call
+	active      map[string]*ActiveCall // "caller→callee" → call
 	conferences *ConferenceTracker
 	health      healthLifecycle
 	dashEvents  dashNotifier
@@ -90,7 +92,7 @@ type Tracker struct {
 func New(d *db.Database) *Tracker {
 	return &Tracker{
 		db:          d,
-		active:      make(map[string]*activeCall),
+		active:      make(map[string]*ActiveCall),
 		conferences: NewConferenceTracker(),
 	}
 }
@@ -148,7 +150,7 @@ func (t *Tracker) OnCallInitiated(ctx context.Context, from, to string) (int64, 
 	}
 
 	t.mu.Lock()
-	t.active[callKey(from, to)] = &activeCall{
+	t.active[callKey(from, to)] = &ActiveCall{
 		ID:        id,
 		Caller:    from,
 		Callee:    to,
@@ -442,13 +444,13 @@ func (t *Tracker) InCall(a, b string) bool {
 	return fwd || rev
 }
 
-func (t *Tracker) Active() []activeCall {
+func (t *Tracker) Active() []ActiveCall {
 	if s := t.callStateSnapshot(); s != nil {
 		return s.Active(context.Background())
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	calls := make([]activeCall, 0, len(t.active))
+	calls := make([]ActiveCall, 0, len(t.active))
 	for _, c := range t.active {
 		calls = append(calls, *c)
 	}
@@ -736,7 +738,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 		if b < a {
 			a, b = b, a
 		}
-		t.active[callKey(a, b)] = &activeCall{ID: continuationCallID, Caller: a, Callee: b, StartedAt: time.Now()}
+		t.active[callKey(a, b)] = &ActiveCall{ID: continuationCallID, Caller: a, Callee: b, StartedAt: time.Now()}
 	}
 	h := t.health
 	s := t.state

--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -73,7 +73,7 @@ func NewRedisBridge(redisURL string) (*RedisBridge, error) {
 		client = redis.NewClient(opts)
 	}
 
-	podID, _ := os.Hostname()
+	podID, _ := os.Hostname() //nolint:errcheck // empty hostname is fine
 	if podID == "" {
 		podID = "unknown"
 	}


### PR DESCRIPTION
## Code quality audit: server/

**Before grade: 74/100**
**After grade: 77/100**

### What was audited

Full static analysis of `server/` covering: idiomatic Go, project layout, stale/unreferenced symbols, error handling, test coverage, and lint consistency.

### What was found (and what wasn't)

The server is well-structured overall: standard project layout, raw SQL with no ORM, proper context propagation, interface-based design with compile-time checks, and a clean three-tier test strategy (unit / integration / e2e). Most low coverage numbers on packages like `auth`, `household`, and `line` are explained by `//go:build integration` tags: the real tests exist and require a live Postgres instance.

Three genuine issues were found and fixed.

### Changes

**1. Export `activeCall` as `ActiveCall`**

`Tracker.Active()` and `CallState.Active()` both returned `[]activeCall` where `activeCall` was unexported. External callers in `internal/web/` and `cmd/signald/` were already ranging over the results and reading `.Caller`, `.Callee`, and `.StartedAt`. Go permits this via type inference but it is non-idiomatic: callers cannot name the type, IDEs surface a type that signals private, and the pattern is flagged by linters such as `revive`. Renamed to `ActiveCall` with a doc comment.

**2. Add `default:` guard to `CursorForEntry`**

The companion function `kindCode` in the same file panics on an unknown `HistoryEntryKind`. `CursorForEntry` had no such guard: a future third enum value would silently produce a cursor with an empty ID. Added the matching `default: panic(...)` so both switch sites fail fast consistently.

**3. Add `//nolint:errcheck` to `os.Hostname()` in `signaling/redis.go`**

`tracing.go` (lines 277, 300) and `profiling.go` (line 140) all annotate the same blank-discard with `//nolint:errcheck // empty hostname is fine`. The equivalent line in `NewRedisBridge` was missing the annotation. Added for consistency.

### What was not changed

- Panics in `httputil.Healthz` and `handler_ws.mustMarshal` are intentional programmer-error guards consistent with the "must" convention.
- Low unit-test coverage on DB-backed packages is expected; those packages carry integration tests gated by `//go:build integration`.
- Inline HTML fragments in `handler_api.go` are deliberate small htmx partials.
- Large handler files (`handler_phones.go` ~800 lines) are dense but not disorganized; splitting them would require new packages with little benefit.

### Simplify pass

`/simplify` was run after the changes. All four review angles (reuse, simplification, efficiency, altitude) returned clean.