### PR TITLE
refactor(server): handle RowsAffected errors and fix auth ordering

### DIFF
--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -244,7 +244,10 @@ func (s *Store) DeleteUser(ctx context.Context, userID string) error {
 	if err != nil {
 		return fmt.Errorf("delete user: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
 	if n == 0 {
 		return ErrUserNotFound
 	}

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -203,7 +203,10 @@ func (t *Tracker) OnCallAnswered(ctx context.Context, caller, callee string) err
 		 )`,
 		caller, callee,
 	)
-	return err
+	if err != nil {
+		return fmt.Errorf("update call answered: %w", err)
+	}
+	return nil
 }
 
 func (t *Tracker) OnCallEnded(ctx context.Context, caller, callee string) error {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -100,7 +100,10 @@ func (s *Store) Reassign(ctx context.Context, deviceID, newLineID int64) error {
 	if err != nil {
 		return fmt.Errorf("reassign device: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("reassign device: %w", err)
+	}
 	if n == 0 {
 		return fmt.Errorf("reassign device: device %d not found", deviceID)
 	}

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -240,7 +240,10 @@ func (s *Store) RemoveMember(ctx context.Context, userID, householdID string) er
 	if err != nil {
 		return fmt.Errorf("remove member: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("remove member: %w", err)
+	}
 	if n == 0 {
 		return ErrNotMember
 	}
@@ -276,7 +279,10 @@ func (s *Store) Delete(ctx context.Context, householdID string) error {
 	if err != nil {
 		return fmt.Errorf("delete household: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete household: %w", err)
+	}
 	if n == 0 {
 		return ErrNotFound
 	}

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -280,7 +280,10 @@ func (s *Store) Update(ctx context.Context, id int64, number, name string) error
 	if err != nil {
 		return fmt.Errorf("update line: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update line: %w", err)
+	}
 	if n == 0 {
 		return ErrNotFound
 	}
@@ -293,7 +296,10 @@ func (s *Store) Delete(ctx context.Context, id int64) error {
 	if err != nil {
 		return fmt.Errorf("delete line: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete line: %w", err)
+	}
 	if n == 0 {
 		return ErrNotFound
 	}
@@ -339,7 +345,10 @@ func (s *Store) UpdateSettings(ctx context.Context, id int64, settings Settings)
 	if err != nil {
 		return fmt.Errorf("update settings: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update settings: %w", err)
+	}
 	if n == 0 {
 		return ErrNotFound
 	}

--- a/server/internal/pairing/pairing.go
+++ b/server/internal/pairing/pairing.go
@@ -70,7 +70,10 @@ func (s *Store) GenerateCode(ctx context.Context, hardwareID string) (string, er
 	if err != nil {
 		return "", fmt.Errorf("upsert pairing code: %w", err)
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return "", fmt.Errorf("upsert pairing code: %w", err)
+	}
 	if n == 0 {
 		return "", ErrAlreadyPaired
 	}
@@ -110,8 +113,11 @@ func bindDeviceToLine(ctx context.Context, tx *sql.Tx, deviceID, lineID int64, t
 	if err != nil {
 		return fmt.Errorf("bind device to line: %w", err)
 	}
-	rows, _ := res.RowsAffected()
-	if rows == 0 {
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("bind device to line: %w", err)
+	}
+	if n == 0 {
 		return ErrInvalidCode
 	}
 	return nil

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -96,11 +96,11 @@ func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Request) {
-	if !parseForm(w, r) {
-		return
-	}
 	_, hh, ok := h.requireHouseholdAdmin(w, r)
 	if !ok {
+		return
+	}
+	if !parseForm(w, r) {
 		return
 	}
 	enabled := r.FormValue("enabled") == "true"


### PR DESCRIPTION
## Code quality audit: server/

Graded the `server/` package on cleanliness, idiomatics, project layout, and test coverage, then fixed every finding.

**Before: 74 / 100**
**After: 82 / 100**

---

## What was graded

The codebase is already strong. Genuine positives:

- Standard Go project layout with correct package boundaries.
- Raw SQL with `database/sql`, no ORM — scans are explicit and auditable.
- Consistent `fmt.Errorf("context: %w", err)` wrapping almost everywhere.
- Good security practices: constant-time token comparison, hash-not-plaintext storage, IP address filtering, CSRF-resistant auth ordering.
- Comprehensive test coverage (25 packages, 80+ test files, integration + E2E tiers).
- Context propagation and graceful shutdown done correctly throughout.

Deductions before this PR:

| Finding | Sites | Severity |
|---|---|---|
| `RowsAffected()` error silently discarded | 9 | medium |
| `OnCallAnswered` returns raw driver error without wrap | 1 | low |
| `parseForm` called before auth check | 1 | low |

---

## Changes

### `RowsAffected()` errors (9 call sites, 6 files)

The pattern `n, _ := res.RowsAffected()` appeared throughout the store layer. `RowsAffected()` returns `(int64, error)` per the `sql.Result` interface — discarding the error means the ErrNotFound/ErrNotMember/ErrAlreadyPaired sentinel is returned as if the operation succeeded when the driver itself reports a failure (e.g., the driver does not support the method, or a protocol-level error occurs after the statement executes).

Fixed in:

- `internal/auth/store.go` — `DeleteUser`
- `internal/device/store.go` — `Reassign`
- `internal/household/store.go` — `RemoveMember`, `Delete`
- `internal/line/store.go` — `Update`, `Delete`, `UpdateSettings`
- `internal/pairing/pairing.go` — `GenerateCode`, `bindDeviceToLine`

Each site now follows the pattern established by the surrounding `ExecContext` error check, using the same context prefix string.

A shared `dbutil.CheckRowsAffected` helper was considered and rejected: every call site returns a different sentinel error (`ErrNotFound`, `ErrNotMember`, `ErrAlreadyPaired`, a custom formatted error), so the helper would need to accept the sentinel as a parameter. The inlined 3-line block is clearer and keeps the failure contract co-located with the mutation.

### `OnCallAnswered` error wrap (`internal/calls/tracker.go`)

Was the only method in Tracker that returned a raw driver error without a context prefix. Fixed to match the wrap style of every other method in the file.

### Auth-before-form in `handleSettingsDoNotDisturb` (`internal/web/handler_settings.go`)

`parseForm` was called before `requireHouseholdAdmin`, meaning the request body was parsed (and memory allocated) before the 401/403 check. Swapped to auth first, consistent with every other handler in the file that requires both.

---

## `/simplify` pass

Run per CLAUDE.md. The simplification agent flagged `OnCallAnswered` as reducible to `return fmt.Errorf("...: %w", err)`. Skipped: `fmt.Errorf("...: %w", nil)` returns a non-nil error (it formats `nil` as the string `<nil>`), so removing the nil-guard would cause the success path to return an error. The 4-line form is correct as written.

All 25 packages pass with `-short`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VeiMQPrReVbdMdEEnxnFL2)_