### PR TITLE
docs: refresh ICE-restart status to reflect debounce, 25s recovery, and grace window

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -135,8 +135,9 @@ Bandwidth per active TURN-relayed call: ~40kbps per direction. Negligible at sma
 - Bidirectional Opus/WebRTC audio across NAT (STUN/TURN)
 - End-to-end encrypted calls (DTLS-SRTP)
 - ICE server credential fetch from signald with periodic refresh
-- ICE restart on transient connection drops (caller-initiated, single attempt with 15s timeout)
-- Connection failure detection (hangup after failed ICE restart)
+- Mid-call media recovery on transient connection drops: 4s `Disconnected` debounce, then caller-initiated ICE restart with a 25s recovery deadline; recovery is also driven on either side from a signaling-WebSocket reconnect when local media has dropped
+- Signaling-reconnect grace window: the server holds a 2-party call open for 20s after the WebSocket drops so a phone can resume the call instead of losing it; new callers reaching a grace-held line get busy
+- Connection failure detection (hangup after recovery deadline)
 - Mechanical bell, dial tone, ringback, and busy tone
 - Household linking via invite codes
 - Device pairing via one-time codes


### PR DESCRIPTION
## Cross-PR finding

`docs/architecture/overview.md` line 138 described mid-call recovery as

> ICE restart on transient connection drops (caller-initiated, single attempt with 15s timeout)

That is the pre-#677 model. The mid-call recovery cluster merged today (#677, #678, #680, #682, #683) changed every part of that sentence:

- **#677 / #682:** A 4s `Disconnected` debounce now precedes recovery so pion's own STUN consent / connectivity checks can self-heal transient blips. The recovery deadline rose from 15s to 25s to exceed the new server-side grace window with margin. Recovery can also be entered when the signaling WebSocket reconnects and local media has dropped (`tryResumeAfterReconnect` -> `enterICERecovery`), so it is no longer caller-initiated only.
- **#678 / #680:** When a phone's signaling WebSocket drops mid-call, the server now holds the 2-party call open for a 20s grace window before tearing down. If the phone re-registers within that window, the call resumes; otherwise it is ended via the same path as a hangup so call-return and persistence fire (#680).
- **#683:** A new caller dialing a grace-held line now gets `TypeBusy` instead of `phone not connected`.

## Change

Three updated bullets under "Current Status > Working" so the doc matches what shipped:

- Mid-call media recovery with debounce and recovery deadline, driven from either pion state changes or signaling reconnect.
- Server-side grace window plus busy semantics for grace-held lines.
- Hangup wording switched from "after failed ICE restart" to "after recovery deadline" since debounce + reconnect-driven entry now sit in front of the restart itself.

Docs-only; no code changes.