### PR TITLE
fix(firmware): off-hook timeout, keypad debounce, and breathing LED flash

### DIFF
--- a/firmware/src/keypad.c
+++ b/firmware/src/keypad.c
@@ -10,8 +10,14 @@
 #define KEYPAD_SETTLE_US 5
 #define KEYPAD_DEBOUNCE_MS 80
 
+// s_last_key is the key currently believed to be held (the last one accepted),
+// or '\0' once a release has been confirmed. s_change_time marks the last
+// debounced state change (accept or confirmed release); a new transition is
+// honored only after KEYPAD_DEBOUNCE_MS has elapsed since it, which rejects
+// contact bounce on a single key without measuring distinct presses against an
+// unrelated earlier key's accept time.
 static char s_last_key = '\0';
-static absolute_time_t s_last_press_time;
+static absolute_time_t s_change_time;
 
 void keypad_init(void) {
     for (int i = 0; i < KEYPAD_NUM_ROWS; ++i) {
@@ -27,7 +33,7 @@ void keypad_init(void) {
     }
 
     s_last_key = '\0';
-    s_last_press_time = get_absolute_time();
+    s_change_time = get_absolute_time();
 }
 
 char keypad_scan_raw(void) {
@@ -52,16 +58,50 @@ char keypad_scan_raw(void) {
 
 char keypad_scan(void) {
     char pressed = keypad_scan_raw();
-
     absolute_time_t now = get_absolute_time();
-    if (pressed != '\0' && pressed != s_last_key) {
-        if (absolute_time_diff_us(s_last_press_time, now) >= (KEYPAD_DEBOUNCE_MS * 1000)) {
-            s_last_key = pressed;
-            s_last_press_time = now;
-            return pressed;
+
+    // Holding the same key: no new event, and no auto-repeat.
+    if (pressed == s_last_key) {
+        return '\0';
+    }
+
+    bool debounce_elapsed =
+        absolute_time_diff_us(s_change_time, now) >= (KEYPAD_DEBOUNCE_MS * 1000);
+
+    if (pressed == '\0') {
+        // Release edge. Confirm it only after the debounce window so brief
+        // mid-press contact chatter (key momentarily reads open) does not arm
+        // acceptance of a bounce re-close as a fresh press. Once confirmed,
+        // s_change_time is reset so the next distinct key is debounced against
+        // this release, not against the previous key's accept time.
+        if (debounce_elapsed) {
+            s_last_key = '\0';
+            s_change_time = now;
         }
-    } else if (pressed == '\0') {
-        s_last_key = '\0';
+        return '\0';
+    }
+
+    if (s_last_key == '\0') {
+        // No key was held (release already confirmed): this is a genuine new
+        // press. Accept immediately. It cannot be bounce of a prior key because
+        // a confirmed release intervened, so fast distinct-digit dialing is not
+        // throttled. Same-key bounce never reaches here: a brief mid-press open
+        // does not confirm the release (it re-closes before the window), so
+        // s_last_key stays the held key and the re-close is a held no-op above.
+        s_last_key = pressed;
+        s_change_time = now;
+        return pressed;
+    }
+
+    // A different key appeared while one was still believed held (no confirmed
+    // release between them, e.g. rollover or a fast slide across two contacts).
+    // Treat it as a real transition once the debounce window since the last
+    // accept has elapsed, so genuine adjacent presses are not lost, while
+    // electrical cross-talk within the window is rejected.
+    if (debounce_elapsed) {
+        s_last_key = pressed;
+        s_change_time = now;
+        return pressed;
     }
 
     return '\0';

--- a/firmware/src/led.c
+++ b/firmware/src/led.c
@@ -96,6 +96,14 @@ void led_set_mode(led_mode_t mode) {
     } else if (mode == LED_MODE_ON) {
         s_led_on = true;
         pwm_set_gpio_level(board->led_pin, PWM_WRAP);
+    } else if (mode == LED_MODE_BREATHING) {
+        // Breathing is driven from a LUT in led_update starting at phase 0 (the
+        // ramp's dim end). Seed the output to that same starting level instead
+        // of full brightness so there is no one-tick full-bright flash on mode
+        // entry, including at boot when PHASE_PAIRED selects breathing.
+        s_led_on = true;
+        pwm_set_gpio_level(board->led_pin, s_breathe_lut[0]);
+        s_last_toggle = get_absolute_time();
     } else {
         s_led_on = true;
         pwm_set_gpio_level(board->led_pin, PWM_WRAP);

--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -523,8 +523,19 @@ void phone_fsm_update(void) {
 
     process_key(keypad_scan());
 
-    if (s_state == PHONE_STATE_DIALING && !s_dial_sent && s_digits_len > 0) {
+    // Off-hook timeout in DIALING: fire regardless of accumulated digit count.
+    // s_dialing_start_ms is set on DIALING entry and is not reset per digit, so
+    // this bounds total time in DIALING before a completed DIAL. It covers the
+    // partial-dial case (some digits, never reached the required count) and the
+    // zero-digit case where the first key was '*' or '#' (a service-code or
+    // recovery prefix that does not increment s_digits_len), which would
+    // otherwise sit silently in DIALING until the handset is cradled. Preserves
+    // the Bellcore off-hook-timeout intent the DIAL_TONE path cites. Reuses the
+    // TIMEOUT:DIAL_TONE event so digitsd applies its existing off-hook
+    // permanent-signal treatment rather than seeing a new unhandled event.
+    if (s_state == PHONE_STATE_DIALING && !s_dial_sent) {
         if ((now_ms() - s_dialing_start_ms) >= DIAL_TIMEOUT_MS) {
+            uart_proto_send("TIMEOUT:DIAL_TONE");
             set_state(PHONE_STATE_BUSY);
         }
     }


### PR DESCRIPTION
## What

Fixes three verified code-review findings in the Pico H firmware (`firmware/src/`).

**Finding 1 (MEDIUM): DIALING off-hook timeout never fires for star/pound-only input.** `firmware/src/phone_fsm.c:526` (with `412-418`). Off-hook enters DIAL_TONE; the first keypress transitions to DIALING regardless of key. The DIALING timeout only fired when `s_digits_len > 0`, and `s_digits_len` increments only for `'0'-'9'`. A first key of `*` or `#` (a service-code or recovery prefix) leaves `s_digits_len == 0`, so neither the DIALING timeout nor the now-exited DIAL_TONE timeout applied, and the phone sat silently in DIALING until the handset was cradled. Fix: drop the `s_digits_len > 0` guard so the timeout fires on time since DIALING entry (`s_dialing_start_ms`, set on entry, not reset per digit) regardless of digit count, transitioning to BUSY exactly like the existing path. Sequences containing at least one numeric digit already worked and are unchanged; the completed-dial path still short-circuits via `!s_dial_sent`. Reuses the existing `TIMEOUT:DIAL_TONE` UART event so digitsd applies its off-hook permanent-signal treatment instead of seeing a new unhandled event.

**Finding 2 (MEDIUM): fast distinct-digit dialing drops keys.** `firmware/src/keypad.c:53-68`. The debounce timer was updated only on accept and never reset on release, so a distinct key B pressed within `KEYPAD_DEBOUNCE_MS` (80ms) of key A's accept was dropped because the window was still measured from A's accept time. Fix: track the last debounced state change and confirm releases. A genuinely new key after a confirmed release is accepted immediately (it cannot be bounce of a prior key because a release intervened), while same-key bounce is still rejected: a brief mid-press open does not persist long enough to confirm the release, so a bounce re-close remains a held no-op. Holding a key still produces no auto-repeat. State walk `no key -> A -> no key -> B` now accepts both; `A -> brief open -> A` (bounce) still yields a single A.

**Finding 3 (LOW): one-tick full-bright flash on breathing entry.** `firmware/src/led.c:99-103` (with `176-186`). `led_set_mode(LED_MODE_BREATHING)` fell into the generic else branch that forces `PWM_WRAP` (full brightness); `led_update` then started the breathe LUT at phase 0 (dim), producing a visible full-bright flash on every breathing entry, including at boot (`main.c` PHASE_PAIRED). Fix: on breathing entry, seed the output to `s_breathe_lut[0]` (the ramp's dim start) so the entry level matches the first `led_update` step and there is no flash.

**Finding 4 (INVESTIGATE): V1 L298N ENABLE handling. Decision: skip, no code change.** The concern was that `set_hbridge`/`stop_hbridge` assume IN1=IN2=LOW silences the coil, which on the V1 L298N depends on the ENABLE pin that the firmware never drives. Investigation of the V1 hardware (`hardware/pcb/v1/ERRATA.md`, `hardware/pcb/v1/PLAN.md`, `docs/build/wiring.md`) shows the firmware cannot and need not drive ENABLE on V1:

- V1's ringer is an external L298N module on header J5, which breaks out only IN1, IN2, +12V, and GND (`PLAN.md` J5 row; `ERRATA.md` root-cause entry). There is no ENABLE conductor routed to the Pico, so there is no pin for the firmware to control.
- On the standard L298N module the ENA/ENB enable inputs carry onboard jumpers tying them to +5V, so the output stage is permanently enabled. With ENABLE held high, IN1=IN2=LOW puts the bridge in brake-to-ground (both low-side devices on), which clamps the transformer primary at 0V: no AC drive, silent. The firmware assumption holds.
- The Pico GPIO pins on the V1 profile (`firmware/src/board.c`: `ringer_in1_pin = 11`, `ringer_in2_pin = 15`) match the documented J5 IN1/IN2 wiring, confirming the two control lines are the only ringer signals under firmware control.

No safe, verifiable code change is warranted: there is no V1 ENABLE wire to drive, and the existing both-LOW silence behavior is correct for both the V1 L298N (brake while enabled) and the V2 DRV8871 (coast). This is a concrete hardware reason, not a deferral.

## Why

These are correctness bugs in production phone hardware: a phone that hangs in DIALING after a `*`/`#` prefix, dropped digits during normal fast dialing, and a cosmetic LED flash on every breathing entry.

## Test plan

- `make firmware` (Docker build) succeeds cleanly, ELF and UF2 produced.
- Self-verified the FSM, keypad, and LED state machines by tracing the affected transitions, since hardware flashing is not available in this environment:
  - DIALING timeout: zero-digit (`*`/`#`-only) now transitions to BUSY at `DIAL_TIMEOUT_MS`; numeric partial dials unchanged; completed 7-digit dial still short-circuits via `!s_dial_sent`.
  - Keypad: `no key -> A -> no key -> B` accepts both; same-key bounce yields one event; held key gives no auto-repeat; double-tap of the same digit after a confirmed release registers twice.
  - LED: breathing entry now writes `s_breathe_lut[0]` (dim), matching the first `led_update` step, eliminating the full-bright tick.