### PR TITLE
refactor(server): collapse TemplateFuncs and baseTemplateFuncs into one

### DIFF
--- a/server/internal/web/clock_test.go
+++ b/server/internal/web/clock_test.go
@@ -51,7 +51,7 @@ func TestFmtElapsed(t *testing.T) {
 }
 
 func TestFmtDurationClock(t *testing.T) {
-	funcs := baseTemplateFuncs()
+	funcs := TemplateFuncs()
 	fn := funcs["fmtDurationClock"].(func(int) string)
 
 	tests := []struct {

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -50,10 +50,6 @@ func TemplateFS() embed.FS {
 // Exposed so test helpers that parse templates directly (without going through
 // NewHandler) get the same {{static}}, {{fmtPhone}}, etc. helpers as prod.
 func TemplateFuncs() template.FuncMap {
-	return baseTemplateFuncs()
-}
-
-func baseTemplateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"fmtPhone": line.FormatNumber,
 		"fmtDuration": func(seconds int) string {
@@ -366,7 +362,7 @@ func wsRateLimit(cfg HandlerConfig) int {
 // NewHandler constructs a Handler, parses all embedded HTML templates, and
 // wires up rate limiters. Returns an error if any template fails to parse.
 func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
-	funcMap := baseTemplateFuncs()
+	funcMap := TemplateFuncs()
 	// parsePage closes over the layout + shared-partials file list so each
 	// page only names itself. Adding a new layout or partial touches one line.
 	parsePage := func(page string) (*template.Template, error) {


### PR DESCRIPTION
## Why

`web.TemplateFuncs()` was a one-line wrapper that did nothing but `return baseTemplateFuncs()`. The exported/unexported split had no behavioral or readability purpose: both callers (one internal, one in test) ended up reaching for whichever name was reachable from their scope, and a reader hitting this file had to verify the two were not subtly different before moving on.

## What

- Inline the `template.FuncMap` literal into the exported `TemplateFuncs()`.
- Drop `baseTemplateFuncs()`.
- Update the two in-package callers (`NewHandler` and `TestFmtDurationClock`) to use the exported name.

No behavior change. `go test ./...` passes.