### PR TITLE
fix(digitsd): keep Pico forwarding keypad DTMF during voicemail sessions

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -312,6 +312,10 @@ func (d *daemonCallbacks) NotifyCallConnected() {
 	d.serial.CallConnected()
 }
 
+func (d *daemonCallbacks) NotifyPicoReset() {
+	d.serial.Reset()
+}
+
 func (d *daemonCallbacks) EnableFlashDetection() {
 	d.serial.EnableFlashDetection()
 }

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -94,7 +94,8 @@ type Callbacks interface {
 	InitiateCall(number string) error // Start outgoing WebRTC call
 	AnswerCall()                // Accept incoming WebRTC call
 	HangupCall()                // Tear down WebRTC call
-	NotifyCallConnected()       // Notify the Pico that the WebRTC peer answered
+	NotifyCallConnected()       // Notify the Pico that the WebRTC peer answered (Pico -> CONNECTED)
+	NotifyPicoReset()           // Reset the Pico FSM to IDLE, releasing a CALL:CONNECTED hold taken for a peerless local session
 	MutePeer(phone string)                                // Silence both directions of the A↔B audio path (silent hold)
 	UnmutePeer(phone string)                              // Restore both directions of the A↔B audio path
 	TearDownPeer(phone string)                            // Hang up and tear down the connection to a peer
@@ -310,6 +311,15 @@ func (c *Controller) Reset() {
 func (c *Controller) ResetToDialtone() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Release the CALL:CONNECTED hold taken when entering a peerless voicemail
+	// session (see the *98/*97 transitions). Without this the Pico stays in
+	// CONNECTED, where it never re-collects a dial buffer or fires DIAL:, so the
+	// next call after voicemail (without a hook cycle) could not be placed.
+	// Hangup exits don't reach here: that path goes through StateIDLE and the
+	// Pico self-resets on HOOK:ON.
+	if c.state == StateVOICEMAIL_PLAYBACK || c.state == StateVOICEMAIL_RECORD_GREETING {
+		c.cb.NotifyPicoReset()
+	}
 	c.state = StateDIALTONE
 	c.digits = ""
 }
@@ -527,6 +537,14 @@ func (c *Controller) onKey(digit string) {
 				slog.Info("phone: retrieval code detected, entering VOICEMAIL_PLAYBACK", "code", code)
 				c.digits = ""
 				c.state = StateVOICEMAIL_PLAYBACK
+				// Voicemail playback is peerless and local, but the user still
+				// drives it with the keypad (7/9/#/*). The Pico only forwards
+				// keys in DIALING or CONNECTED, and a partial dial (e.g. "*98")
+				// trips its 15s inter-digit timeout into BUSY, which silently
+				// drops every subsequent key. Move the Pico to CONNECTED so it
+				// keeps forwarding DTMF for the whole session; ResetToDialtone
+				// releases it on exit.
+				c.cb.NotifyCallConnected()
 				c.cb.VoicemailEnterPlayback()
 				return
 			}
@@ -571,6 +589,10 @@ func (c *Controller) onKey(digit string) {
 				slog.Info("phone: *97 detected, entering greeting record")
 				c.digits = ""
 				c.state = StateVOICEMAIL_RECORD_GREETING
+				// Same Pico key-forwarding hold as *98 playback: greeting record
+				// ends on "#", which the Pico would drop once the partial-dial
+				// timeout flips it to BUSY. ResetToDialtone releases on exit.
+				c.cb.NotifyCallConnected()
 				go c.cb.VoicemailRecordGreeting()
 				return
 			}

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -22,6 +22,7 @@ type mockCallbacks struct {
 	hangups            int
 	answers            int
 	callConnectedCalls int
+	picoResets         int
 	callReturns        int
 	ringPatterns       []int
 	callReturnCancels  int
@@ -96,6 +97,11 @@ func (m *mockCallbacks) NotifyCallConnected() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.callConnectedCalls++
+}
+func (m *mockCallbacks) NotifyPicoReset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.picoResets++
 }
 func (m *mockCallbacks) MutePeer(phone string) { m.setMuted(phone, true) }
 
