### PR TITLE
fix(image): correct firmware precedence, fail-fast downloads, safer SD detect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ flash: ## Flash newest image (use flash-v1 / flash-v2 to pick, or IMAGE=<path>)
 	if [ -n "$(SD)" ]; then \
 		SD_DEV="$(SD)"; \
 	else \
-		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN,SUBSYSTEMS | awk '/(usb|mmc)/ && /[0-9]+\.?[0-9]*G/ { dev="/dev/"$$1; size=$$2+0; if (size >= 4 && size <= 64) print dev }' | head -1); \
+		SD_DEV=$$(lsblk -d -n -o NAME,SIZE,TRAN | awk '($$3 == "usb" || $$3 == "mmc") && $$2 ~ /G$$/ { size=$$2+0; if (size >= 4 && size <= 64) print "/dev/"$$1 }' | head -1); \
 		if [ -z "$$SD_DEV" ]; then echo "No SD card detected. Specify manually: make flash SD=/dev/sdX"; exit 1; fi; \
 	fi; \
 	if [ ! -e "$$SD_DEV" ]; then echo "ERROR: $$SD_DEV does not exist. Is the card inserted?"; exit 1; fi; \
@@ -90,7 +90,8 @@ flash: ## Flash newest image (use flash-v1 / flash-v2 to pick, or IMAGE=<path>)
 	echo "Flashing $$IMAGE -> $$SD_DEV"; \
 	lsblk "$$SD_DEV"; \
 	echo "WARNING: This will overwrite all data on $$SD_DEV."; \
-	read -r -p "Continue? [y/N] " ans; \
+	printf "Continue? [y/N] "; \
+	read -r ans; \
 	if [ "$$ans" != "y" ] && [ "$$ans" != "Y" ]; then echo "Aborted."; exit 1; fi; \
 	sudo umount "$$SD_DEV"* 2>/dev/null || true; \
 	gunzip -c "$$IMAGE" | sudo dd of="$$SD_DEV" bs=4M status=progress conv=fsync && \
@@ -102,9 +103,17 @@ flash-v1: flash ## Flash newest V1/prototype image
 flash-v2: IMAGE_GLOB = digits-pi-v2-*.img.gz
 flash-v2: flash ## Flash newest V2 carrier board image
 
-image-flash: image-dev flash-v1 ## Build V1 dev image and flash
+# Run build and flash as ordered sub-makes so `make -j` can't flash a stale or
+# partial image: the image must finish building before flash-v1/flash-v2 reads
+# the newest .img.gz. Listing them as plain prerequisites would let parallel
+# make run them concurrently.
+image-flash: ## Build V1 dev image and flash
+	$(MAKE) image-dev
+	$(MAKE) flash-v1
 
-image-v2-flash: image-v2-dev flash-v2 ## Build V2 dev image and flash
+image-v2-flash: ## Build V2 dev image and flash
+	$(MAKE) image-v2-dev
+	$(MAKE) flash-v2
 
 # ── Utilities ────────────────────────────────────────────────────────────────
 

--- a/pi/image/build-docker.sh
+++ b/pi/image/build-docker.sh
@@ -33,6 +33,7 @@
 set -euo pipefail
 
 die()  { echo "ERROR: $*" >&2; exit 1; }
+warn() { echo "WARNING: $*" >&2; }
 info() { echo "==> $*"; }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/pi/image/entrypoint.sh
+++ b/pi/image/entrypoint.sh
@@ -58,7 +58,24 @@ if [[ -z "$SOURCE_IMAGE" ]]; then
         info "Using cached base image: $SOURCE_IMAGE"
     else
         info "Downloading Raspberry Pi OS Lite (Bookworm arm64)..."
-        curl -L --progress-bar -o "$SOURCE_IMAGE" "$BASE_IMAGE_URL"
+        # Download to a temp path and only promote to the cached name on
+        # success. --fail makes curl exit non-zero on an HTTP error instead of
+        # writing the error page as the image; --show-error surfaces the
+        # reason under --progress-bar. Without this, a failed download was
+        # cached forever in the digits-image-cache volume and every later
+        # build reused the corrupt file.
+        DOWNLOAD_TMP="${SOURCE_IMAGE}.partial"
+        if ! curl -fL --show-error --progress-bar -o "$DOWNLOAD_TMP" "$BASE_IMAGE_URL"; then
+            rm -f "$DOWNLOAD_TMP"
+            die "Failed to download base image from $BASE_IMAGE_URL. Nothing was cached; re-run to retry. If a stale partial persists, clear the cache volume: docker volume rm digits-image-cache"
+        fi
+        # Sanity check: a real .img.xz is an XZ stream, not an HTML error page
+        # that slipped through (e.g. a 200 with a body). Guard before caching.
+        if [[ ! -s "$DOWNLOAD_TMP" ]] || ! xz -t "$DOWNLOAD_TMP" 2>/dev/null; then
+            rm -f "$DOWNLOAD_TMP"
+            die "Downloaded base image is empty or not a valid .xz archive. Nothing was cached; re-run to retry. If a stale file persists, clear the cache volume: docker volume rm digits-image-cache"
+        fi
+        mv "$DOWNLOAD_TMP" "$SOURCE_IMAGE"
     fi
 
     # Verify integrity (if hash is configured)
