### PR TITLE
feat(server): hold calls through a brief signaling reconnect grace window

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -181,6 +181,7 @@ func run(ctx context.Context) error {
 	relay.HealthStore = healthStore
 	relay.Errors = mreg
 	tracker.SetCallEndObserver(relay)
+	hub.SetReconnectHook(relay.HandleRemoteReconnect)
 	if cfg.TURNEnabled {
 		if cfg.TURNSecret == "" {
 			return errors.New("SIGNALD_TURN_SECRET must be set when TURN is enabled")

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -1,0 +1,16 @@
+package signaling
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewRelaySetsDefaultGraceWindow(t *testing.T) {
+	r := NewRelay(NewHub(), newMockTracker(), nil, nil)
+	if r.GraceWindow != 20*time.Second {
+		t.Fatalf("default GraceWindow = %v, want 20s", r.GraceWindow)
+	}
+	if r.graceTimers == nil {
+		t.Fatal("graceTimers map not initialized")
+	}
+}

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -1,6 +1,7 @@
 package signaling
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -97,5 +98,38 @@ loop:
 	}
 	if got := tracker.clearedNumbers(); len(got) != 1 {
 		t.Fatalf("ClearByNumber calls = %v, want exactly 1", got)
+	}
+}
+
+func TestOnDisconnectHoldsInCall2Party(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = time.Hour // never fires during the test
+
+	relay.OnDisconnect(context.Background(), "3140001", "hw-1")
+
+	if got := tracker.clearedNumbers(); len(got) != 0 {
+		t.Fatalf("ClearByNumber called immediately: %v", got)
+	}
+	if !relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("no grace timer pending after in-call disconnect")
+	}
+}
+
+func TestOnDisconnectIdlePhoneClearsImmediately(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{} // not in any call
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	relay.OnDisconnect(context.Background(), "3140009", "hw-9")
+
+	if got := tracker.clearedNumbers(); len(got) != 1 || got[0] != "3140009" {
+		t.Fatalf("idle disconnect ClearByNumber = %v, want [3140009]", got)
+	}
+	if relay.cancelGraceLocal("3140009", "hw-9") {
+		t.Fatal("idle disconnect should not arm a grace timer")
 	}
 }

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -133,3 +133,34 @@ func TestOnDisconnectIdlePhoneClearsImmediately(t *testing.T) {
 		t.Fatal("idle disconnect should not arm a grace timer")
 	}
 }
+
+func TestDeliverFromRedisReconnectInvokesHook(t *testing.T) {
+	hub := NewHub()
+	var gotNumber, gotHW string
+	hub.SetReconnectHook(func(number, hardwareID string) {
+		gotNumber, gotHW = number, hardwareID
+	})
+	hub.deliverFromRedis(&Envelope{
+		TargetType: "reconnect",
+		Target:     "3140001",
+		Message:    &Message{HardwareID: "hw-1"},
+	})
+	if gotNumber != "3140001" || gotHW != "hw-1" {
+		t.Fatalf("hook got (%q,%q), want (3140001,hw-1)", gotNumber, gotHW)
+	}
+}
+
+func TestPublishReconnectPublishesEnvelope(t *testing.T) {
+	hub := NewHub()
+	fb := newFakeRedis()
+	hub.SetRedis(fb)
+	hub.PublishReconnect("3140001", "hw-1")
+	envs := fb.publishedEnvelopes()
+	if len(envs) != 1 {
+		t.Fatalf("published %d envelopes, want 1", len(envs))
+	}
+	env := envs[0]
+	if env.TargetType != "reconnect" || env.Target != "3140001" || env.Message == nil || env.Message.HardwareID != "hw-1" {
+		t.Fatalf("unexpected envelope: %+v", env)
+	}
+}

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -213,3 +213,55 @@ func TestPublishReconnectNoRedisIsNoop(t *testing.T) {
 	hub := NewHub()                         // no redis configured
 	hub.PublishReconnect("3140001", "hw-1") // must not panic, no-op
 }
