### PR TITLE
test(server): use status constants in integration tests missed by #669

### DIFF
--- a/server/internal/household/e2e_link_test.go
+++ b/server/internal/household/e2e_link_test.go
@@ -65,7 +65,7 @@ func TestE2EHouseholdLinkFlow(t *testing.T) {
 	if len(link.InviteCode) != 8 {
 		t.Fatalf("invite code length = %d, want 8", len(link.InviteCode))
 	}
-	if link.Status != "pending" {
+	if link.Status != LinkStatusPending {
 		t.Fatalf("status = %q, want pending", link.Status)
 	}
 	t.Logf("Invite code: %s", link.InviteCode)
@@ -84,7 +84,7 @@ func TestE2EHouseholdLinkFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AcceptInvite: %v", err)
 	}
-	if accepted.Status != "active" {
+	if accepted.Status != LinkStatusActive {
 		t.Fatalf("accepted status = %q, want active", accepted.Status)
 	}
 

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -474,7 +474,7 @@ func TestForceDisconnect_WritesAuditAndTearsDown(t *testing.T) {
 	).Scan(&status, &endedAt); err != nil {
 		t.Fatalf("scan call: %v", err)
 	}
-	if status != "ended" {
+	if status != calls.CallStatusEnded {
 		t.Fatalf("status: got %q want ended", status)
 	}
 	if !endedAt.Valid {


### PR DESCRIPTION
## What

Three integration-test status assertions compare to bare string literals instead of the `LinkStatus*` / `CallStatus*` constants introduced in #669:

- `server/internal/household/e2e_link_test.go:68`: `link.Status != "pending"` becomes `link.Status != LinkStatusPending`.
- `server/internal/household/e2e_link_test.go:87`: `accepted.Status != "active"` becomes `accepted.Status != LinkStatusActive`.
- `server/internal/web/linkhealth_integration_test.go:477`: `calls.status` SELECT result compared to `"ended"` becomes `calls.CallStatusEnded`.

The `calls` package is already imported in the link-health file; `e2e_link_test.go` lives in the `household` package so the constants are unqualified.

## Why

Holistic across-PR review (last 24h, #664-#671). #669 explicitly took the position that test assertions should use the new constants so renaming a constant propagates to assertions automatically. It updated `tracker_test.go`, `link_test.go`, and `invite_test.go` but missed these three sites (both files have integration build tags, which makes them easy to miss with a plain `grep` against a non-integration build). Same author intent, same fix, picked up by the cross-PR sweep.

## Test plan

- [x] `go build -tags integration ./...` clean
- [x] `go vet -tags integration ./internal/household/... ./internal/web/...` clean
- [x] `go test ./...` (non-integration suite) passes

`golangci-lint` could not run locally: the v2.5.0 binary in this environment was built against go1.25 and refuses to load a go1.26 module. CI runs the correct version.
