### PR TITLE
fix(digitsd): auto-launch the captive portal in recovery mode

### DIFF
--- a/pi/digitsd/cmd/digitsd/captive.go
+++ b/pi/digitsd/cmd/digitsd/captive.go
@@ -1,0 +1,27 @@
+package main
+
+import "net/http"
+
+// captivePortalProbePaths are the URLs Android, iOS/macOS, and Windows fetch to
+// decide whether a network is open or behind a captive portal. With AP-mode DNS
+// wildcarded to the device, these requests land on our web server; a 302 to the
+// portal root is what makes the OS pop its "sign in to network" page. Anything
+// else (a 204, or a 404 from the static file server) reads as "no portal", so
+// the page never auto-launches.
+var captivePortalProbePaths = []string{
+	"/generate_204",              // Android, ChromeOS
+	"/hotspot-detect.html",       // iOS, macOS
+	"/connecttest.txt",           // Windows
+	"/library/test/success.html", // older iOS
+}
+
+// mountCaptivePortalRedirects registers a 302 redirect to target for each OS
+// captive-portal probe path. Both setup (AP) mode and recovery mode mount this
+// so the sign-in page auto-launches identically in either.
+func mountCaptivePortalRedirects(mux *http.ServeMux, target string) {
+	for _, path := range captivePortalProbePaths {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target, http.StatusFound)
+		})
+	}
+}

--- a/pi/digitsd/cmd/digitsd/captive_test.go
+++ b/pi/digitsd/cmd/digitsd/captive_test.go
@@ -24,6 +24,27 @@ func TestMountCaptivePortalRedirects(t *testing.T) {
 	}
 }
 
+// The actual recovery bug was probe paths falling through to the "/" catch-all
+// (the static FileServer) and 404'ing. Verify the probe redirect wins over a
+// "/" handler on the same mux, which is the real setup/recovery arrangement.
+func TestMountCaptivePortalRedirects_BeatsRootHandler(t *testing.T) {
+	mux := http.NewServeMux()
+	rootHit := false
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { rootHit = true })
+	mountCaptivePortalRedirects(mux, "/")
+
+	req := httptest.NewRequest(http.MethodGet, "/generate_204", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rootHit {
+		t.Fatal("/generate_204 was claimed by the \"/\" handler instead of the redirect")
+	}
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d (302)", rec.Code, http.StatusFound)
+	}
+}
+
 // A path that isn't a probe must not be claimed by the redirect handlers, so
 // the static file server / other routes still see it.
 func TestMountCaptivePortalRedirects_LeavesOtherPathsAlone(t *testing.T) {

--- a/pi/digitsd/cmd/digitsd/captive_test.go
+++ b/pi/digitsd/cmd/digitsd/captive_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMountCaptivePortalRedirects(t *testing.T) {
+	mux := http.NewServeMux()
+	mountCaptivePortalRedirects(mux, "/")
+
+	for _, path := range captivePortalProbePaths {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("%s: status = %d, want %d (302)", path, rec.Code, http.StatusFound)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/" {
+			t.Errorf("%s: Location = %q, want %q", path, loc, "/")
+		}
+	}
+}
+
+// A path that isn't a probe must not be claimed by the redirect handlers, so
+// the static file server / other routes still see it.
+func TestMountCaptivePortalRedirects_LeavesOtherPathsAlone(t *testing.T) {
+	mux := http.NewServeMux()
+	mountCaptivePortalRedirects(mux, "/")
+	hit := false
+	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) { hit = true })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !hit {
+		t.Fatal("/api/status was not routed to its own handler")
+	}
+}

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -212,6 +212,12 @@ func mountRecoveryRoutes(mux *http.ServeMux, state *recoveryState, mixer *audio.
 
 	mux.Handle("/", http.FileServer(http.FS(staticFS)))
 
+	// Redirect OS captive-portal probes to the recovery UI so it auto-launches
+	// on connect, the same way AP/setup mode does. Without this the probes fall
+	// through to the static file server, 404, and the device looks like a dead
+	// network instead of popping the sign-in page.
+	mountCaptivePortalRedirects(mux, "/")
+
 	mux.HandleFunc("/boot-status", func(w http.ResponseWriter, r *http.Request) {
 		count, _ := bootcount.Read(bootcount.DefaultPath)
 		w.Header().Set("Content-Type", "application/json")

--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -50,11 +50,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 	}
 	mux.Handle("/", http.FileServer(http.FS(staticSub)))
 
-	for _, path := range []string{"/generate_204", "/hotspot-detect.html", "/connecttest.txt", "/library/test/success.html"} {
-		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/", http.StatusFound)
-		})
-	}
+	mountCaptivePortalRedirects(mux, "/")
 
 	mux.HandleFunc("/api/networks", func(w http.ResponseWriter, r *http.Request) {
 		networks, err := wifi.Scan()


### PR DESCRIPTION
## Problem

Connecting an Android phone to recovery mode's `Digits-Recovery` AP does not auto-launch the recovery page, whereas setup/AP mode pops the "sign in to network" page on connect.

## Root cause

Both modes wildcard DNS to `192.168.4.1` and serve the web UI on `:80`, so the probes reach our server in both. The difference is the HTTP response:

- **Setup mode** (`setup.go`) registers the OS captive-portal probe URLs and 302-redirects them to `/`:
  ```go
  for _, path := range []string{"/generate_204", "/hotspot-detect.html", "/connecttest.txt", "/library/test/success.html"} {
      mux.HandleFunc(path, func(w, r) { http.Redirect(w, r, "/", http.StatusFound) })
  }
  ```
  The 302 is what triggers the OS sign-in popup.
- **Recovery mode** (`recovery.go`) never registered those paths, so a probe like `/generate_204` fell through to the `/` static `FileServer` and returned 404. Android reads a 404 as "no portal, no internet" and does not launch the captive UI.

## Fix

Factor the probe list and the redirect into a shared `mountCaptivePortalRedirects(mux, target)` helper (`captive.go`) and mount it in both setup and recovery. Recovery now 302s the probes to its UI root, so the page auto-launches the same way AP mode does. Keeping it in one helper means the two modes can't drift apart again (which is exactly how this gap arose).

## Testing

- `go build ./...`, `go test ./cmd/digitsd/`, and `golangci-lint run ./...` clean in `pi/digitsd`.
- New unit tests assert every probe path 302-redirects to the target and that non-probe paths (e.g. `/api/status`) are left for their own handlers.
- On-hardware check to follow: connect Android to `Digits-Recovery` and confirm the sign-in page auto-opens.

## Related

Part of the same fresh/unpaired-device recoverability work as #689 (setup-mode auto-flash) and #690 (service codes while unpaired).