@@ -293,6 +299,11 @@ func (m *mockCallbacks) CallConnectedCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.callConnectedCalls
+}
+func (m *mockCallbacks) PicoResets() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.picoResets
 }
 func (m *mockCallbacks) VoicemailAutoAnswers() int {
 	m.mu.Lock()
@@ -2423,6 +2434,84 @@ func TestRetrievalCodeIntercept(t *testing.T) {
 	}
 	if len(cb.Calls()) != 0 {
 		t.Errorf("expected no InitiateCall, got %v", cb.Calls())
+	}
+}
+
+// TestVoicemailPlaybackPicoHoldAndRelease verifies the Pico key-forwarding
+// hold around a peerless *98 session: entering playback moves the Pico to
+// CONNECTED (NotifyCallConnected) so it keeps forwarding DTMF past its 15s
+// partial-dial timeout, and the exit-to-dialtone path releases that hold
+// (NotifyPicoReset) so the next call can be dialed without a hook cycle.
+func TestVoicemailPlaybackPicoHoldAndRelease(t *testing.T) {
+	cb := &mockCallbacks{
+		voicemailEnabled: func() (bool, time.Duration) { return true, 20 * time.Second },
+	}
+	c := newTestController(cb, "5551000")
+	defer c.Close()
+
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:*")
+	c.HandleEvent("KEY:9")
+	c.HandleEvent("KEY:8")
+
+	if got := cb.CallConnectedCalls(); got != 1 {
+		t.Fatalf("expected 1 NotifyCallConnected (Pico hold) on *98 entry, got %d", got)
+	}
+	if got := cb.PicoResets(); got != 0 {
+		t.Fatalf("expected no NotifyPicoReset before exit, got %d", got)
+	}
+
+	c.ResetToDialtone()
+
+	if got := cb.PicoResets(); got != 1 {
+		t.Fatalf("expected 1 NotifyPicoReset on exit from playback, got %d", got)
+	}
+	if c.State() != StateDIALTONE {
+		t.Errorf("expected DIALTONE after reset, got %s", c.State())
+	}
+}
+
+// TestRecordGreetingPicoHold verifies that *97 greeting record takes the same
+// Pico hold (so "#" still terminates after 15s) and releases it on exit.
+func TestRecordGreetingPicoHold(t *testing.T) {
+	cb := &mockCallbacks{
+		voicemailEnabled: func() (bool, time.Duration) { return true, 20 * time.Second },
+	}
+	c := newTestController(cb, "5551000")
+	defer c.Close()
+
+	c.HandleEvent("HOOK:OFF")
+	c.HandleEvent("KEY:*")
+	c.HandleEvent("KEY:9")
+	c.HandleEvent("KEY:7")
+
+	if c.State() != StateVOICEMAIL_RECORD_GREETING {
+		t.Fatalf("expected VOICEMAIL_RECORD_GREETING after *97, got %s", c.State())
+	}
+	if got := cb.CallConnectedCalls(); got != 1 {
+		t.Fatalf("expected 1 NotifyCallConnected (Pico hold) on *97 entry, got %d", got)
+	}
+
+	c.ResetToDialtone()
+
+	if got := cb.PicoResets(); got != 1 {
+		t.Fatalf("expected 1 NotifyPicoReset on exit from record greeting, got %d", got)
+	}
+}
+
+// TestResetToDialtoneNoPicoResetOutsideVoicemail guards the release: a plain
+// ResetToDialtone from a non-voicemail state (e.g. mid-dial) must NOT poke the
+// Pico, since no CALL:CONNECTED hold was taken for those flows.
+func TestResetToDialtoneNoPicoResetOutsideVoicemail(t *testing.T) {
+	cb := &mockCallbacks{}
+	c := newTestController(cb, "5551000")
+	defer c.Close()
+
+	c.setStateForTest(StateDIALING)
+	c.ResetToDialtone()
+
+	if got := cb.PicoResets(); got != 0 {
+		t.Errorf("expected no NotifyPicoReset from non-voicemail ResetToDialtone, got %d", got)
 	}
 }
 

