### PR TITLE
refactor(server): tighten OpenSQLDB signature to match its actual contract

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -28,7 +28,7 @@ func Open(databaseURL string) (*Database, error) {
 	// into the active HTTP request span. otelsql's DisableQuery option is
 	// set there to prevent SQL text from reaching span attributes; see
 	// internal/tracing/db.go for the privacy rationale.
-	db, err := tracing.OpenSQLDB("postgres", databaseURL, "digits")
+	db, err := tracing.OpenSQLDB(databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}

--- a/server/internal/tracing/db.go
+++ b/server/internal/tracing/db.go
@@ -10,10 +10,10 @@ import (
 )
 
 // OpenSQLDB opens a *sql.DB through otelsql so every query produces a
-// child span on the surrounding HTTP request span. The driver name is
-// fixed to "postgres" (lib/pq) because that's the only driver we use;
-// passing a different name is a sign of a bug at the call site, not a
-// configuration knob.
+// child span on the surrounding HTTP request span. The driver is hardcoded
+// to "postgres" (lib/pq) and the db.name attribute to "digits"; both
+// would be configuration theater since signald only ever talks to one
+// Postgres database.
 //
 // Privacy: otelsql is configured with DisableQuery=true, which suppresses
 // the db.statement span attribute. The default behavior would echo the
@@ -28,20 +28,17 @@ import (
 // What otelsql still records:
 //
 //   - db.system: "postgresql"
-//   - db.name (the database identifier, e.g. "digits")
+//   - db.name: "digits"
 //   - the operation kind (db.connection.prepare, db.connection.query,
 //     etc.) plus duration
 //   - error attribute on failed calls
 //
 // None of those carry user identifiers.
-func OpenSQLDB(driverName, dataSourceName string, dbName string) (*sql.DB, error) {
-	if driverName == "" {
-		driverName = "postgres"
-	}
-	db, err := otelsql.Open(driverName, dataSourceName,
+func OpenSQLDB(dataSourceName string) (*sql.DB, error) {
+	db, err := otelsql.Open("postgres", dataSourceName,
 		otelsql.WithAttributes(
 			semconv.DBSystemPostgreSQL,
-			attribute.String("db.name", dbName),
+			attribute.String("db.name", "digits"),
 		),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			// DisableQuery suppresses the db.statement attribute so
@@ -61,7 +58,7 @@ func OpenSQLDB(driverName, dataSourceName string, dbName string) (*sql.DB, error
 		}),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("otelsql open %s: %w", driverName, err)
+		return nil, fmt.Errorf("otelsql open postgres: %w", err)
 	}
 	return db, nil
 }


### PR DESCRIPTION
## What

`tracing.OpenSQLDB` accepted `driverName` and `dbName` parameters, but its own doc comment said the driver "is fixed to `postgres` (lib/pq) because that's the only driver we use; passing a different name is a sign of a bug at the call site, not a configuration knob." The single caller in `internal/db.Open` passed the literals `("postgres", url, "digits")`, and the function had an `if driverName == ""` default that was never triggered.

The signature said "configurable", the comment said "do not configure", and the only caller's behavior matched the comment. The parameters were configuration theater.

## How

Drop both parameters. `OpenSQLDB` now takes just the data-source string and hardcodes `"postgres"` and `"digits"` inline. The signature matches the documented intent.

```go
// before
func OpenSQLDB(driverName, dataSourceName string, dbName string) (*sql.DB, error)
tracing.OpenSQLDB("postgres", databaseURL, "digits")

// after
func OpenSQLDB(dataSourceName string) (*sql.DB, error)
tracing.OpenSQLDB(databaseURL)
```

The package doc still lists `db.name` as the `digits` literal we emit, and the comment in `internal/db.Open` already pointed at `internal/tracing/db.go` for the privacy rationale.

## Verify

- `go build ./...`, `go test ./...`, and `go vet ./...` clean from `server/`.