### PR TITLE
fix(digitsd): recovery serial device and the Try Again reboot loop

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -881,10 +881,24 @@ func playPairingAnnouncement(mixer *audio.Mixer, code string, expiresAt time.Tim
 	mixer.PlayOnce(unitClip)
 }
 
+// recoverySerialDevice returns the raw UART node for the Pico. Recovery mode
+// runs as PID 1 without udev, so the /dev/serial0 symlink that normal boot
+// relies on does not exist; only the kernel-created device node does. Under
+// disable-bt the Pico is on the PL011 (/dev/ttyAMA0). Falls back to the
+// configured -serial value if neither raw node is present.
+func recoverySerialDevice() string {
+	for _, dev := range []string{"/dev/ttyAMA0", "/dev/ttyS0"} {
+		if _, err := os.Stat(dev); err == nil {
+			return dev
+		}
+	}
+	return *serialDev
+}
+
 func recoveryRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subsystem.SerialModule, *subsystem.AudioModule) {
 	web := subsystem.NewWebModule()
 	gpclk0 := subsystem.NewGPCLK0Module()
-	serial := subsystem.NewSerialModule(subsystem.SerialConfig{Device: *serialDev, Baud: 115200})
+	serial := subsystem.NewSerialModule(subsystem.SerialConfig{Device: recoverySerialDevice(), Baud: 115200})
 	audio := subsystem.NewAudioModule(subsystem.AudioConfig{
 		ToneDir:         "/tones",
 		MixerStateFile:  "/mixer.state",

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -263,7 +263,7 @@ setTimeout(poll,2000)}poll()</script></body></html>`)
 		}
 		state.startTryAgain()
 		dbg.add("action", "try-again via web")
-		_ = bootcount.Clear(bootcount.DefaultPath)
+		clearRecoveryBootState()
 		w.WriteHeader(http.StatusOK)
 		go doReboot()
 	})
@@ -309,7 +309,7 @@ func recoveryHandleKey(sp *phone.SerialPort, key string, events <-chan string, m
 		slog.Info("recovery: restart triggered via keypad")
 		mixer.PlayOnce("restarting")
 		waitForOnceComplete(mixer, 5*time.Second)
-		_ = bootcount.Clear(bootcount.DefaultPath)
+		clearRecoveryBootState()
 		doReboot()
 		return true
 
@@ -448,6 +448,17 @@ func syncAndHalt() {
 		_ = modeLogFile.Sync()
 	}
 	select {}
+}
+
+// clearRecoveryBootState clears the boot counter and removes the recovery-mode
+// flag so the next boot proceeds normally. Used by the try-again paths, which
+// run with /data already mounted; clearing only the boot counter (the previous
+// behavior) left the recovery-mode flag set, so boot-check re-entered recovery
+// on the next boot and "Try Again" looped. Unlike clearRecoveryFlags this does
+// not mount/unmount /data, so it must not be called before /data is mounted.
+func clearRecoveryBootState() {
+	_ = bootcount.Clear(bootcount.DefaultPath)
+	_ = os.Remove("/data/digits/recovery-mode")
 }
 
 // clearRecoveryFlags mounts /data temporarily to clear the boot counter


### PR DESCRIPTION
## Problems

Two recovery-mode bugs that compound into "recovery is unusable":

### 1. No recovery audio, dead hook switch
Recovery runs as PID 1 (`/sbin/init` -> `/digits-recovery`) with no udev. The `/dev/serial0` that normal boot uses is a udev-created symlink, so it does not exist in recovery; only the kernel device node (`/dev/ttyAMA0` under `disable-bt`) does. But `recoveryRegistrations` opened the default `/dev/serial0`, so the serial subsystem failed, the Pico was unreachable, and `runRecoveryMode` hit its `serial or audio unavailable, voice menu disabled` branch. The phone plays nothing and the hook switch does nothing.

### 2. "Try Again" reboots straight back into recovery
`boot-check.sh` enters recovery whenever `/data/digits/recovery-mode` exists (set by the panic button or a boot-counter trip). Both "Try Again" paths (the web button and voice-menu key 1) cleared only the boot counter and never removed that flag, so the next boot re-entered recovery. The `clearRecoveryFlags` helper that clears both was never wired to either path.

## Fixes

1. `recoverySerialDevice()` opens the raw UART (`/dev/ttyAMA0`, falling back to `/dev/ttyS0`, then the configured `-serial` value), so the serial subsystem comes up and the voice menu runs. Combined with the post-playback-open mixer re-apply already on main (#692), recovery audio plays at the right level.
2. A shared `clearRecoveryBootState()` clears the boot counter **and** removes `/data/digits/recovery-mode`; both try-again paths now call it, so "Try Again" actually exits recovery.

## Testing

- `go build`, `go vet`, `go test ./cmd/digitsd/`, `golangci-lint` clean in `pi/digitsd`.
- This is the recovery-partition binary, so it ships via an image rebuild + reflash of the recovery partition; it can't be verified by deploying to the running rootfs. On-hardware check after reflash: hold `*` at boot to enter recovery, confirm the menu speaks on hook-lift, and confirm "Try Again" boots normally instead of looping.

## Escaping the loop on an already-affected device
Until this ships, the web "Try Again" loops. Escape via the recovery web UI Factory Reset (wipes `/data`, clearing the flag), or by mounting the `data` partition offline and deleting `digits/recovery-mode`.