### PR TITLE
refactor(server): drop dead HardwareID fallback in relay device_info dispatch

### DIFF
--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -194,12 +194,9 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 	case TypeRequestICE:
 		r.handleRequestICE(ctx, from)
 	case TypeDeviceInfo:
-		updated := false
-		if msg.HardwareID != "" {
-			updated = r.Hub.UpdateDeviceInfoByHardware(msg.HardwareID, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr, msg.DevMode)
-		} else {
-			updated = r.Hub.UpdateDeviceInfo(from, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr, msg.DevMode)
-		}
+		// msg.HardwareID is always set: the WS handler stamps it from
+		// conn.HardwareID and rejects registrations without a hardware_id.
+		updated := r.Hub.UpdateDeviceInfoByHardware(msg.HardwareID, msg.PiVersion, msg.PiCommit, msg.FirmwareVersion, msg.FirmwareCommit, msg.LocalAddr, msg.DevMode)
 		if updated {
 			slog.InfoContext(ctx, "device_info", "number", from,
 				"hardware_id", msg.HardwareID,


### PR DESCRIPTION
## What

Collapse the `TypeDeviceInfo` dispatch in `Relay.HandleMessage` to a single `Hub.UpdateDeviceInfoByHardware` call, removing the `else` branch that fell back to `Hub.UpdateDeviceInfo` when `msg.HardwareID` was empty.

## Why

`msg.HardwareID` is always set when the relay receives a `TypeDeviceInfo` message:

1. `handler_ws.go` rejects any register message without `hardware_id` (line 69-73), so every `Conn` has a non-empty `HardwareID`.
2. The same handler stamps `msg.HardwareID = conn.HardwareID` on every subsequent message before forwarding to the relay (line 224).

The `else` branch was unreachable in production. The only non-relay caller of `Hub.UpdateDeviceInfo` (the `handleDevSeedFirmware` test helper) keeps using it directly and is unaffected by this change.

A short comment captures the invariant so the next reader does not reintroduce a fallback. `Hub.UpdateDeviceInfoByHardware` already returns `false` for an empty id, so the change degrades to a silent no-op if the invariant ever breaks.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes across all server packages
- [x] `go vet ./...` clean