### PR TITLE
fix(ci): Helm chart and release config hardening

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -34,7 +34,7 @@ jobs:
             --set ingress.enabled=true \
             --set ingress.signald.host=app.example.com \
             --set cnpg.enabled=true \
-            --set redis.url=redis://redis:6379 \
+            --set redis.enabled=true \
             --set observability.enabled=true \
             --set observability.otelEndpoint=otel:4317 \
             --set observability.serviceMonitor.enabled=true
@@ -53,7 +53,7 @@ jobs:
             --set cnpg.backup.destinationPath=s3://backups \
             --set cnpg.backup.endpointURL=http://minio:9000 \
             --set cnpg.backup.s3CredentialsSecret=minio-creds \
-            --set redis.url=redis://redis:6379 \
+            --set redis.enabled=true \
             --set observability.enabled=true \
             --set observability.otelEndpoint=otel:4317 \
             --set observability.pyroscopeEndpoint=http://pyroscope:4040 \

--- a/charts/digits/templates/cluster-userdb.yaml
+++ b/charts/digits/templates/cluster-userdb.yaml
@@ -46,10 +46,12 @@ spec:
         compression: gzip
     retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
   {{- end }}
-  {{- if .Values.cnpg.userdb.sharedPreloadLibraries }}
+  {{- if or .Values.cnpg.userdb.sharedPreloadLibraries .Values.cnpg.userdb.parameters }}
   postgresql:
+    {{- if .Values.cnpg.userdb.sharedPreloadLibraries }}
     shared_preload_libraries:
       {{- toYaml .Values.cnpg.userdb.sharedPreloadLibraries | nindent 6 }}
+    {{- end }}
     {{- if .Values.cnpg.userdb.parameters }}
     parameters:
       {{- toYaml .Values.cnpg.userdb.parameters | nindent 6 }}

--- a/charts/digits/templates/redis-sentinel.yaml
+++ b/charts/digits/templates/redis-sentinel.yaml
@@ -110,8 +110,16 @@ spec:
             - -c
             - |
               cp /etc/redis/redis.conf /tmp/redis.conf
-              if [ "$(hostname)" != "{{ include "digits.fullname" . }}-redis-0" ]; then
-                echo "replicaof {{ include "digits.fullname" . }}-redis-0.{{ include "digits.fullname" . }}-redis-headless.{{ .Release.Namespace }}.svc.cluster.local 6379" >> /tmp/redis.conf
+              # Query any already-running sentinel to discover the current master.
+              # This prevents redis-0 from re-asserting itself as master after a
+              # failover: if sentinel promoted redis-1, a restarted redis-0 must
+              # replicate from redis-1 rather than starting as a standalone master.
+              SENTINEL_SVC="{{ include "digits.fullname" . }}-redis-sentinel.{{ .Release.Namespace }}.svc.cluster.local"
+              MASTER=$(redis-cli -h "$SENTINEL_SVC" -p 26379 SENTINEL get-master-addr-by-name {{ .Values.redis.sentinelMasterName }} 2>/dev/null | head -1)
+              MY_FQDN="{{ include "digits.fullname" . }}-$(hostname | awk -F- '{print $NF}').{{ include "digits.fullname" . }}-redis-headless.{{ .Release.Namespace }}.svc.cluster.local"
+              if [ -n "$MASTER" ] && [ "$MASTER" != "$MY_FQDN" ]; then
+                MASTER_PORT=$(redis-cli -h "$SENTINEL_SVC" -p 26379 SENTINEL get-master-addr-by-name {{ .Values.redis.sentinelMasterName }} 2>/dev/null | tail -1)
+                echo "replicaof $MASTER ${MASTER_PORT:-6379}" >> /tmp/redis.conf
               fi
               exec redis-server /tmp/redis.conf
           volumeMounts:
@@ -149,11 +157,17 @@ spec:
             - sh
             - -c
             - |
-              cp /etc/redis/sentinel.conf /tmp/sentinel.conf
-              exec redis-sentinel /tmp/sentinel.conf
+              # Use a PVC-backed state file if one already exists (persists failover
+              # elections across restarts). Seed from the ConfigMap on first boot.
+              if [ ! -f /sentinel-state/sentinel.conf ]; then
+                cp /etc/redis/sentinel.conf /sentinel-state/sentinel.conf
+              fi
+              exec redis-sentinel /sentinel-state/sentinel.conf
           volumeMounts:
             - name: config
               mountPath: /etc/redis
+            - name: sentinel-state
+              mountPath: /sentinel-state
             - name: tmp
               mountPath: /tmp
           resources:
