### PR TITLE
fix(digitsd): clear Pico RECOVERY phase on Try Again so recovery actually exits

### DIFF
--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -282,6 +282,7 @@ setTimeout(poll,2000)}poll()</script></body></html>`)
 		state.startTryAgain()
 		dbg.add("action", "try-again via web")
 		clearRecoveryBootState()
+		clearRecoveryPhase(sp)
 		w.WriteHeader(http.StatusOK)
 		go doReboot()
 	})
@@ -328,6 +329,7 @@ func recoveryHandleKey(sp *phone.SerialPort, key string, events <-chan string, m
 		mixer.PlayOnce("restarting")
 		waitForOnceComplete(mixer, 5*time.Second)
 		clearRecoveryBootState()
+		clearRecoveryPhase(sp)
 		doReboot()
 		return true
 
@@ -477,6 +479,20 @@ func syncAndHalt() {
 func clearRecoveryBootState() {
 	_ = bootcount.Clear(bootcount.DefaultPath)
 	_ = os.Remove("/data/digits/recovery-mode")
+}
+
+// clearRecoveryPhase overwrites the Pico's persisted RECOVERY phase byte (set
+// by StateSet("RECOVERY") on recovery entry) with a non-recovery value. Without
+// this, the try-again exits clear the /data flag but leave the Pico in the
+// RECOVERY phase, so the next normal boot's phase check sees RECOVERY, the
+// panic-button handler re-writes /data/digits/recovery-mode, and the device
+// bounces straight back into recovery. Normal boot re-sets the correct
+// paired/unpaired phase from the device token, so UNPAIRED is a safe neutral.
+// nil-safe: if serial never came up, recovery never set the phase.
+func clearRecoveryPhase(sp *phone.SerialPort) {
+	if sp != nil {
+		sp.StateSet("UNPAIRED")
+	}
 }
 
 // clearRecoveryFlags mounts /data temporarily to clear the boot counter


### PR DESCRIPTION
## Problem

In recovery mode, "Try Again" reboots straight back into recovery instead of returning to normal boot. (Factory Reset escapes fine.)

## Root cause

`runRecoveryMode` sets the Pico's persisted phase byte to `RECOVERY` (`recovery.go`, `StateSet("RECOVERY")`, for the fast-blink LED). On a normal boot, the panic-button handler reads that byte and, if it's `RECOVERY`, re-writes `/data/digits/recovery-mode` and reboots back into recovery. Both Try-Again exits cleared the `/data` flag and boot counter but never cleared the Pico phase, so:

```
try-again -> reboot -> normal boot reads PHASE_RECOVERY
   -> panic handler recreates /data/digits/recovery-mode -> recovery -> loop
```

Factory Reset already avoided this by calling `StateSet("SETUP")` before its reboot; the two Try-Again paths did not.

This only became visible once recovery serial actually worked (the `/dev/ttyAMA0` fix that merged with the recovery functionality PR). With the prior broken `/dev/serial0`, `sp` was nil so `StateSet("RECOVERY")` never ran, the phase was never set, and Try-Again appeared to work. The earlier `/data`-flag fixes were necessary but not sufficient; the Pico phase is a second, independent persistent trigger.

## Fix

Add `clearRecoveryPhase(sp)` (StateSet to a non-recovery value, `UNPAIRED`) on both Try-Again exits. Normal boot re-sets the correct paired/unpaired phase from the device token, so `UNPAIRED` is a safe neutral. nil-safe: if serial never came up, recovery never set the phase, so there's nothing to clear.

## Testing

- `go build`, `go test ./cmd/digitsd/`, `golangci-lint` clean in `pi/digitsd`.
- Recovery is the recovery-partition binary, so this is verified on-hardware only after an image rebuild + reflash: enter recovery, hit Try Again, confirm it boots to normal instead of looping.

## Note
Follow-up to the recovery functionality PR (merged); this is the piece that makes Try Again exit. Until reflashed, the loop can be escaped on an affected device with the recovery web UI Factory Reset.