### PR TITLE
refactor(server): collapse ratelimit cleanup loop into constructor

### DIFF
--- a/server/internal/ratelimit/ratelimit.go
+++ b/server/internal/ratelimit/ratelimit.go
@@ -34,16 +34,14 @@ func New(limit int, window time.Duration) *Limiter {
 		limit:   limit,
 		window:  window,
 	}
-	go l.cleanupLoop()
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			l.evictExpired()
+		}
+	}()
 	return l
-}
-
-func (l *Limiter) cleanupLoop() {
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-	for range ticker.C {
-		l.Cleanup()
-	}
 }
 
 // Allow checks whether the given IP is within its rate limit.
@@ -64,8 +62,7 @@ func (l *Limiter) Allow(ip string) bool {
 	return true
 }
 
-// Cleanup removes expired bucket entries. Call periodically to prevent memory leak.
-func (l *Limiter) Cleanup() {
+func (l *Limiter) evictExpired() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	now := time.Now()

--- a/server/internal/ratelimit/ratelimit_test.go
+++ b/server/internal/ratelimit/ratelimit_test.go
@@ -104,11 +104,11 @@ func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesStaleEntries(t *testing.T) {
+func TestEvictExpiredRemovesStaleEntries(t *testing.T) {
 	lim := New(1, 50*time.Millisecond)
 	lim.Allow("stale-ip")
 	time.Sleep(60 * time.Millisecond)
-	lim.Cleanup()
+	lim.evictExpired()
 	lim.mu.Lock()
 	_, exists := lim.buckets["stale-ip"]
 	lim.mu.Unlock()


### PR DESCRIPTION
`ratelimit.Limiter` exposed a `Cleanup()` method and split its eviction
goroutine across a separate `cleanupLoop()` helper, but `Cleanup()` is
never called from outside the package (only the loop and a test reach
for it) and `cleanupLoop()` is only called from `New()`.

Inline the loop body into the goroutine launched from `New()` and
rename the eviction helper to `evictExpired` (unexported). The
limiter's lifecycle is now visible at the constructor instead of
spread across three methods, and the package no longer offers a
public eviction hook for callers who would have to know not to
call it.

Test rename mirrors the helper rename; eviction behaviour is
unchanged.