### PR TITLE
feat(digitsd): survive media blips and signaling reconnects mid-call

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -119,6 +119,7 @@ type daemonCallbacks struct {
 	callReturnOrigin      atomic.Bool // true when the current call was initiated via *69
 	isRestartingICE       bool        // true while an ICE restart is in progress
 	restartTimer          *time.Timer // timeout for ICE restart attempt
+	disconnectTimer       *time.Timer // debounce before reacting to pion Disconnected
 
 	// Link-health reporter: spawned when a call reaches Connected, canceled on teardown.
 	// Protected by mu.

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2587,17 +2587,20 @@ func main() {
 				}
 				slog.Info("signal: reconnected")
 
-				// Tear down any active call. The server cleaned up its
-				// side on disconnect (OnDisconnect), but the local WebRTC
-				// peer connection and audio pipeline survive the WebSocket
-				// drop. Without this, the phone's ICE agent keeps sending
-				// renegotiation messages for a call the server no longer
-				// tracks, producing "sdp/ice without active call" errors.
+				// A 2-party call whose media survived the WebSocket drop is
+				// resumed in place; if media also dropped, drive ICE recovery.
+				// Anything else (conference, voicemail, ringing) is torn down:
+				// the server already cleared its side or will after its grace
+				// window, and stale renegotiation would error.
 				if ctrl.State() != phone.StateIDLE {
-					slog.Info("signal: tearing down stale call after reconnect", "state", ctrl.State())
-					cb.TearDownAllMeshPeers()
-					cb.HangupCall()
-					ctrl.Reset()
+					if cb.tryResumeAfterReconnect(ctrl.State()) {
+						slog.Info("signal: resumed call after reconnect", "state", ctrl.State())
+					} else {
+						slog.Info("signal: tearing down stale call after reconnect", "state", ctrl.State())
+						cb.TearDownAllMeshPeers()
+						cb.HangupCall()
+						ctrl.Reset()
+					}
 				}
 
 				sendDeviceInfo(sig, fwVersion, fwCommit)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -42,9 +42,18 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/wififallback"
 )
 
-// iceRestartTimeout is how long to wait for an ICE restart to succeed
-// before giving up and hanging up the call.
-const iceRestartTimeout = 15 * time.Second
+// iceRestartTimeout is how long to wait for ICE recovery to succeed before
+// giving up and hanging up the call. It MUST exceed the server-side grace
+// window (20s in server/internal/signaling/relay.go) plus margin, so a peer
+// that stays connected does not give up before a dropped phone can reconnect
+// its WebSocket and re-establish media within that window.
+const iceRestartTimeout = 25 * time.Second
+
+// disconnectDebounce is how long the daemon waits after pion reports the
+// peer connection Disconnected before proactively driving ICE recovery.
+// pion can recover a transient blip on its own (STUN consent / connectivity
+// checks) within this window, in which case no restart is needed.
+const disconnectDebounce = 4 * time.Second
 
 // pairingRefreshInterval is how often an unpaired device reconnects to
 // obtain a fresh pairing code. Must be shorter than the server-side
