### PR TITLE
fix(server): end grace-expired calls like a hangup so call-return and persistence fire

### DIFF
--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -19,6 +19,7 @@ func TestNewRelaySetsDefaultGraceWindow(t *testing.T) {
 func TestGraceTimerFiresTeardownAndHangsUpPeer(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.GraceWindow = 20 * time.Millisecond
 
@@ -36,14 +37,15 @@ func TestGraceTimerFiresTeardownAndHangsUpPeer(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("peer never received hangup after grace expiry")
 	}
-	if got := tracker.clearedNumbers(); len(got) != 1 || got[0] != "3140001" {
-		t.Fatalf("ClearByNumber calls = %v, want [3140001]", got)
+	if len(tracker.ended) != 1 || tracker.ended[0] != "3140001→3140002" {
+		t.Fatalf("OnCallEnded = %v, want [3140001->3140002]", tracker.ended)
 	}
 }
 
 func TestCancelGraceLocalPreventsTeardown(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.GraceWindow = 50 * time.Millisecond
 
@@ -60,14 +62,15 @@ func TestCancelGraceLocalPreventsTeardown(t *testing.T) {
 		t.Fatal("peer received a hangup; grace should have been canceled")
 	case <-time.After(120 * time.Millisecond):
 	}
-	if got := tracker.clearedNumbers(); len(got) != 0 {
-		t.Fatalf("ClearByNumber called %v; expected none", got)
+	if len(tracker.ended) != 0 {
+		t.Fatalf("OnCallEnded called %v; expected none", tracker.ended)
 	}
 }
 
 func TestStartGraceTimerReplacesExistingTimer(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.GraceWindow = 30 * time.Millisecond
 
@@ -96,8 +99,8 @@ loop:
 	if hangups != 1 {
 		t.Fatalf("got %d hangups, want exactly 1 (old timer replaced, not double-fired)", hangups)
 	}
-	if got := tracker.clearedNumbers(); len(got) != 1 {
-		t.Fatalf("ClearByNumber calls = %v, want exactly 1", got)
+	if len(tracker.ended) != 1 {
+		t.Fatalf("OnCallEnded = %v, want exactly 1", tracker.ended)
 	}
 }
 
@@ -112,6 +115,9 @@ func TestOnDisconnectHoldsInCall2Party(t *testing.T) {
 
 	if got := tracker.clearedNumbers(); len(got) != 0 {
 		t.Fatalf("ClearByNumber called immediately: %v", got)
+	}
+	if len(tracker.ended) != 0 {
+		t.Fatalf("OnCallEnded called immediately (held, nothing ended yet): %v", tracker.ended)
 	}
 	if !relay.cancelGraceLocal("3140001", "hw-1") {
 		t.Fatal("no grace timer pending after in-call disconnect")
@@ -230,8 +236,8 @@ func TestGraceLifecycleReconnectWithinWindowKeepsCall(t *testing.T) {
 	relay.OnReconnect(context.Background(), "3140001", "hw-1")
 
 	time.Sleep(120 * time.Millisecond)
-	if got := tracker.clearedNumbers(); len(got) != 0 {
-		t.Fatalf("call torn down despite reconnect: %v", got)
+	if len(tracker.ended) != 0 {
+		t.Fatalf("call torn down despite reconnect: ended=%v", tracker.ended)
 	}
 	select {
 	case <-peer.Send:
@@ -261,7 +267,7 @@ func TestGraceLifecycleExpiryTearsDownAndNotifiesPeer(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("peer never notified after grace expiry")
 	}
-	if got := tracker.clearedNumbers(); len(got) != 1 {
-		t.Fatalf("ClearByNumber calls = %v, want one", got)
+	if len(tracker.ended) != 1 || tracker.ended[0] != "3140001→3140002" {
+		t.Fatalf("OnCallEnded = %v, want [3140001->3140002]", tracker.ended)
 	}
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -429,30 +429,37 @@ func (r *Relay) handleHangup(ctx context.Context, from string, msg *Message) {
 	// Resolve the set of peers to notify. In pre-merge ADD_* flows the host
 	// may have multiple active 2-party calls (A-B held and A-C active); a
 	// single hook-on ends both. For the normal 2-party case this is one peer.
-	var peers []string
-	if r.Tracker != nil {
-		peers = r.Tracker.AllPeersOf(ctx, from)
+	r.endActiveCallsAsHangup(ctx, from)
+}
+
+// endActiveCallsAsHangup ends every active 2-party call involving number the
+// same way an explicit hangup does: it records each call end (DB persistence
+// plus the OnCallEndedNotify observer that drives *69 retries) and forwards a
+// Hangup to each peer, then clears extension state. Shared by the hangup
+// handler and the grace-window expiry path so the two cannot drift.
+func (r *Relay) endActiveCallsAsHangup(ctx context.Context, number string) {
+	if r.Tracker == nil {
+		return
 	}
+	peers := r.Tracker.AllPeersOf(ctx, number)
 	if len(peers) == 0 {
-		slog.DebugContext(ctx, "hangup from phone not in any active call", "from", from)
+		slog.DebugContext(ctx, "end calls: phone not in any active call", "number", number)
 		return
 	}
 	for _, peer := range peers {
-		if r.Tracker != nil {
-			callID := r.Tracker.CallIDForPair(ctx, from, peer)
-			if err := r.Tracker.OnCallEnded(ctx, from, peer); err != nil {
-				slog.ErrorContext(ctx, "failed to track call end", "err", err)
-			}
-			if callID != 0 {
-				attrs := []any{"call_id", callID, "from", from, "to", peer}
-				attrs = append(attrs, r.lineAttrs(ctx, from)...)
-				slog.InfoContext(ctx, "call ended", attrs...)
-				setSpanCallID(ctx, callID)
-			}
+		callID := r.Tracker.CallIDForPair(ctx, number, peer)
+		if err := r.Tracker.OnCallEnded(ctx, number, peer); err != nil {
+			slog.ErrorContext(ctx, "failed to track call end", "err", err)
 		}
-		_ = r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: from, To: peer})
+		if callID != 0 {
+			attrs := []any{"call_id", callID, "from", number, "to", peer}
+			attrs = append(attrs, r.lineAttrs(ctx, number)...)
+			slog.InfoContext(ctx, "call ended", attrs...)
+			setSpanCallID(ctx, callID)
+		}
+		_ = r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: number, To: peer})
 	}
-	r.clearExtensionsForCall(ctx, from)
+	r.clearExtensionsForCall(ctx, number)
 }
 
 func (r *Relay) handleSDP(ctx context.Context, from string, msg *Message) {
@@ -793,13 +800,7 @@ func (r *Relay) startGraceTimer(number, hardwareID, peer string) {
 
 		ctx := context.Background()
 		slog.InfoContext(ctx, "grace: window expired, tearing down call", "number", number, "peer", peer)
-		if r.Tracker != nil {
-			r.Tracker.ClearByNumber(ctx, number)
-		}
-		r.clearExtensionsForCall(ctx, number)
-		if err := r.Hub.SendTo(peer, &Message{Type: TypeHangup, From: number, To: peer}); err != nil {
-			slog.DebugContext(ctx, "grace: hangup to peer failed", "peer", peer, "err", err)
-		}
+		r.endActiveCallsAsHangup(ctx, number)
 	})
 	r.graceTimers[key] = entry
 	r.graceMu.Unlock()

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -127,6 +127,11 @@ func (m *mockTracker) PeerOf(_ context.Context, number string) string {
 }
 
 func (m *mockTracker) AllPeersOf(_ context.Context, number string) []string {
+	// Explicit peers map takes precedence, mirroring PeerOf behavior so
+	// grace-window tests that stage via peers instead of calls still work.
+	if peer, ok := m.peers[number]; ok && peer != "" {
+		return []string{peer}
+	}
 	var peers []string
 	for k := range m.calls {
 		a, b, _ := strings.Cut(k, "→")


### PR DESCRIPTION
## Summary

- Grace-window expiry now tears a 2-party call down exactly like an explicit hangup. Previously the grace timer called `ClearByNumber` (which fires `OnCallEndedNotify` with an empty callee) plus a single peer hangup; the normal hangup path calls `OnCallEnded(from, peer)` per peer, which persists the call end and fires the call-return observer with both names so `*69` retries targeting the peer run.
- Extracts a shared `endActiveCallsAsHangup` helper used by both `handleHangup` and the grace-expiry callback, so the two teardown paths cannot drift again. The idle and conference disconnect paths keep using `ClearByNumber` (no active 2-party call to end there).

## Why

Follow-up to a code-review finding on #678 (the reconnect grace window). On the merged code, a grace-expired call cleared in-memory and DB state but did not fire the call-return observer with the peer, so a `*69` callback waiting on the peer could be missed. Mirroring the hangup teardown closes that gap.

## Test plan

- [x] `go test ./internal/signaling/` (incl. the multi-peer hangup test; the `handleHangup` refactor is behavior-preserving), `-race`, `gofmt`, `go build`.
- [x] Grace tests assert the exact `caller -> callee` end (stronger than the old count-only check); idle/conference tests still assert the `ClearByNumber` path.