### PR TITLE
fix(digitsd): harden mid-call recovery (fast reconnect, fresh TURN creds, locked state read)

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -67,6 +67,12 @@ const pairingRefreshInterval = 9 * time.Minute
 // first time.
 const pairingAnnouncementInterval = 15 * time.Second
 
+// activeCallReconnectBackoff is the fixed wait between WebSocket reconnect
+// attempts when a call is active. Short so the caller side re-establishes
+// signaling quickly enough for tryResumeAfterReconnect to send the ICE-restart
+// offer within the peer's 25s recovery window.
+const activeCallReconnectBackoff = 2 * time.Second
+
 func init() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 }
@@ -2364,7 +2370,19 @@ func main() {
 						Credential: s.Credential,
 					})
 				}
+				// Push fresh creds into the live 2-party PeerConnection so an
+				// ICE restart triggered after the TURN TTL (2h) uses valid creds.
+				// Mesh peers are not updated here; see PeerManager.UpdateICEServers.
+				pm := cb.peerMgr
+				servers := cb.iceServers
 				cb.mu.Unlock()
+				if pm != nil {
+					if err := pm.UpdateICEServers(servers); err != nil {
+						slog.Warn("ice: failed to update live peer connection", "error", err)
+					} else {
+						slog.Info("ice: updated live peer connection with fresh servers")
+					}
+				}
 				slog.Info("ice: cached servers from signald", "count", len(msg.Servers))
 
 			case sigclient.TypePairingCode:
@@ -2571,18 +2589,28 @@ func main() {
 
 		case <-sig.Done():
 			backoff := 3 * time.Second
+			first := true
 			for {
-				slog.Info("signal: connection lost, reconnecting", "backoff", backoff)
-				time.Sleep(backoff)
+				if first {
+					// Attempt the first reconnect immediately: no sleep on the
+					// first try so a transient blip resolves as fast as possible.
+					// This is especially important during an active call so the
+					// caller can re-deliver the ICE-restart offer before the peer's
+					// 25s recovery window expires.
+					first = false
+				} else {
+					// Active calls use a short fixed interval to stay within the
+					// recovery window. Idle paths use standard exponential backoff.
+					backoff = nextReconnectBackoff(backoff, ctrl.IsCallActive())
+					slog.Info("signal: connection lost, reconnecting", "backoff", backoff)
+					time.Sleep(backoff)
+				}
 				sig = sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken)
 				cb.mu.Lock()
 				cb.sig = sig
 				cb.mu.Unlock()
 				if err := sig.Connect(); err != nil {
 					slog.Warn("signal: reconnect failed", "error", err)
-					if backoff < 60*time.Second {
-						backoff *= 2
-					}
 					continue
 				}
 				slog.Info("signal: reconnected")
@@ -2610,6 +2638,21 @@ func main() {
 			}
 		}
 	}
