### PR TITLE
refactor(server): generic nullablePtr and test gaps in calls/pairing

### DIFF
--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -527,24 +527,17 @@ func (s *HealthStore) writeSample(ctx context.Context, key SessionKey, ep endpoi
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		 ON CONFLICT DO NOTHING`,
 		callID, confID, ep.From, peer, sample.TS,
-		nullableFloat(sample.LossPct),
-		nullableFloat(sample.JitterMs),
-		nullableFloat(sample.RttMs),
+		nullablePtr(sample.LossPct),
+		nullablePtr(sample.JitterMs),
+		nullablePtr(sample.RttMs),
 		nullableString(sample.ConnType),
-		nullableInt(sample.BytesIn),
-		nullableInt(sample.BytesOut),
+		nullablePtr(sample.BytesIn),
+		nullablePtr(sample.BytesOut),
 	)
 	return err
 }
 
-func nullableFloat(p *float32) any {
-	if p == nil {
-		return nil
-	}
-	return *p
-}
-
-func nullableInt(p *int64) any {
+func nullablePtr[T any](p *T) any {
 	if p == nil {
 		return nil
 	}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -422,6 +422,20 @@ func TestSessionKeyIsConfConfIDWins(t *testing.T) {
 	}
 }
 
+func TestNullablePtr(t *testing.T) {
+	if nullablePtr[float32](nil) != nil {
+		t.Error("nil pointer: want nil any")
+	}
+	v := float32(1.5)
+	if nullablePtr(&v) != float32(1.5) {
+		t.Errorf("non-nil pointer: got %v, want 1.5", nullablePtr(&v))
+	}
+	n := int64(42)
+	if nullablePtr(&n) != int64(42) {
+		t.Errorf("int64 pointer: got %v, want 42", nullablePtr(&n))
+	}
+}
+
 func TestHealthStoreConferenceRoundTrip(t *testing.T) {
 	s := NewHealthStore(nil)
 	confID := uuid.New()

--- a/server/internal/pairing/crypto_test.go
+++ b/server/internal/pairing/crypto_test.go
@@ -2,7 +2,11 @@ package pairing
 
 import (
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/lib/pq"
 )
 
 func TestRandomCode_Format(t *testing.T) {
@@ -33,5 +37,24 @@ func TestRandomHex_Length(t *testing.T) {
 		if _, err := hex.DecodeString(got); err != nil {
 			t.Errorf("randomHex(%d): not valid hex: %v", n, err)
 		}
+	}
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	uniqueErr := &pq.Error{Code: "23505"}
+	if !isUniqueViolation(uniqueErr) {
+		t.Error("expected true for pq unique-violation error")
+	}
+	if !isUniqueViolation(fmt.Errorf("wrapped: %w", uniqueErr)) {
+		t.Error("expected true for wrapped unique-violation error")
+	}
+	if isUniqueViolation(errors.New("some other error")) {
+		t.Error("expected false for non-pq error")
+	}
+	if isUniqueViolation(&pq.Error{Code: "23000"}) {
+		t.Error("expected false for different pq error code")
+	}
+	if isUniqueViolation(nil) {
+		t.Error("expected false for nil error")
 	}
 }


### PR DESCRIPTION
## Code quality audit: server/

Full audit of the `server/` folder for code cleanliness, idiomatic Go, stale
code, project layout, and test coverage. Prior commits on this branch (PRs
#715, #716, #718) addressed the larger findings. This commit addresses the
remaining items.

### Before grade: 88/100

The codebase is genuinely high quality: consistent error wrapping with `%w`,
narrow interfaces defined at the consumer, raw SQL with no ORM, idempotent
migrations, privacy-first tracing and metrics design, graceful shutdown with
draining. The main remaining gaps were a small duplication in nullable helpers
and a few untested private functions that can be exercised without a database.

### After grade: 89/100

---

## Changes

### `calls/linkhealth.go`: generic `nullablePtr`

`nullableFloat` and `nullableInt` were two identical functions differing only
by type parameter. Replaced both with `nullablePtr[T any]`, which halves the
implementation and makes the nil-to-SQL-NULL contract explicit in a single
place. `nullableString` is intentionally separate: it converts an empty string
to `nil` (absent value), not a nil pointer, so the semantics differ and the
function stays as-is.

### `calls/linkhealth_test.go`: `TestNullablePtr`

Tests the new generic covering nil pointer, `float32`, and `int64` cases.

### `pairing/crypto_test.go`: `TestIsUniqueViolation`

`isUniqueViolation` was only reachable via integration tests (which require a
live Postgres). Added a unit test covering: direct `pq.Error` with code
`23505`, the same error wrapped with `fmt.Errorf`, a non-pq error, a pq error
with a different code, and nil. No database required.

---

## Skipped findings

- **`nullableString` rename**: single callsite, naming is consistent with the
  SQL "nullable" convention used throughout the file. YAGNI.
- **Move `nullablePtr` to `dbutil`**: single callsite. Moving to a shared
  package for one caller is premature abstraction.
- **Move `isUniqueViolation` to `dbutil`**: single callsite in `pairing`.
  No other package has hit a unique-violation path yet. YAGNI.
- **`TestIsUniqueViolation` subtests**: flat `if`-block style with descriptive
  `t.Error` messages is consistent with the existing tests in `crypto_test.go`.
  No behavior change from switching to `t.Run`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016gaox4vXDrCN6uZwrrz2KS)_