+
+func TestGraceLifecycleReconnectWithinWindowKeepsCall(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002", "3140002": "3140001"}
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 80 * time.Millisecond
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	relay.OnDisconnect(context.Background(), "3140001", "hw-1")
+
+	time.Sleep(20 * time.Millisecond)
+	relay.OnReconnect(context.Background(), "3140001", "hw-1")
+
+	time.Sleep(120 * time.Millisecond)
+	if got := tracker.clearedNumbers(); len(got) != 0 {
+		t.Fatalf("call torn down despite reconnect: %v", got)
+	}
+	select {
+	case <-peer.Send:
+		t.Fatal("peer received hangup despite reconnect")
+	default:
+	}
+}
+
+func TestGraceLifecycleExpiryTearsDownAndNotifiesPeer(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002", "3140002": "3140001"}
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 30 * time.Millisecond
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	relay.OnDisconnect(context.Background(), "3140001", "hw-1")
+
+	select {
+	case data := <-peer.Send:
+		msg, _ := ParseMessage(data)
+		if msg.Type != TypeHangup {
+			t.Fatalf("peer got %q, want hangup", msg.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("peer never notified after grace expiry")
+	}
+	if got := tracker.clearedNumbers(); len(got) != 1 {
+		t.Fatalf("ClearByNumber calls = %v, want one", got)
+	}
+}

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -14,3 +14,52 @@ func TestNewRelaySetsDefaultGraceWindow(t *testing.T) {
 		t.Fatal("graceTimers map not initialized")
 	}
 }
+
+func TestGraceTimerFiresTeardownAndHangsUpPeer(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 20 * time.Millisecond
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+
+	select {
+	case data := <-peer.Send:
+		msg, _ := ParseMessage(data)
+		if msg.Type != TypeHangup {
+			t.Fatalf("peer got %q, want hangup", msg.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("peer never received hangup after grace expiry")
+	}
+	if got := tracker.clearedNumbers(); len(got) != 1 || got[0] != "3140001" {
+		t.Fatalf("ClearByNumber calls = %v, want [3140001]", got)
+	}
+}
+
+func TestCancelGraceLocalPreventsTeardown(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 50 * time.Millisecond
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+	if !relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("cancelGraceLocal returned false; expected a live timer")
+	}
+
+	select {
+	case <-peer.Send:
+		t.Fatal("peer received a hangup; grace should have been canceled")
+	case <-time.After(120 * time.Millisecond):
+	}
+	if got := tracker.clearedNumbers(); len(got) != 0 {
+		t.Fatalf("ClearByNumber called %v; expected none", got)
+	}
+}

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -164,3 +164,52 @@ func TestPublishReconnectPublishesEnvelope(t *testing.T) {
 		t.Fatalf("unexpected envelope: %+v", env)
 	}
 }
+
+func TestOnReconnectCancelsLocalTimerAndPublishes(t *testing.T) {
+	hub := NewHub()
+	fake := newFakeRedis()
+	hub.SetRedis(fake)
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = time.Hour
+
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+	relay.OnReconnect(context.Background(), "3140001", "hw-1")
+
+	if relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("grace timer still present after OnReconnect")
+	}
+	envs := fake.publishedEnvelopes()
+	if len(envs) != 1 || envs[0].TargetType != "reconnect" {
+		t.Fatalf("expected one reconnect publish, got %+v", envs)
+	}
+}
+
+func TestHandleRemoteReconnectCancelsWithoutPublishing(t *testing.T) {
+	hub := NewHub()
+	fake := newFakeRedis()
+	hub.SetRedis(fake)
+	relay := NewRelay(hub, newMockTracker(), nil, nil)
+	relay.GraceWindow = time.Hour
+
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+	relay.HandleRemoteReconnect("3140001", "hw-1")
+
+	if relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("grace timer still present after HandleRemoteReconnect")
+	}
+	if envs := fake.publishedEnvelopes(); len(envs) != 0 {
+		t.Fatalf("HandleRemoteReconnect published %d envelopes, want 0", len(envs))
+	}
+}
+
+func TestDeliverFromRedisReconnectNilHookNoPanic(t *testing.T) {
+	hub := NewHub() // no hook set
+	hub.deliverFromRedis(&Envelope{TargetType: "reconnect", Target: "x", Message: &Message{HardwareID: "y"}})
+	// reaching here without panic is the assertion
+}
+
+func TestPublishReconnectNoRedisIsNoop(t *testing.T) {
+	hub := NewHub()                         // no redis configured
+	hub.PublishReconnect("3140001", "hw-1") // must not panic, no-op
+}