+}
+
+// nextReconnectBackoff returns the backoff duration to use before the next
+// WebSocket reconnect attempt. When a call is active, a short fixed interval
+// keeps the caller within the peer's ICE-restart recovery window. When idle,
+// the backoff doubles each attempt up to a 60s cap (standard exponential).
+func nextReconnectBackoff(current time.Duration, callActive bool) time.Duration {
+	if callActive {
+		return activeCallReconnectBackoff
+	}
+	next := current * 2
+	if next > 60*time.Second {
+		return 60 * time.Second
+	}
+	return next
 }
 
 // requestICEServers asks signald for STUN/TURN server configs.

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
@@ -213,5 +214,37 @@ func TestTryResumeConferenceReturnsFalse(t *testing.T) {
 	d := &daemonCallbacks{peerMgr: pm, mesh: mesh, isCaller: true, callPeer: "x"}
 	if d.tryResumeAfterReconnect(phone.StateCONFERENCE_MERGED) {
 		t.Fatal("conference must not resume via the 2-party path")
+	}
+}
+
+// TestNextReconnectBackoff verifies the pure backoff helper: active calls
+// always get the short fixed interval; idle paths get exponential growth
+// capped at 60 s.
+func TestNextReconnectBackoff(t *testing.T) {
+	// Active call: always returns activeCallReconnectBackoff regardless of current.
+	for _, cur := range []time.Duration{3 * time.Second, 6 * time.Second, 60 * time.Second} {
+		got := nextReconnectBackoff(cur, true)
+		if got != activeCallReconnectBackoff {
+			t.Errorf("active: nextReconnectBackoff(%v, true) = %v, want %v", cur, got, activeCallReconnectBackoff)
+		}
+	}
+
+	// Idle: doubles from 3 s -> 6 s -> 12 s -> ... -> 60 s cap.
+	cases := []struct {
+		current time.Duration
+		want    time.Duration
+	}{
+		{3 * time.Second, 6 * time.Second},
+		{6 * time.Second, 12 * time.Second},
+		{12 * time.Second, 24 * time.Second},
+		{24 * time.Second, 48 * time.Second},
+		{48 * time.Second, 60 * time.Second},
+		{60 * time.Second, 60 * time.Second}, // cap
+	}
+	for _, tc := range cases {
+		got := nextReconnectBackoff(tc.current, false)
+		if got != tc.want {
+			t.Errorf("idle: nextReconnectBackoff(%v, false) = %v, want %v", tc.current, got, tc.want)
+		}
 	}
 }

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -705,12 +705,12 @@ func (d *daemonCallbacks) tryResumeAfterReconnect(ctrlState phone.State) bool {
 	d.mu.Lock()
 	pm := d.peerMgr
 	hasMesh := d.mesh != nil
-	d.mu.Unlock()
-
+	// Read connection state under the same lock as pm so the pair is consistent.
 	var connState webrtc.PeerConnectionState
 	if pm != nil {
 		connState = pm.ConnectionState()
 	}
+	d.mu.Unlock()
 
 	switch reconnectAction(ctrlState, hasMesh, pm != nil, connState) {
 	case reconnResumeNoop:

--- a/pi/digitsd/internal/webrtc/peer.go
+++ b/pi/digitsd/internal/webrtc/peer.go
@@ -271,3 +271,20 @@ func (m *PeerManager) Close() error {
 func (m *PeerManager) ConnectionState() webrtc.PeerConnectionState {
 	return m.pc.ConnectionState()
 }
+
+// UpdateICEServers replaces the STUN/TURN server list on the live
+// PeerConnection so that a subsequent ICE restart uses fresh credentials.
+// TURN credentials issued by the signaling server expire after 2 hours; this
+// keeps long calls from ice-restarting with stale creds after a media blip.
+//
+// Note: this updates the 2-party PeerManager only. Conference mesh peers
+// (owebrtc.MeshManager) are out of scope; mesh calls are short-lived relative
+// to the TURN credential TTL.
+func (m *PeerManager) UpdateICEServers(servers []ICEServerConfig) error {
+	iceCfg := NewICEConfig(servers)
+	if err := m.pc.SetConfiguration(iceCfg.WebRTCConfig()); err != nil {
+		return fmt.Errorf("update ICE servers: %w", err)
+	}
+	m.iceCfg = iceCfg
+	return nil
+}

--- a/pi/digitsd/internal/webrtc/peer_test.go
+++ b/pi/digitsd/internal/webrtc/peer_test.go
@@ -185,3 +185,54 @@ func TestPeerManagerConnectionStateInitiallyNew(t *testing.T) {
 		t.Fatalf("fresh peer ConnectionState = %v, want New", got)
 	}
 }
+
+// TestUpdateICEServers verifies that UpdateICEServers does not error on a
+// live PeerConnection and that the peer remains usable (CreateRestartOffer
+// still works) after the update. We cannot easily assert the new URLs appear
+// in the SDP without a full ICE handshake, but a no-error round-trip through
+// SetConfiguration + CreateRestartOffer is sufficient to confirm the PC is
+// still healthy.
+func TestUpdateICEServers(t *testing.T) {
+	pm, err := NewPeerManager(NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = pm.Close() }()
+
+	// Do a full offer/answer so the PC is in stable state (required for
+	// CreateRestartOffer to succeed).
+	remote, err := NewPeerManager(NewICEConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = remote.Close() }()
+
+	offer, err := pm.CreateOffer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer, err := remote.AcceptOffer(offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pm.SetAnswer(answer); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now update with a new server list (STUN only, no creds needed for test).
+	servers := []ICEServerConfig{
+		{URLs: []string{"stun:stun.l.google.com:19302"}},
+	}
+	if err := pm.UpdateICEServers(servers); err != nil {
+		t.Fatalf("UpdateICEServers: %v", err)
+	}
+
+	// The peer connection must still be usable after the update.
+	restartOffer, err := pm.CreateRestartOffer()
+	if err != nil {
+		t.Fatalf("CreateRestartOffer after UpdateICEServers: %v", err)
+	}
+	if restartOffer == "" {
+		t.Fatal("empty restart offer after UpdateICEServers")
+	}
+}


### PR DESCRIPTION
Addresses findings from a holistic review of the merged connection-resilience work.

## Changes

- **Fast reconnect during an active call (C1/M2).** The WS reconnect loop now attempts the first reconnect immediately (no pre-sleep) and uses a short fixed `activeCallReconnectBackoff` (2s) while a call is active, instead of the exponential 3s->60s schedule. This is what makes caller-side recovery actually fire: when the *caller's* network drops, it must reconnect and send the ICE-restart offer before the callee's recovery deadline; the old exponential backoff meant the caller often reconnected too late. Idle reconnects keep the exponential backoff. The decision is a pure `nextReconnectBackoff` (table-tested).
- **Apply refreshed TURN creds to the live PeerConnection (gap-a).** TURN credentials have a 2h TTL; the live `*webrtc.PeerConnection` config was set once at creation and never updated, so a media blip on a >2h call would ICE-restart with expired creds. `PeerManager.UpdateICEServers` now calls `pc.SetConfiguration` with the refreshed servers, invoked whenever the (already-existing) ICE-server refresh fires and a 2-party peer is active. `SetConfiguration` is future-only (affects the next ICE gather/restart, no media teardown). Mesh peers out of scope.
- **Read connection state under lock (I3).** `tryResumeAfterReconnect` now reads `pm.ConnectionState()` inside the same `d.mu` critical section as the `pm` snapshot, consistent with the file's stale-peer invariant.

## Test plan

- [x] `go test ./cmd/digitsd/ ./internal/webrtc/ ./internal/phone/`, `go test -race ./cmd/digitsd/`, `golangci-lint run ./...`, `make build` (arm64 cross-compile) all pass.
- [x] `TestNextReconnectBackoff` (active ignores current; idle doubles, capped at 60s); `TestUpdateICEServers` (live config update keeps the PC usable for a subsequent restart offer).
- [ ] Hardware: caller-drop recovery on real phones still pending.