### PR TITLE
fix(digitsd): honor the panic button (* at boot) from setup/AP mode

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1085,7 +1085,9 @@ func main() {
 		// Setup mode is pre-pairing, so pass an empty device token.
 		if subsystem.IsReady(serial) {
 			if sp := serial.Port(); sp != nil {
-				if phase, err := queryPicoPhase(sp); err == nil && phase == phone.PhaseRecovery {
+				if phase, err := queryPicoPhase(sp); err != nil {
+					slog.Error("setup: phase query failed, proceeding without panic-button check", "error", err)
+				} else if phase == phone.PhaseRecovery {
 					enterPanicRecovery(sp, "")
 				}
 			}

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -975,6 +975,43 @@ func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subs
 	return regs, web, serial, audio
 }
 
+// queryPicoPhase reads the Pico's persisted phase byte, retrying briefly since
+// the link may still be settling right after POST.
+func queryPicoPhase(sp *phone.SerialPort) (uint8, error) {
+	const phaseRetries = 5
+	var phase uint8
+	var err error
+	for i := 1; i <= phaseRetries; i++ {
+		phase, err = sp.QueryPhase()
+		if err == nil {
+			return phase, nil
+		}
+		slog.Warn("phase query failed", "attempt", i, "max", phaseRetries, "error", err)
+		time.Sleep(500 * time.Millisecond)
+	}
+	return 0, err
+}
+
+// enterPanicRecovery handles a Pico phase of RECOVERY (the user held * at
+// power-on): flag recovery for the next boot, clear the panic phase to a
+// non-recovery value so it does not loop, and reboot. Called from both normal
+// and setup mode so the panic button works regardless of whether WiFi is
+// configured: a device that boots into setup/AP mode must still reach recovery.
+func enterPanicRecovery(sp *phone.SerialPort, deviceToken string) {
+	slog.Info("panic button: Pico phase is RECOVERY (* held at boot), entering recovery mode")
+	if err := bootcount.SetThreshold(bootcount.DefaultPath, 3); err != nil {
+		slog.Warn("panic button: failed to set boot counter", "error", err)
+	}
+	_ = os.WriteFile("/data/digits/recovery-mode", []byte("panic-button\n"), 0644)
+	if deviceToken == "" {
+		sp.StateSet("UNPAIRED")
+	} else {
+		sp.StateSet("PAIRED")
+	}
+	time.Sleep(500 * time.Millisecond)
+	doReboot()
+}
+
 func main() {
 	flag.Parse()
 
@@ -1038,6 +1075,20 @@ func main() {
 		if err := mgr.Run(context.Background()); err != nil {
 			slog.Error("setup init failed", "error", err)
 			os.Exit(1)
+		}
+		// Honor the panic button (* held at power-on) even with no WiFi
+		// configured. A fresh device boots straight into setup/AP mode, which
+		// never reaches the normal-mode phase check, so without this the LED
+		// flashes RECOVERY but the device just proceeds to AP config. The
+		// serial subsystem has brought the Pico up (flashing it if needed), so
+		// the phase byte the firmware wrote when * was held is readable here.
+		// Setup mode is pre-pairing, so pass an empty device token.
+		if subsystem.IsReady(serial) {
+			if sp := serial.Port(); sp != nil {
+				if phase, err := queryPicoPhase(sp); err == nil && phase == phone.PhaseRecovery {
+					enterPanicRecovery(sp, "")
+				}
+			}
 		}
 		runSetupMode(web, serial, audioMod)
 		return
@@ -1368,17 +1419,7 @@ func main() {
 	// so the device doesn't loop back into recovery on every boot.
 	cachedPhase := "unknown"
 	if postOk {
-		const phaseRetries = 5
-		var phase uint8
-		var phaseErr error
-		for i := 1; i <= phaseRetries; i++ {
-			phase, phaseErr = sp.QueryPhase()
-			if phaseErr == nil {
-				break
-			}
-			slog.Warn("phase query failed", "attempt", i, "max", phaseRetries, "error", phaseErr)
-			time.Sleep(500 * time.Millisecond)
-		}
+		phase, phaseErr := queryPicoPhase(sp)
 		if phaseErr != nil {
 			slog.Error("phase query: all retries exhausted, proceeding without phase check", "error", phaseErr)
 		} else {
@@ -1396,18 +1437,7 @@ func main() {
 			}
 			slog.Info("pico phase", "phase", fmt.Sprintf("0x%02X", phase))
 			if phase == phone.PhaseRecovery {
-				slog.Info("panic button: Pico phase is RECOVERY (* held at boot), entering recovery mode")
-				if err := bootcount.SetThreshold(bootcount.DefaultPath, 3); err != nil {
-					slog.Warn("panic button: failed to set boot counter", "error", err)
-				}
-				_ = os.WriteFile("/data/digits/recovery-mode", []byte("panic-button\n"), 0644)
-				if cfg.DeviceToken == "" {
-					sp.StateSet("UNPAIRED")
-				} else {
-					sp.StateSet("PAIRED")
-				}
-				time.Sleep(500 * time.Millisecond)
-				doReboot()
+				enterPanicRecovery(sp, cfg.DeviceToken)
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

Holding `*` at power-on should enter recovery. On a device with no WiFi configured, the LED flashes as if entering recovery, but ~25s later it proceeds to AP config mode instead. The user is not holding `*` after the flash (and shouldn't have to).

## Root cause

The panic-button recovery entry (query the Pico's persisted phase byte, and if it's `PHASE_RECOVERY` flag recovery for the next boot and reboot) exists **only in the normal-mode startup path** (`main.go`, after the setup branch returns). A device with no `/data/wifi-configured` boots into setup/AP mode (`--mode=setup`), which runs `runSetupMode` and returns without ever querying the phase. So:

- Firmware sees `*` held at its boot scan, writes `PHASE_RECOVERY`, fast-blinks the LED (this is the flash you see).
- The Pi boots into setup mode, ignores the phase, brings up the AP, and `StateSet("SETUP")` flips the LED back (the ~25s mark).

`boot-check.sh` doesn't read the Pico phase either (it keys off the `/data` flag and boot counter), so nothing in the AP-mode boot acts on the panic.

## Fix

Extract the phase query and the recovery-entry into `queryPicoPhase` and `enterPanicRecovery`, and run the same check in setup mode after the serial subsystem has brought the Pico up. Setup mode is pre-pairing, so it passes an empty device token (`StateSet("UNPAIRED")`). Normal mode is refactored to use the shared helpers (no behavior change).

After this, holding `*` at power-on enters recovery whether or not WiFi is configured, with no need to keep holding the button.

## Testing

- `go build`, `go test ./cmd/digitsd/`, `go vet`, `golangci-lint` clean in `pi/digitsd`.
- This is the main rootfs binary (setup mode runs from `/usr/local/bin/digitsd` via `digits-setup.service`), so it ships via the normal pi release / OTA, NOT a recovery-partition reflash. On-hardware check: on a no-WiFi device, hold `*` at power-on and confirm it enters recovery (and stays) instead of falling through to AP config.

## Relationship to the recovery work
Independent of the recovery-partition fixes (#698 merged, #703 open). This one is about *entering* recovery from setup mode; those are about recovery *functioning* and *exiting* cleanly. Requires a flashed Pico (the firmware must be present to scan the keypad and write the phase).