### PR TITLE
refactor(server): extract samplesToWindow helper for link-health endpoints

### DIFF
--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -100,41 +100,20 @@ func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls
 	}
 }
 
-// lastSample returns a pointer to the last element of window, or nil if empty.
-// Copies the value to avoid aliasing the slice backing array.
-func lastSample(window []LinkHealthSample) *LinkHealthSample {
-	if len(window) == 0 {
-		return nil
-	}
-	s := window[len(window)-1]
-	return &s
-}
-
 func (h *Handler) buildConferenceLinkHealthEdge(ctx context.Context, confID uuid.UUID, from, peer string) ConferenceLinkHealthEdge {
 	out := ConferenceLinkHealthEdge{From: from, Peer: peer, Window: []LinkHealthSample{}}
 
-	// Memory first.
-	windowMem := h.healthStore.WindowEdge(confID, from, peer)
-	if len(windowMem) > 0 {
-		out.Window = make([]LinkHealthSample, len(windowMem))
-		for i, s := range windowMem {
-			out.Window[i] = toAPISample(s)
-		}
-		out.Latest = lastSample(out.Window)
+	if windowMem := h.healthStore.WindowEdge(confID, from, peer); len(windowMem) > 0 {
+		out.Window, out.Latest = samplesToWindow(windowMem)
 		return out
 	}
-	// DB fallback.
 	dbSamples, err := h.healthStore.ReadbackEdge(ctx, confID, from, peer, calls.RingCapacity)
 	if err != nil {
 		slog.WarnContext(ctx, "ReadbackEdge failed; serving empty window",
 			"conf_id", confID, "from", from, "peer", peer, "err", err)
 		return out
 	}
-	out.Window = make([]LinkHealthSample, len(dbSamples))
-	for i, s := range dbSamples {
-		out.Window[i] = toAPISample(s)
-	}
-	out.Latest = lastSample(out.Window)
+	out.Window, out.Latest = samplesToWindow(dbSamples)
 	return out
 }
 

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -57,6 +57,22 @@ func toAPISample(s calls.Sample) LinkHealthSample {
 	}
 }
 
+// samplesToWindow converts a calls.Sample slice into a LinkHealthSample window
+// and a pointer to the most recent sample. Returns an empty (non-nil) window
+// and a nil latest when samples is empty, matching the JSON shape callers
+// emit for endpoints with no observations.
+func samplesToWindow(samples []calls.Sample) ([]LinkHealthSample, *LinkHealthSample) {
+	if len(samples) == 0 {
+		return []LinkHealthSample{}, nil
+	}
+	window := make([]LinkHealthSample, len(samples))
+	for i, s := range samples {
+		window[i] = toAPISample(s)
+	}
+	latest := window[len(window)-1]
+	return window, &latest
+}
+
 func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	idStr := r.PathValue("id")
 	callID, err := strconv.ParseInt(idStr, 10, 64)
@@ -104,31 +120,16 @@ func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, num
 	// linked-index for peer names, then bare number as fallback.
 	out.DisplayName = resolveMemberDisplayName(number, ownedLines, linkedIndex)
 
-	// Memory first.
-	windowMem := h.healthStore.Window(callID, number)
-	if len(windowMem) > 0 {
-		out.Window = make([]LinkHealthSample, len(windowMem))
-		for i, s := range windowMem {
-			out.Window[i] = toAPISample(s)
-		}
-		la := toAPISample(windowMem[len(windowMem)-1])
-		out.Latest = &la
+	if windowMem := h.healthStore.Window(callID, number); len(windowMem) > 0 {
+		out.Window, out.Latest = samplesToWindow(windowMem)
 		return out, nil
 	}
 
-	// DB fallback.
 	dbSamples, err := h.healthStore.Readback(ctx, callID, number, calls.RingCapacity)
 	if err != nil {
 		return out, fmt.Errorf("readback %d/%s: %w", callID, number, err)
 	}
-	out.Window = make([]LinkHealthSample, len(dbSamples))
-	for i, s := range dbSamples {
-		out.Window[i] = toAPISample(s)
-	}
-	if len(dbSamples) > 0 {
-		la := toAPISample(dbSamples[len(dbSamples)-1])
-		out.Latest = &la
-	}
+	out.Window, out.Latest = samplesToWindow(dbSamples)
 	return out, nil
 }
 


### PR DESCRIPTION
`buildLinkHealthEndpoint` (2-party calls) and `buildConferenceLinkHealthEdge` (conference per-edge view) both follow the same shape: try the in-memory window first, fall back to a DB readback, then convert each `calls.Sample` into a `LinkHealthSample` and set `Latest` to the last element. That meant four copies of the same convert-loop + latest-pointer pattern across the two functions. The conference file also carried a single-use `lastSample` helper for the latter half.

Extract a `samplesToWindow(samples []calls.Sample) ([]LinkHealthSample, *LinkHealthSample)` helper alongside `toAPISample` and rewrite both call sites in terms of it. The memory and DB branches collapse to one line each, the `lastSample` helper goes away, and the empty-window invariant (`[]LinkHealthSample{}`, not `nil`) is enforced in one place.

Net 20-line reduction; behavior unchanged. Existing web tests cover both endpoints.

## Test plan

- [x] `go build ./...` in `server/`
- [x] `go test ./...` in `server/`
- [x] `golangci-lint run ./...` in `server/`
