### PR TITLE
refactor(server): drop unused static active_devices and active_calls gauges

### DIFF
--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -52,8 +52,6 @@ type Registry struct {
 	HTTPRequestsTotal   *prometheus.CounterVec
 	HTTPRequestDuration *prometheus.HistogramVec
 
-	ActiveDevices   prometheus.Gauge
-	ActiveCalls     prometheus.Gauge
 	SignalingErrors *prometheus.CounterVec
 	BuildInfo       *prometheus.GaugeVec
 }
@@ -94,18 +92,6 @@ func New(version, commit string) *Registry {
 		},
 		[]string{"route", "method", "status"},
 	)
-	r.ActiveDevices = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "digits",
-		Subsystem: serviceName,
-		Name:      "active_devices",
-		Help:      "Currently connected phones. Count only; no identifiers.",
-	})
-	r.ActiveCalls = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "digits",
-		Subsystem: serviceName,
-		Name:      "active_calls",
-		Help:      "Currently active calls. Count only; no participants or routing.",
-	})
 	r.SignalingErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "digits",
@@ -129,8 +115,6 @@ func New(version, commit string) *Registry {
 	reg.MustRegister(
 		r.HTTPRequestsTotal,
 		r.HTTPRequestDuration,
-		r.ActiveDevices,
-		r.ActiveCalls,
 		r.SignalingErrors,
 		r.BuildInfo,
 	)
@@ -155,14 +139,14 @@ func (r *Registry) registerScrapeGauge(name, help string, read func() float64) {
 // count. Use a closure that returns len(hub.OnlineNumbers()).
 func (r *Registry) RegisterDevicesGauge(read func() float64) {
 	r.registerScrapeGauge("active_devices_current",
-		"Current active device count, sampled at scrape time. Identical in meaning to active_devices but read live; the static gauge exists for tests that drive it directly.",
+		"Current active device count, sampled at scrape time.",
 		read)
 }
 
 // RegisterCallsGauge mirrors RegisterDevicesGauge for active calls.
 func (r *Registry) RegisterCallsGauge(read func() float64) {
 	r.registerScrapeGauge("active_calls_current",
-		"Current active call count, sampled at scrape time. Identical in meaning to active_calls but read live.",
+		"Current active call count, sampled at scrape time.",
 		read)
 }
 

--- a/server/internal/metrics/metrics_test.go
+++ b/server/internal/metrics/metrics_test.go
@@ -210,6 +210,8 @@ func TestPromhttpExportsExpectedMetrics(t *testing.T) {
 	// at least one labelled child has been observed.
 	r.HTTPRequestsTotal.WithLabelValues("/api/status", "GET", "200").Inc()
 	r.HTTPRequestDuration.WithLabelValues("/api/status", "GET", "200").Observe(0.012)
+	r.RegisterDevicesGauge(func() float64 { return 0 })
+	r.RegisterCallsGauge(func() float64 { return 0 })
 	r.ObserveSignalingError("turn_alloc_failed")
 
 	srv := httptest.NewServer(promhttp.HandlerFor(r.Reg, promhttp.HandlerOpts{Registry: r.Reg}))
@@ -225,8 +227,8 @@ func TestPromhttpExportsExpectedMetrics(t *testing.T) {
 	for _, want := range []string{
 		"digits_signald_http_requests_total",
 		"digits_signald_http_request_duration_seconds",
-		"digits_signald_active_devices",
-		"digits_signald_active_calls",
+		"digits_signald_active_devices_current",
+		"digits_signald_active_calls_current",
 		"digits_signald_signaling_errors_total",
 		"digits_signald_build_info",
 		"go_goroutines",


### PR DESCRIPTION
## What

The `metrics.Registry` struct held two `prometheus.Gauge` fields, `ActiveDevices` and `ActiveCalls`, that were created and registered with the prometheus registry but never `.Set()` or `.Inc()`'d anywhere in production or test code. Every scrape emitted them as zero. The real live counts are served by the `active_devices_current` and `active_calls_current` scrape-time `GaugeFunc`s installed from `cmd/signald/main.go` via `RegisterDevicesGauge` / `RegisterCallsGauge`, which read from `hub.LocalConnectionCount()` and `len(tracker.Active(...))` directly.

The help text on the `_current` gauges even called this out: "the static gauge exists for tests that drive it directly", but no test drove it. The only thing referencing the static names was `TestPromhttpExportsExpectedMetrics` checking their HELP/TYPE lines appeared in the scrape body.

## How

- Remove `ActiveDevices` and `ActiveCalls` from `Registry`, their `prometheus.NewGauge` construction in `New`, and their `MustRegister` arguments.
- Drop the "static gauge exists for tests" sentence from the help text on the `_current` variants.
- In `TestPromhttpExportsExpectedMetrics`, call `RegisterDevicesGauge` / `RegisterCallsGauge` to install the scrape gauges and assert against the `_current` names instead. That way the scrape-body check covers what production actually emits.

Net `-20 / +6` lines. No external metric is added or removed: dashboards and alerts wired to `active_devices` / `active_calls` would have been reading a frozen zero, and the `_current` series is the one with the real values.

## Verify

- `go build ./...`, `go test ./...`, and `go vet ./...` clean from `server/`.