### PR TITLE
fix(server): reliable cross-pod ICE-restart delivery and busy for grace-held lines

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -182,6 +182,7 @@ func run(ctx context.Context) error {
 	relay.Errors = mreg
 	tracker.SetCallEndObserver(relay)
 	hub.SetReconnectHook(relay.HandleRemoteReconnect)
+	hub.SetDropHook(func() { mreg.ObserveSignalingError("send_buffer_full") })
 	if cfg.TURNEnabled {
 		if cfg.TURNSecret == "" {
 			return errors.New("SIGNALD_TURN_SECRET must be set when TURN is enabled")

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -180,6 +180,7 @@ var validErrorCategories = map[string]struct{}{
 	"auth_failed":       {},
 	"invalid_message":   {},
 	"relay_delivery":    {},
+	"send_buffer_full":  {},
 }
 
 // ObserveSignalingError records one signaling error, partitioned by category.

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -555,41 +555,77 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 	return nil
 }
 
-// SendToWithTimeout attempts to deliver msg to every local device on number,
-// waiting up to timeout for each device's send buffer to have room. Unlike
-// SendTo it does NOT fall back to Redis on success (local-only delivery);
-// callers that need cross-pod delivery for the non-full case should use
-// SendTo. Returns ErrSendTimeout if any device's buffer stays full for the
-// entire timeout. Returns ErrNotConnected if no local device is present
-// (Redis paths are out of scope for timeout delivery).
+// sendRetryInterval is how long SendToWithTimeout sleeps between attempts to
+// re-offer a message to a device whose send buffer was full.
+const sendRetryInterval = 20 * time.Millisecond
+
+// SendToWithTimeout delivers msg to every local device on number, retrying
+// buffer-full devices until the buffer drains or the timeout elapses. Each
+// send is attempted under the read lock inside a non-blocking select, so a
+// concurrent Unregister (which closes conn.Send under the write lock) can
+// never close a channel out from under an in-flight send: a removed conn is
+// simply absent from the next iteration's list. delivered (keyed by *Conn)
+// prevents re-sending to a device that already accepted the message while a
+// sibling's buffer was still full.
+//
+// When no local device is connected the message is published to Redis for
+// cross-pod delivery, mirroring SendTo, so reliable callers (ICE-restart)
+// reach peers on other pods. Returns ErrSendTimeout if any device's buffer
+// stays full for the whole timeout, ErrNotConnected if there is neither a
+// local conn nor a Redis bridge.
 func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Duration) error {
 	data, err := msg.Marshal()
 	if err != nil {
 		return err
 	}
 
-	h.mu.RLock()
-	conns := h.conns[number]
-	if len(conns) == 0 {
-		h.mu.RUnlock()
-		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
-	}
-	// Snapshot so we release the lock before blocking.
-	targets := make([]*Conn, len(conns))
-	copy(targets, conns)
-	h.mu.RUnlock()
-
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-
-	for _, conn := range targets {
-		select {
-		case conn.Send <- data:
-		case <-deadline.C:
-			return fmt.Errorf("phone %s hw %s: %w", number, conn.HardwareID, ErrSendTimeout)
+	deadline := time.Now().Add(timeout)
+	delivered := make(map[*Conn]bool)
+	for {
+		h.mu.RLock()
+		conns := h.conns[number]
+		bridge := h.redis
+		dropHook := h.dropHook
+		if len(conns) == 0 {
+			h.mu.RUnlock()
+			// No local conn: fall back to cross-pod delivery via Redis,
+			// best-effort, exactly as SendTo does.
+			if bridge != nil {
+				bridge.Publish(context.Background(), &Envelope{
+					TargetType: "number",
+					Target:     number,
+					Message:    msg,
+				})
+				return nil
+			}
+			return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
 		}
+		pending := false
+		for _, conn := range conns {
+			if delivered[conn] {
+				continue
+			}
+			select {
+			case conn.Send <- data:
+				delivered[conn] = true
+			default:
+				pending = true
+			}
+		}
+		h.mu.RUnlock()
+
+		if !pending {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			slog.Warn("SendToWithTimeout: send buffer full past deadline", "number", number)
+			if dropHook != nil {
+				dropHook()
+			}
+			return fmt.Errorf("phone %s: %w", number, ErrSendTimeout)
+		}
+		time.Sleep(sendRetryInterval)
 	}
-	return nil
 }
 
 func (h *Hub) SendToHardware(hardwareID string, msg *Message) error {

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -88,6 +88,10 @@ type Hub struct {
 	state            *DeviceState // nil = single-instance mode (no cluster state)
 	draining         bool         // set by StartDraining; blocks new Register calls
 	reconnectHook    func(number, hardwareID string)
+	// dropHook is called each time a best-effort SendTo skips a device whose
+	// send buffer is full. Optional; nil disables. Wired in cmd/signald/main.go
+	// to the metrics registry to count dropped signaling sends.
+	dropHook func()
 }
 
 // NewHub creates a Hub ready for use. Call SetRedis and SetDeviceState before
@@ -117,6 +121,17 @@ func (h *Hub) SetRedis(bridge redisPubSub) {
 func (h *Hub) SetReconnectHook(fn func(number, hardwareID string)) {
 	h.mu.Lock()
 	h.reconnectHook = fn
+	h.mu.Unlock()
+}
+
+// SetDropHook registers a zero-argument callback that is called each time
+// SendTo skips a device because its send buffer is full. Used by
+// cmd/signald/main.go to wire in the metrics counter for dropped sends;
+// nil disables instrumentation. Must be called before the hub starts
+// handling messages.
+func (h *Hub) SetDropHook(fn func()) {
+	h.mu.Lock()
+	h.dropHook = fn
 	h.mu.Unlock()
 }
 
@@ -495,6 +510,10 @@ func (h *Hub) ConnectionCount(number string) int {
 	return len(h.conns[number])
 }
 
+// ErrSendTimeout is returned by SendToWithTimeout when the target's send
+// buffer does not drain within the deadline.
+var ErrSendTimeout = errors.New("send timed out: buffer full")
+
 // SendTo marshals msg and sends it to every device on the given line number.
 // This is the POTS extension model: a ring reaches all phones on the line.
 // Returns ErrNotConnected only when no devices are connected locally AND
@@ -520,15 +539,56 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 		}
 		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
 	}
+	dropHook := h.dropHook
 	for _, conn := range conns {
 		select {
 		case conn.Send <- data:
 		default:
 			slog.Warn("SendTo: send buffer full, skipping device",
 				"number", number, "hardware_id", conn.HardwareID)
+			if dropHook != nil {
+				dropHook()
+			}
 		}
 	}
 	h.mu.RUnlock()
+	return nil
+}
+
+// SendToWithTimeout attempts to deliver msg to every local device on number,
+// waiting up to timeout for each device's send buffer to have room. Unlike
+// SendTo it does NOT fall back to Redis on success (local-only delivery);
+// callers that need cross-pod delivery for the non-full case should use
+// SendTo. Returns ErrSendTimeout if any device's buffer stays full for the
+// entire timeout. Returns ErrNotConnected if no local device is present
+// (Redis paths are out of scope for timeout delivery).
+func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Duration) error {
+	data, err := msg.Marshal()
+	if err != nil {
+		return err
+	}
+
+	h.mu.RLock()
+	conns := h.conns[number]
+	if len(conns) == 0 {
+		h.mu.RUnlock()
+		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
+	}
+	// Snapshot so we release the lock before blocking.
+	targets := make([]*Conn, len(conns))
+	copy(targets, conns)
+	h.mu.RUnlock()
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for _, conn := range targets {
+		select {
+		case conn.Send <- data:
+		case <-deadline.C:
+			return fmt.Errorf("phone %s hw %s: %w", number, conn.HardwareID, ErrSendTimeout)
+		}
+	}
 	return nil
 }
 

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -390,12 +390,70 @@ func TestSendToWithTimeoutReturnsErrorWhenBufferFullAndNotDrained(t *testing.T) 
 }
 
 // TestSendToWithTimeoutReturnsNotConnectedWhenNoDevice verifies the offline
