### PR TITLE
refactor(digitsd): use cancelRestartTimerLocked in TypeICERestart handler

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2345,9 +2345,7 @@ func main() {
 				}
 				cb.mu.Lock()
 				cb.isRestartingICE = true
-				if cb.restartTimer != nil {
-					cb.restartTimer.Stop()
-				}
+				cb.cancelRestartTimerLocked()
 				cb.startRestartTimeout()
 				cb.mu.Unlock()
 				if peer == "" {


### PR DESCRIPTION
## Cross-PR finding

Holistic review of the mid-call recovery cluster merged today (#677, #678, #680, #682, #683) caught a phase-sequencing gap from #677.

#677 introduced `cancelRestartTimerLocked` (symmetric with `cancelDisconnectDebounceLocked`) and replaced every open-coded `restartTimer.Stop()` + `= nil` block in `pi/digitsd/cmd/digitsd/webrtc.go` with the helper. The callee-side `TypeICERestart` handler in `pi/digitsd/cmd/digitsd/main.go` was the lone holdout: it still stops the timer inline and skips the nil-out (benign only because `startRestartTimeout` immediately replaces it on the next line).

## Change

Single 4-line swap in the `TypeICERestart` handler so all `restartTimer` cleanup flows through the same helper.

## Test

- `go build ./...`: clean.
- `go test ./...`: all packages pass, including `cmd/digitsd` and `internal/webrtc`.
- Behavior preserved: `cancelRestartTimerLocked` is `Stop()` + `= nil`; `startRestartTimeout` then reassigns the field. Net effect identical to the prior code, with no nil-window since we hold `d.mu` across both calls.