### PR TITLE
feat(server): collapse quiet-hours config until the toggle is on

### DIFF
--- a/server/internal/web/static/answering-machine.css
+++ b/server/internal/web/static/answering-machine.css
@@ -2483,3 +2483,12 @@ body.am .pair-mode-field legend {
   align-self: flex-start;
   margin-top: 4px;
 }
+
+/* Quiet hours: collapse the window/day config until the enable toggle is on.
+   Scoped to the quiet-hours section so it never touches the voicemail
+   section's identically-classed field wrapper. Driven off the rendered
+   checkbox state, so the initial paint matches the saved setting and
+   toggling reacts instantly with no JS. */
+#quiet-hours-section form:not(:has(input[name="enabled"]:checked)) .am-voicemail-fields {
+  display: none;
+}

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -751,6 +751,13 @@ body.dialup:not(.crt-all) .dialup-window {
   inset: 2px;
   background: var(--dialup-accent-red);
 }
+
+/* Quiet hours: collapse the window/day config until the enable toggle is on.
+   Driven off the rendered checkbox state, so the initial paint matches the
+   saved setting and toggling reacts instantly with no JS. */
+#quiet-hours-section form:not(:has(input[name="enabled"]:checked)) .quiet-hours-fields {
+  display: none;
+}
 .radio-card__desc {
   margin: 3px 0 0 18px;
   font-size: 11px;

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -807,6 +807,13 @@ hr { border: 0; border-top: 1px solid var(--rule); margin: 0; }
   background: var(--brass);
   border-radius: 50%;
 }
+
+/* Quiet hours: collapse the window/day config until the enable toggle is on.
+   Driven off the rendered checkbox state, so the initial paint matches the
+   saved setting and toggling reacts instantly with no JS. */
+#quiet-hours-section form:not(:has(input[name="enabled"]:checked)) .quiet-hours-fields {
+  display: none;
+}
 .radio-card__desc {
   margin: 3px 0 0 24px;
   font-size: 12.5px;

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -798,7 +798,7 @@
       household's timezone.
     </p>
 
-    <div class="quiet-hours-fields" {{if not .Line.Settings.QuietHours.Enabled}}style="opacity: 0.55;"{{end}}>
+    <div class="quiet-hours-fields">
       <div class="hstack hstack--wrap" style="gap: 16px; margin-top: 8px;">
         <div class="field">
           <label for="qh-start" class="field__label">From</label>
@@ -860,7 +860,7 @@
       </div>
     </div>
 
-    <div class="am-voicemail-fields" {{if not .Line.Settings.QuietHours.Enabled}}style="opacity: 0.55;"{{end}}>
+    <div class="am-voicemail-fields">
       <div class="am-settings__field">
         <label for="qh-start" class="am-label am-settings__field-label">From</label>
         <input type="time" id="qh-start" name="start"

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -828,9 +828,9 @@
           {{end}}
         </div>
       </div>
-
-      <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 10px;">Save</button>
     </div>
+
+    <button type="submit" class="btn btn--primary btn--sm" style="margin-top: 10px;">Save</button>
   </form>
 </div>
 {{end}}
@@ -886,12 +886,12 @@
           {{end}}
         </div>
       </div>
-
-      <button type="submit" class="am-key am-settings__submit">
-        <span class="am-key__symbol">&#x25B6;</span>
-        <span class="am-key__label">Save</span>
-      </button>
     </div>
+
+    <button type="submit" class="am-key am-settings__submit">
+      <span class="am-key__symbol">&#x25B6;</span>
+      <span class="am-key__label">Save</span>
+    </button>
   </form>
 </div>
 {{end}}


### PR DESCRIPTION
## What

On the per-line drill-down page, the quiet-hours window (From/To), day pickers, and Save button were always rendered, just dimmed to 55% opacity when the feature was off. The controls stayed fully interactive even when disabled, which read as clutter and let you edit a window that had no effect.

Now the config collapses until the **Scheduled quiet hours** toggle is checked:

- Toggle OFF: From/To/Days hidden.
- Toggle ON: From/To/Days shown.
- Reactive: toggling shows/hides instantly, no reload.
- Initial render reflects the saved state.
- The enable toggle and Save button stay visible in both states, so you can still turn quiet hours off and persist it.

## How

A CSS `:has()` rule on `#quiet-hours-section` drives the show/hide off the live checkbox state. No JS. Because the rule keys on the rendered `checked` attribute, the first paint already matches the saved setting, and because it keys on the live checkbox, toggling reacts instantly. The htmx outerHTML swap on save re-renders the section with the correct `checked`, so the state survives a save.

Only the From/To/Days inputs collapse. The enable checkbox and the Save button live in the `<form>` but outside the collapsing wrapper, so unchecking and saving the disabled state always works. The fields use `display:none` rather than `disabled`, so their values still submit and the handler keeps reading the full window on save.

Applied to all three themes:

- intercom: `server/internal/web/static/digits.css`
- dialup: `server/internal/web/static/dialup.css`
- answering-machine: `server/internal/web/static/answering-machine.css`

The answering-machine markup reuses the `.am-voicemail-fields` class, so that rule is scoped to `#quiet-hours-section` and never touches the voicemail section's identically-classed wrapper.

## Verification

Built and ran locally (`make dev-up`), drove with agent-browser. For each theme, confirmed: From/To/Days hidden when off, appear when toggled on, initial state matches saved setting, the disable path (uncheck a genuinely-enabled line, click Save) persists `enabled: false` to the DB, and the voicemail section's fields stay visible. `make test` and `golangci-lint run ./...` both clean. No Go changed (template + CSS only).

Screenshots in the PR comments: collapsed vs expanded per theme, and the corrected collapsed state showing Save remains reachable.