@@ -176,50 +193,79 @@ else
     info "Binaries ready in tools/build/"
 fi
 
-# ── firmware: host-staged, release download, or error ────────────────────────
+# ── firmware: release download vs host-staged ELF ────────────────────────────
 #
-# An image without firmware is a regression we don't ship. Priority:
-#   1. Host-staged ELF (make stage-firmware, or release mode put it there).
-#   2. FIRMWARE_TAG env var: download from that specific fw/v* release.
-#   3. Auto-detect: download from the latest fw/v* release on GitHub.
-#   4. Die if none of the above succeed.
-
-# An image without firmware is a regression we don't ship: prefer the
-# host-staged ELF (make stage-firmware), fall back to GitHub release,
-# die if neither is available.
+# An image without firmware is a regression we don't ship. The correct source
+# depends on the build mode, because the staged ELF at $FW_ELF persists in the
+# bind-mounted repo across builds: make stage-firmware writes it, and release
+# mode used to write it there too. Treating that staged ELF as top priority
+# regardless of mode was wrong: a plain `make image` after any `make image-dev`
+# would bundle stale local dev firmware into a "release" image, and an explicit
+# FIRMWARE_TAG was silently ignored whenever an ELF happened to exist.
+#
+#   Local build mode (BUILD_LOCAL set):
+#     The staged ELF is the freshly cross-compiled local firmware (the dev
+#     targets run `make stage-firmware` before launching the container). Use
+#     it. Fall back to a release download only if it is somehow missing.
+#
+#   Release mode (BUILD_LOCAL unset):
+#     1. FIRMWARE_TAG: download from that specific fw/v* release. This is
+#        unconditional, as CLAUDE.md documents: a stale staged ELF must never
+#        override an explicit pin.
+#     2. Otherwise: download from the latest fw/v* release on GitHub.
+#     The staged ELF is deliberately ignored so release images never inherit
+#     leftover dev firmware.
+#
+# In every case, die if no firmware can be obtained.
 FW_ELF=/digits/tools/build/firmware.elf
 FW_VER_FILE=/digits/tools/build/firmware.elf.version