-// case.
+// case with no Redis bridge.
 func TestSendToWithTimeoutReturnsNotConnectedWhenNoDevice(t *testing.T) {
 	hub := NewHub()
 	err := hub.SendToWithTimeout("3140099", &Message{Type: TypeRing}, time.Second)
 	if !errors.Is(err, ErrNotConnected) {
 		t.Errorf("expected ErrNotConnected for offline number, got: %v", err)
+	}
+}
+
+// TestSendToWithTimeoutFallsBackToRedis verifies that with no local
+// connection but a Redis bridge configured, SendToWithTimeout publishes a
+// cross-pod envelope and returns nil instead of dropping the message. This
+// guards the regression where reliable ICE-restart delivery to a peer on
+// another pod was silently dropped.
+func TestSendToWithTimeoutFallsBackToRedis(t *testing.T) {
+	hub := NewHub()
+	fake := newFakeRedis()
+	hub.SetRedis(fake)
+
+	err := hub.SendToWithTimeout("3140002", &Message{Type: TypeICERestart, From: "3140001", To: "3140002"}, time.Second)
+	if err != nil {
+		t.Fatalf("SendToWithTimeout returned error, want nil with Redis fallback: %v", err)
+	}
+	envs := fake.publishedEnvelopes()
+	if len(envs) != 1 {
+		t.Fatalf("published %d envelopes, want 1", len(envs))
+	}
+	if envs[0].TargetType != "number" || envs[0].Target != "3140002" {
+		t.Fatalf("unexpected envelope: %+v", envs[0])
+	}
+	if envs[0].Message == nil || envs[0].Message.Type != TypeICERestart {
+		t.Fatalf("envelope message = %+v, want ICERestart", envs[0].Message)
+	}
+}
+
+// TestSendToWithTimeoutNoPanicOnConcurrentUnregister verifies the panic-safety
+// fix: closing a conn's Send channel (via Unregister) while a
+// SendToWithTimeout is retrying against a full buffer must not send on a
+// closed channel. The call should return cleanly once the conn is gone.
+func TestSendToWithTimeoutNoPanicOnConcurrentUnregister(t *testing.T) {
+	hub := NewHub()
+	// Buffered capacity 1, pre-filled so the next send blocks (buffer full).
+	conn := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-1"}
+	conn.Send <- []byte("prefill")
+	_ = hub.Register("3140001", conn)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- hub.SendToWithTimeout("3140001", &Message{Type: TypeICERestart}, 2*time.Second)
+	}()
+
+	// Let the sender spin on the full buffer, then unregister (closes Send).
+	time.Sleep(40 * time.Millisecond)
+	hub.Unregister("3140001", conn)
+
+	select {
+	case err := <-done:
+		// After Unregister the line has no conns, no Redis bridge: expect
+		// ErrNotConnected, and crucially no panic.
+		if !errors.Is(err, ErrNotConnected) {
+			t.Fatalf("expected ErrNotConnected after unregister, got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendToWithTimeout did not return after conn was unregistered")
 	}
 }
 

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -3,7 +3,9 @@ package signaling
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestUnregisterOnlyRemovesMatchingConnection(t *testing.T) {
@@ -335,5 +337,99 @@ func TestRekeyNumberMovesVoicemailUnheard(t *testing.T) {
 	}
 	if got := hub.LineVoicemailUnheard("3140002"); got != 7 {
 		t.Errorf("new number should have summed counts, got %d, want 7", got)
+	}
+}
+
+// TestSendToWithTimeoutDeliversWhenBufferHasRoom verifies that
+// SendToWithTimeout successfully enqueues a message when the channel has
+// capacity.
+func TestSendToWithTimeoutDeliversWhenBufferHasRoom(t *testing.T) {
+	hub := NewHub()
+	conn := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", conn)
+
+	err := hub.SendToWithTimeout("3140001", &Message{Type: TypeRing, From: "3140002"}, time.Second)
+	if err != nil {
+		t.Fatalf("SendToWithTimeout returned unexpected error: %v", err)
+	}
+	select {
+	case data := <-conn.Send:
+		msg, _ := ParseMessage(data)
+		if msg.Type != TypeRing {
+			t.Errorf("got type %q, want ring", msg.Type)
+		}
+	default:
+		t.Fatal("no message in send channel after SendToWithTimeout")
+	}
+}
+
+// TestSendToWithTimeoutReturnsErrorWhenBufferFullAndNotDrained verifies that
+// SendToWithTimeout returns ErrSendTimeout promptly when the buffer is full
+// and no reader drains it, rather than blocking forever.
+func TestSendToWithTimeoutReturnsErrorWhenBufferFullAndNotDrained(t *testing.T) {
+	hub := NewHub()
+	// Unbuffered channel: any send blocks immediately.
+	conn := &Conn{Send: make(chan []byte)}
+	_ = hub.Register("3140001", conn)
+
+	timeout := 50 * time.Millisecond
+	start := time.Now()
+	err := hub.SendToWithTimeout("3140001", &Message{Type: TypeRing}, timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from SendToWithTimeout on full buffer, got nil")
+	}
+	if !errors.Is(err, ErrSendTimeout) {
+		t.Errorf("expected ErrSendTimeout, got: %v", err)
+	}
+	// Must return within roughly 2x the timeout, not hang.
+	if elapsed > 5*timeout {
+		t.Errorf("SendToWithTimeout took %v, expected ~%v", elapsed, timeout)
+	}
+}
+
+// TestSendToWithTimeoutReturnsNotConnectedWhenNoDevice verifies the offline
+// case.
+func TestSendToWithTimeoutReturnsNotConnectedWhenNoDevice(t *testing.T) {
+	hub := NewHub()
+	err := hub.SendToWithTimeout("3140099", &Message{Type: TypeRing}, time.Second)
+	if !errors.Is(err, ErrNotConnected) {
+		t.Errorf("expected ErrNotConnected for offline number, got: %v", err)
+	}
+}
+
+// TestSendToInvokesDropHookOnFullBuffer verifies that the best-effort SendTo
+// path calls the drop hook when a device's send buffer is full.
+func TestSendToInvokesDropHookOnFullBuffer(t *testing.T) {
+	hub := NewHub()
+	var drops int
+	hub.SetDropHook(func() { drops++ })
+
+	// Unbuffered channel: send immediately triggers the default branch.
+	conn := &Conn{Send: make(chan []byte)}
+	_ = hub.Register("3140001", conn)
+
+	_ = hub.SendTo("3140001", &Message{Type: TypeRing})
+
+	if drops != 1 {
+		t.Errorf("drop hook called %d times, want 1", drops)
+	}
+}
+
+// TestSendToDoesNotInvokeDropHookOnSuccessfulSend verifies the hook is NOT
+// called when the message is delivered.
+func TestSendToDoesNotInvokeDropHookOnSuccessfulSend(t *testing.T) {
+	hub := NewHub()
+	var drops int
+	hub.SetDropHook(func() { drops++ })
+
+	conn := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", conn)
+
+	_ = hub.SendTo("3140001", &Message{Type: TypeRing})
+
+	if drops != 0 {
+		t.Errorf("drop hook called %d times on successful send, want 0", drops)
 	}
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -364,11 +364,11 @@ func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
 }
 
 // iceRestartDeliveryTimeout is how long handleICERestart waits for the