--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -63,3 +63,39 @@ func TestCancelGraceLocalPreventsTeardown(t *testing.T) {
 		t.Fatalf("ClearByNumber called %v; expected none", got)
 	}
 }
+
+func TestStartGraceTimerReplacesExistingTimer(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 30 * time.Millisecond
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	// Two starts for the same key: the first must be canceled and replaced,
+	// so exactly one teardown fires.
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+	relay.startGraceTimer("3140001", "hw-1", "3140002")
+
+	// Drain hangups for ~120ms (4x window) and count them.
+	deadline := time.After(150 * time.Millisecond)
+	hangups := 0
+loop:
+	for {
+		select {
+		case data := <-peer.Send:
+			if msg, _ := ParseMessage(data); msg.Type == TypeHangup {
+				hangups++
+			}
+		case <-deadline:
+			break loop
+		}
+	}
+	if hangups != 1 {
+		t.Fatalf("got %d hangups, want exactly 1 (old timer replaced, not double-fired)", hangups)
+	}
+	if got := tracker.clearedNumbers(); len(got) != 1 {
+		t.Fatalf("ClearByNumber calls = %v, want exactly 1", got)
+	}
+}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -216,6 +216,8 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 		slog.Debug("redis: delivered broadcast from remote pod", "pod", env.PodID)
 
 	case "reconnect":
+		// env.Message is guaranteed non-nil by the early return at the top of
+		// deliverFromRedis.
 		h.mu.RLock()
 		hook := h.reconnectHook
 		h.mu.RUnlock()

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -219,7 +219,7 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 		h.mu.RLock()
 		hook := h.reconnectHook
 		h.mu.RUnlock()
-		if hook != nil && env.Message != nil {
+		if hook != nil {
 			hook(env.Target, env.Message.HardwareID)
 		}
 	}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -87,6 +87,7 @@ type Hub struct {
 	redis            redisPubSub  // nil = single-instance mode (no Redis)
 	state            *DeviceState // nil = single-instance mode (no cluster state)
 	draining         bool         // set by StartDraining; blocks new Register calls
+	reconnectHook    func(number, hardwareID string)
 }
 
 // NewHub creates a Hub ready for use. Call SetRedis and SetDeviceState before
@@ -108,6 +109,31 @@ func (h *Hub) SetRedis(bridge redisPubSub) {
 	h.mu.Lock()
 	h.redis = bridge
 	h.mu.Unlock()
+}
+
+// SetReconnectHook registers a callback invoked when a "reconnect" envelope
+// arrives from another pod. Used to cancel a grace timer held on this pod
+// for a device that re-registered elsewhere.
+func (h *Hub) SetReconnectHook(fn func(number, hardwareID string)) {
+	h.mu.Lock()
+	h.reconnectHook = fn
+	h.mu.Unlock()
+}
+
+// PublishReconnect broadcasts that a device re-registered, so any pod holding
+// a grace timer for it cancels. No-op in single-instance mode.
+func (h *Hub) PublishReconnect(number, hardwareID string) {
+	h.mu.RLock()
+	bridge := h.redis
+	h.mu.RUnlock()
+	if bridge == nil {
+		return
+	}
+	bridge.Publish(context.Background(), &Envelope{
+		TargetType: "reconnect",
+		Target:     number,
+		Message:    &Message{HardwareID: hardwareID},
+	})
 }
 
 // SetDeviceState attaches a DeviceState to the hub, enabling cluster-wide
@@ -188,6 +214,14 @@ func (h *Hub) deliverFromRedis(env *Envelope) {
 		}
 		h.mu.RUnlock()
 		slog.Debug("redis: delivered broadcast from remote pod", "pod", env.PodID)