-if [[ -f "$FW_ELF" ]]; then
-    if [[ -f "$FW_VER_FILE" ]]; then
-        info "Using host-staged Pico firmware ($(tr -d '[:space:]' < "$FW_VER_FILE"))"
-    else
-        info "Using host-staged Pico firmware (no version file)"
-    fi
-else
+
+fetch_firmware_release() {
+    # Resolve the fw/v* tag (explicit FIRMWARE_TAG, else latest), download the
+    # ELF to $FW_ELF, and record its version. Dies on any failure.
+    local fw_tag fw_version
     if [[ -n "${FIRMWARE_TAG:-}" ]]; then
         # Explicit firmware release tag supplied.
-        FW_TAG="${FIRMWARE_TAG}"
-        if ! gh release view "${FW_TAG}" --repo justinlindh/digits &>/dev/null; then
-            die "GitHub release '${FW_TAG}' not found. Check FIRMWARE_TAG and try again."
+        fw_tag="${FIRMWARE_TAG}"
+        if ! gh release view "${fw_tag}" --repo justinlindh/digits &>/dev/null; then
+            die "GitHub release '${fw_tag}' not found. Check FIRMWARE_TAG and try again."
         fi
     else
         # Auto-detect the latest fw/v* release.
         info "Resolving latest Pico firmware release from GitHub..."
-        FW_TAG=$(gh release list --repo justinlindh/digits --limit 50 --json tagName \
+        fw_tag=$(gh release list --repo justinlindh/digits --limit 50 --json tagName \
             --jq '[.[].tagName | select(startswith("fw/"))] | first' 2>/dev/null || true)
-        if [[ -z "$FW_TAG" ]]; then
-            die "Could not determine latest fw/v* release tag from GitHub. Run 'make stage-firmware' first or set FIRMWARE_TAG."
+        if [[ -z "$fw_tag" ]]; then
+            die "Could not determine latest fw/v* release tag from GitHub. Set FIRMWARE_TAG=fw/v<version>, or use BUILD_LOCAL=1 with a staged firmware."
         fi
     fi
 
-    FW_VERSION="${FW_TAG#fw/v}"
-    info "Downloading Pico firmware ${FW_VERSION} from GitHub release ${FW_TAG}..."
-    gh release download "${FW_TAG}" \
+    fw_version="${fw_tag#fw/v}"
+    info "Downloading Pico firmware ${fw_version} from GitHub release ${fw_tag}..."
+    gh release download "${fw_tag}" \
         --repo justinlindh/digits \
-        --pattern "firmware-${FW_VERSION}.elf" \
+        --pattern "firmware-${fw_version}.elf" \
         --output "$FW_ELF"
-    printf '%s\n' "$FW_VERSION" > "$FW_VER_FILE"
-    info "Firmware downloaded: tools/build/firmware.elf ($FW_VERSION)"
+    printf '%s\n' "$fw_version" > "$FW_VER_FILE"
+    info "Firmware downloaded: tools/build/firmware.elf ($fw_version)"
+}
+
+if [[ -n "${BUILD_LOCAL:-}" ]]; then
+    # Local build mode: prefer the freshly staged local ELF.
+    if [[ -f "$FW_ELF" ]]; then
+        if [[ -f "$FW_VER_FILE" ]]; then
+            info "Using host-staged Pico firmware ($(tr -d '[:space:]' < "$FW_VER_FILE"))"
+        else
+            info "Using host-staged Pico firmware (no version file)"
+        fi
+    else
+        info "No host-staged firmware found; falling back to GitHub release..."
+        fetch_firmware_release
+    fi
+else
+    # Release mode: an explicit FIRMWARE_TAG (or the latest release) wins over
+    # any stale staged ELF, so a clean release image never bundles dev firmware.
+    fetch_firmware_release
 fi
 [[ -f "$FW_ELF" ]] || die "Firmware ELF still missing at $FW_ELF after fetch"
 

--- a/tools/README-image-builder.md
+++ b/tools/README-image-builder.md
@@ -4,30 +4,46 @@ Build a flashable SD card image for Digits Pi phones from a stock Raspberry Pi O
 
 ## Quick Start (Docker)
 
-The easiest way to build. Only requires Docker on your machine.
+The easiest way to build. The Docker container handles the base Pi OS download, QEMU for ARM64 chroot, partitioning, and packaging. The one host dependency is Go, used to run `make embed` (stages the rootfs overlay, tones, and mixer state) before the container runs.
+
+### Release mode (default)
+
+By default the builder downloads pre-built artifacts from GitHub Releases: the Pi binaries from the latest `pi/v*` release and the Pico firmware from the latest `fw/v*` release. This produces a clean production image without a local cross-compile of digitsd or the firmware. Because it hits the GitHub API, it requires a `GITHUB_TOKEN` with read access to `justinlindh/digits`:
 
 ```bash
-# Build the image (downloads Pi OS automatically on first run)
-./pi/image/build-docker.sh
+# Build the image (downloads Pi OS, Pi binaries, and firmware on first run)
+GITHUB_TOKEN=ghp_... ./pi/image/build-docker.sh
 
 # Flash to SD card
 gunzip -c digits-pi-*.img.gz | sudo dd of=/dev/sdX bs=4M status=progress
 ```
 
-The Docker container handles everything: downloading the base Pi OS image, cross-compiling the Go binaries, setting up QEMU for ARM64 chroot, partitioning, and packaging. No host dependencies needed beyond Docker.
+Pin specific releases instead of taking the latest:
+
+```bash
+RELEASE_TAG=pi/v1.21.0 FIRMWARE_TAG=fw/v0.9.0 GITHUB_TOKEN=ghp_... ./pi/image/build-docker.sh
+```
 
 The base Pi OS image is cached in a Docker volume (`digits-image-cache`) so it's only downloaded once. You can also provide your own:
 
 ```bash
-./pi/image/build-docker.sh path/to/raspios-lite.img.xz
+GITHUB_TOKEN=ghp_... ./pi/image/build-docker.sh path/to/raspios-lite.img.xz
+```
+
+### Local build mode (no token)
+
+Set `BUILD_LOCAL=1` to cross-compile digitsd from the working tree instead of downloading release artifacts. No `GITHUB_TOKEN` is needed unless the firmware also has to come from a release (stage it locally first with `make stage-firmware`, or the dev `make` targets do it for you):
+
+```bash
+BUILD_LOCAL=1 ./pi/image/build-docker.sh
 ```
 
 ### Dev mode
 
-Adds SSH access with user `dev` / password `digits` for debugging:
+Adds SSH access with user `dev` / password `digits` for debugging. The `--dev` flag is paired with `BUILD_LOCAL=1` (the top-level `make image-dev` / `make image-v2-dev` targets set both and stage firmware for you):
 
 ```bash
-./pi/image/build-docker.sh --dev
+BUILD_LOCAL=1 ./pi/image/build-docker.sh --dev
 ```
 
 ## Manual Build (No Docker)


### PR DESCRIPTION
## What

Fixes seven verified review findings in the Pi OS image builder and top-level build tooling.

**FINDING 1 (HIGH) `pi/image/entrypoint.sh`** firmware sourcing precedence. The block checked for a staged `tools/build/firmware.elf` before consulting `FIRMWARE_TAG` or the latest `fw/v*` release. That ELF persists in the bind-mounted repo across builds (release mode even wrote it there), so `make image` after any `make image-dev` bundled stale dev firmware into a "release" image, and `FIRMWARE_TAG=fw/vX make image` was silently ignored whenever an ELF existed. The precedence is now mode-aware: in `BUILD_LOCAL` mode the freshly staged local ELF wins (falling back to a release download only if missing); in release mode `FIRMWARE_TAG` then the latest `fw/v*` release win unconditionally and the staged ELF is ignored. Shared download logic moved into `fetch_firmware_release()`.

**FINDING 2 (MEDIUM) `pi/image/build-docker.sh`** undefined `warn`. The missing-`GITHUB_TOKEN` branch called `warn`, which did not exist. Under `set -euo pipefail`, `make image` without a token exited 127 with `warn: command not found` instead of the intended guidance. Added a `warn()` helper writing to stderr.

**FINDING 3 (MEDIUM) `pi/image/entrypoint.sh`** base image download without `--fail`. An HTTP error page was saved as the `.img.xz` with exit 0 and cached forever in the `digits-image-cache` volume. The download now uses `curl -fL --show-error`, writes to a `.partial` temp file, validates it is a non-empty XZ stream (`xz -t`), and only then promotes it to the cached name. Failure messages hint at clearing the cache volume. `BASE_IMAGE_SHA256` remains an empty opt-in (no published checksum to enforce).

**FINDING 4 (MEDIUM) top-level `Makefile`** SD auto-detection matched `/(usb|mmc)/` against the whole `lsblk` line, so `SUBSYSTEMS` strings like `block:scsi:usb:pci` qualified and any USB disk in the 4-64GB window could be picked. Detection now matches the `TRAN` column exactly (`usb` or `mmc`) and a gigabyte size unit. The `lsblk` printout and y/N confirmation are unchanged.

**FINDING 5 (LOW) top-level `Makefile`** `read -r -p` is unsupported on dash, so `make flash` errored before the prompt on Debian/Ubuntu `/bin/sh`. Replaced with `printf` + `read -r`.

**FINDING 6 (LOW) top-level `Makefile`** `image-flash`/`image-v2-flash` listed build and flash as plain prerequisites, so `make -j` could flash a stale or partial image. Both now run build then flash as ordered sub-make invocations.

**FINDING 7 (LOW) `tools/README-image-builder.md`** Quick Start claimed "no host dependencies needed beyond Docker" and never mentioned release mode, `GITHUB_TOKEN`, or `BUILD_LOCAL`, contradicting the actual default. Rewritten to document release-mode default (token + `RELEASE_TAG`/`FIRMWARE_TAG`), the `BUILD_LOCAL` path, and the Go dependency for `make embed`, matching CLAUDE.md.

## Why

These are shell/Makefile bugs that silently produce wrong artifacts (stale firmware in release images, cached corrupt downloads, wrong flash target) or break documented invocations (`make image` exit 127, `make flash` on dash, ignored `FIRMWARE_TAG`).

## Test plan

- `bash -n` clean on `pi/image/entrypoint.sh` and `pi/image/build-docker.sh`.
- `make help` parses; new `image-flash`/`image-v2-flash` recipes present.
- SD-detection awk validated against real `lsblk` output: a 3.6T USB HDD is correctly excluded, a simulated 32G USB device is selected.
- `shellcheck` was not available on this host; no new warnings were introduced by inspection.
- A full `make image` was NOT run locally: it needs a `GITHUB_TOKEN` and is slow. The release-mode firmware/download paths were reviewed by reasoning through `set -euo pipefail` semantics and the `BUILD_LOCAL`/`FIRMWARE_TAG` plumbing rather than executed.