@@ -76,20 +85,20 @@ var (
 
 // daemonCallbacks implements phone.Callbacks and wires hardware + WebRTC.
 type daemonCallbacks struct {
-	serial           *phone.SerialPort
-	sig              *sigclient.Client
-	mixer            *audio.Mixer
-	serviceCodes     *phone.ServiceCodeHandler
-	ctrl             *phone.Controller
-	mu               sync.Mutex
-	peerMgr          *owebrtc.PeerManager
-	mesh             *owebrtc.MeshManager // conference-only peer pool; 2-party calls use peerMgr
-	pipeline         *audio.Pipeline
-	number           string
-	cfg              *config.Config
-	pendingOffer     string
-	pendingCaller    string
-	pendingICE       []string // ICE candidates received before peerMgr is created
+	serial        *phone.SerialPort
+	sig           *sigclient.Client
+	mixer         *audio.Mixer
+	serviceCodes  *phone.ServiceCodeHandler
+	ctrl          *phone.Controller
+	mu            sync.Mutex
+	peerMgr       *owebrtc.PeerManager
+	mesh          *owebrtc.MeshManager // conference-only peer pool; 2-party calls use peerMgr
+	pipeline      *audio.Pipeline
+	number        string
+	cfg           *config.Config
+	pendingOffer  string
+	pendingCaller string
+	pendingICE    []string // ICE candidates received before peerMgr is created
 	// preAnswer holds a PeerConnection created during the ring phase to
 	// reduce call-answer latency. Promoted into the active call state on
 	// HOOK:OFF; torn down if the caller hangs up before we answer.
@@ -100,22 +109,22 @@ type daemonCallbacks struct {
 		candidates []string // local ICE candidates gathered during ring, sent on pickup
 		caller     string   // pendingCaller at time of preparation
 	}
-	iceServers       []owebrtc.ICEServerConfig // cached STUN/TURN servers from signald
-	debugMode        bool     // read from DIGITS_DEBUG env at startup
-	paired           atomic.Bool
-	pairingCode          string    // current pairing code from server
-	pairingCodeReceivedAt time.Time // when the current pairing code was received
-	callPeer             string // number of the remote party during an active call
-	isCaller             bool   // true if we initiated the current call
-	callReturnOrigin     atomic.Bool // true when the current call was initiated via *69
-	isRestartingICE      bool   // true while an ICE restart is in progress
-	restartTimer     *time.Timer // timeout for ICE restart attempt
+	iceServers            []owebrtc.ICEServerConfig // cached STUN/TURN servers from signald
+	debugMode             bool                      // read from DIGITS_DEBUG env at startup
+	paired                atomic.Bool
+	pairingCode           string      // current pairing code from server
+	pairingCodeReceivedAt time.Time   // when the current pairing code was received
+	callPeer              string      // number of the remote party during an active call
+	isCaller              bool        // true if we initiated the current call
+	callReturnOrigin      atomic.Bool // true when the current call was initiated via *69
+	isRestartingICE       bool        // true while an ICE restart is in progress
+	restartTimer          *time.Timer // timeout for ICE restart attempt
 
 	// Link-health reporter: spawned when a call reaches Connected, canceled on teardown.
 	// Protected by mu.
-	reporterCancel      context.CancelFunc
-	linkHealthDisabled  bool
-	linkHealthInterval  time.Duration
+	reporterCancel     context.CancelFunc
+	linkHealthDisabled bool
+	linkHealthInterval time.Duration
 
 	// meshReporterCancels holds one CancelFunc per mesh peer's link-health
 	// reporter. Keyed by peer phone. Protected by mu, same as mesh.

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -22,6 +22,7 @@ func TestConnStateAction(t *testing.T) {
 		{"disconnected while debouncing is noop", webrtc.PeerConnectionStateDisconnected, false, true, actionNone},
 		{"disconnected while recovering is noop", webrtc.PeerConnectionStateDisconnected, true, false, actionNone},
 		{"failed fresh enters recovery", webrtc.PeerConnectionStateFailed, false, false, actionEnterRecovery},
+		{"failed during debounce enters recovery", webrtc.PeerConnectionStateFailed, false, true, actionEnterRecovery},
 		{"failed while recovering is noop", webrtc.PeerConnectionStateFailed, true, false, actionNone},
 		{"connecting is noop", webrtc.PeerConnectionStateConnecting, false, false, actionNone},
 		{"closed is noop", webrtc.PeerConnectionStateClosed, false, false, actionNone},

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
+	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
+	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -60,5 +62,79 @@ func TestReconnectAction(t *testing.T) {
 					tc.ctrlState, tc.hasMesh, tc.hasPeer, tc.connState, got, tc.want)
 			}
 		})
+	}
+}
+
+func newTestPeerManager(t *testing.T) *owebrtc.PeerManager {
+	t.Helper()
+	pm, err := owebrtc.NewPeerManager(owebrtc.NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = pm.Close() })
+	// Drive a full offer/answer handshake against a throwaway remote peer so the
+	// local PC reaches the stable signaling state with a live ICE agent. Recovery
+	// only ever runs on an established peer, where CreateRestartOffer can rotate
+	// credentials; a fresh PC has no ICE agent and CreateRestartOffer errors.
+	remote, err := owebrtc.NewPeerManager(owebrtc.NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = remote.Close() })
+	offer, err := pm.CreateOffer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer, err := remote.AcceptOffer(offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.SetAnswer(answer); err != nil {
+		t.Fatal(err)
+	}
+	return pm
+}
+
+func TestEnterICERecoveryCallerArmsTimerAndRecovers(t *testing.T) {
+	pm := newTestPeerManager(t)
+	// An unconnected client makes sendSignal return an error cleanly instead of
+	// dereferencing a nil receiver; the recovery bookkeeping still stands.
+	sig := sigclient.NewClient("ws://127.0.0.1:0/ws", "3140000", "hw", "tok")
+	d := &daemonCallbacks{peerMgr: pm, isCaller: true, callPeer: "3140002", sig: sig}
+	d.enterICERecovery(pm, "test")
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.isRestartingICE {
+		t.Fatal("caller recovery did not set isRestartingICE")
+	}
+	if d.restartTimer == nil {
+		t.Fatal("caller recovery did not arm the restart timeout")
+	}
+}
+
+func TestEnterICERecoveryCalleeWaitsWithoutOffer(t *testing.T) {
+	pm := newTestPeerManager(t)
+	d := &daemonCallbacks{peerMgr: pm, isCaller: false, callPeer: "3140001"}
+	d.enterICERecovery(pm, "test")
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.isRestartingICE {
+		t.Fatal("callee recovery did not set isRestartingICE")
+	}
+	if d.restartTimer == nil {
+		t.Fatal("callee recovery did not arm the wait timeout")
+	}
+}
+
+func TestEnterICERecoveryIdempotentWhenAlreadyRecovering(t *testing.T) {
+	pm := newTestPeerManager(t)
+	d := &daemonCallbacks{peerMgr: pm, isCaller: true, callPeer: "x", isRestartingICE: true}
+	d.enterICERecovery(pm, "test") // must be a no-op
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.restartTimer != nil {
+		t.Fatal("second recovery armed a duplicate timer")
 	}
 }

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -165,3 +165,36 @@ func TestHandleConnStateFailedWhileRecoveringDoesNotHangUp(t *testing.T) {
 		t.Fatal("Failed-while-recovering stopped the restart timer; deadline must still govern")
 	}
 }
