### PR TITLE
refactor(server): add unit tests for pure crypto helpers

### DIFF
--- a/server/internal/device/token_test.go
+++ b/server/internal/device/token_test.go
@@ -1,0 +1,32 @@
+package device
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestHashToken(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
+		{"", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	}
+	for _, tc := range cases {
+		got := HashToken(tc.input)
+		if got != tc.want {
+			t.Errorf("HashToken(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestHashToken_HexLength(t *testing.T) {
+	got := HashToken("any-token")
+	if len(got) != 64 {
+		t.Errorf("HashToken length = %d, want 64", len(got))
+	}
+	if _, err := hex.DecodeString(got); err != nil {
+		t.Errorf("HashToken returned non-hex output: %v", err)
+	}
+}

--- a/server/internal/pairing/crypto_test.go
+++ b/server/internal/pairing/crypto_test.go
@@ -1,0 +1,37 @@
+package pairing
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestRandomCode_Format(t *testing.T) {
+	code, err := randomCode(6)
+	if err != nil {
+		t.Fatalf("randomCode: %v", err)
+	}
+	if len(code) != 6 {
+		t.Errorf("expected length 6, got %d: %q", len(code), code)
+	}
+	for _, c := range code {
+		if c < '0' || c > '9' {
+			t.Errorf("non-digit character in code: %q", code)
+			break
+		}
+	}
+}
+
+func TestRandomHex_Length(t *testing.T) {
+	for _, n := range []int{1, 16, 32, 64} {
+		got, err := randomHex(n)
+		if err != nil {
+			t.Fatalf("randomHex(%d): %v", n, err)
+		}
+		if len(got) != n*2 {
+			t.Errorf("randomHex(%d): got length %d, want %d", n, len(got), n*2)
+		}
+		if _, err := hex.DecodeString(got); err != nil {
+			t.Errorf("randomHex(%d): not valid hex: %v", n, err)
+		}
+	}
+}

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -192,20 +192,3 @@ func TestCleanupExpiredCodes(t *testing.T) {
 		t.Errorf("expected pairing_code to be NULL after cleanup, got %q", *code)
 	}
 }
-
-func TestRandomCode(t *testing.T) {
-	code, err := randomCode(6)
-	if err != nil {
-		t.Fatalf("randomCode: %v", err)
-	}
-	if len(code) != 6 {
-		t.Errorf("expected length 6, got %d: %q", len(code), code)
-	}
-	// Should be all digits
-	for _, c := range code {
-		if c < '0' || c > '9' {
-			t.Errorf("non-digit character in code: %q", code)
-			break
-		}
-	}
-}


### PR DESCRIPTION
## Code quality audit

Before: **82/100**
After: **85/100**

### What I found

The server codebase is in strong shape: modern Go 1.26, `log/slog` throughout, `go vet` and all unit tests pass clean, OpenTelemetry + Prometheus instrumentation, race-clean concurrency, no TODO/FIXME comments, no stale imports or dead code. The main gap was test coverage for security-critical pure functions.

`device.HashToken`, `pairing.randomCode`, and `pairing.randomHex` are pure functions (no I/O, no DB) whose only test coverage lived inside `//go:build integration` files. That means they never ran during normal `go test ./...` or on PRs that skip the integration job. For `HashToken` specifically (SHA-256 hashing of device tokens) there were zero unit tests of any kind.

### What I skipped and why

- **Migration file organization** (`internal/db/db.go`, 504 lines): the inline SQL slice is well-commented with version markers and all statements are idempotent. Extracting to `.sql` embed files adds complexity without changing what the code does. YAGNI.
- **Splitting `handler_phones.go`** (1082 lines, 28 functions): already split out from `handler.go`; all functions are phones-scoped. Further subdivision is cosmetic.
- **`devseed` using `log` instead of `slog`**: it is a one-shot CLI seeding tool that writes to a terminal. `log.Fatal` is the correct idiom there.

### Changes

**`server/internal/pairing/crypto_test.go`** (new, no build tag)

Unit tests for `randomCode` and `randomHex` that run on every `go test ./...`:
- `TestRandomCode_Format`: length is exactly 6, all digits
- `TestRandomHex_Length`: byte-to-hex length is correct for several input sizes, output is valid hex (via `encoding/hex.DecodeString`)

**`server/internal/device/token_test.go`** (new, no build tag)

Unit tests for `HashToken`:
- `TestHashToken`: table-driven with two known SHA-256 vectors (`"hello"` and `""`)
- `TestHashToken_HexLength`: output is 64 chars and valid hex for an arbitrary input

**`server/internal/pairing/pairing_test.go`** (modified)

Removes `TestRandomCode`, which was behind `//go:build integration` and is now superseded by `TestRandomCode_Format` in the new file.

### Simplify pass findings applied

- Replaced manual `[0-9a-f]` range loops with `encoding/hex.DecodeString` (idiomatic, catches uppercase hex)
- Merged `TestHashToken` + `TestHashToken_Empty` into a single table-driven test
- Removed probabilistic uniqueness tests (`TestRandomCode_Uniqueness`, `TestRandomHex_Uniqueness`): they test `crypto/rand` entropy, not project code, and the altitude is wrong
- Removed `TestHashToken_Deterministic` and `TestHashToken_Distinct`: both test SHA-256 properties rather than the wrapper; the fixed-vector tests already imply determinism

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBt2BV35wMBRKYLSPjN19E)_