-// peer's send buffer to accept the offer before giving up. This is a
-// deliberate local-pod blocking send: losing the ICE-restart offer during
-// recovery stalls reconnection into a hangup, so a short wait is preferable
-// to the silent drop that SendTo's best-effort path would apply. Cross-pod
-// (Redis) forwarding continues to use best-effort delivery.
+// peer's send buffer to accept the offer before giving up. Losing the
+// ICE-restart offer during recovery stalls reconnection into a hangup, so a
+// short bounded retry is preferable to the silent drop that SendTo's
+// best-effort path would apply. When the peer has no local connection the
+// send falls back to Redis for cross-pod delivery, like SendTo.
 const iceRestartDeliveryTimeout = 2 * time.Second
 
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
@@ -383,9 +383,9 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 		r.observeError("invalid_message")
 		return
 	}
-	// Use a blocking send with a short deadline so the offer is not silently
-	// dropped when the peer's send buffer is temporarily full during recovery.
-	// Redis forwarding stays best-effort: SendToWithTimeout is local-only.
+	// Bounded retry so the offer is not silently dropped when the peer's send
+	// buffer is temporarily full during recovery. SendToWithTimeout falls back
+	// to Redis when the peer has no local connection (cross-pod delivery).
 	if err := r.Hub.SendToWithTimeout(msg.To, msg, iceRestartDeliveryTimeout); err != nil {
 		slog.ErrorContext(ctx, "ice_restart delivery failed", "to", msg.To, "err", err)
 		r.observeError("relay_delivery")

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -354,6 +354,14 @@ func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
 	r.forward(ctx, msg)
 }
 
