### PR TITLE
docs: refresh voicemail retrieval code references after #717

### DIFF
--- a/docs/voicemail.md
+++ b/docs/voicemail.md
@@ -377,9 +377,10 @@ Bounds are package constants in `line/settings.go`, shared by the HTTP handler,
 | `ring_timeout_seconds` | 5 | 60 | 20 |
 
 Ring timeout is the only validated field. The message-storage cap and the
-retrieval code are no longer per-line settings: they are fixed in `digitsd` as
-the `VoicemailMaxStoredMessages` (50) and `VoicemailRetrievalCode` (`*98`)
-constants in `internal/config/config.go`.
+retrieval code are no longer per-line settings: the storage cap is the fixed
+`VoicemailMaxStoredMessages` (50) constant in `internal/config/config.go`,
+and the retrieval code is the fixed `voicemailRetrievalCode` (`*98`) constant
+in `internal/phone/controller.go`.
 
 ### Endpoints
 
@@ -509,8 +510,9 @@ to dial tone.
 ## Limits and defaults
 
 The two server-pushed settings are defined in `internal/config/config.go`
-(`defaultVoicemail()`). The message-storage cap and retrieval code are fixed
-constants in the same file; the two recording caps are fixed constants in
+(`defaultVoicemail()`). The message-storage cap is a fixed constant in the
+same file; the retrieval code is a fixed constant in
+`internal/phone/controller.go`; the two recording caps are fixed constants in
 `internal/voicemail/store.go`.
 
 | Setting | Config field or constant | Default | Notes |
@@ -518,7 +520,7 @@ constants in the same file; the two recording caps are fixed constants in
 | Voicemail enabled | `Voicemail.Enabled` | `true` | Server-pushed; read live; off at boot means the store is never opened |
 | Ring timeout before auto-answer | `Voicemail.RingTimeout` | 20 s | Server-pushed; read live; `0` disables auto-answer |
 | Max stored messages | `VoicemailMaxStoredMessages` | 50 | Fixed constant; baked into the store at boot; FIFO eviction past the cap |
-| Retrieval code | `VoicemailRetrievalCode` | `*98` | Fixed constant |
+| Retrieval code | `voicemailRetrievalCode` | `*98` | Fixed constant in `phone/controller.go` |
 | Max message duration | `messageMaxDuration` | 10 min | Fixed in `store.go`, not configurable; a backstop for a caller who never hangs up |
 | Max greeting duration | `greetingMaxDuration` | 60 s | Fixed in `store.go`, not configurable |
 


### PR DESCRIPTION
## Holistic review finding (last 24h merges)

Motivated by #717 (`refactor(digitsd): inline voicemail retrieval code constant`).

That PR moved the retrieval-code constant out of the daemon config layer and into the phone controller:

- `config.VoicemailRetrievalCode` in `pi/digitsd/internal/config/config.go` was deleted.
- `voicemailRetrievalCode` (unexported) now lives in `pi/digitsd/internal/phone/controller.go`.

`docs/voicemail.md` was not updated as part of #717, so it still names a symbol and file path that no longer exist. Two locations:

1. **Validation ranges section** (line 379-382). Claimed both `VoicemailMaxStoredMessages` and `VoicemailRetrievalCode` live as constants in `internal/config/config.go`. After #717, only the storage cap does.
2. **Limits and defaults table** (line 511-521). The intro paragraph says "the message-storage cap and retrieval code are fixed constants in the same file"; the table row reads `| Retrieval code | VoicemailRetrievalCode | ... |`. Both lie about the current code.

## Fix

Update both spots to point at the symbol that exists today (`voicemailRetrievalCode` in `internal/phone/controller.go`), keeping the storage-cap reference unchanged. Doc-only change; no code paths touched.

## Test plan

- [x] `grep -r VoicemailRetrievalCode` across the repo returns zero hits after the edit.
- [x] No em dashes introduced.