+
+func TestTryResumeNonResumableReturnsFalse(t *testing.T) {
+	d := &daemonCallbacks{} // no peerMgr
+	if d.tryResumeAfterReconnect(phone.StateCONNECTED) {
+		t.Fatal("resume reported true with no active peer")
+	}
+}
+
+func TestTryResumeMediaDownRequestsRecovery(t *testing.T) {
+	pm := newTestPeerManager(t)
+	sig := sigclient.NewClient("ws://127.0.0.1:0/ws", "3140000", "hw", "tok")
+	d := &daemonCallbacks{peerMgr: pm, isCaller: true, callPeer: "x", sig: sig}
+	// A fresh/handshaked PeerManager is not Connected, so a CONNECTED 2-party
+	// call with non-connected media must drive recovery and return true.
+	if !d.tryResumeAfterReconnect(phone.StateCONNECTED) {
+		t.Fatal("resume reported false for a CONNECTED 2-party call")
+	}
+	d.mu.Lock()
+	recovering := d.isRestartingICE
+	d.mu.Unlock()
+	if !recovering {
+		t.Fatal("resume did not drive ICE recovery for dropped media")
+	}
+}
+
+func TestTryResumeConferenceReturnsFalse(t *testing.T) {
+	pm := newTestPeerManager(t)
+	mesh := owebrtc.NewMeshManager(owebrtc.NewICEConfig(nil))
+	d := &daemonCallbacks{peerMgr: pm, mesh: mesh, isCaller: true, callPeer: "x"}
+	if d.tryResumeAfterReconnect(phone.StateCONFERENCE_MERGED) {
+		t.Fatal("conference must not resume via the 2-party path")
+	}
+}

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -166,10 +166,26 @@ func TestHandleConnStateFailedWhileRecoveringDoesNotHangUp(t *testing.T) {
 	}
 }
 
