### PR TITLE
refactor(digitsd): rename TestModuleStatusString to TestStateString

### DIFF
--- a/pi/digitsd/internal/subsystem/module_test.go
+++ b/pi/digitsd/internal/subsystem/module_test.go
@@ -2,7 +2,7 @@ package subsystem
 
 import "testing"
 
-func TestModuleStatusString(t *testing.T) {
+func TestStateString(t *testing.T) {
 	tests := []struct {
 		state State
 		want  string


### PR DESCRIPTION
## Summary

Drift left by #708: when `Module.Status()` collapsed to `IsReady()` and the `ModuleStatus` struct was deleted, the only test in `pi/digitsd/internal/subsystem/module_test.go` kept its old name `TestModuleStatusString`. The body of the test calls `tt.state.String()` directly on the `State` enum, so the name now points at a struct that no longer exists. Rename to `TestStateString` so the name matches what the test exercises.

## Motivated by (last 24h)

- #708 refactor(digitsd): collapse Module.Status() to IsReady() and drop dead per-module state

## Test plan

- [x] `go build ./...` in `pi/digitsd/`
- [x] `go test ./...` in `pi/digitsd/` (all packages pass, including renamed test)
- [ ] CI lint pass (golangci-lint v2.5.0 in this sandbox does not support Go 1.26.1; CI will exercise the real toolchain)