+
+	case "reconnect":
+		h.mu.RLock()
+		hook := h.reconnectHook
+		h.mu.RUnlock()
+		if hook != nil && env.Message != nil {
+			hook(env.Target, env.Message.HardwareID)
+		}
 	}
 }
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -23,6 +23,12 @@ const (
 	callReturnExpiry = 30 * time.Minute
 	// googleSTUN is the public STUN server included in every ICE-servers response.
 	googleSTUN = "stun:stun.l.google.com:19302"
+	// graceWindow is how long the server holds a 2-party call open after a
+	// phone's signaling WebSocket drops, giving the phone time to reconnect
+	// before the call is torn down. The Pi-side ICE recovery timeout
+	// (iceRestartTimeout) must exceed this so a waiting peer does not give up
+	// before a dropped phone can return.
+	graceWindow = 20 * time.Second
 )
 
 // CallTracker is the subset of *calls.Tracker that the Relay needs to track
@@ -106,6 +112,27 @@ type Relay struct {
 
 	pendingReturnsMu sync.Mutex
 	pendingReturns   map[string]*pendingCallReturn // requester number -> pending retry
+
+	// GraceWindow is how long a 2-party call is held open after the last
+	// device on a line disconnects, before teardown. Defaults to
+	// graceWindow; overridable in tests.
+	GraceWindow time.Duration
+
+	graceMu     sync.Mutex
+	graceTimers map[string]*graceEntry // key: graceKey(number, hardwareID)
+}
+
+// graceEntry holds a pending grace timer plus a cancel flag that closes the
+// time.AfterFunc race: a fire that is already past the deadline but blocked
+// on graceMu observes canceled == true (set by cancelGraceLocal under the
+// same lock) and bails instead of tearing down a call that just reconnected.
+type graceEntry struct {
+	timer    *time.Timer
+	canceled bool
+}
+
+func graceKey(number, hardwareID string) string {
+	return number + "\x00" + hardwareID
 }
 
 // observeError is a nil-safe pass-through to the SignalingErrorObserver.
@@ -154,6 +181,8 @@ func NewRelay(hub *Hub, tracker CallTracker, authorizer CallAuthorizer, lineStor
 		LineStore:      lineStore,
 		extensions:     make(map[string]*activeExtension),
 		pendingReturns: make(map[string]*pendingCallReturn),
+		GraceWindow:    graceWindow,
+		graceTimers:    make(map[string]*graceEntry),
 	}
 }
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -758,6 +758,59 @@ func (r *Relay) clearExtensionsForCall(ctx context.Context, lineNumber string) {
 	}
 }
 
