### PR TITLE
refactor(server): check auth before parseForm in phone handlers

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -446,17 +446,16 @@ func (h *Handler) handlePhoneEditGet(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneEditPost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
+	if ln == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
 	name, err := validateLineName(r.FormValue("name"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
-	if ln == nil {
 		return
 	}
 
@@ -505,14 +504,14 @@ func (h *Handler) handlePhoneNameEditGet(w http.ResponseWriter, r *http.Request)
 
 func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if !parseForm(w, r) {
-		return
-	}
-	raw := r.FormValue("name")
 	ln := h.requireLineOwnership(w, r, number)
 	if ln == nil {
 		return
 	}
+	if !parseForm(w, r) {
+		return
+	}
+	raw := r.FormValue("name")
 	name, verr := validateLineName(raw)
 	if verr != nil {
 		renderWithStatus(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "name-section-edit", "am-name-section-edit"), nameSectionData{Line: *ln, Value: raw, Error: verr.Error()}, http.StatusBadRequest)
@@ -535,15 +534,14 @@ func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) {
 	oldNumber := r.PathValue("number")
-	if !parseForm(w, r) {
-		return
-	}
-	newNumber := line.StripNumber(r.FormValue("number"))
-
 	ln, _ := h.requireLineOwnershipAdmin(w, r, oldNumber)
 	if ln == nil {
 		return
 	}
+	if !parseForm(w, r) {
+		return
+	}
+	newNumber := line.StripNumber(r.FormValue("number"))
 
 	if h.tracker != nil && h.tracker.Busy(r.Context(), oldNumber) {
 		http.Redirect(w, r, "/phones/"+oldNumber+"?number_error="+url.QueryEscape("cannot change number while on an active call"), http.StatusSeeOther)
@@ -635,12 +633,12 @@ func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Reque
 // form. On success the new settings persist and push, then the quiet-hours
 // section partial is swapped (htmx) or the detail page reloads.
 func (h *Handler) handlePhoneQuietHoursPost(w http.ResponseWriter, r *http.Request) {
-	if !parseForm(w, r) {
-		return
-	}
 	number := r.PathValue("number")
 	ln := h.requireLineOwnership(w, r, number)
 	if ln == nil {
+		return
+	}
+	if !parseForm(w, r) {
 		return
 	}
 
@@ -682,6 +680,11 @@ func (h *Handler) handlePhoneQuietHoursPost(w http.ResponseWriter, r *http.Reque
 // then either the voicemail-section partial is swapped (htmx) or the user
 // is redirected back to the phone detail page (regular form post).
 func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
@@ -690,12 +693,6 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 	ring, ok := parseClampedInt(w, r, "ring_timeout_seconds",
 		line.VoicemailRingTimeoutMin, line.VoicemailRingTimeoutMax)
 	if !ok {
-		return
-	}
-
-	number := r.PathValue("number")
-	ln := h.requireLineOwnership(w, r, number)
-	if ln == nil {
 		return
 	}
 
@@ -990,6 +987,10 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneConvert(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
+	srcLn, _ := h.requireLineOwnershipAdmin(w, r, number)
+	if srcLn == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
@@ -1002,11 +1003,6 @@ func (h *Handler) handlePhoneConvert(w http.ResponseWriter, r *http.Request) {
 	targetLineID, err := strconv.ParseInt(targetLineIDStr, 10, 64)
 	if err != nil {
 		http.Error(w, "invalid target line", http.StatusBadRequest)
-		return
-	}
-
-	srcLn, _ := h.requireLineOwnershipAdmin(w, r, number)
-	if srcLn == nil {
 		return
 	}
 	if srcLn.ID == targetLineID {


### PR DESCRIPTION
## Holistic review finding (last 24h merges)

Motivated by #716 (`refactor(server): handle RowsAffected errors and fix auth ordering`).

That PR moved the auth check before `parseForm` in `handleSettingsDoNotDisturb`, with this rationale:

> `parseForm` was called before `requireHouseholdAdmin`, meaning the request body was parsed (and memory allocated) before the 401/403 check. Swapped to auth first, consistent with every other handler in the file that requires both.

The "consistent with every other handler" claim held for `handler_settings.go` but did not extend to `handler_phones.go`, where six POST handlers still parse the request body before any auth check:

- `handlePhoneEditPost`
- `handlePhoneNamePost`
- `handlePhoneNumberPost`
- `handlePhoneQuietHoursPost`
- `handlePhoneVoicemailPost`
- `handlePhoneConvert`

## Fix

Reorder each of the six handlers so `requireLineOwnership` / `requireLineOwnershipAdmin` / `requireLineOwnershipWithHousehold` runs first, then `parseForm`, then field reads. The path-value lookup (`r.PathValue("number")`) does not require a parsed form, so the swap is free.

## Skipped intentionally

`handlePhoneVoiceStylePost`, `handlePhoneSilentModePost`, and `handlePhoneAutoUpdatePost` also `parseForm` before any auth call, but they delegate to `updateLineSetting`, which is the helper that owns the ownership check. They must parse the form first to read the field that selects which `*line.Settings` mutation to apply. Doing the ownership check upfront in each handler would either duplicate the DB lookup that the helper already performs, or require reshaping the helper's signature. Out of scope for a same-day style alignment.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes (25 packages)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] No em dashes in code or PR body