+// iceRestartDeliveryTimeout is how long handleICERestart waits for the
+// peer's send buffer to accept the offer before giving up. This is a
+// deliberate local-pod blocking send: losing the ICE-restart offer during
+// recovery stalls reconnection into a hangup, so a short wait is preferable
+// to the silent drop that SendTo's best-effort path would apply. Cross-pod
+// (Redis) forwarding continues to use best-effort delivery.
+const iceRestartDeliveryTimeout = 2 * time.Second
+
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
 	if !r.inCallOrConference(ctx, from, msg.To) {
 		slog.WarnContext(ctx, "ice_restart without active call", "from", from, "to", msg.To)
@@ -361,7 +369,18 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
 		return
 	}
-	r.forward(ctx, msg)
+	if msg.To == "" {
+		slog.WarnContext(ctx, "no destination for ice_restart", "from", from)
+		r.observeError("invalid_message")
+		return
+	}
+	// Use a blocking send with a short deadline so the offer is not silently
+	// dropped when the peer's send buffer is temporarily full during recovery.
+	// Redis forwarding stays best-effort: SendToWithTimeout is local-only.
+	if err := r.Hub.SendToWithTimeout(msg.To, msg, iceRestartDeliveryTimeout); err != nil {
+		slog.ErrorContext(ctx, "ice_restart delivery failed", "to", msg.To, "err", err)
+		r.observeError("relay_delivery")
+	}
 }
 
 func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -279,6 +279,15 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 
 func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 	if !r.Hub.IsOnline(msg.To) {
+		// During the grace window a line's WebSocket is offline but its call
+		// is still tracked (Busy == true). Return busy instead of
+		// "phone not connected" so the caller gets the correct signal.
+		// Dashboard/presence remains transport-truth; this only corrects
+		// new-call routing to a grace-held line.
+		if r.Tracker != nil && r.Tracker.Busy(ctx, msg.To) {
+			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
+			return
+		}
 		r.observeError("peer_unreachable")
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "phone not connected"})
 		return

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1383,3 +1383,66 @@ func TestRelayVoicemailStateZeroExplicitlyOverwrites(t *testing.T) {
 		t.Errorf("explicit zero should overwrite, got %d", got)
 	}
 }