+// startGraceTimer holds a 2-party call open for GraceWindow after the last
+// device on `number` disconnects. If the device re-registers within the
+// window (cancelGraceLocal), the call survives. Otherwise the call is torn
+// down and `peer` receives an explicit hangup.
+func (r *Relay) startGraceTimer(number, hardwareID, peer string) {
+	key := graceKey(number, hardwareID)
+	r.graceMu.Lock()
+	if old, ok := r.graceTimers[key]; ok {
+		old.canceled = true
+		old.timer.Stop()
+	}
+	entry := &graceEntry{}
+	entry.timer = time.AfterFunc(r.GraceWindow, func() {
+		r.graceMu.Lock()
+		if entry.canceled {
+			r.graceMu.Unlock()
+			return
+		}
+		delete(r.graceTimers, key)
+		r.graceMu.Unlock()
+
+		ctx := context.Background()
+		slog.InfoContext(ctx, "grace: window expired, tearing down call", "number", number, "peer", peer)
+		if r.Tracker != nil {
+			r.Tracker.ClearByNumber(ctx, number)
+		}
+		r.clearExtensionsForCall(ctx, number)
+		if err := r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: number, To: peer}); err != nil {
+			slog.DebugContext(ctx, "grace: hangup to peer failed", "peer", peer, "err", err)
+		}
+	})
+	r.graceTimers[key] = entry
+	r.graceMu.Unlock()
+	slog.Info("grace: holding call through reconnect window", "number", number, "peer", peer, "window", r.GraceWindow)
+}
+
+// cancelGraceLocal stops a pending grace timer held by THIS pod. Returns
+// true if a live timer was found and canceled. Does not publish anything.
+func (r *Relay) cancelGraceLocal(number, hardwareID string) bool {
+	key := graceKey(number, hardwareID)
+	r.graceMu.Lock()
+	defer r.graceMu.Unlock()
+	entry, ok := r.graceTimers[key]
+	if !ok {
+		return false
+	}
+	entry.canceled = true
+	entry.timer.Stop()
+	delete(r.graceTimers, key)
+	slog.Info("grace: canceled by reconnect", "number", number)
+	return true
+}
+
 func (r *Relay) forward(ctx context.Context, msg *Message) {
 	if msg.To == "" {
 		slog.WarnContext(ctx, "no destination for message", "type", msg.Type, "from", msg.From)

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -823,6 +823,20 @@ func (r *Relay) cancelGraceLocal(number, hardwareID string) bool {
 	return true
 }
 
+// OnReconnect is called when a paired device re-registers. It cancels any
+// grace timer held locally and broadcasts the reconnect so a sibling pod
+// holding the timer cancels too.
+func (r *Relay) OnReconnect(ctx context.Context, number, hardwareID string) {
+	r.cancelGraceLocal(number, hardwareID)
+	r.Hub.PublishReconnect(number, hardwareID)
+}
+
+// HandleRemoteReconnect is invoked from the Redis reconnect dispatch. It
+// cancels a locally held grace timer only; it never re-publishes.
+func (r *Relay) HandleRemoteReconnect(number, hardwareID string) {
+	r.cancelGraceLocal(number, hardwareID)
+}
+
 func (r *Relay) forward(ctx context.Context, msg *Message) {
 	if msg.To == "" {
 		slog.WarnContext(ctx, "no destination for message", "type", msg.Type, "from", msg.From)

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -791,7 +791,7 @@ func (r *Relay) startGraceTimer(number, hardwareID, peer string) {
 	})
 	r.graceTimers[key] = entry
 	r.graceMu.Unlock()
-	slog.Info("grace: holding call through reconnect window", "number", number, "peer", peer, "window", r.GraceWindow)
+	slog.InfoContext(context.Background(), "grace: holding call through reconnect window", "number", number, "peer", peer, "window", r.GraceWindow)
 }
 
 // cancelGraceLocal stops a pending grace timer held by THIS pod. Returns
@@ -807,7 +807,7 @@ func (r *Relay) cancelGraceLocal(number, hardwareID string) bool {
 	entry.canceled = true
 	entry.timer.Stop()
 	delete(r.graceTimers, key)
-	slog.Info("grace: canceled by reconnect", "number", number)
+	slog.InfoContext(context.Background(), "grace: canceled by reconnect", "number", number)
 	return true
 }
 

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -587,12 +587,24 @@ func (r *Relay) OnDisconnect(ctx context.Context, number string, hardwareID stri
 	if r.Tracker == nil {
 		return
 	}
+	// Other devices remain on the line: the call is still held by a sibling.
 	if r.Hub.ConnectionCount(number) > 1 {
 		return
 	}
+	// Conferences are out of scope for the grace window: tear down now.
 	if conf := r.Tracker.Conferences().ConferenceByPhone(ctx, number); conf != nil {
 		r.endConference(ctx, conf.ID, "disconnect")
+		r.Tracker.ClearByNumber(ctx, number)
+		r.clearExtensionsForCall(ctx, number)
+		return
 	}
+	// Active 2-party call: hold it open through a reconnect grace window
+	// instead of tearing down immediately. The peer is NOT notified yet.
+	if peer := r.Tracker.PeerOf(ctx, number); peer != "" {
+		r.startGraceTimer(number, hardwareID, peer)
+		return
+	}
+	// Not in a call: nothing to hold; clear (no-op for an idle line).
 	r.Tracker.ClearByNumber(ctx, number)
 	r.clearExtensionsForCall(ctx, number)
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -107,16 +107,17 @@ type Relay struct {
 	// in cmd/signald/main.go.
 	Errors SignalingErrorObserver
 
+	// GraceWindow is how long a 2-party call is held open after the last
+	// device on a line disconnects, before teardown. Defaults to
+	// graceWindow; overridable in tests. Must be set before the relay starts
+	// handling messages; it is read without synchronization.
+	GraceWindow time.Duration
+
 	extMu      sync.Mutex
 	extensions map[string]*activeExtension // hardware_id -> extension state
 
 	pendingReturnsMu sync.Mutex
 	pendingReturns   map[string]*pendingCallReturn // requester number -> pending retry
-
-	// GraceWindow is how long a 2-party call is held open after the last
-	// device on a line disconnects, before teardown. Defaults to
-	// graceWindow; overridable in tests.
-	GraceWindow time.Duration
 
 	graceMu     sync.Mutex
 	graceTimers map[string]*graceEntry // key: graceKey(number, hardwareID)

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -20,6 +20,7 @@ type mockTracker struct {
 	cleared           []string
 	calls             map[string]bool  // "a→b" keys for active calls
 	callIDs           map[string]int64 // "a→b" keys for active call IDs
+	peers             map[string]string
 	conferences       *calls.ConferenceTracker
 	lastInboundCaller string
 }
@@ -107,6 +108,12 @@ func (m *mockTracker) InCall(_ context.Context, a, b string) bool {
 }
 
 func (m *mockTracker) PeerOf(_ context.Context, number string) string {
+	// Explicit peers map takes precedence; used by OnDisconnect grace-window tests.
+	if peer, ok := m.peers[number]; ok {
+		return peer
+	}
+	// Fall back to the calls map so extension and call-flow tests continue to
+	// work without needing to pre-populate peers.
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number {
@@ -681,6 +688,7 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
 	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = 20 * time.Millisecond
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -698,16 +706,25 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 		t.Fatal("expected phone 2 to be busy after call initiated")
 	}
 
-	// Simulate Phone 2 disconnecting (WebSocket drops)
+	// Simulate Phone 2 disconnecting (WebSocket drops). Because a peer exists,
+	// the call is held for GraceWindow before teardown.
 	relay.OnDisconnect(context.Background(), "3140002", "")
 
-	// Phone 2 should no longer be busy
-	if tracker.Busy(context.Background(), "3140002") {
-		t.Fatal("expected phone 2 to not be busy after disconnect cleanup")
+	// Grace window is running: Phone 1 receives a hangup and state is cleared
+	// after the window expires.
+	select {
+	case data := <-conn1.Send:
+		msg, _ := ParseMessage(data)
+		if msg.Type != TypeHangup {
+			t.Fatalf("expected hangup for peer after grace expiry, got: %+v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("peer (phone 1) did not receive hangup after grace window expired")
 	}
-	// Phone 1 should also be freed (its call was with Phone 2)
-	if tracker.Busy(context.Background(), "3140001") {
-		t.Fatal("expected phone 1 to not be busy after peer disconnected")
+
+	// After grace expiry the tracker has cleared phone 2's call state.
+	if tracker.Busy(context.Background(), "3140002") {
+		t.Fatal("expected phone 2 to not be busy after grace expiry")
 	}
 
 	// Phone 3 can now call Phone 2 (once reconnected)
@@ -721,7 +738,7 @@ func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 		if msg.Type != TypeRing {
 			t.Fatalf("expected ring on reconnected phone 2, got: %+v", msg)
 		}
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("reconnected phone 2 did not receive ring")
 	}
 }

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -15,6 +15,7 @@ type mockTracker struct {
 	initiated         []string
 	answered          []string
 	ended             []string
+	cleared           []string
 	calls             map[string]bool  // "a→b" keys for active calls
 	callIDs           map[string]int64 // "a→b" keys for active call IDs
 	conferences       *calls.ConferenceTracker
@@ -59,6 +60,7 @@ func (m *mockTracker) OnCallEnded(ctx context.Context, caller, callee string) er
 	return nil
 }
 func (m *mockTracker) ClearByNumber(ctx context.Context, number string) {
+	m.cleared = append(m.cleared, number)
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number || b == number {
@@ -67,6 +69,7 @@ func (m *mockTracker) ClearByNumber(ctx context.Context, number string) {
 		}
 	}
 }
+func (m *mockTracker) clearedNumbers() []string { return m.cleared }
 func (m *mockTracker) Busy(_ context.Context, number string) bool {
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ type mockTracker struct {
 	initiated         []string
 	answered          []string
 	ended             []string
+	mu                sync.Mutex
 	cleared           []string
 	calls             map[string]bool  // "a→b" keys for active calls
 	callIDs           map[string]int64 // "a→b" keys for active call IDs
@@ -60,7 +62,9 @@ func (m *mockTracker) OnCallEnded(ctx context.Context, caller, callee string) er
 	return nil
 }
 func (m *mockTracker) ClearByNumber(ctx context.Context, number string) {
+	m.mu.Lock()
 	m.cleared = append(m.cleared, number)
+	m.mu.Unlock()
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")
 		if a == number || b == number {
@@ -69,7 +73,11 @@ func (m *mockTracker) ClearByNumber(ctx context.Context, number string) {
 		}
 	}
 }
-func (m *mockTracker) clearedNumbers() []string { return m.cleared }
+func (m *mockTracker) clearedNumbers() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.cleared...)
+}
 func (m *mockTracker) Busy(_ context.Context, number string) bool {
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -141,6 +141,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	if isPaired {
 		h.relay.OnRegistered(r.Context(), msg.Number)
+		h.relay.OnReconnect(r.Context(), msg.Number, msg.HardwareID)
 	}
 	number := msg.Number
 	ctx := r.Context()


### PR DESCRIPTION
## Summary

- When the last device on a line drops its signaling WebSocket mid-call, the relay no longer tears the 2-party call down immediately. It holds the call open for a 20s grace window (a timer keyed by number + hardware ID) so the phone can reconnect and resume.
- Re-registration cancels the hold: `OnReconnect` cancels the local grace timer and broadcasts a `reconnect` event over the existing Redis pub/sub bridge, so whichever of the replicas holds the timer cancels it (the receiving side, `HandleRemoteReconnect`, cancels without re-publishing, so there is no pod-to-pod loop).
- If the phone does not return within the window, the call is torn down as before and the peer now gets an explicit `TypeHangup` instead of being left to discover the dead call via its own media timeout.
- Idle lines and conferences are unchanged: idle disconnects clear immediately, conferences still end immediately on disconnect. Only an established 2-party call is held.
- Degrades cleanly to single-instance (no Redis): the local timer and local cancel are all that is needed; the cross-pod broadcast no-ops when Redis is not configured.

## Why

A call placed from outside the LAN dropped after a brief interruption. Previously any signaling-WebSocket blip (a transient network hiccup, a NAT rebind, or a routine `signald` redeploy) tore down the call instantly, even when the peer-to-peer media path was still healthy. The grace window lets a call survive a short control-plane interruption.

## Companion

Pairs with a digitsd PR that reacts to media-plane blips (debounced ICE recovery, resume-on-reconnect, recovery timeout raised to 25s to exceed this 20s window). Either is safe to merge alone; together they cover both the control-plane and media-plane interruption cases.

## Test plan

- [x] `make test` and `make test-integration` (local Postgres) pass.
- [x] `golangci-lint run ./...`: 0 issues. `go test -race ./internal/signaling/` clean. `make build` succeeds.
- [x] Unit coverage: grace timer fire (teardown + peer hangup), local cancel, replace-existing-timer, OnDisconnect hold-vs-idle-vs-conference, cross-pod reconnect dispatch + publish, no-Redis no-op, and end-to-end lifecycle (reconnect-within-window keeps the call; expiry tears down and notifies the peer).
- [ ] Multi-replica behavior in the k8s cluster (cross-pod cancel) observed in a real deploy: pending.