### PR TITLE
fix(digitsd): let service codes interrupt the pairing announcement when unpaired

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1984,6 +1984,16 @@ func main() {
 				slog.Info("phone: playing pairing code via voice", "code", code)
 				go func() {
 					for {
+						// Check cancellation at the top too: without this a
+						// cancel landing just after the interval wait would
+						// still queue one more full announcement before the
+						// next ctx.Done() check, so a service code that stops
+						// the announcement could be talked over.
+						select {
+						case <-ctx.Done():
+							return
+						default:
+						}
 						if cb.paired.Load() || code == "" {
 							return
 						}
@@ -2009,6 +2019,19 @@ func main() {
 			// via SendTone(ToneStop); we only queue the DTMF beep here.
 			if strings.HasPrefix(event, "KEY:") && len(event) > 4 {
 				key := string(event[4])
+				// An unpaired phone loops the pairing announcement on off-hook
+				// and skips the dialing FSM, which otherwise drowns out service
+				// codes and their confirmation prompts. The '*' that begins
+				// every service code (e.g. *#73887# to clear Wi-Fi, *#00000#
+				// to factory reset) doubles as the cue to stop the announcement
+				// so the keypad flow is usable while unpaired. Re-lifting the
+				// handset restarts the announcement via the HOOK:OFF branch.
+				if key == "*" && !cb.paired.Load() && pairingAnnouncementCancel != nil {
+					slog.Info("service code: '*' pressed while unpaired, stopping pairing announcement")
+					pairingAnnouncementCancel()
+					pairingAnnouncementCancel = nil
+					mixer.StopAll()
+				}
 				dtmfName := dtmfToneName(key)
 				if dtmfName != "" {
 					mixer.PlayOnce(dtmfName)


### PR DESCRIPTION
## Problem

On an unpaired phone, the keypad is effectively dead for service codes. When the device is unpaired and the server has handed it a pairing code, lifting the handset starts a looping spoken announcement ("welcome, your code is...") and `continue`s past the dialing FSM (`main.go`). Service-code keys still dispatch to `svcCodes.AddKey`, but the looping audio talks over the DTMF feedback and, crucially, over the confirmation prompts. The result: `*#73887#` (clear Wi-Fi / re-provision) and `*#00000#` (factory reset) can't be driven from the keypad while unpaired. The only ways out were SSH or the hold-`*`-at-power-on panic button into recovery.

## Fix

The `*` that begins every service code doubles as the cue to stop the announcement:

- When `*` is pressed while unpaired with an announcement active, cancel the announcement loop and `StopAll()` the mixer, so the DTMF beep, the rest of the service code, and its confirmation prompt are all audible. Re-lifting the handset restarts the announcement via the existing `HOOK:OFF` branch, so nothing is lost for a user who actually wants to pair.
- Add a `ctx.Done()` check at the top of the announcement goroutine loop. Without it, a cancel that lands right after the inter-announcement wait would still queue one more full pass before the next check, which could talk over the service code that just stopped it.

After this, the unpaired keypad flow is: lift handset, dial `*#73887#` (or `*#00000#`), the announcement stops on the `*`, the confirm prompt plays, press `*` to confirm.

## Testing

- `go build ./...`, `go vet`, `golangci-lint run ./...`, and `go test ./...` all clean in `pi/digitsd`.
- The change is in `main()`'s serial-event select loop, which has no unit-test seam, so it needs on-hardware verification: an unpaired device that is announcing a pairing code, then `*#73887#` from the keypad clearing Wi-Fi and rebooting into AP mode. Verification to follow on this PR.

## Related

Complements the hold-`*`-at-power-on recovery path (firmware `main.c` writes `PHASE_RECOVERY`) and the setup-mode auto-flash in #689; together they make a fresh or unpaired device recoverable from the device itself rather than only over SSH.