### PR TITLE
fix(server): make pairing-code digits legible in intercom night mode

### DIFF
--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -2287,6 +2287,13 @@ html[data-theme="dark"] .keypad-wrap__strip {
 html[data-theme="dark"] .toggle__track::after {
   box-shadow: 0 1px 2px rgba(0,0,0,0.5), inset 0 1px 0 rgba(221,168,103,0.08);
 }
+/* Pairing-code slots: the day palette hardcodes a cream slot fill, so in night
+   mode the cream --ink digits would render cream-on-cream and disappear. Flip
+   the fill to the same deep walnut the field inputs use so the entered code is
+   legible. The border and is-filled/is-active accents already adapt via vars. */
+html[data-theme="dark"] .pin__slot {
+  background: #120e08;
+}
 /* Primary button flips: ink-on-paper in light mode becomes
    parchment-on-walnut; hover raises toward pure parchment. */
 html[data-theme="dark"] .btn--primary {


### PR DESCRIPTION
## What

On the pair-a-phone keypad (`/phones`), the row of six pin-code boxes above the keypad did not visibly reflect the entered code in intercom **night** mode. The digits were written into the boxes but rendered invisible.

## Root cause

`server/internal/web/static/digits.css`: the `.pin__slot` rule hardcodes a cream fill (`background: #fbf7ef`) from the day palette and colors the digit with `color: var(--ink)`. In night mode (`html[data-theme="dark"]`), `--ink` flips to a light cream (`#ede3d1`), so the digit rendered cream-on-cream and disappeared. The slot background had no night-mode override, unlike the field inputs.

The JS that mirrors the code into the slots was working correctly the whole time; this was purely a contrast bug in the night palette.

## Fix

Add a single night-mode override that flips the slot fill to the same deep walnut (`#120e08`) the field inputs already use in dark mode. The slot border and the `is-filled` / `is-active` accent colors already adapt through CSS vars, so only the background needed fixing.

## Themes verified (local dev, agent-browser)

| Theme / mode | Before | After |
|---|---|---|
| intercom day | correct (dark ink on cream) | unchanged |
| intercom night | digits invisible (cream on cream) | digits legible (cream on walnut) |
| dialup | correct (gold fill) | unchanged |
| answering-machine | correct (amber LED on dark slot) | unchanged |

Confirmed the boxes mirror both tapped keypad input and typed input on the affected theme.

## Before / after (intercom night)

Before:

![before](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/695-keypad-night-before.png)

After:

![after](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/695-keypad-night-after.png)
