### PR TITLE
fix(digitsd): cap spoken pairing-expiry minutes at 9 so the number is audible

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -867,10 +867,14 @@ func playPairingAnnouncement(mixer *audio.Mixer, code string, expiresAt time.Tim
 		mixer.PlayOnce("spoken_" + string(ch))
 	}
 	minutesLeft := int(math.Ceil(time.Until(expiresAt).Minutes()))
+	// Spoken number clips only exist for 0-9, so cap at 9. A fresh code (TTL
+	// 10m) reads "9 minutes" for its first minute, which is true and
+	// conservative (it is valid for at least that long); without the cap it
+	// would play the nonexistent spoken_10 and the number would be silent.
 	if minutesLeft < 1 {
 		minutesLeft = 1
-	} else if minutesLeft > 10 {
-		minutesLeft = 10
+	} else if minutesLeft > 9 {
+		minutesLeft = 9
 	}
 	unitClip := "pairing_expires_minutes"
 	if minutesLeft == 1 {

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -860,29 +860,34 @@ func resetPicoHardware(sp *phone.SerialPort) {
 // the dispatcher's TypePairingCode handler. minutesLeft is computed from the
 // server-reported expiry on each call so a long-listening user hears an
 // accurate countdown that matches when the server actually invalidates it.
-func playPairingAnnouncement(mixer *audio.Mixer, code string, expiresAt time.Time) {
-	mixer.PlayOnce("pairing_silence")
-	mixer.PlayOnce("pairing_welcome")
-	for _, ch := range code {
-		mixer.PlayOnce("spoken_" + string(ch))
-	}
-	minutesLeft := int(math.Ceil(time.Until(expiresAt).Minutes()))
-	// Spoken number clips only exist for 0-9, so cap at 9. A fresh code (TTL
-	// 10m) reads "9 minutes" for its first minute, which is true and
-	// conservative (it is valid for at least that long); without the cap it
-	// would play the nonexistent spoken_10 and the number would be silent.
+// pairingAnnouncementClips returns the ordered mixer clip names for one pairing
+// announcement: silence pad, welcome, the code digits, "expires in", the minute
+// count, and the singular/plural unit. minutesLeft is capped at 9 because the
+// spoken number clips only exist for spoken_0..spoken_9; a fresh code (TTL 10m)
+// would otherwise reference a nonexistent spoken_10 and play a silent number.
+// Pure (no mixer) so the clamp and sequence are unit-testable.
+func pairingAnnouncementClips(code string, minutesLeft int) []string {
 	if minutesLeft < 1 {
 		minutesLeft = 1
 	} else if minutesLeft > 9 {
 		minutesLeft = 9
 	}
+	clips := []string{"pairing_silence", "pairing_welcome"}
+	for _, ch := range code {
+		clips = append(clips, "spoken_"+string(ch))
+	}
 	unitClip := "pairing_expires_minutes"
 	if minutesLeft == 1 {
 		unitClip = "pairing_expires_minute"
 	}
-	mixer.PlayOnce("pairing_expires_prefix")
-	mixer.PlayOnce(fmt.Sprintf("spoken_%d", minutesLeft))
-	mixer.PlayOnce(unitClip)
+	return append(clips, "pairing_expires_prefix", fmt.Sprintf("spoken_%d", minutesLeft), unitClip)
+}
+
+func playPairingAnnouncement(mixer *audio.Mixer, code string, expiresAt time.Time) {
+	minutesLeft := int(math.Ceil(time.Until(expiresAt).Minutes()))
+	for _, clip := range pairingAnnouncementClips(code, minutesLeft) {
+		mixer.PlayOnce(clip)
+	}
 }
 
 // recoverySerialDevice returns the raw UART node for the Pico. Recovery mode

--- a/pi/digitsd/cmd/digitsd/pairing_announcement_test.go
+++ b/pi/digitsd/cmd/digitsd/pairing_announcement_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestPairingAnnouncementClips(t *testing.T) {
+	// The regression: 10+ minutes must cap to spoken_9, never the nonexistent
+	// spoken_10 (which played as a silent number).
+	for _, m := range []int{10, 11, 100} {
+		clips := pairingAnnouncementClips("12", m)
+		if !slices.Contains(clips, "spoken_9") {
+			t.Errorf("minutesLeft=%d: want spoken_9, got %v", m, clips)
+		}
+		if slices.Contains(clips, "spoken_10") {
+			t.Errorf("minutesLeft=%d: must not reference the nonexistent spoken_10", m)
+		}
+		if !slices.Contains(clips, "pairing_expires_minutes") {
+			t.Errorf("minutesLeft=%d: want plural unit", m)
+		}
+	}
+
+	// Exactly 1 minute uses the singular unit.
+	one := pairingAnnouncementClips("9", 1)
+	if !slices.Contains(one, "spoken_1") || !slices.Contains(one, "pairing_expires_minute") {
+		t.Errorf("minutesLeft=1: want spoken_1 + singular unit, got %v", one)
+	}
+	if slices.Contains(one, "pairing_expires_minutes") {
+		t.Error("minutesLeft=1 must use the singular unit, not plural")
+	}
+
+	// 0 / negative floor to 1 (singular).
+	zero := pairingAnnouncementClips("9", 0)
+	if !slices.Contains(zero, "spoken_1") || !slices.Contains(zero, "pairing_expires_minute") {
+		t.Errorf("minutesLeft=0: want clamp to 1, got %v", zero)
+	}
+
+	// Full sequence: code digits expand in order, framed by the fixed clips.
+	got := pairingAnnouncementClips("314", 5)
+	want := []string{
+		"pairing_silence", "pairing_welcome",
+		"spoken_3", "spoken_1", "spoken_4",
+		"pairing_expires_prefix", "spoken_5", "pairing_expires_minutes",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sequence mismatch:\n got %v\nwant %v", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

Pairing a new device reads the code, then says "this code expires in **[silence]** minutes" instead of "expires in **X** minutes". Regression.

## Root cause

`playPairingAnnouncement` clamps `minutesLeft` to a max of 10 and plays `spoken_<minutesLeft>`, but the spoken number clips only exist for `spoken_0`..`spoken_9` (no `spoken_10`). When the pairing `CodeTTL` was raised from 3 to 10 minutes (#694), a freshly issued code computes `ceil(time.Until(expiresAt)) == 10` for its first minute, so it plays the nonexistent `spoken_10` and the number is silent. Before #694 the count was based on the 9-minute refresh interval and never reached 10, so this never surfaced.

## Fix

Cap `minutesLeft` at 9 (the highest available clip). A fresh 10-minute code reads "9 minutes" for its first minute, which is true and conservative (the code is valid for at least that long); after the first minute it tracks accurately (8, 7, ...). Robust to future TTL changes since it can never exceed the available clips.

## Testing

- `go build`, `go test ./cmd/digitsd/`, `golangci-lint` clean in `pi/digitsd`.
- On-hardware: pair a device and confirm the spoken count is present ("expires in 9 minutes") rather than silent.