@@ -188,6 +202,17 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: sentinel-state
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Mi
+        {{- if .Values.redis.sentinelStorageClass }}
+        storageClassName: {{ .Values.redis.sentinelStorageClass }}
+        {{- end }}
 ---
 {{- if .Values.observability.enabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/charts/digits/values.yaml
+++ b/charts/digits/values.yaml
@@ -26,6 +26,8 @@ redis:
   enabled: false
   replicas: 3
   sentinelMasterName: digits
+  # Storage class for the sentinel-state PVC. Empty string uses the cluster default.
+  sentinelStorageClass: ""
   resources:
     requests:
       cpu: 50m
@@ -44,6 +46,8 @@ cnpg:
     database: digits
     owner: digits
     sharedPreloadLibraries: []
+    # parameters: {}  # e.g. { pg_stat_statements.max: "10000" }
+    parameters: {}
     customQueriesConfigMap: []
     postInitSQL: []
     postInitApplicationSQL: []

--- a/server/.releaserc.cjs
+++ b/server/.releaserc.cjs
@@ -1,9 +1,26 @@
-// Server semantic-release config — runs from server/ working directory
+// Server semantic-release config, runs from server/ working directory.
+//
+// Uses tools/semantic-release-squash-expander instead of the standard
+// commit-analyzer / release-notes-generator pair so GitHub squash-merge
+// commits get expanded into their per-bullet virtual commits before scope
+// matching. See firmware/.releaserc-full.cjs for the rationale.
+const path = require('path');
+const squashExpander = path.resolve(__dirname, '..', 'tools', 'semantic-release-squash-expander.cjs');
+// The expander lives outside server/node_modules; load the wrapped plugins
+// here where they're installed and pass them through plugin options.
+const wrapped = {
+  commitAnalyzer: require('@semantic-release/commit-analyzer'),
+  releaseNotesGenerator: require('@semantic-release/release-notes-generator'),
+};
+
 module.exports = {
   branches: ['main'],
   tagFormat: 'server/v${version}',
   plugins: [
-    ['@semantic-release/commit-analyzer', {
+    [squashExpander, {
+      _wrapped: wrapped,
+      pathScopes: { 'server/': 'server' },
+      // Wrapped commit-analyzer options.
       releaseRules: [
         // Scope globs use micromatch substring patterns so multi-scope commits
         // like fix(digitsd,firmware,server) trigger this release too.
@@ -13,15 +30,12 @@ module.exports = {
         { scope: '*server*', breaking: true, release: 'major' },
         { scope: '!*server*', release: false },
       ],
+      // Shared parser opts (analyzer + notes-generator both honor these).
       parserOpts: {
         noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
       },
-    }],
-    ['@semantic-release/release-notes-generator', {
+      // Wrapped release-notes-generator options.
       preset: 'conventionalcommits',
-      parserOpts: {
-        noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
-      },
       writerOpts: {
         // Only include commits whose scope is or contains "server".
         // Multi-scope commits like fix(digitsd,firmware,server) are included.


### PR DESCRIPTION
## What

Four correctness fixes across the Helm chart and release config.

**Finding 1: Redis Sentinel split-brain after failover** (`charts/digits/templates/redis-sentinel.yaml`)

Sentinel state was written to `/tmp` (emptyDir), so every pod restart re-seeded from the ConfigMap and treated redis-0 as master. After a real failover (say redis-1 promoted), a restarted redis-0 would boot a second master and restarted sentinels would re-monitor it, diverging writes silently.

Two changes:
- Sentinel state is now written to a PVC-backed `sentinel-state` volume (1Mi volumeClaimTemplate per pod). First boot seeds from ConfigMap; restarts use the persisted state including any elections.
- Each redis pod's startup script queries the sentinel ClusterIP service for the current master before deciding its role. If sentinel reports a different master, `replicaof` is added to redis.conf, preventing redis-0 from starting standalone after losing an election.

Residual limitation: the startup master-discovery query fires before sentinel has re-established consensus when all three pods restart simultaneously (e.g. a full cluster reboot). In that case the sentinel ClusterIP returns nothing, the script falls through, and each pod starts without a `replicaof` directive. Sentinel will then run its own election and issue `SLAVEOF` to the losers within the `down-after-milliseconds` window (5 s). Persistent sentinel state prevents this from regressing after the first election converges. This is the standard behavior for a cold-start cluster and is safe for this workload.

`redis.sentinelStorageClass` added to values.yaml (defaults to cluster default).

**Finding 2: Redis templates never rendered in CI** (`.github/workflows/helm-ci.yml`, lines 37 and 56)

Both lint and template jobs passed `--set redis.url=redis://redis:6379`. No such key exists in the chart; the actual gate is `redis.enabled`. The redis-sentinel, pdb-redis, and service templates were never exercised, so a syntax error there would merge green. Replaced with `--set redis.enabled=true`.

**Finding 3: CNPG `parameters` silently swallowed** (`charts/digits/templates/cluster-userdb.yaml`, lines 49-56)

The `parameters` block was nested inside the `sharedPreloadLibraries` conditional, so setting `cnpg.userdb.parameters` alone rendered nothing. Both blocks are now independent under a shared `or` guard on the outer `postgresql:` key. `cnpg.userdb.parameters` added to values.yaml as a discoverable knob.

**Finding 4: Server release misses cross-component squash commits** (`server/.releaserc.cjs`)

The server config used the plain commit-analyzer. A cross-component squash commit with a non-server PR title scope but `fix(server): ...` bullets in the body would not trigger a server release. `pi/.releaserc.cjs` and `firmware/.releaserc-full.cjs` already use the squash-expander for this exact reason. Applied the same pattern to the server config, with `pathScopes: { 'server/': 'server' }` for path-based inference.

## Why

These are latent correctness gaps in production infrastructure: split-brain data divergence, invisible chart syntax errors, silently-void Postgres configuration knobs, and missed server releases on cross-component PRs.

## Test plan

- `helm lint charts/digits/` clean
- `helm lint charts/digits/ --set redis.enabled=true` clean
- `helm template` with redis enabled: StatefulSet renders with `volumeClaimTemplates.sentinel-state`, sentinel startup script uses `/sentinel-state/sentinel.conf`, redis startup script queries sentinel service
- `helm template` with `cnpg.userdb.parameters` only: renders `postgresql.parameters` without `shared_preload_libraries`
- `helm template` with `cnpg.userdb.sharedPreloadLibraries` only: renders without `parameters`
- `helm template` with both: renders both under `postgresql:`
- `helm template` with neither: no `postgresql:` block
- server `.releaserc.cjs` path resolution for squash-expander verified to point at `tools/semantic-release-squash-expander.cjs` which exists