### PR TITLE
docs: reflect stable Pi-serial hostname in first-boot docs

### DIFF
--- a/docs/build/wiring.md
+++ b/docs/build/wiring.md
@@ -249,7 +249,7 @@ Full mixer documentation: `pi/README-mixer.md`
 | `digits-ap.service`       | hostapd AP mode (setup only)              | Conditional |
 | `digits-dnsmasq-ap.service` | dnsmasq DHCP/DNS for AP mode            | Conditional |
 | `digits-setup.service`    | Captive portal web server (setup only)    | Conditional |
-| `digits-first-boot.service` | First-boot hostname/SSH key randomization | Conditional (oneshot) |
+| `digits-first-boot.service` | First-boot identity setup: stable hostname from Pi serial, fresh SSH host keys | Conditional (oneshot) |
 | `dtmf-uart.service`       | *(DISABLED)* -- replaced by digitsd       | Disabled |
 | `digits-dac-keepalive.service` | *(DISABLED)* -- moved into digitsd    | Disabled |
 

--- a/tools/README-image-builder.md
+++ b/tools/README-image-builder.md
@@ -106,8 +106,8 @@ The final image is ~7 GB uncompressed. An **8 GB microSD card** is the minimum r
 
 On first power-on, the device will:
 
-1. **Generate unique identity** -- hostname `digits-XXXX`, SSH keys, device ID
-2. **Start AP mode** -- broadcasts `Digits-XXXX` Wi-Fi network
+1. **Generate unique identity** -- stable hostname `digits-<serial>` derived from the Pi's hardware serial (so it survives factory resets), SSH keys, device ID
+2. **Start AP mode** -- broadcasts `Digits-XXXX` Wi-Fi network (XXXX from the device UUID)
 3. **Serve captive portal** -- user connects, configures home network + pairing code
 4. **Reboot to normal mode** -- connects to configured Wi-Fi, pairs with server
 


### PR DESCRIPTION
## Summary

PR #707 changed the first-boot hostname from a random 4-hex-char suffix to one derived from the Pi's hardware serial, so the same physical device keeps the same name across factory resets. Two committed docs still describe the pre-#707 behavior:

- `tools/README-image-builder.md` listed the hostname as `digits-XXXX`. After #707 the actual format is `digits-{serial}` (typically the full 16-hex Pi serial, with cosmetic leading zeros trimmed), and that suffix is no longer related to the AP SSID's `Digits-XXXX` suffix (which is still 4 hex chars derived from the random device UUID). Calling them both `XXXX` implied they share a format; they don't.
- `docs/build/wiring.md` described `digits-first-boot.service` as "hostname/SSH key randomization". After #707 only the SSH host keys are still randomized; the hostname is stable.

This PR updates both descriptions to match what `pi/image/rootfs-overlay/usr/local/bin/digits-first-boot.sh` actually does today. No code or behavior change.

Motivated by (last 24h):

- #707 fix(image): derive the device hostname from the Pi serial so it stops churning

## Test plan

- [ ] Docs-only change; no build, test, or lint surface touched. Skim the rendered markdown for both files.