+
+// TestHandleCallGraceHeldLineReturnsBusy verifies Fix I1: when the callee is
+// offline (grace window holding the call) but still Busy, a new caller
+// receives TypeBusy instead of TypeError "phone not connected".
+func TestHandleCallGraceHeldLineReturnsBusy(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	// 3140002 is in a call with 3140003 but its WebSocket is offline (grace window).
+	tracker.onCallInitiated("3140002", "3140003")
+
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	caller := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", caller)
+	// 3140002 is intentionally NOT registered so IsOnline returns false.
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+
+	select {
+	case data := <-caller.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeBusy {
+			t.Fatalf("expected TypeBusy for grace-held line, got type=%q error=%q", msg.Type, msg.Error)
+		}
+	default:
+		t.Fatal("caller did not receive any message")
+	}
+}
+
+// TestHandleCallOfflineAndIdleReturnsNotConnected verifies that the busy-first
+// check does not regress the existing "offline and not in a call" path: the
+// caller should still receive TypeError "phone not connected".
+func TestHandleCallOfflineAndIdleReturnsNotConnected(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	// 3140002 is offline and not in any call.
+
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	caller := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", caller)
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+
+	select {
+	case data := <-caller.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeError {
+			t.Fatalf("expected TypeError for offline idle line, got type=%q", msg.Type)
+		}
+		if msg.Error != "phone not connected" {
+			t.Fatalf("expected 'phone not connected', got %q", msg.Error)
+		}
+	default:
+		t.Fatal("caller did not receive any message")
+	}
+}


### PR DESCRIPTION
Addresses two findings from a holistic review of the merged connection-resilience work.

## Changes

- **ICE-restart offers no longer silently dropped, and stay cross-pod (I2).** The relay forwards a `TypeICERestart` offer via a new `Hub.SendToWithTimeout`: it retries the non-blocking send (under the read lock, re-fetching connections each pass so it is panic-safe against a concurrent `Unregister`) up to a 2s deadline instead of dropping on a momentarily-full send buffer, and falls back to Redis publish when the peer has no local connection so delivery still works across the 3 prod replicas. A `send_buffer_full` metric now counts best-effort `SendTo` drops for visibility.
- **A grace-held line returns busy, not "not connected" (I1).** During the server-side reconnect grace window a held line's presence is offline but the call is still tracked. `handleCall` now checks `Busy` before the not-connected path, so a third party calling the held line gets `TypeBusy` rather than "phone not connected". Dashboard presence remains transport-truth (this only corrects new-call routing).

## Test plan

- [x] `make test`, `go test -race ./internal/signaling/` (panic-free), `golangci-lint run ./...`, `make build` all pass.
- [x] `SendToWithTimeout` tests: delivers when room; bounded timeout when full; no panic on concurrent `Unregister` (under `-race`); cross-pod Redis fallback publishes when no local conn; drop hook fires on the best-effort path.
- [x] `handleCall`: offline+busy -> `TypeBusy` (no `OnCallInitiated`); offline+idle -> "phone not connected".