### PR TITLE
refactor(digitsd): drop the unused Playback.Prime buffer-priming method

### DIFF
--- a/pi/digitsd/internal/audio/alsa.go
+++ b/pi/digitsd/internal/audio/alsa.go
@@ -319,34 +319,6 @@ func (p *Playback) PeriodSize() int {
 	return p.cfg.FrameSize
 }
 
-// Prime writes silence to fill the ALSA buffer, preventing the first real
-// snd_pcm_writei from blocking while the hardware buffer drains.
-// Call once before switching from idle/keepalive to live audio playback.
-func (p *Playback) Prime() error {
-	silence := make([]int16, p.cfg.FrameSize*p.cfg.Channels)
-
-	// Recover from any prior underrun state
-	state := C.snd_pcm_state(p.handle)
-	if state == C.SND_PCM_STATE_XRUN || state == C.SND_PCM_STATE_SETUP {
-		C.snd_pcm_prepare(p.handle)
-	}
-
-	// Fill the buffer (4 periods = 80ms at 960-sample period, 48kHz)
-	for i := 0; i < 4; i++ {
-		rc := C.snd_pcm_writei(p.handle, unsafe.Pointer(&silence[0]),
-			C.snd_pcm_uframes_t(p.cfg.FrameSize))
-		if rc < 0 {
-			C.snd_pcm_recover(p.handle, C.int(rc), 0)
-			rc = C.snd_pcm_writei(p.handle, unsafe.Pointer(&silence[0]),
-				C.snd_pcm_uframes_t(p.cfg.FrameSize))
-			if rc < 0 {
-				return fmt.Errorf("snd_pcm_writei (prime): %s", C.GoString(C.snd_strerror(C.int(rc))))
-			}
-		}
-	}
-	return nil
-}
-
 // Close drains and closes the playback handle.
 func (p *Playback) Close() {
 	if p.handle != nil {


### PR DESCRIPTION
## What

Removes the dead `Playback.Prime()` method from `pi/digitsd/internal/audio/alsa.go` (28 lines, including its cgo body).

## Why

`Prime()` wrote silence into the ALSA buffer so the first real `snd_pcm_writei` would not block while the hardware buffer drained. Its doc comment told the reader to "call once before switching from idle/keepalive to live audio playback."

Two things make this dead weight:

1. **No caller.** A repo-wide search (`grep -rn '\.Prime\b'`, including `cmd/digitsd/` and tests) finds only the definition. The live playback path is `WriteFrame`, which already recovers from underrun inline (`snd_pcm_recover`), so nothing primes the buffer up front.
2. **The doc lies about the architecture.** There is no idle/keepalive playback path to switch away from. A reader encountering `Prime()` would reasonably assume the daemon pre-fills the buffer before going live; it does not. Keeping the method invites that wrong mental model and carries a chunk of cgo (`snd_pcm_state` / `snd_pcm_prepare` / `snd_pcm_writei`) that no longer earns its place.

## Scope

Just the one dead method. The backing `Playback` type and its real API (`WriteFrame`, `PeriodSize`, `Handle`, `Close`) are untouched and still used.

## Validation

From `pi/digitsd/`:

- `go build ./...` clean
- `go test ./...` clean (includes `internal/audio` with the ALSA/Opus cgo deps)
- `golangci-lint run ./...` reports 0 issues