-func TestTryResumeNonResumableReturnsFalse(t *testing.T) {
+func TestTryResumeNoPeerReturnsFalse(t *testing.T) {
 	d := &daemonCallbacks{} // no peerMgr
 	if d.tryResumeAfterReconnect(phone.StateCONNECTED) {
 		t.Fatal("resume reported true with no active peer")
+	}
+}
+
+func TestTryResumeNonConnectedStateReturnsFalse(t *testing.T) {
+	pm := newTestPeerManager(t)
+	// Active 2-party peerMgr, no mesh, but the controller is RINGING (not
+	// CONNECTED): must tear down, not resume, and must not start recovery.
+	d := &daemonCallbacks{peerMgr: pm, isCaller: true, callPeer: "x"}
+	if d.tryResumeAfterReconnect(phone.StateRINGING) {
+		t.Fatal("non-CONNECTED state must not resume")
+	}
+	d.mu.Lock()
+	recovering := d.isRestartingICE
+	d.mu.Unlock()
+	if recovering {
+		t.Fatal("teardown path must not start ICE recovery")
 	}
 }
 

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+func TestConnStateAction(t *testing.T) {
+	cases := []struct {
+		name            string
+		state           webrtc.PeerConnectionState
+		recovering      bool
+		debouncePending bool
+		want            connAction
+	}{
+		{"connected clears", webrtc.PeerConnectionStateConnected, true, true, actionClearRecovery},
+		{"disconnected fresh starts debounce", webrtc.PeerConnectionStateDisconnected, false, false, actionStartDebounce},
+		{"disconnected while debouncing is noop", webrtc.PeerConnectionStateDisconnected, false, true, actionNone},
+		{"disconnected while recovering is noop", webrtc.PeerConnectionStateDisconnected, true, false, actionNone},
+		{"failed fresh enters recovery", webrtc.PeerConnectionStateFailed, false, false, actionEnterRecovery},
+		{"failed while recovering is noop", webrtc.PeerConnectionStateFailed, true, false, actionNone},
+		{"connecting is noop", webrtc.PeerConnectionStateConnecting, false, false, actionNone},
+		{"closed is noop", webrtc.PeerConnectionStateClosed, false, false, actionNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := connStateAction(tc.state, tc.recovering, tc.debouncePending)
+			if got != tc.want {
+				t.Fatalf("connStateAction(%v, recovering=%v, debounce=%v) = %v, want %v",
+					tc.state, tc.recovering, tc.debouncePending, got, tc.want)
+			}
+		})
+	}
+}

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -29,6 +30,34 @@ func TestConnStateAction(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf("connStateAction(%v, recovering=%v, debounce=%v) = %v, want %v",
 					tc.state, tc.recovering, tc.debouncePending, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReconnectAction(t *testing.T) {
+	cases := []struct {
+		name      string
+		ctrlState phone.State
+		hasMesh   bool
+		hasPeer   bool
+		connState webrtc.PeerConnectionState
+		want      reconnAction
+	}{
+		{"connected 2party media-up resumes noop", phone.StateCONNECTED, false, true, webrtc.PeerConnectionStateConnected, reconnResumeNoop},
+		{"connected 2party media-down restarts", phone.StateCONNECTED, false, true, webrtc.PeerConnectionStateDisconnected, reconnResumeRestart},
+		{"connected 2party media-failed restarts", phone.StateCONNECTED, false, true, webrtc.PeerConnectionStateFailed, reconnResumeRestart},
+		{"conference tears down", phone.StateCONFERENCE_MERGED, true, true, webrtc.PeerConnectionStateConnected, reconnTeardown},
+		{"no peer tears down", phone.StateCONNECTED, false, false, webrtc.PeerConnectionStateConnected, reconnTeardown},
+		{"ringing tears down", phone.StateRINGING, false, true, webrtc.PeerConnectionStateConnected, reconnTeardown},
+		{"voicemail recording tears down", phone.StateVOICEMAIL_RECORDING, false, true, webrtc.PeerConnectionStateConnected, reconnTeardown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reconnectAction(tc.ctrlState, tc.hasMesh, tc.hasPeer, tc.connState)
+			if got != tc.want {
+				t.Fatalf("reconnectAction(%v, mesh=%v, peer=%v, %v) = %v, want %v",
+					tc.ctrlState, tc.hasMesh, tc.hasPeer, tc.connState, got, tc.want)
 			}
 		})
 	}

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -138,3 +138,30 @@ func TestEnterICERecoveryIdempotentWhenAlreadyRecovering(t *testing.T) {
 		t.Fatal("second recovery armed a duplicate timer")
 	}
 }
+
+func TestHandleConnStateFailedWhileRecoveringDoesNotHangUp(t *testing.T) {
+	pm := newTestPeerManager(t)
+	// nil ctrl: triggerHangup would early-return on nil ctrl anyway, but the
+	// point is the actionNone branch must not even attempt teardown. We assert
+	// recovery state is left intact (isRestartingICE stays true, no panic).
+	d := &daemonCallbacks{peerMgr: pm, isCaller: true, callPeer: "x", isRestartingICE: true}
+	// restartTimer would normally be armed during recovery; simulate that.
+	d.mu.Lock()
+	d.startRestartTimeout()
+	d.mu.Unlock()
+
+	d.handleConnectionStateChange(pm, webrtc.PeerConnectionStateFailed)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.isRestartingICE {
+		t.Fatal("Failed-while-recovering cleared recovery state; it must let the deadline timer govern")
+	}
+	if d.restartTimer != nil {
+		// Timer is still armed (not stopped by a teardown); stop it so the test
+		// does not leave a 25s AfterFunc dangling.
+		d.restartTimer.Stop()
+	} else {
+		t.Fatal("Failed-while-recovering stopped the restart timer; deadline must still govern")
+	}
+}

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -700,6 +700,34 @@ func reconnectAction(ctrlState phone.State, hasMesh, hasPeer bool, connState web
 	return reconnResumeRestart
 }
 
+// tryResumeAfterReconnect handles an active call when the signaling WebSocket
+// reconnects. It returns true if it took ownership of the call (resumed or
+// kept it), false if the caller should fall back to full teardown. Only an
+// established 2-party call resumes; conference/voicemail/ringing tear down.
+func (d *daemonCallbacks) tryResumeAfterReconnect(ctrlState phone.State) bool {
+	d.mu.Lock()
+	pm := d.peerMgr
+	hasMesh := d.mesh != nil
+	d.mu.Unlock()
+
+	var connState webrtc.PeerConnectionState
+	if pm != nil {
+		connState = pm.ConnectionState()
+	}
+
+	switch reconnectAction(ctrlState, hasMesh, pm != nil, connState) {
+	case reconnResumeNoop:
+		slog.Info("signal: media survived reconnect, call continues")
+		return true
+	case reconnResumeRestart:
+		slog.Info("signal: media dropped during reconnect, driving ICE recovery")
+		d.enterICERecovery(pm, "ws-reconnect")
+		return true
+	default: // reconnTeardown
+		return false
+	}
+}
+
 // cancelDisconnectDebounceLocked stops a pending Disconnected debounce timer.
 // Must be called with d.mu held.
 func (d *daemonCallbacks) cancelDisconnectDebounceLocked() {

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -336,10 +336,7 @@ func (d *daemonCallbacks) HangupCall() {
 	d.isCaller = false
 	d.callReturnOrigin.Store(false)
 	d.isRestartingICE = false
-	if d.restartTimer != nil {
-		d.restartTimer.Stop()
-		d.restartTimer = nil
-	}
+	d.cancelRestartTimerLocked()
 	d.cancelDisconnectDebounceLocked()
 
 	sendSignal(d.sig, &sigclient.Message{Type: sigclient.TypeHangup, To: peer})
@@ -737,6 +734,15 @@ func (d *daemonCallbacks) cancelDisconnectDebounceLocked() {
 	}
 }
 
+// cancelRestartTimerLocked stops the ICE-restart deadline timer.
+// Must be called with d.mu held.
+func (d *daemonCallbacks) cancelRestartTimerLocked() {
+	if d.restartTimer != nil {
+		d.restartTimer.Stop()
+		d.restartTimer = nil
+	}
+}
+
 // enterICERecovery starts media recovery for the active 2-party call. The
 // caller side rotates ICE credentials and sends a fresh restart offer; the
 // callee side arms the wait timeout and waits for the caller's offer. Single
@@ -769,10 +775,7 @@ func (d *daemonCallbacks) enterICERecovery(pm *owebrtc.PeerManager, reason strin
 	if err != nil {
 		slog.Error("ice-recovery: create offer failed", "error", err, "reason", reason)
 		d.isRestartingICE = false
-		if d.restartTimer != nil {
-			d.restartTimer.Stop()
-			d.restartTimer = nil
-		}
+		d.cancelRestartTimerLocked()
 		d.mu.Unlock()
 		d.triggerHangup()
 		return
@@ -819,10 +822,7 @@ func (d *daemonCallbacks) handleConnectionStateChange(pm *owebrtc.PeerManager, s
 		wasRestarting := d.isRestartingICE
 		d.isRestartingICE = false
 		d.cancelDisconnectDebounceLocked()
-		if d.restartTimer != nil {
-			d.restartTimer.Stop()
-			d.restartTimer = nil
-		}
+		d.cancelRestartTimerLocked()
 		// Spawn the link-health reporter once per call (not on recovery).
 		if !d.linkHealthDisabled && d.reporterCancel == nil && d.peerMgr != nil {
 			rctx, cancel := context.WithCancel(context.Background())

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -642,6 +642,38 @@ func (d *daemonCallbacks) triggerHangup() {
 	go d.ctrl.HandleSignal("hangup", "")
 }
 
+// connAction is the decision output for a pion connection-state change.
+type connAction int
+
+const (
+	actionNone          connAction = iota
+	actionStartDebounce            // Disconnected: wait before reacting
+	actionEnterRecovery            // Failed (or debounce expiry): drive ICE recovery
+	actionClearRecovery            // Connected: cancel timers, recovery succeeded
+)
+
+// connStateAction maps a pion connection state plus current recovery flags to
+// the action the daemon should take. Pure and table-tested; the side effects
+// live in handleConnectionStateChange.
+func connStateAction(state webrtc.PeerConnectionState, recovering, debouncePending bool) connAction {
+	switch state {
+	case webrtc.PeerConnectionStateConnected:
+		return actionClearRecovery
+	case webrtc.PeerConnectionStateDisconnected:
+		if recovering || debouncePending {
+			return actionNone
+		}
+		return actionStartDebounce
+	case webrtc.PeerConnectionStateFailed:
+		if recovering {
+			return actionNone
+		}
+		return actionEnterRecovery
+	default:
+		return actionNone
+	}
+}
+
 // handleConnectionStateChange is called (without d.mu held) from a pion
 // goroutine when the WebRTC peer connection state changes.  On transient
 // failures the original caller attempts a single ICE restart before giving up.

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
 	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
+	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
 
@@ -672,6 +673,30 @@ func connStateAction(state webrtc.PeerConnectionState, recovering, debouncePendi
 	default:
 		return actionNone
 	}
+}
+
+// reconnAction is the decision output for a signaling-WebSocket reconnect that
+// happened while the phone was not idle.
+type reconnAction int
+
+const (
+	reconnTeardown      reconnAction = iota // not a resumable 2-party call: tear down
+	reconnResumeNoop                        // 2-party call, media survived: keep going
+	reconnResumeRestart                     // 2-party call, media dropped: drive ICE recovery
+)
+
+// reconnectAction decides what to do with an active call when the signaling
+// WebSocket reconnects. Only an established 2-party call (no mesh, has peer,
+// controller in CONNECTED) is resumable; everything else (ringing, calling,
+// voicemail, conference) tears down as before. Pure and table-tested.
+func reconnectAction(ctrlState phone.State, hasMesh, hasPeer bool, connState webrtc.PeerConnectionState) reconnAction {
+	if !hasPeer || hasMesh || ctrlState != phone.StateCONNECTED {
+		return reconnTeardown
+	}
+	if connState == webrtc.PeerConnectionStateConnected {
+		return reconnResumeNoop
+	}
+	return reconnResumeRestart
 }
 
 // handleConnectionStateChange is called (without d.mu held) from a pion

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -340,6 +340,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.restartTimer.Stop()
 		d.restartTimer = nil
 	}
+	d.cancelDisconnectDebounceLocked()
 
 	sendSignal(d.sig, &sigclient.Message{Type: sigclient.TypeHangup, To: peer})
 

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -717,10 +717,10 @@ func (d *daemonCallbacks) tryResumeAfterReconnect(ctrlState phone.State) bool {
 
 	switch reconnectAction(ctrlState, hasMesh, pm != nil, connState) {
 	case reconnResumeNoop:
-		slog.Info("signal: media survived reconnect, call continues")
+		slog.Info("signal: media survived reconnect, call continues", "state", ctrlState)
 		return true
 	case reconnResumeRestart:
-		slog.Info("signal: media dropped during reconnect, driving ICE recovery")
+		slog.Info("signal: media dropped during reconnect, driving ICE recovery", "state", ctrlState)
 		d.enterICERecovery(pm, "ws-reconnect")
 		return true
 	default: // reconnTeardown

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -699,19 +699,89 @@ func reconnectAction(ctrlState phone.State, hasMesh, hasPeer bool, connState web
 	return reconnResumeRestart
 }
 
+// cancelDisconnectDebounceLocked stops a pending Disconnected debounce timer.
+// Must be called with d.mu held.
+func (d *daemonCallbacks) cancelDisconnectDebounceLocked() {
+	if d.disconnectTimer != nil {
+		d.disconnectTimer.Stop()
+		d.disconnectTimer = nil
+	}
+}
+
+// enterICERecovery starts media recovery for the active 2-party call. The
+// caller side rotates ICE credentials and sends a fresh restart offer; the
+// callee side arms the wait timeout and waits for the caller's offer. Single
+// offerer (caller) avoids offer/answer glare. Idempotent: if recovery is
+// already in progress, it does nothing and lets the deadline timer govern.
+// Must NOT be called with d.mu held.
+func (d *daemonCallbacks) enterICERecovery(pm *owebrtc.PeerManager, reason string) {
+	d.mu.Lock()
+	if d.peerMgr != pm {
+		d.mu.Unlock()
+		return
+	}
+	if d.isRestartingICE {
+		d.mu.Unlock()
+		return
+	}
+	d.isRestartingICE = true
+	d.cancelDisconnectDebounceLocked()
+	d.startRestartTimeout()
+	isCaller := d.isCaller
+	peer := d.callPeer
+
+	if !isCaller {
+		d.mu.Unlock()
+		slog.Warn("ice-recovery: waiting for restart offer from caller", "reason", reason)
+		return
+	}
+
+	offer, err := d.peerMgr.CreateRestartOffer()
+	if err != nil {
+		slog.Error("ice-recovery: create offer failed", "error", err, "reason", reason)
+		d.isRestartingICE = false
+		if d.restartTimer != nil {
+			d.restartTimer.Stop()
+			d.restartTimer = nil
+		}
+		d.mu.Unlock()
+		d.triggerHangup()
+		return
+	}
+	sig := d.sig
+	d.mu.Unlock()
+
+	slog.Info("ice-recovery: sending restart offer", "peer", peer, "reason", reason, "bytes", len(offer))
+	sendSignal(sig, &sigclient.Message{
+		Type: sigclient.TypeICERestart,
+		To:   peer,
+		SDP:  offer,
+	})
+}
+
 // handleConnectionStateChange is called (without d.mu held) from a pion
-// goroutine when the WebRTC peer connection state changes.  On transient
-// failures the original caller attempts a single ICE restart before giving up.
+// goroutine when the WebRTC peer connection state changes. The action is
+// decided by connStateAction: Connected clears recovery, Disconnected starts a
+// debounce, Failed enters recovery, and a Failed event while already recovering
+// is ignored so the restart deadline timer governs the hangup.
 //
 // pm is the PeerManager captured at callback-setup time. Because HangupCall
 // detaches teardown into a goroutine, pion may fire a state change on a
 // pre-hangup peer after the daemon has already moved on to a new call. Every
-// branch that reads d.peerMgr / d.isCaller therefore checks d.peerMgr == pm
-// under d.mu and bails on mismatch, so a stale Failed event can't trigger an
-// ICE restart against the new call's peer.
+// branch that reads d.peerMgr therefore checks d.peerMgr == pm under d.mu and
+// bails on mismatch, so a stale event can't drive recovery against the new
+// call's peer.
 func (d *daemonCallbacks) handleConnectionStateChange(pm *owebrtc.PeerManager, state webrtc.PeerConnectionState) {
-	switch state {
-	case webrtc.PeerConnectionStateConnected:
+	d.mu.Lock()
+	if d.peerMgr != pm {
+		d.mu.Unlock()
+		return
+	}
+	action := connStateAction(state, d.isRestartingICE, d.disconnectTimer != nil)
+	d.mu.Unlock()
+
+	switch action {
+	case actionClearRecovery:
 		d.mu.Lock()
 		if d.peerMgr != pm {
 			d.mu.Unlock()
@@ -719,11 +789,12 @@ func (d *daemonCallbacks) handleConnectionStateChange(pm *owebrtc.PeerManager, s
 		}
 		wasRestarting := d.isRestartingICE
 		d.isRestartingICE = false
+		d.cancelDisconnectDebounceLocked()
 		if d.restartTimer != nil {
 			d.restartTimer.Stop()
 			d.restartTimer = nil
 		}
-		// Spawn the link-health reporter once per call (not on ICE restart recovery).
+		// Spawn the link-health reporter once per call (not on recovery).
 		if !d.linkHealthDisabled && d.reporterCancel == nil && d.peerMgr != nil {
 			rctx, cancel := context.WithCancel(context.Background())
 			d.reporterCancel = cancel
@@ -748,69 +819,46 @@ func (d *daemonCallbacks) handleConnectionStateChange(pm *owebrtc.PeerManager, s
 			d.mu.Unlock()
 		}
 		if wasRestarting {
-			slog.Info("webrtc: ICE restart succeeded -- connection recovered")
+			slog.Info("webrtc: ICE recovery succeeded -- connection recovered")
 		}
 
-	case webrtc.PeerConnectionStateFailed:
+	case actionStartDebounce:
 		d.mu.Lock()
-		if d.peerMgr != pm {
+		if d.peerMgr != pm || d.isRestartingICE || d.disconnectTimer != nil {
 			d.mu.Unlock()
 			return
 		}
-		alreadyRestarting := d.isRestartingICE
-		isCaller := d.isCaller
-		d.mu.Unlock()
-
-		if alreadyRestarting {
-			slog.Warn("webrtc: ICE restart failed, hanging up")
-			d.triggerHangup()
-			return
-		}
-
-		if isCaller {
-			slog.Warn("webrtc: connection failed, attempting ICE restart")
-			d.attemptICERestart()
-		} else {
-			slog.Warn("webrtc: connection failed, waiting for ICE restart from caller")
+		d.disconnectTimer = time.AfterFunc(disconnectDebounce, func() {
 			d.mu.Lock()
-			d.isRestartingICE = true
-			d.startRestartTimeout()
+			d.disconnectTimer = nil
+			stale := d.peerMgr != pm
+			recovering := d.isRestartingICE
 			d.mu.Unlock()
+			if stale || recovering {
+				return
+			}
+			if pm.ConnectionState() == webrtc.PeerConnectionStateConnected {
+				slog.Info("webrtc: disconnected self-healed during debounce")
+				return
+			}
+			slog.Warn("webrtc: still disconnected after debounce, entering ICE recovery")
+			d.enterICERecovery(pm, "disconnected-debounce")
+		})
+		d.mu.Unlock()
+		slog.Info("webrtc: disconnected, starting debounce", "debounce", disconnectDebounce)
+
+	case actionEnterRecovery:
+		d.mu.Lock()
+		d.cancelDisconnectDebounceLocked()
+		d.mu.Unlock()
+		slog.Warn("webrtc: connection failed, entering ICE recovery")
+		d.enterICERecovery(pm, "failed")
+
+	case actionNone:
+		if state == webrtc.PeerConnectionStateFailed {
+			slog.Warn("webrtc: connection failed while recovering; deadline timer governs")
 		}
 	}
-}
-
-// attemptICERestart creates a new SDP offer with rotated ICE credentials
-// and sends it to the remote peer.  Must NOT be called with d.mu held.
-func (d *daemonCallbacks) attemptICERestart() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	if d.peerMgr == nil {
-		slog.Warn("ice-restart: no peer manager, hanging up")
-		d.triggerHangup()
-		return
-	}
-
-	d.isRestartingICE = true
-
-	offer, err := d.peerMgr.CreateRestartOffer()
-	if err != nil {
-		slog.Error("ice-restart: create offer failed", "error", err)
-		d.isRestartingICE = false
-		d.triggerHangup()
-		return
-	}
-
-	peer := d.callPeer
-	d.startRestartTimeout()
-
-	slog.Info("ice-restart: sending restart offer", "peer", peer, "bytes", len(offer))
-	sendSignal(d.sig, &sigclient.Message{
-		Type: sigclient.TypeICERestart,
-		To:   peer,
-		SDP:  offer,
-	})
 }
 
 // startRestartTimeout sets a timer that hangs up the call if the ICE restart

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -265,3 +265,9 @@ func (m *PeerManager) GetStats() webrtc.StatsReport {
 func (m *PeerManager) Close() error {
 	return m.pc.Close()
 }
+
+// ConnectionState reports the current peer connection state. Used by the
+// reconnect path to decide whether media survived a signaling blip.
+func (m *PeerManager) ConnectionState() webrtc.PeerConnectionState {
+	return m.pc.ConnectionState()
+}

--- a/pi/digitsd/internal/webrtc/peer_test.go
+++ b/pi/digitsd/internal/webrtc/peer_test.go
@@ -173,3 +173,15 @@ func TestPeerManager_ICERestart(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPeerManagerConnectionStateInitiallyNew(t *testing.T) {
+	pm, err := NewPeerManager(NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = pm.Close() }()
+
+	if got := pm.ConnectionState(); got != webrtc.PeerConnectionStateNew {
+		t.Fatalf("fresh peer ConnectionState = %v, want New", got)
+	}
+}


### PR DESCRIPTION
## What

Hardens the daemon's WebRTC call against transient media-path and signaling interruptions, so a brief blip no longer drops an in-progress call.

- **React to pion `Disconnected`, not just `Failed`.** A new ~4s debounce: if the peer connection recovers on its own (STUN consent / connectivity checks) nothing happens; if it is still down after the debounce, recovery is driven proactively instead of waiting ~25s for `Failed`.
- **Unified, glare-free ICE recovery.** `attemptICERestart` is replaced by `enterICERecovery`, shared by the `Disconnected`-debounce, `Failed`, and WS-reconnect triggers. It is idempotent and keeps the single-offerer rule (caller offers a restart, callee waits), so two simultaneous offers cannot happen.
- **`Failed` while already recovering no longer hangs up immediately.** pion naturally escalates `Disconnected` to `Failed` while a restart is in flight; the recovery deadline timer now governs giving up, rather than tearing the call down at the first `Failed`.
- **Recovery timeout raised 15s to 25s.** It must exceed the server-side reconnect grace window (20s) plus margin, so a peer that stayed connected does not give up before a dropped phone can reconnect its WebSocket and re-establish media.
- **Resume a 2-party call across a signaling reconnect.** On WS reconnect the daemon no longer tears down an established 2-party call: if media survived the blip the call simply continues; if media also dropped it drives ICE recovery. Conferences, voicemail, and ringing states still tear down as before.

## Why

A call placed from outside the LAN dropped after a brief interruption. The daemon previously gave up on media recovery too quickly (single attempt, 15s, only on `Failed`) and unconditionally destroyed any active call the moment its signaling WebSocket reconnected, even when the peer-to-peer media path was still healthy. These changes let a call ride out a realistic latency spike, packet-loss burst, or short reconnect.

## Design notes

- The connection-state and reconnect decisions are pure functions (`connStateAction`, `reconnectAction`), exhaustively table-tested; the imperative wrappers (`handleConnectionStateChange`, `tryResumeAfterReconnect`) only do the locking and side effects.
- pion's `PeerConnectionState` is driven by DTLS/ICE, independent of the signaling WebSocket, so checking it right after a WS reconnect correctly distinguishes "media survived" from "media dropped".

## Companion

Pairs with a server-side change (separate PR) that holds a 2-party call open for a 20s grace window when a phone's signaling WebSocket drops, instead of tearing it down instantly. Either PR is safe to merge alone; together they cover both the control-plane and media-plane interruption cases.

## Testing

- `make test`, `golangci-lint run ./...`, `go test -race ./cmd/digitsd/ ./internal/webrtc/`, and `make build` (arm64 cross-compile) all pass.
- Unit coverage for the decision functions and the recovery/resume bookkeeping (caller offers, callee waits, idempotency, Failed-while-recovering does not hang up, non-CONNECTED and conference states tear down).
- **Hardware verification on real phones is still pending** (deploy + simulate a mid-call signaling blip and a media blip). Not yet run.