--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -245,6 +245,14 @@ func (sp *SerialPort) CallConnected() {
 	sp.SendFire("CALL:CONNECTED")
 }
 
+// Reset sends RESET to the Pico, returning its FSM to IDLE (RST:OK). Used to
+// release a CALL:CONNECTED hold taken for a peerless local session (voicemail)
+// so the Pico re-arms its dial path and can place the next call without a hook
+// cycle.
+func (sp *SerialPort) Reset() {
+	sp.SendFire("RESET")
+}
+
 // EnableFlashDetection opens the flash-detection window on the Pico: after
 // on-hook it waits up to 600ms to distinguish a flash from a hangup. The Pi
 // enables this only while in a call.


### PR DESCRIPTION
## Problem

On a phone with voicemail, dialing `*98` to retrieve messages plays the prompts and messages fine, but pressing keys to delete (`7`), save (`9`), skip (`#`), or replay (`*`) does nothing. The same applies to `*97` greeting record, where `#` is supposed to end the recording. This effectively never worked for a normal session.

## Root cause

Voicemail retrieval (`*98`) and greeting record (`*97`) run as **peerless, digitsd-local** sessions: there is no WebRTC peer, and digitsd handles the keypad menu itself.

The Pico firmware only forwards keypad events over UART while its FSM is in `DIALING` or `CONNECTED` (`firmware/src/phone_fsm.c:416`). Dialing a service code like `*98` leaves a partial dial buffer (`"98"`, the `*` is not a digit) that never reaches the 7-digit threshold to fire `DIAL:`. So the Pico's 15s inter-digit timeout (`DIAL_TIMEOUT_MS`, `phone_fsm.c:526`) fires and flips it to `BUSY`, after which **every keypress is silently dropped**. Since voicemail playback runs well past 15s, by the time the user presses a key the Pico is already `BUSY`.

Device logs made this unambiguous: across a ~63s `*98` session there was not a single `RX line=KEY:` event, even though plain dialing logs keys fine.

## Fix

digitsd-side only, no firmware reflash. The firmware already does the right thing on `CALL:CONNECTED` (accepts the transition from `DIALING` into `CONNECTED`, which both opens the key gate and stops the partial-dial timeout); it just was never told to do so for voicemail.

- On entering `*98` playback / `*97` record, send `CALL:CONNECTED` (the same command used when a real call answers) so the Pico stays in a key-forwarding state for the whole session.
- On returning to dial tone, send a Pico `RESET` so it leaves `CONNECTED` and can collect a fresh dial buffer again (normal calls fire `DIAL:` only from `DIALING`). This is gated on the voicemail interactive states inside `ResetToDialtone`, so it covers every exit path (end of messages, `#`, duration cap, error paths) in one place.
- The hangup path is unaffected: on `HOOK:ON` the Pico self-resets to `IDLE` and `ResetToDialtone` is not on that path.

The Pico shows its `CONNECTED` breathing LED during the session, which reads naturally as an active "call to your mailbox."

## Tests

- New controller unit tests: hold fires on `*98`/`*97` entry, release fires on exit to dial tone, and a non-voicemail `ResetToDialtone` does **not** poke the Pico.
- Full `pi/digitsd` suite passes; `golangci-lint` clean.

## Verification status

On-device verification is pending: the test device dropped off the network mid-session. Once it is back I will deploy this build and confirm, with the handset, that `7`/`9`/`#`/`*` now land during playback (logs show `RX line=KEY:` past the 15s mark and the matching delete/save/skip action), and that dialing still works after a voicemail session ends without hanging up.