### PR TITLE
fix(server): extend pairing code TTL and report it to the device

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -55,10 +55,16 @@ const iceRestartTimeout = 25 * time.Second
 // checks) within this window, in which case no restart is needed.
 const disconnectDebounce = 4 * time.Second
 
-// pairingRefreshInterval is how often an unpaired device reconnects to
-// obtain a fresh pairing code. Must be shorter than the server-side
-// CodeTTL (10 min) so the code is refreshed before it expires.
+// pairingRefreshInterval is the fallback reconnect cadence for obtaining a
+// fresh pairing code, used only when the server does not report a TTL. When
+// the server sends PairingCodeTTL (it does), the device instead refreshes
+// pairingRefreshMargin before the reported expiry.
 const pairingRefreshInterval = 9 * time.Minute
+
+// pairingRefreshMargin is how far ahead of the server-reported code expiry the
+// device reconnects for a fresh code, so the announced code is still valid
+// while a user is typing it into the web UI.
+const pairingRefreshMargin = 60 * time.Second
 
 // pairingAnnouncementInterval is how long to wait between repeats of the
 // spoken pairing-code sequence while the phone is unpaired and off-hook.
@@ -119,7 +125,7 @@ type daemonCallbacks struct {
 	debugMode             bool                      // read from DIGITS_DEBUG env at startup
 	paired                atomic.Bool
 	pairingCode           string      // current pairing code from server
-	pairingCodeReceivedAt time.Time   // when the current pairing code was received
+	pairingCodeExpiresAt  time.Time   // server-reported expiry of the current pairing code
 	callPeer              string      // number of the remote party during an active call
 	isCaller              bool        // true if we initiated the current call
 	callReturnOrigin      atomic.Bool // true when the current call was initiated via *69
@@ -848,19 +854,19 @@ func resetPicoHardware(sp *phone.SerialPort) {
 
 // playPairingAnnouncement queues one full pairing-voice sequence on mixer:
 // silence pad, welcome, the code digits, and the "expires in N minute(s)"
-// tail. code and receivedAt are passed explicitly (not read from cb) so the
+// tail. code and expiresAt are passed explicitly (not read from cb) so the
 // caller controls the cross-goroutine read: the announcement runs from a
 // goroutine spawned on HOOK:OFF and reading cb.pairingCode there would race
-// the dispatcher's TypePairingCode handler. minutesLeft is computed from
-// receivedAt on each call so a long-listening user hears an accurate
-// countdown.
-func playPairingAnnouncement(mixer *audio.Mixer, code string, receivedAt time.Time) {
+// the dispatcher's TypePairingCode handler. minutesLeft is computed from the
+// server-reported expiry on each call so a long-listening user hears an
+// accurate countdown that matches when the server actually invalidates it.
+func playPairingAnnouncement(mixer *audio.Mixer, code string, expiresAt time.Time) {
 	mixer.PlayOnce("pairing_silence")
 	mixer.PlayOnce("pairing_welcome")
 	for _, ch := range code {
 		mixer.PlayOnce("spoken_" + string(ch))
 	}
-	minutesLeft := int(math.Ceil(pairingRefreshInterval.Minutes() - time.Since(receivedAt).Minutes()))
+	minutesLeft := int(math.Ceil(time.Until(expiresAt).Minutes()))
 	if minutesLeft < 1 {
 		minutesLeft = 1
 	} else if minutesLeft > 10 {
@@ -2002,13 +2008,13 @@ func main() {
 				// Snapshot the pairing-code state on the dispatcher goroutine
 				// (the same one TypePairingCode writes from) and pass into the
 				// announcement goroutine. Avoids cross-goroutine reads of
-				// cb.pairingCode + cb.pairingCodeReceivedAt. The code/receivedAt
+				// cb.pairingCode + cb.pairingCodeExpiresAt. The code/expiry
 				// won't change for this off-hook session: a new code only lands
-				// after pairingRefreshInterval, by which point HOOK:ON has
-				// cancelled this goroutine. cb.paired is atomic, so the
-				// post-pair exit check stays accurate without a snapshot.
+				// on the next refresh, by which point HOOK:ON has cancelled
+				// this goroutine. cb.paired is atomic, so the post-pair exit
+				// check stays accurate without a snapshot.
 				code := cb.pairingCode
-				receivedAt := cb.pairingCodeReceivedAt
+				expiresAt := cb.pairingCodeExpiresAt
 				slog.Info("phone: playing pairing code via voice", "code", code)
 				go func() {
 					for {
@@ -2025,7 +2031,7 @@ func main() {
 						if cb.paired.Load() || code == "" {
 							return
 						}
-						playPairingAnnouncement(mixer, code, receivedAt)
+						playPairingAnnouncement(mixer, code, expiresAt)
 						for mixer.OncePlaying() {
 							select {
 							case <-ctx.Done():
@@ -2456,9 +2462,24 @@ func main() {
 
 			case sigclient.TypePairingCode:
 				cb.pairingCode = msg.PairingCode
-				cb.pairingCodeReceivedAt = time.Now()
-				slog.Info("PAIRING REQUIRED: pick up handset to hear it", "code", msg.PairingCode)
-				pairingRefresh.Reset(pairingRefreshInterval)
+				refresh := pairingRefreshInterval
+				if msg.PairingCodeTTL > 0 {
+					ttl := time.Duration(msg.PairingCodeTTL) * time.Second
+					cb.pairingCodeExpiresAt = time.Now().Add(ttl)
+					// Refresh a margin before expiry so the announced code is
+					// still valid while a user types it. Guard against a TTL
+					// shorter than the margin.
+					if d := ttl - pairingRefreshMargin; d > 0 {
+						refresh = d
+					} else {
+						refresh = ttl / 2
+					}
+				} else {
+					// Older server without a TTL: fall back to the fixed cadence.
+					cb.pairingCodeExpiresAt = time.Now().Add(pairingRefreshInterval)
+				}
+				slog.Info("PAIRING REQUIRED: pick up handset to hear it", "code", msg.PairingCode, "ttl_s", msg.PairingCodeTTL)
+				pairingRefresh.Reset(refresh)
 
 			case sigclient.TypePaired:
 				pairingRefresh.Stop()

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -183,8 +183,11 @@ type Message struct {
 	Servers     []ICEServer    `json:"servers,omitempty"`
 	Contacts    []ContactEntry `json:"contacts,omitempty"`
 	PairingCode string         `json:"pairing_code,omitempty"`
-	HardwareID  string         `json:"hardware_id,omitempty"`
-	DeviceToken string         `json:"device_token,omitempty"`
+	// PairingCodeTTL is the server-reported validity of PairingCode, in
+	// seconds. Drives the spoken countdown and the pre-expiry refresh.
+	PairingCodeTTL int            `json:"pairing_code_ttl,omitempty"`
+	HardwareID     string         `json:"hardware_id,omitempty"`
+	DeviceToken    string         `json:"device_token,omitempty"`
 
 	// Version info (device_info messages)
 	PiVersion       string `json:"pi_version,omitempty"`

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -26,8 +26,11 @@ import (
 const (
 	// CodeLength is the number of digits in a pairing code.
 	CodeLength = 6
-	// CodeTTL is how long a pairing code remains valid.
-	CodeTTL = 3 * time.Minute
+	// CodeTTL is how long a pairing code remains valid. The device is told
+	// this TTL (via PairingCodeTTL) so its spoken countdown matches and it
+	// refreshes before expiry; keep it comfortably longer than the time it
+	// takes a user to hear the code and type it into the web UI.
+	CodeTTL = 10 * time.Minute
 )
 
 var (

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -164,8 +164,13 @@ type Message struct {
 	Error       string      `json:"error,omitempty"`
 	Servers     []ICEServer `json:"servers,omitempty"`
 	PairingCode string      `json:"pairing_code,omitempty"`
-	HardwareID  string      `json:"hardware_id,omitempty"`
-	DeviceToken string      `json:"device_token,omitempty"`
+	// PairingCodeTTL is how many seconds the accompanying PairingCode stays
+	// valid. Sent so the device can announce an accurate countdown and refresh
+	// the code before the server expires it, rather than guessing from a local
+	// constant.
+	PairingCodeTTL int    `json:"pairing_code_ttl,omitempty"`
+	HardwareID     string `json:"hardware_id,omitempty"`
+	DeviceToken    string `json:"device_token,omitempty"`
 
 	// Version info (device_info messages)
 	PiVersion       string `json:"pi_version,omitempty"`

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/justinlindh/digits/server/internal/pairing"
 	"github.com/justinlindh/digits/server/internal/signaling"
 )
 
@@ -89,8 +90,9 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 				slog.ErrorContext(r.Context(), "generate pairing code failed", "hardware_id", msg.HardwareID, "err", err)
 			} else {
 				_ = ws.WriteMessage(websocket.TextMessage, mustMarshal(&signaling.Message{
-					Type:        signaling.TypePairingCode,
-					PairingCode: code,
+					Type:           signaling.TypePairingCode,
+					PairingCode:    code,
+					PairingCodeTTL: int(pairing.CodeTTL.Seconds()),
 				}))
 			}
 			// Unpaired devices register under their hardware ID (not a line


### PR DESCRIPTION
## Problem

A phone announces a pairing code over voice, says it's valid for several minutes, but the web app rejects it as "invalid or expired."

## Root cause

Two independent constants had drifted apart:

- Server `pairing.CodeTTL = 3 * time.Minute`. The claim query requires `pairing_code_expires_at > NOW()`.
- Device `pairingRefreshInterval = 9 * time.Minute`. Both the spoken countdown (`ceil(9min - elapsed)`) and the reconnect-for-fresh-code timer derived from this.

So a code was actually valid for only the first 3 of every 9 minutes, but the phone kept reading it out as valid for the whole 9. (Tellingly, the device const's own comment already said it "must be shorter than the server-side CodeTTL (10 min)", so the server value, not the device, was the drift.)

Confirmed on hardware (device `0000000053906216`):
```
07:59:06  received pairing code 223864
08:07:24  announced 223864 via voice   (8m18s after receipt)
08:08:20  "pairing code expiring, reconnecting for fresh code" -> 511579
```
The server expired `223864` at ~08:02:06; it was announced as valid more than 5 minutes after it died. Server logs show the periodic "pairing cleanup complete expired_codes:1" nulling it out.

## Fix

Eliminate the drift by making the server's TTL authoritative on the device:

- The server reports the code's validity in the `pairing_code` message (`PairingCodeTTL`, seconds).
- The device drives both its spoken countdown and its refresh timer from that value: it announces the real remaining time and reconnects `pairingRefreshMargin` (60s) before the reported expiry, so the announced code is always still valid when a user types it. Falls back to the fixed interval for servers that do not report a TTL.
- Bump `CodeTTL` from 3 to 10 minutes: a code a user must hear and type needs a comfortable window, and 10m keeps the device's existing ~9m refresh cadence safely inside the validity window.

A TTL (seconds) is sent rather than an absolute timestamp so device/server clock skew cannot distort the countdown.

## Testing

- `go build`, `go test` (unit), `golangci-lint` clean on both `server/` and `pi/digitsd/` (server pairing integration tests run in CI / `make test-integration`).
- Full end-to-end needs the server released to prod (so it sends the TTL) plus the new digitsd on a device. The server-side `CodeTTL` bump alone already makes the existing device cadence correct, and the device change degrades gracefully (fallback) against an old server.

## Rollout note

The device-side precision/refresh change lives in `pi/digitsd` and reaches phones with the next pi image build. The `fix(server)` release restores correct behavior for already-deployed devices on its own, because the 10m TTL matches their existing 9m refresh assumption.