### PR TITLE
refactor(digitsd): collapse Module.Status() to IsReady() and drop dead per-module state

### DIFF
--- a/pi/digitsd/internal/subsystem/audio.go
+++ b/pi/digitsd/internal/subsystem/audio.go
@@ -17,21 +17,19 @@ type AudioConfig struct {
 }
 
 type AudioModule struct {
-	cfg    AudioConfig
-	pb     *audio.Playback
-	mixer  *audio.Mixer
-	status ModuleStatus
+	cfg   AudioConfig
+	pb    *audio.Playback
+	mixer *audio.Mixer
+	ready bool
 }
 
 func NewAudioModule(cfg AudioConfig) *AudioModule {
-	return &AudioModule{cfg: cfg, status: ModuleStatus{State: StatePending}}
+	return &AudioModule{cfg: cfg}
 }
 
 func (a *AudioModule) Name() string { return "audio" }
 
 func (a *AudioModule) Init(ctx context.Context) error {
-	a.status.State = StateInitializing
-
 	if a.cfg.MixerStateFile != "" {
 		cmd := exec.Command("alsactl", "restore", "-f", a.cfg.MixerStateFile)
 		if out, err := cmd.CombinedOutput(); err != nil {
@@ -51,7 +49,6 @@ func (a *AudioModule) Init(ctx context.Context) error {
 		pbCfg.Device = "hw:CARD=digitscodec,DEV=0"
 		pb, err = audio.NewPlayback(pbCfg)
 		if err != nil {
-			a.status = ModuleStatus{State: StateFailed, Message: err.Error()}
 			return fmt.Errorf("playback open: %w", err)
 		}
 	}
@@ -88,12 +85,12 @@ func (a *AudioModule) Init(ctx context.Context) error {
 		}
 	}
 
-	a.status.State = StateReady
+	a.ready = true
 	return nil
 }
 
-func (a *AudioModule) Mixer() *audio.Mixer  { return a.mixer }
-func (a *AudioModule) Status() ModuleStatus { return a.status }
+func (a *AudioModule) Mixer() *audio.Mixer { return a.mixer }
+func (a *AudioModule) IsReady() bool       { return a.ready }
 
 func (a *AudioModule) Shutdown(ctx context.Context) error {
 	if a.mixer != nil {

--- a/pi/digitsd/internal/subsystem/gpclk0.go
+++ b/pi/digitsd/internal/subsystem/gpclk0.go
@@ -25,22 +25,20 @@ const (
 // GPCLK0Module configures BCM2835 GPCLK0 on GPIO4 at 12.288 MHz for the
 // TLV320AIC3104 MCLK.
 type GPCLK0Module struct {
-	status ModuleStatus
+	ready bool
 }
 
 func NewGPCLK0Module() *GPCLK0Module {
-	return &GPCLK0Module{status: ModuleStatus{State: StatePending}}
+	return &GPCLK0Module{}
 }
 
 func (g *GPCLK0Module) Name() string { return "gpclk0" }
 
 func (g *GPCLK0Module) Init(ctx context.Context) error {
-	g.status.State = StateInitializing
 	if err := enableGPCLK0(); err != nil {
-		g.status = ModuleStatus{State: StateFailed, Message: err.Error()}
 		return err
 	}
-	g.status.State = StateReady
+	g.ready = true
 	return nil
 }
 
@@ -50,7 +48,7 @@ func (g *GPCLK0Module) Retrigger() error {
 	return enableGPCLK0()
 }
 
-func (g *GPCLK0Module) Status() ModuleStatus               { return g.status }
+func (g *GPCLK0Module) IsReady() bool                      { return g.ready }
 func (g *GPCLK0Module) Shutdown(ctx context.Context) error { return nil }
 
 // EnableGPCLK0 configures BCM2835 GPCLK0 on GPIO4 at 12.288 MHz. Exported

--- a/pi/digitsd/internal/subsystem/kernmods.go
+++ b/pi/digitsd/internal/subsystem/kernmods.go
@@ -14,18 +14,16 @@ import (
 // KernModsModule loads the kernel modules needed for WiFi and audio on the
 // recovery partition, where udev is not running.
 type KernModsModule struct {
-	status ModuleStatus
+	ready bool
 }
 
 func NewKernModsModule() *KernModsModule {
-	return &KernModsModule{status: ModuleStatus{State: StatePending}}
+	return &KernModsModule{}
 }
 
 func (k *KernModsModule) Name() string { return "kernel-modules" }
 
 func (k *KernModsModule) Init(ctx context.Context) error {
-	k.status.State = StateInitializing
-
 	kver := kernelVersion()
 	modDir := filepath.Join("/lib/modules", kver)
 
@@ -81,11 +79,11 @@ func (k *KernModsModule) Init(ctx context.Context) error {
 	// Wait for sound card to register.
 	waitForSoundCard("digitscodec", 3*time.Second)
 
-	k.status.State = StateReady
+	k.ready = true
 	return nil
 }
 
-func (k *KernModsModule) Status() ModuleStatus               { return k.status }
+func (k *KernModsModule) IsReady() bool                      { return k.ready }
 func (k *KernModsModule) Shutdown(ctx context.Context) error { return nil }
 
 func kernelVersion() string {
@@ -130,4 +128,3 @@ func waitForSoundCard(name string, timeout time.Duration) {
 	}
 	slog.Warn("subsystem kernel-modules: sound card not found", "name", name, "timeout", timeout)
 }
-

--- a/pi/digitsd/internal/subsystem/manager.go
+++ b/pi/digitsd/internal/subsystem/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) Shutdown(ctx context.Context) {
 		var wg sync.WaitGroup
 		for _, r := range layer {
 			r := r
-			if !IsReady(r.Module) {
+			if !r.Module.IsReady() {
 				continue
 			}
 			wg.Add(1)

--- a/pi/digitsd/internal/subsystem/manager_test.go
+++ b/pi/digitsd/internal/subsystem/manager_test.go
@@ -32,14 +32,10 @@ func (s *stubModule) Init(_ context.Context) error {
 	return nil
 }
 
-func (s *stubModule) Status() ModuleStatus {
+func (s *stubModule) IsReady() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	st := StatePending
-	if s.ready {
-		st = StateReady
-	}
-	return ModuleStatus{State: st}
+	return s.ready
 }
 
 func (s *stubModule) Shutdown(_ context.Context) error {

--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -2,7 +2,6 @@ package subsystem
 
 import (
 	"context"
-	"time"
 )
 
 type State int
@@ -32,24 +31,19 @@ func (s State) String() string {
 	}
 }
 
-type ModuleStatus struct {
-	State    State
-	Message  string
-	Duration time.Duration
-}
-
+// Module is a unit of initialization managed by Manager. IsReady reports
+// whether the module's Init completed successfully; the rich state (message,
+// duration) is tracked by the Manager and exposed via Manager.Status.
 type Module interface {
 	Name() string
 	Init(ctx context.Context) error
-	Status() ModuleStatus
+	IsReady() bool
 	Shutdown(ctx context.Context) error
 }
 
-// IsReady reports whether m has finished its Init successfully and has not
-// since failed or been disabled.
-func IsReady(m Module) bool {
-	return m.Status().State == StateReady
-}
+// IsReady is a convenience wrapper so callers that hold a Module can write
+// `subsystem.IsReady(m)` to match the natural "is X ready?" reading order.
+func IsReady(m Module) bool { return m.IsReady() }
 
 // Registration declares a module and how the Manager should treat it.
 // The zero value is the common case: enabled, not required, no deps. Set

--- a/pi/digitsd/internal/subsystem/mounts.go
+++ b/pi/digitsd/internal/subsystem/mounts.go
@@ -8,18 +8,16 @@ import (
 )
 
 type MountsModule struct {
-	status ModuleStatus
+	ready bool
 }
 
 func NewMountsModule() *MountsModule {
-	return &MountsModule{status: ModuleStatus{State: StatePending}}
+	return &MountsModule{}
 }
 
 func (m *MountsModule) Name() string { return "mounts" }
 
 func (m *MountsModule) Init(ctx context.Context) error {
-	m.status.State = StateInitializing
-
 	_ = os.MkdirAll("/tmp", 0755)
 	if err := syscall.Mount("tmpfs", "/tmp", "tmpfs", 0, "size=64M"); err != nil {
 		slog.Warn("mounts: /tmp mount failed (may already be mounted)", "error", err)
@@ -30,9 +28,9 @@ func (m *MountsModule) Init(ctx context.Context) error {
 		slog.Warn("mounts: /data mount failed (non-fatal)", "error", err)
 	}
 
-	m.status.State = StateReady
+	m.ready = true
 	return nil
 }
 
-func (m *MountsModule) Status() ModuleStatus               { return m.status }
+func (m *MountsModule) IsReady() bool                      { return m.ready }
 func (m *MountsModule) Shutdown(ctx context.Context) error { return nil }

--- a/pi/digitsd/internal/subsystem/reaper.go
+++ b/pi/digitsd/internal/subsystem/reaper.go
@@ -9,22 +9,19 @@ import (
 
 // ReaperModule reaps zombie child processes when running as PID 1.
 type ReaperModule struct {
-	status ModuleStatus
-	stop   chan struct{}
+	stop  chan struct{}
+	ready bool
 }
 
 func NewReaperModule() *ReaperModule {
 	return &ReaperModule{
-		status: ModuleStatus{State: StatePending},
-		stop:   make(chan struct{}),
+		stop: make(chan struct{}),
 	}
 }
 
 func (r *ReaperModule) Name() string { return "reaper" }
 
 func (r *ReaperModule) Init(ctx context.Context) error {
-	r.status.State = StateInitializing
-
 	sigchld := make(chan os.Signal, 1)
 	signal.Notify(sigchld, syscall.SIGCHLD)
 
@@ -46,11 +43,11 @@ func (r *ReaperModule) Init(ctx context.Context) error {
 		}
 	}()
 
-	r.status.State = StateReady
+	r.ready = true
 	return nil
 }
 
-func (r *ReaperModule) Status() ModuleStatus { return r.status }
+func (r *ReaperModule) IsReady() bool { return r.ready }
 func (r *ReaperModule) Shutdown(ctx context.Context) error {
 	close(r.stop)
 	return nil

--- a/pi/digitsd/internal/subsystem/serial.go
+++ b/pi/digitsd/internal/subsystem/serial.go
@@ -21,20 +21,18 @@ type SerialConfig struct {
 }
 
 type SerialModule struct {
-	cfg    SerialConfig
-	port   *phone.SerialPort
-	status ModuleStatus
+	cfg   SerialConfig
+	port  *phone.SerialPort
+	ready bool
 }
 
 func NewSerialModule(cfg SerialConfig) *SerialModule {
-	return &SerialModule{cfg: cfg, status: ModuleStatus{State: StatePending}}
+	return &SerialModule{cfg: cfg}
 }
 
 func (s *SerialModule) Name() string { return "serial" }
 
 func (s *SerialModule) Init(ctx context.Context) error {
-	s.status.State = StateInitializing
-
 	// probe opens the port and PINGs the Pico, stashing the port on success.
 	probe := func() bool {
 		sp, err := phone.OpenSerial(s.cfg.Device, s.cfg.Baud, slog.Default())
@@ -63,13 +61,11 @@ func (s *SerialModule) Init(ctx context.Context) error {
 	if attemptSerialBringup(probe, s.cfg.FlashOnFail, firstAttempts, 10, func() {
 		time.Sleep(500 * time.Millisecond)
 	}) {
-		s.status.State = StateReady
+		s.ready = true
 		return nil
 	}
 
-	err := fmt.Errorf("failed to open and ping after retries")
-	s.status = ModuleStatus{State: StateFailed, Message: err.Error()}
-	return err
+	return fmt.Errorf("failed to open and ping after retries")
 }
 
 // attemptSerialBringup probes for a reachable Pico, flashing the firmware once
@@ -109,7 +105,7 @@ func attemptSerialBringup(probe func() bool, flash func(reason string) error, fi
 }
 
 func (s *SerialModule) Port() *phone.SerialPort { return s.port }
-func (s *SerialModule) Status() ModuleStatus    { return s.status }
+func (s *SerialModule) IsReady() bool            { return s.ready }
 
 func (s *SerialModule) Shutdown(ctx context.Context) error {
 	if s.port != nil {

--- a/pi/digitsd/internal/subsystem/web.go
+++ b/pi/digitsd/internal/subsystem/web.go
@@ -18,14 +18,13 @@ type WebModule struct {
 	mgr     *Manager
 	ln      net.Listener
 	logPath string
-	status  ModuleStatus
+	ready   bool
 }
 
 func NewWebModule() *WebModule {
 	return &WebModule{
 		mux:     http.NewServeMux(),
 		logPath: "/tmp/subsystem.log",
-		status:  ModuleStatus{State: StatePending},
 	}
 }
 
@@ -36,14 +35,11 @@ func (w *WebModule) Name() string { return "web" }
 func (w *WebModule) SetManager(mgr *Manager) { w.mgr = mgr }
 
 func (w *WebModule) Init(ctx context.Context) error {
-	w.status.State = StateInitializing
-
 	w.mux.HandleFunc("/status", w.handleStatus)
 	w.mux.HandleFunc("/log/raw", w.handleLogRaw)
 
 	ln, err := net.Listen("tcp", ":80")
 	if err != nil {
-		w.status = ModuleStatus{State: StateFailed, Message: err.Error()}
 		return fmt.Errorf("listen :80: %w", err)
 	}
 	w.ln = ln
@@ -54,13 +50,13 @@ func (w *WebModule) Init(ctx context.Context) error {
 		}
 	}()
 
-	w.status.State = StateReady
+	w.ready = true
 	slog.Info("subsystem web: listening on :80")
 	return nil
 }
 
-func (w *WebModule) Mux() *http.ServeMux  { return w.mux }
-func (w *WebModule) Status() ModuleStatus { return w.status }
+func (w *WebModule) Mux() *http.ServeMux { return w.mux }
+func (w *WebModule) IsReady() bool       { return w.ready }
 
 func (w *WebModule) Shutdown(ctx context.Context) error {
 	if w.ln != nil {

--- a/pi/digitsd/internal/subsystem/wifiap.go
+++ b/pi/digitsd/internal/subsystem/wifiap.go
@@ -19,8 +19,8 @@ type WiFiAPConfig struct {
 }
 
 type WiFiAPModule struct {
-	cfg    WiFiAPConfig
-	status ModuleStatus
+	cfg   WiFiAPConfig
+	ready bool
 }
 
 func NewWiFiAPModule(cfg WiFiAPConfig) *WiFiAPModule {
@@ -36,25 +36,29 @@ func NewWiFiAPModule(cfg WiFiAPConfig) *WiFiAPModule {
 	if cfg.InterfaceWait == 0 {
 		cfg.InterfaceWait = 15 * time.Second
 	}
-	return &WiFiAPModule{cfg: cfg, status: ModuleStatus{State: StatePending}}
+	return &WiFiAPModule{cfg: cfg}
 }
 
 func (w *WiFiAPModule) Name() string { return "wifi-ap" }
 
 func (w *WiFiAPModule) Init(ctx context.Context) error {
-	w.status.State = StateInitializing
-
 	slog.Info("subsystem wifi-ap: waiting for wlan0")
 	if err := waitForInterface("wlan0", w.cfg.InterfaceWait); err != nil {
-		w.status = ModuleStatus{State: StateFailed, Message: err.Error()}
 		return err
 	}
 	unblockWifi()
 
+	var initErr error
 	if w.cfg.UseSystemd {
-		return w.initSystemd()
+		initErr = w.initSystemd()
+	} else {
+		initErr = w.initDirect()
 	}
-	return w.initDirect()
+	if initErr != nil {
+		return initErr
+	}
+	w.ready = true
+	return nil
 }
 
 func (w *WiFiAPModule) initDirect() error {
@@ -95,7 +99,6 @@ func (w *WiFiAPModule) initDirect() error {
 		return fmt.Errorf("dnsmasq: %w", err)
 	}
 
-	w.status.State = StateReady
 	slog.Info("subsystem wifi-ap: AP started", "ssid", w.cfg.SSID)
 	return nil
 }
@@ -106,7 +109,6 @@ func (w *WiFiAPModule) initSystemd() error {
 			return fmt.Errorf("start %s: %w", svc, err)
 		}
 	}
-	w.status.State = StateReady
 	slog.Info("subsystem wifi-ap: AP started via systemd", "ssid", w.cfg.SSID)
 	return nil
 }
@@ -123,7 +125,7 @@ func (w *WiFiAPModule) Teardown() error {
 	return nil
 }
 
-func (w *WiFiAPModule) Status() ModuleStatus               { return w.status }
+func (w *WiFiAPModule) IsReady() bool                      { return w.ready }
 func (w *WiFiAPModule) Shutdown(ctx context.Context) error { return w.Teardown() }
 
 func waitForInterface(name string, timeout time.Duration) error {


### PR DESCRIPTION
## Motivation

Each `subsystem.Module` carried a `ModuleStatus` (State + Message + Duration) and walked it through Pending → Initializing → Ready/Failed inside `Init`, in parallel with the `Manager`'s own `m.states` map. Only one bit of that machine was ever observed:

- `subsystem.IsReady(m Module)` (used by `Manager.Shutdown` and the cmd/digitsd setup/recovery paths) checked `Status().State == StateReady`.
- The `Message` and `Duration` fields on the module's `ModuleStatus` were written and never read. The Manager already records messages and durations in `NamedStatus`, and that's what the `/status` HTTP endpoint serves.
- The intermediate `StateInitializing` and `StateFailed` transitions inside modules were never observed by anything.

So every module was running a four-state machine to expose one bit, while the canonical rich state already lived on the Manager.

## Shape of the change

- Replace `Status() ModuleStatus` on the `Module` interface with `IsReady() bool`.
- Delete the `ModuleStatus` struct.
- Each of the seven modules (audio, gpclk0, kernmods, mounts, reaper, serial, web, wifiap) drops its `status` field and the Pending/Initializing/Failed assignments; on success `Init` flips a single `ready` bool.
- `Manager.Shutdown` calls `r.Module.IsReady()` directly. The free `subsystem.IsReady(m)` wrapper stays so existing `cmd/digitsd` callsites (`if serial != nil && subsystem.IsReady(serial)`) keep reading naturally.
- Manager-side state (`NamedStatus` with Name/State/Message/Duration/Required) is untouched: it's still the source of truth for the `/status` JSON and the existing `manager_test.go` assertions.

Net diff: 11 files, +59/-88.

## Test plan

- [x] `go build ./...` in `pi/digitsd/`
- [x] `go test ./...` in `pi/digitsd/` (subsystem and cmd/digitsd packages pass)
- [x] `golangci-lint run ./...` clean