### PR TITLE
fix(digitsd): flash Pico in setup mode when it does not answer

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -592,30 +592,42 @@ func readBundledFirmwareVersion() string {
 	return strings.TrimSpace(string(data))
 }
 
-// reflashPico delegates to flash-pico.sh (RESCUE retry, FLASHSIZE override,
-// PCB-rev marker write at 0x101FF000) and re-establishes the serial port.
-// Aborts on serial-reopen failure: nothing else digitsd does works without
-// UART. Returns the reopened port and whether the post-flash PING passed.
-func reflashPico(sp *phone.SerialPort, serialDev string, serialLogger *slog.Logger, reason string) (*phone.SerialPort, bool) {
+// runPicoFlashScript invokes flash-pico.sh (RESCUE retry, FLASHSIZE override,
+// PCB-rev marker write at 0x101FF000) against the bundled firmware.
+// SKIP_SERVICE_CONTROL=1 stops the script from systemctl-stopping us (we ARE
+// digitsd) and from doing its own post-flash PING; callers own the serial port
+// and re-PING themselves. Returns an error if there is no firmware to flash or
+// the script fails, so callers can decide whether to retry the serial link.
+func runPicoFlashScript(reason string) error {
 	if _, err := os.Stat(defaultFirmwarePath); err != nil {
-		slog.Info("reflash: no firmware at path, skipping", "path", defaultFirmwarePath, "reason", reason)
-		return sp, false
+		return fmt.Errorf("no firmware at %s: %w", defaultFirmwarePath, err)
 	}
 	slog.Info("reflash: starting", "path", defaultFirmwarePath, "reason", reason)
-	if err := sp.Close(); err != nil {
-		slog.Warn("reflash: close serial failed", "error", err)
-	}
-	// SKIP_SERVICE_CONTROL=1 stops the script from systemctl-stopping us
-	// (we ARE digitsd) and from doing its own post-flash PING (we hold
-	// the serial port; we'll PING ourselves below).
 	cmd := exec.Command("setsid", "bash", defaultFlashScript, defaultFirmwarePath)
 	cmd.Env = append(os.Environ(), "SKIP_SERVICE_CONTROL=1")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		slog.Error("reflash: flash script failed", "error", err, "reason", reason)
-	} else {
-		slog.Info("reflash: flash script succeeded", "reason", reason)
+		return fmt.Errorf("flash script failed: %w", err)
+	}
+	slog.Info("reflash: flash script succeeded", "reason", reason)
+	return nil
+}
+
+// reflashPico delegates to runPicoFlashScript and re-establishes the serial
+// port. Aborts on serial-reopen failure: nothing else digitsd does works
+// without UART. Returns the reopened port and whether the post-flash PING
+// passed.
+func reflashPico(sp *phone.SerialPort, serialDev string, serialLogger *slog.Logger, reason string) (*phone.SerialPort, bool) {
+	if _, err := os.Stat(defaultFirmwarePath); err != nil {
+		slog.Info("reflash: no firmware at path, skipping", "path", defaultFirmwarePath, "reason", reason)
+		return sp, false
+	}
+	if err := sp.Close(); err != nil {
+		slog.Warn("reflash: close serial failed", "error", err)
+	}
+	if err := runPicoFlashScript(reason); err != nil {
+		slog.Error("reflash: flash failed", "error", err, "reason", reason)
 	}
 	time.Sleep(2 * time.Second)
 	newSp, err := phone.OpenSerial(serialDev, 115200, serialLogger)
@@ -889,7 +901,15 @@ func recoveryRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *s
 func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subsystem.SerialModule, *subsystem.AudioModule) {
 	web := subsystem.NewWebModule()
 	gpclk0 := subsystem.NewGPCLK0Module()
-	serial := subsystem.NewSerialModule(subsystem.SerialConfig{Device: *serialDev, Baud: 115200})
+	// A fresh device boots straight into setup/AP mode and never runs the
+	// normal-mode reflash path, so a board whose RP2040 was never programmed
+	// has a dead UART: no hook events, no setup voice prompts. Flash the Pico
+	// on the way up if it doesn't answer.
+	serial := subsystem.NewSerialModule(subsystem.SerialConfig{
+		Device:      *serialDev,
+		Baud:        115200,
+		FlashOnFail: runPicoFlashScript,
+	})
 	audio := subsystem.NewAudioModule(subsystem.AudioConfig{
 		ToneDir:         *toneDir,
 		GPCLK0Retrigger: gpclk0.Retrigger,

--- a/pi/digitsd/internal/subsystem/serial.go
+++ b/pi/digitsd/internal/subsystem/serial.go
@@ -12,6 +12,12 @@ import (
 type SerialConfig struct {
 	Device string
 	Baud   int
+	// FlashOnFail, when set, is called once if the Pico cannot be reached on
+	// the initial probe. It flashes the bundled firmware so a board whose
+	// RP2040 was never programmed (e.g. a fresh device that boots straight
+	// into setup/AP mode, which never runs the normal-mode reflash path) can
+	// still bring up the serial link. nil disables the fallback.
+	FlashOnFail func(reason string) error
 }
 
 type SerialModule struct {
@@ -28,29 +34,74 @@ func (s *SerialModule) Name() string { return "serial" }
 
 func (s *SerialModule) Init(ctx context.Context) error {
 	s.status.State = StateInitializing
-	logger := slog.Default()
 
-	for attempt := 1; attempt <= 10; attempt++ {
-		sp, err := phone.OpenSerial(s.cfg.Device, s.cfg.Baud, logger)
+	// probe opens the port and PINGs the Pico, stashing the port on success.
+	probe := func() bool {
+		sp, err := phone.OpenSerial(s.cfg.Device, s.cfg.Baud, slog.Default())
 		if err != nil {
-			slog.Warn("subsystem serial: open failed", "attempt", attempt, "error", err)
-			time.Sleep(500 * time.Millisecond)
-			continue
+			slog.Warn("subsystem serial: open failed", "error", err)
+			return false
 		}
 		if err = sp.Ping(); err != nil {
-			slog.Warn("subsystem serial: ping failed", "attempt", attempt, "error", err)
+			slog.Warn("subsystem serial: ping failed", "error", err)
 			_ = sp.Close()
-			time.Sleep(500 * time.Millisecond)
-			continue
+			return false
 		}
 		s.port = sp
+		return true
+	}
+
+	// Without a flash fallback (recovery mode) keep the original 10-attempt
+	// budget. With one (setup mode) probe only briefly before flashing: a
+	// healthy Pico answers on the first attempt, so a long probe just delays
+	// the flash a virgin board actually needs.
+	firstAttempts := 10
+	if s.cfg.FlashOnFail != nil {
+		firstAttempts = 3
+	}
+
+	if attemptSerialBringup(probe, s.cfg.FlashOnFail, firstAttempts, 10, func() {
+		time.Sleep(500 * time.Millisecond)
+	}) {
 		s.status.State = StateReady
 		return nil
 	}
 
-	err := fmt.Errorf("failed to open and ping after 10 attempts")
+	err := fmt.Errorf("failed to open and ping after retries")
 	s.status = ModuleStatus{State: StateFailed, Message: err.Error()}
 	return err
+}
+
+// attemptSerialBringup probes for a reachable Pico, flashing the firmware once
+// as a fallback if the initial probe fails and flash is non-nil. It returns
+// true as soon as a probe succeeds. The probe/flash/sleep funcs are injected so
+// the orchestration can be unit-tested without real hardware.
+func attemptSerialBringup(probe func() bool, flash func(reason string) error, firstAttempts, afterFlashAttempts int, sleep func()) bool {
+	for i := 0; i < firstAttempts; i++ {
+		if probe() {
+			return true
+		}
+		sleep()
+	}
+
+	if flash == nil {
+		return false
+	}
+
+	slog.Warn("subsystem serial: Pico unreachable, flashing firmware")
+	if err := flash("serial-init"); err != nil {
+		slog.Error("subsystem serial: flash attempt failed", "error", err)
+		return false
+	}
+
+	for i := 0; i < afterFlashAttempts; i++ {
+		if probe() {
+			slog.Info("subsystem serial: Pico reachable after flash")
+			return true
+		}
+		sleep()
+	}
+	return false
 }
 
 func (s *SerialModule) Port() *phone.SerialPort { return s.port }

--- a/pi/digitsd/internal/subsystem/serial.go
+++ b/pi/digitsd/internal/subsystem/serial.go
@@ -81,7 +81,9 @@ func attemptSerialBringup(probe func() bool, flash func(reason string) error, fi
 		if probe() {
 			return true
 		}
-		sleep()
+		if i < firstAttempts-1 {
+			sleep()
+		}
 	}
 
 	if flash == nil {
@@ -99,7 +101,9 @@ func attemptSerialBringup(probe func() bool, flash func(reason string) error, fi
 			slog.Info("subsystem serial: Pico reachable after flash")
 			return true
 		}
-		sleep()
+		if i < afterFlashAttempts-1 {
+			sleep()
+		}
 	}
 	return false
 }

--- a/pi/digitsd/internal/subsystem/serial_test.go
+++ b/pi/digitsd/internal/subsystem/serial_test.go
@@ -1,0 +1,113 @@
+package subsystem
+
+import (
+	"errors"
+	"testing"
+)
+
+// probeAfter returns a probe func that fails the first n calls then succeeds,
+// recording the total number of calls.
+func probeAfter(n int, calls *int) func() bool {
+	return func() bool {
+		*calls++
+		return *calls > n
+	}
+}
+
+func TestAttemptSerialBringup_SucceedsWithoutFlash(t *testing.T) {
+	calls := 0
+	flashed := 0
+	flash := func(string) error { flashed++; return nil }
+
+	ok := attemptSerialBringup(probeAfter(0, &calls), flash, 3, 10, func() {})
+
+	if !ok {
+		t.Fatal("expected bringup to succeed on first probe")
+	}
+	if flashed != 0 {
+		t.Fatalf("flash should not run when probe succeeds, got %d calls", flashed)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 probe, got %d", calls)
+	}
+}
+
+func TestAttemptSerialBringup_FlashesThenSucceeds(t *testing.T) {
+	calls := 0
+	flashed := 0
+	// Fail every probe until after the flash runs, then succeed.
+	probe := func() bool {
+		calls++
+		return flashed > 0
+	}
+	flash := func(reason string) error {
+		if reason != "serial-init" {
+			t.Errorf("unexpected flash reason %q", reason)
+		}
+		flashed++
+		return nil
+	}
+
+	ok := attemptSerialBringup(probe, flash, 3, 10, func() {})
+
+	if !ok {
+		t.Fatal("expected bringup to succeed after flash")
+	}
+	if flashed != 1 {
+		t.Fatalf("expected exactly 1 flash, got %d", flashed)
+	}
+	// 3 failed pre-flash probes + at least one successful post-flash probe.
+	if calls < 4 {
+		t.Fatalf("expected probes before and after flash, got %d", calls)
+	}
+}
+
+func TestAttemptSerialBringup_NoFlashConfigured(t *testing.T) {
+	calls := 0
+	ok := attemptSerialBringup(probeAfter(100, &calls), nil, 10, 10, func() {})
+
+	if ok {
+		t.Fatal("expected bringup to fail when probe never succeeds and no flash")
+	}
+	if calls != 10 {
+		t.Fatalf("expected 10 probes (no post-flash retries), got %d", calls)
+	}
+}
+
+func TestAttemptSerialBringup_FlashErrorAborts(t *testing.T) {
+	calls := 0
+	flashed := 0
+	flash := func(string) error { flashed++; return errors.New("no firmware") }
+
+	ok := attemptSerialBringup(probeAfter(100, &calls), flash, 3, 10, func() {})
+
+	if ok {
+		t.Fatal("expected bringup to fail when flash errors")
+	}
+	if flashed != 1 {
+		t.Fatalf("expected 1 flash attempt, got %d", flashed)
+	}
+	// Only the 3 pre-flash probes; no post-flash retries after a flash error.
+	if calls != 3 {
+		t.Fatalf("expected 3 probes (no post-flash retries), got %d", calls)
+	}
+}
+
+func TestAttemptSerialBringup_FlashSucceedsButStillUnreachable(t *testing.T) {
+	calls := 0
+	flashed := 0
+	flash := func(string) error { flashed++; return nil }
+
+	ok := attemptSerialBringup(probeAfter(100, &calls), flash, 3, 10, func() {})
+
+	if ok {
+		t.Fatal("expected bringup to fail when Pico stays unreachable after flash")
+	}
+	if flashed != 1 {
+		t.Fatalf("expected 1 flash attempt, got %d", flashed)
+	}
+	// 3 pre-flash + 10 post-flash probes.
+	if calls != 13 {
+		t.Fatalf("expected 13 probes, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Problem

A fresh device whose RP2040 has never been programmed is silent on first power-up: no setup voice prompts when you lift the hook in WiFi AP/setup mode.

## Root cause

The Pico is auto-flashed **only** by the normal-mode daemon (the POST-FAIL / version-mismatch reflash in `reflashPico`). But a fresh device has no `/data/wifi-configured`, so it boots straight into `--mode=setup` (AP mode), which never runs that path. The result is a chicken-and-egg gap:

- Setup mode opens the UART and PINGs the Pico, gets no response (virgin chip), and the serial subsystem just gives up (`StateFailed`).
- The setup voice loop is gated on `HOOK:OFF` events, which arrive over UART from the Pico. No firmware on the Pico means no hook events, ever.
- So lifting the hook does nothing and the phone stays silent until the user configures WiFi and reboots into normal mode, which finally flashes the Pico.

Reproduced on a V3 board by wiping the RP2040 flash (`openocd ... flash erase_address 0x10000000 0x200000`): `--mode=setup` comes up (web/gpclk0/audio ready) but the serial subsystem PINGs and fails in a loop, with no flash attempt anywhere.

## Fix

Make setup mode flash the Pico when it does not answer, mirroring normal mode:

- `SerialConfig` gains an optional `FlashOnFail func(reason string) error`. When the initial probe fails and a callback is wired, the serial subsystem flashes the firmware once and re-probes before declaring failure. `nil` preserves the old probe-only behavior (recovery mode keeps it).
- Setup mode wires `FlashOnFail` to `runPicoFlashScript`, a shared `flash-pico.sh` runner extracted out of `reflashPico` (same RESCUE retry / FLASHSIZE override / PCB-rev marker, same `SKIP_SERVICE_CONTROL=1` semantics). `flash-pico.sh` already has the RESCUE pre-pass for exactly this virgin-chip case.
- With a flash fallback wired, the pre-flash probe is shortened (a healthy Pico answers on the first attempt, so a long probe just delays the flash a fresh board actually needs); without one the original 10-attempt budget is kept.

The probe/flash/retry orchestration is factored into a pure `attemptSerialBringup` helper so it can be unit-tested without real hardware.

## Testing

- `go test ./...` and `golangci-lint run ./...` clean in `pi/digitsd`.
- New unit tests cover the orchestration: success without flash, flash-then-success, no-flash-configured, flash-error abort, and flash-succeeds-but-still-unreachable.
- Hardware verification on a V3 board with a wiped RP2040 is in progress; results to follow on this PR.