### PR TITLE
fix(image): derive the device hostname from the Pi serial so it stops churning

### DIFF
--- a/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
@@ -31,8 +31,25 @@ restore_ro() {
 }
 trap restore_ro EXIT
 
-# --- 1. Generate unique hostname (digits-XXXX, 4 random hex chars) ---
-HEX_SUFFIX=$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
+# --- 1. Generate a stable hostname (digits-XXXX) from the Pi serial ---
+# Derive the suffix from the unchanging hardware serial, not /dev/urandom, so
+# the hostname is identical every time first-boot runs. A factory reset
+# restores the rootfs and wipes /data, leaving no writable store to remember a
+# random name, so a random suffix would change on every reset and the same
+# physical device (same MAC) would churn between hostnames in the network's
+# client list. The serial is stable across resets, so the name never changes.
+SERIAL=$(grep -m1 -iE '^Serial' /proc/cpuinfo 2>/dev/null | awk '{print $NF}' | tr -d '[:space:]')
+if [[ -z "${SERIAL}" || "${SERIAL}" =~ ^0+$ ]]; then
+    # /proc/cpuinfo had no usable serial; try the device tree.
+    SERIAL=$(tr -d '\0' < /proc/device-tree/serial-number 2>/dev/null)
+fi
+if [[ -n "${SERIAL}" && ! "${SERIAL}" =~ ^0+$ ]]; then
+    HEX_SUFFIX="${SERIAL: -4}"
+else
+    # Last resort if no serial is readable; logged so the churn cause is clear.
+    log "WARNING: no usable Pi serial; falling back to a random hostname suffix"
+    HEX_SUFFIX=$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
+fi
 HOSTNAME="digits-${HEX_SUFFIX}"
 
 log "Setting hostname: ${HOSTNAME}"

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh
@@ -38,17 +38,24 @@ trap restore_ro EXIT
 # random name, so a random suffix would change on every reset and the same
 # physical device (same MAC) would churn between hostnames in the network's
 # client list. The serial is stable across resets, so the name never changes.
-SERIAL=$(grep -m1 -iE '^Serial' /proc/cpuinfo 2>/dev/null | awk '{print $NF}' | tr -d '[:space:]')
+# The `|| true` keeps a failed read (no Serial line, missing device-tree node)
+# from tripping `set -e` before the fallbacks below can run.
+SERIAL=$(grep -m1 -iE '^Serial' /proc/cpuinfo 2>/dev/null | awk '{print $NF}' | tr -d '[:space:]') || true
 if [[ -z "${SERIAL}" || "${SERIAL}" =~ ^0+$ ]]; then
     # /proc/cpuinfo had no usable serial; try the device tree.
-    SERIAL=$(tr -d '\0' < /proc/device-tree/serial-number 2>/dev/null)
+    SERIAL=$(tr -d '\0' < /proc/device-tree/serial-number 2>/dev/null) || true
 fi
 if [[ -n "${SERIAL}" && ! "${SERIAL}" =~ ^0+$ ]]; then
-    HEX_SUFFIX="${SERIAL: -4}"
+    # Use the WHOLE board serial (only cosmetic leading zeros trimmed), not a
+    # short slice. The serial is a unique per-board hardware ID, so the full
+    # value gives distinct hostnames across identical units; a 4-char slice
+    # (16 bits) would risk collisions across a fleet. Pure-bash leading-zero
+    # strip: remove the prefix that precedes the first non-zero char.
+    HEX_SUFFIX="${SERIAL#"${SERIAL%%[!0]*}"}"
 else
     # Last resort if no serial is readable; logged so the churn cause is clear.
     log "WARNING: no usable Pi serial; falling back to a random hostname suffix"
-    HEX_SUFFIX=$(head -c 2 /dev/urandom | od -An -tx1 | tr -d ' \n' | head -c 4)
+    HEX_SUFFIX=$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' \n')
 fi
 HOSTNAME="digits-${HEX_SUFFIX}"
 


### PR DESCRIPTION
## Problem

The network console shows a device constantly churning its hostname, cycling between two `digits-XXXX` names (e.g. `digits-1671` and `digits-4094`).

## Root cause

`digits-first-boot.sh` generated the hostname suffix from `/dev/urandom`, so a new value is produced every time first-boot runs. first-boot is guarded to run once per `/data` lifetime (`ConditionPathExists=!/data/.initialized`), but:

- A factory reset wipes `/data` (so `/data/.initialized` is gone and first-boot re-runs), and
- A factory reset also restores the rootfs from the snapshot (so `/etc/hostname` is reset too).

So nothing writable survives a reset to remember the name, and each reset yields a new random hostname. The same physical device (same MAC) then presents multiple hostnames over time, which the network client tracking shows as churn. Confirmed on a device: it is stable within a boot with a single random name, so the churn is reset-driven, and the heavy factory-reset testing made it frequent.

The script comment already claimed the identity is "based on the Pi's serial number"; the hostname just was not.

## Fix

Derive the suffix from the Pi serial (`/proc/cpuinfo` `Serial`, falling back to the device-tree `serial-number`). The serial is stable hardware identity, so the hostname comes out identical every time it is computed, including after a factory reset. It is set once and never changes. Random remains only as a last-resort fallback if no serial is readable, with a logged warning so the churn cause stays visible.

Example: a Pi with serial `...53906216` becomes `digits-6216` and stays that, reset after reset.

## Scope

Only the hostname is changed. The device-id UUID and AP SSID suffix are left as is (not the reported issue; a factory-reset device arguably should get a fresh pairing identity).

## Testing

- `bash -n` clean (shellcheck not available on this host; the change is a simple serial read with fallbacks).
- Image-overlay script, so it takes effect on a freshly built/reflashed image. On-hardware: reflash, confirm the hostname is `digits-<last4 of serial>`, factory reset, confirm it returns the same.