### PR TITLE
docs(server): note reconnect in Envelope.TargetType comment

### DIFF
--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -17,7 +17,7 @@ const redisChannel = "digits:signal"
 // pods attempt local delivery.
 type Envelope struct {
 	PodID      string   `json:"pod"`
-	TargetType string   `json:"type"`   // "number", "hardware", or "broadcast"
+	TargetType string   `json:"type"`   // "number", "hardware", "broadcast", or "reconnect"
 	Target     string   `json:"target"` // phone number, hardware ID, or empty for broadcast
 	Message    *Message `json:"msg"`
 }


### PR DESCRIPTION
## Summary

- Updates the `Envelope.TargetType` doc comment in `internal/signaling/redis.go` to include `"reconnect"`, which was added as a fourth target type by PR #678 but not reflected in the comment.

Comment-only change, no behavior difference.

Note: the behavioral grace-expiry fix that was briefly described here was split into its own PR; this PR merged the doc comment only.