### PR TITLE
refactor(digitsd): inline voicemail retrieval code constant

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -493,9 +493,9 @@ func (d *daemonCallbacks) publishVoicemailStateInitial() {
 //
 // Live consumption: both fields, Enabled and RingTimeout, are read per ring,
 // so they take effect on the next inbound call without any further wiring.
-// The storage cap and retrieval code are no longer pushed; they are fixed
-// config.VoicemailMaxStoredMessages and config.VoicemailRetrievalCode
-// constants and never flow through this helper.
+// The storage cap is no longer pushed; it is the fixed
+// config.VoicemailMaxStoredMessages constant and never flows through this
+// helper. The retrieval code lives in the phone package as a constant.
 func (d *daemonCallbacks) setVoicemailConfig(vm config.Voicemail) error {
 	d.mu.Lock()
 	d.cfg.Voicemail = vm

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/codec"
-	"github.com/justinlindh/digits/pi/digitsd/internal/config"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	"github.com/justinlindh/digits/pi/digitsd/internal/voicemail"
@@ -774,12 +773,6 @@ func (d *daemonCallbacks) VoicemailDeleteGreeting() {
 		d.playAnnouncementSequence("vm_greeting_deleted")
 		d.SendTone(phone.ToneDial)
 	}
-}
-
-// VoicemailRetrievalCode returns the hardcoded retrieval code that the
-// controller uses to intercept dial-collection and enter VOICEMAIL_PLAYBACK.
-func (d *daemonCallbacks) VoicemailRetrievalCode() string {
-	return config.VoicemailRetrievalCode
 }
 
 // VoicemailEnterPlayback opens the first unheard message and streams it to

--- a/pi/digitsd/internal/config/config.go
+++ b/pi/digitsd/internal/config/config.go
@@ -23,7 +23,6 @@ const (
 // Voicemail constants that are no longer server-configurable.
 const (
 	VoicemailMaxStoredMessages = 50
-	VoicemailRetrievalCode     = "*98"
 )
 
 // WiFiFallback configures the wifi auto-fallback supervisor.

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -63,6 +63,11 @@ const (
 // so the controller self-fires here once it has the full number.
 const addDialDigitsRequired = 7
 
+// voicemailRetrievalCode is the fixed dial sequence that intercepts an
+// outbound call attempt and enters VOICEMAIL_PLAYBACK while voicemail is
+// enabled. Not user-configurable.
+const voicemailRetrievalCode = "*98"
+
 type controllerTiming struct {
 	AutoDialDelay          time.Duration // silence between last digit and first ringback
 	RejectWait             time.Duration // simulated connection attempt before intercept
@@ -120,7 +125,6 @@ type Callbacks interface {
 	VoicemailEnterPlayback()                                      // *98: enter retrieval playback; daemon opens first unheard and streams to mixer
 	VoicemailExitPlayback()                                       // hook-on during playback; daemon tears down player + mixer source
 	VoicemailKey(digit string)                                    // DTMF key during playback (7=delete, 9=mark heard, #=skip, *=replay)
-	VoicemailRetrievalCode() string                               // fixed retrieval code ("*98")
 }
 
 // ContactChecker determines whether a number is in the local contact list.
@@ -527,14 +531,13 @@ func (c *Controller) onKey(digit string) {
 	case StateDIALING:
 		c.digits += digit
 		// Voicemail retrieval-code intercept. Evaluated before the service-code
-		// reset and the 7-digit dial logic so *98 (or whatever the user
-		// configured) short-circuits the outbound call attempt. Exact match
-		// only: if the user dials a number that happens to begin with the
-		// retrieval-code prefix, the accumulator keeps growing past it and the
-		// match never fires.
+		// reset and the 7-digit dial logic so *98 short-circuits the outbound
+		// call attempt. Exact match only: if the user dials a number that
+		// happens to begin with the retrieval-code prefix, the accumulator
+		// keeps growing past it and the match never fires.
 		if enabled, _ := c.cb.VoicemailEnabled(); enabled {
-			if code := c.cb.VoicemailRetrievalCode(); code != "" && c.digits == code {
-				slog.Info("phone: retrieval code detected, entering VOICEMAIL_PLAYBACK", "code", code)
+			if c.digits == voicemailRetrievalCode {
+				slog.Info("phone: retrieval code detected, entering VOICEMAIL_PLAYBACK", "code", voicemailRetrievalCode)
 				c.digits = ""
 				c.state = StateVOICEMAIL_PLAYBACK
 				// Voicemail playback is peerless and local, but the user still

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -48,7 +48,6 @@ type mockCallbacks struct {
 	playbackEnters           int
 	playbackExits            int
 	playbackKeys             []string
-	retrievalCodeReturn      string // "" defaults to "*98"
 }
 
 func (m *mockCallbacks) SendTone(name string) {
@@ -233,14 +232,6 @@ func (m *mockCallbacks) VoicemailKey(digit string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.playbackKeys = append(m.playbackKeys, digit)
-}
-func (m *mockCallbacks) VoicemailRetrievalCode() string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.retrievalCodeReturn == "" {
-		return "*98"
-	}
-	return m.retrievalCodeReturn
 }
 
 // Snapshot accessors — return copies under lock so test assertions are
@@ -2411,8 +2402,8 @@ func TestController_FinishGreetingAudition(t *testing.T) {
 	}
 }
 
-// TestRetrievalCodeIntercept verifies that dialing the configured retrieval
-// code (default *98) from off-hook DIALING enters VOICEMAIL_PLAYBACK and fires
+// TestRetrievalCodeIntercept verifies that dialing the fixed retrieval code
+// (*98) from off-hook DIALING enters VOICEMAIL_PLAYBACK and fires
 // VoicemailEnterPlayback exactly once, without initiating an outbound call.
 func TestRetrievalCodeIntercept(t *testing.T) {
 	cb := &mockCallbacks{


### PR DESCRIPTION
## Motivation

`phone.Callbacks` declared `VoicemailRetrievalCode() string`, implemented in the daemon as a one-line wrapper that returned `config.VoicemailRetrievalCode` (a hardcoded `"*98"`). A comment in the dial-collection path called it `"*98" (or whatever the user configured)`, but nothing makes it user-configurable: no flag, no config knob, no override path. The interface method existed to formalize an indirection that points at a constant. The unit-test mock had a `retrievalCodeReturn string` escape hatch that was never set by any test.

## Shape of the change

- Add `voicemailRetrievalCode = "*98"` to `internal/phone/controller.go`, next to the existing `addDialDigitsRequired` constant.
- Drop `VoicemailRetrievalCode() string` from the `Callbacks` interface.
- Drop the daemon implementation in `cmd/digitsd/voicemail.go` (and its `config` import, which was only there for this one call).
- Drop `config.VoicemailRetrievalCode` from `internal/config/config.go`.
- Drop the mock implementation and the unused `retrievalCodeReturn` field from `controller_test.go`.
- Update the misleading `or whatever the user configured` comment and the storage-cap comment in `main.go` that referenced the removed constant.

The defensive `code != ""` guard at the call site goes away with the indirection, since a package-level `const` cannot be empty.

## Why this scope

Touching only the controller would leave a dangling interface method and a dangling daemon implementation. Touching only the daemon would leave a method with no implementer. The constant has to be moved alongside the interface change, and the mock comes with it because the interface shrinks. The five files are the minimum to land the cleanup coherently.

## Test plan

- [ ] `make test` in `pi/digitsd/`
- [ ] `golangci-lint run ./...` in `pi/digitsd/`
- [ ] Verify `TestRetrievalCodeIntercept` and `TestRetrievalCodeIgnoredWhenDisabled` still pass: both dial `*98` literally, so they exercise the new constant path unchanged.