### PR TITLE
fix(server): harden client-IP resolution and Google OAuth, plus latent concurrency fixes

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -255,6 +255,7 @@ func run(ctx context.Context) error {
 		AdminSecret:       cfg.AdminSecret,
 		DevMode:           cfg.DevMode,
 		WSRateLimitPerMin: cfg.WSRateLimitPerMin,
+		TrustedProxies:    cfg.TrustedProxies,
 	})
 	if err != nil {
 		return fmt.Errorf("create handler: %w", err)

--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -106,12 +106,13 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var info struct {
-		ID    string `json:"id"`
-		Email string `json:"email"`
-		Name  string `json:"name"`
-	}
-	if err := json.Unmarshal(body, &info); err != nil {
+	info, err := parseGoogleUserinfo(body)
+	switch {
+	case errors.Is(err, errUnverifiedEmail):
+		slog.WarnContext(r.Context(), "auth: google callback rejected unverified email", "google_id", info.ID)
+		http.Error(w, "Google account email is not verified", http.StatusForbidden)
+		return
+	case err != nil:
 		http.Error(w, "failed to parse user info", http.StatusInternalServerError)
 		return
 	}
@@ -174,4 +175,33 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	})
 
 	http.Redirect(w, r, safeReturnTo(returnTo, user), http.StatusSeeOther)
+}
+
+// googleUserinfo is the subset of Google's userinfo response we consume.
+type googleUserinfo struct {
+	ID            string `json:"id"`
+	Email         string `json:"email"`
+	Name          string `json:"name"`
+	VerifiedEmail bool   `json:"verified_email"`
+}
+
+// errUnverifiedEmail is returned by parseGoogleUserinfo when Google reports the
+// account's email as unverified. Google lets an account hold an unverified
+// address, so trusting it would let an attacker set a victim's email as their
+// own unverified address and then link to or sign in as the victim's
+// magic-link account.
+var errUnverifiedEmail = errors.New("google account email is not verified")
+
+// parseGoogleUserinfo decodes the userinfo response and enforces that the email
+// is verified. The decoded info is returned even on errUnverifiedEmail so the
+// caller can log the offending Google ID.
+func parseGoogleUserinfo(body []byte) (googleUserinfo, error) {
+	var info googleUserinfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return info, err
+	}
+	if !info.VerifiedEmail {
+		return info, errUnverifiedEmail
+	}
+	return info, nil
 }

--- a/server/internal/auth/google_userinfo_test.go
+++ b/server/internal/auth/google_userinfo_test.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseGoogleUserinfo(t *testing.T) {
+	t.Run("verified email parses", func(t *testing.T) {
+		body := []byte(`{"id":"123","email":"a@example.com","name":"A","verified_email":true}`)
+		info, err := parseGoogleUserinfo(body)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Email != "a@example.com" || info.ID != "123" {
+			t.Fatalf("unexpected info: %+v", info)
+		}
+	})
+
+	t.Run("unverified email is rejected", func(t *testing.T) {
+		body := []byte(`{"id":"123","email":"victim@example.com","name":"A","verified_email":false}`)
+		info, err := parseGoogleUserinfo(body)
+		if !errors.Is(err, errUnverifiedEmail) {
+			t.Fatalf("expected errUnverifiedEmail, got %v", err)
+		}
+		// Info is still returned so the caller can log the offending Google ID.
+		if info.ID != "123" {
+			t.Fatalf("expected info ID to be returned alongside error, got %q", info.ID)
+		}
+	})
+
+	t.Run("missing verified_email field is treated as unverified", func(t *testing.T) {
+		body := []byte(`{"id":"123","email":"victim@example.com","name":"A"}`)
+		_, err := parseGoogleUserinfo(body)
+		if !errors.Is(err, errUnverifiedEmail) {
+			t.Fatalf("expected errUnverifiedEmail for absent field, got %v", err)
+		}
+	})
+
+	t.Run("malformed json returns parse error", func(t *testing.T) {
+		_, err := parseGoogleUserinfo([]byte(`{not json`))
+		if err == nil || errors.Is(err, errUnverifiedEmail) {
+			t.Fatalf("expected a parse error, got %v", err)
+		}
+	})
+}

--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -146,12 +146,15 @@ func (ct *ConferenceTracker) IsBusy(ctx context.Context, phone string) bool {
 	return false
 }
 
-// ConferenceByPhone returns the active conference for a phone, or nil.
+// ConferenceByPhone returns the active conference for a phone, or nil. The
+// returned value is a deep copy: callers read it after the tracker mutex is
+// released while other methods mutate the live conference under lock, so
+// handing back the live pointer would be a data race.
 func (ct *ConferenceTracker) ConferenceByPhone(ctx context.Context, phone string) *Conference {
 	ct.mu.Lock()
 	id, ok := ct.memberIndex[phone]
 	if ok {
-		conf := ct.active[id]
+		conf := ct.snapshotLocked(id)
 		ct.mu.Unlock()
 		return conf
 	}
@@ -229,6 +232,12 @@ func (ct *ConferenceTracker) DropMember(ctx context.Context, confID uuid.UUID, p
 func (ct *ConferenceTracker) Snapshot(id uuid.UUID) *Conference {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
+	return ct.snapshotLocked(id)
+}
+
+// snapshotLocked deep-copies the active conference with the given ID, or
+// returns nil if none exists. Callers must hold ct.mu.
+func (ct *ConferenceTracker) snapshotLocked(id uuid.UUID) *Conference {
 	c, ok := ct.active[id]
 	if !ok {
 		return nil

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -43,6 +43,12 @@ type Config struct {
 	// (per IP, per minute). Default is 30. Set higher for load testing.
 	WSRateLimitPerMin int
 
+	// TrustedProxies is the number of reverse-proxy hops between signald and
+	// the real client, used to resolve the client IP from X-Forwarded-For for
+	// rate limiting. Default is 1 (a single Traefik in front of signald). Set
+	// to 0 to ignore X-Forwarded-For entirely (direct exposure).
+	TrustedProxies int
+
 	// Release index source. Exactly one of FakeUpdates or GitHubRepo (owner/repo)
 	// should be set. FakeUpdates wins if both are set and is intended for e2e
 	// tests. An unset GitHubRepo disables the release endpoint entirely.
@@ -61,6 +67,7 @@ func Load() *Config {
 		SMTPFrom:          "noreply@digits.family",
 		BaseURL:           "https://app.digits.family",
 		WSRateLimitPerMin: 30,
+		TrustedProxies:    1,
 	}
 	StringEnv("SIGNALD_ADDR", &c.Addr)
 	StringEnv("SIGNALD_METRICS_ADDR", &c.MetricsAddr)
@@ -91,6 +98,7 @@ func Load() *Config {
 	StringEnv("REDIS_URL", &c.RedisURL)
 	// Rate limits
 	IntEnv("SIGNALD_WS_RATE_LIMIT", &c.WSRateLimitPerMin)
+	IntEnv("SIGNALD_TRUSTED_PROXIES", &c.TrustedProxies)
 	// Release index
 	OneEnv("TEST_FAKE_UPDATES", &c.FakeUpdates)
 	StringEnv("GITHUB_REPO", &c.GitHubRepo)

--- a/server/internal/httputil/clientip.go
+++ b/server/internal/httputil/clientip.go
@@ -12,21 +12,42 @@ import (
 // ClientIP returns the resolved client IP for an inbound HTTP request.
 //
 // X-Forwarded-For is only trusted when RemoteAddr is a private or loopback
-// address, meaning the request arrived through a local reverse proxy. Direct
-// connections from untrusted networks use RemoteAddr so an attacker cannot
-// rotate XFF to bypass rate limiters.
-func ClientIP(r *http.Request) string {
+// address, meaning the request arrived through a local reverse proxy (in
+// production, Traefik in the cluster). Direct connections from untrusted
+// networks use RemoteAddr.
+//
+// trustedProxies is the number of reverse-proxy hops between this process and
+// the real client (1 for a single Traefik in front of signald). Each trusted
+// proxy appends the address it received the connection from to the right of
+// X-Forwarded-For, so the real client is the entry just to the left of the
+// trusted-proxy hops, counted from the right. Reading the leftmost entry
+// instead would let a client spoof its own X-Forwarded-For value and control
+// the rate-limit key, so the rightmost-minus-hops entry is the only one the
+// chain actually vouches for. A trustedProxies of zero or less ignores
+// X-Forwarded-For entirely and always uses RemoteAddr. If fewer XFF entries
+// are present than the hop count, the rightmost entry is used: it is the one
+// our immediate proxy appended and is never client-controlled.
+func ClientIP(r *http.Request, trustedProxies int) string {
 	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		remoteHost = r.RemoteAddr
 	}
-	if IsPrivateAddr(remoteHost) {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			parts := strings.SplitN(xff, ",", 2)
-			return strings.TrimSpace(parts[0])
-		}
+	if trustedProxies <= 0 || !IsPrivateAddr(remoteHost) {
+		return remoteHost
 	}
-	return remoteHost
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return remoteHost
+	}
+	parts := strings.Split(xff, ",")
+	// The entry the outermost trusted proxy appended is the real client when
+	// trustedProxies == 1. Clamp to the rightmost entry when fewer entries are
+	// present than the configured hop count.
+	idx := len(parts) - trustedProxies
+	if idx < 0 {
+		idx = len(parts) - 1
+	}
+	return strings.TrimSpace(parts[idx])
 }
 
 // IsPrivateAddr reports whether ip parses as an address we treat as

--- a/server/internal/httputil/clientip_test.go
+++ b/server/internal/httputil/clientip_test.go
@@ -7,17 +7,38 @@ import (
 
 func TestClientIP(t *testing.T) {
 	cases := []struct {
-		name       string
-		remoteAddr string
-		xff        string
-		want       string
+		name           string
+		remoteAddr     string
+		xff            string
+		trustedProxies int
+		want           string
 	}{
-		{name: "xff_single", remoteAddr: "172.18.0.1:34567", xff: "192.168.1.42", want: "192.168.1.42"},
-		{name: "xff_with_spaces", remoteAddr: "172.18.0.1:34567", xff: "  192.168.1.42  ", want: "192.168.1.42"},
-		{name: "xff_multiple_takes_first", remoteAddr: "172.18.0.1:34567", xff: "192.168.1.42, 10.0.0.1, 8.8.8.8", want: "192.168.1.42"},
-		{name: "no_xff_uses_remoteaddr", remoteAddr: "192.168.1.42:34567", xff: "", want: "192.168.1.42"},
-		{name: "no_xff_ipv6_brackets", remoteAddr: "[fe80::1]:34567", xff: "", want: "fe80::1"},
-		{name: "no_xff_no_port_returns_raw", remoteAddr: "192.168.1.42", xff: "", want: "192.168.1.42"},
+		// Direct connection from an untrusted network: ignore XFF entirely.
+		{name: "direct_no_xff", remoteAddr: "203.0.113.7:34567", xff: "", trustedProxies: 1, want: "203.0.113.7"},
+		{name: "direct_ignores_spoofed_xff", remoteAddr: "203.0.113.7:34567", xff: "8.8.8.8", trustedProxies: 1, want: "203.0.113.7"},
+
+		// Single trusted proxy (Traefik) appends the real client to the right.
+		{name: "single_proxy_real_client", remoteAddr: "172.18.0.1:34567", xff: "192.168.1.42", trustedProxies: 1, want: "192.168.1.42"},
+		{name: "single_proxy_with_spaces", remoteAddr: "172.18.0.1:34567", xff: "  192.168.1.42  ", trustedProxies: 1, want: "192.168.1.42"},
+
+		// A client that prepends its own XFF entries cannot control the key:
+		// with one trusted proxy we take the rightmost entry, which is what the
+		// proxy itself appended.
+		{name: "spoofed_leftmost_ignored", remoteAddr: "172.18.0.1:34567", xff: "8.8.8.8, 1.1.1.1, 192.168.1.42", trustedProxies: 1, want: "192.168.1.42"},
+
+		// Two trusted proxies: skip both appended hops, take the entry to their left.
+		{name: "two_proxies_real_client", remoteAddr: "172.18.0.1:34567", xff: "8.8.8.8, 192.168.1.42, 10.0.0.5", trustedProxies: 2, want: "192.168.1.42"},
+
+		// Fewer XFF entries than the configured hop count: fall back to rightmost.
+		{name: "hop_count_exceeds_entries", remoteAddr: "172.18.0.1:34567", xff: "8.8.8.8, 192.168.1.42", trustedProxies: 5, want: "192.168.1.42"},
+
+		// Zero trusted proxies ignores XFF entirely, even behind a proxy.
+		{name: "zero_proxies_ignores_xff", remoteAddr: "172.18.0.1:34567", xff: "8.8.8.8", trustedProxies: 0, want: "172.18.0.1"},
+
+		// No XFF behind a proxy: fall back to RemoteAddr.
+		{name: "proxy_no_xff_uses_remoteaddr", remoteAddr: "192.168.1.42:34567", xff: "", trustedProxies: 1, want: "192.168.1.42"},
+		{name: "no_xff_ipv6_brackets", remoteAddr: "[fe80::1]:34567", xff: "", trustedProxies: 1, want: "fe80::1"},
+		{name: "no_xff_no_port_returns_raw", remoteAddr: "192.168.1.42", xff: "", trustedProxies: 1, want: "192.168.1.42"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -28,7 +49,7 @@ func TestClientIP(t *testing.T) {
 			if tc.xff != "" {
 				r.Header.Set("X-Forwarded-For", tc.xff)
 			}
-			if got := ClientIP(r); got != tc.want {
+			if got := ClientIP(r, tc.trustedProxies); got != tc.want {
 				t.Errorf("ClientIP: got %q, want %q", got, tc.want)
 			}
 		})

--- a/server/internal/ratelimit/ratelimit.go
+++ b/server/internal/ratelimit/ratelimit.go
@@ -19,20 +19,24 @@ type bucket struct {
 
 // Limiter is an in-memory IP-based rate limiter using a fixed-window token bucket.
 type Limiter struct {
-	mu      sync.Mutex
-	buckets map[string]*bucket
-	limit   int
-	window  time.Duration
+	mu             sync.Mutex
+	buckets        map[string]*bucket
+	limit          int
+	window         time.Duration
+	trustedProxies int
 }
 
 // New creates a rate limiter that allows `limit` requests per `window` per IP.
-// It starts a background goroutine that evicts stale entries every 5 minutes
-// and runs for the lifetime of the process.
-func New(limit int, window time.Duration) *Limiter {
+// trustedProxies is the reverse-proxy hop count used to resolve the client IP
+// from X-Forwarded-For (see httputil.ClientIP). It starts a background
+// goroutine that evicts stale entries every 5 minutes and runs for the
+// lifetime of the process.
+func New(limit int, window time.Duration, trustedProxies int) *Limiter {
 	l := &Limiter{
-		buckets: make(map[string]*bucket),
-		limit:   limit,
-		window:  window,
+		buckets:        make(map[string]*bucket),
+		limit:          limit,
+		window:         window,
+		trustedProxies: trustedProxies,
 	}
 	go func() {
 		ticker := time.NewTicker(5 * time.Minute)
@@ -76,7 +80,7 @@ func (l *Limiter) evictExpired() {
 // Middleware returns an http.Handler that rejects requests over the rate limit with 429.
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := httputil.ClientIP(r)
+		ip := httputil.ClientIP(r, l.trustedProxies)
 		if !l.Allow(ip) {
 			http.Error(w, "Too many requests. Please try again later.", http.StatusTooManyRequests)
 			return

--- a/server/internal/ratelimit/ratelimit_test.go
+++ b/server/internal/ratelimit/ratelimit_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLimiterAllowsUnderLimit(t *testing.T) {
-	lim := New(5, time.Minute)
+	lim := New(5, time.Minute, 1)
 	for i := 0; i < 5; i++ {
 		if !lim.Allow("1.2.3.4") {
 			t.Fatalf("request %d should be allowed", i+1)
@@ -18,7 +18,7 @@ func TestLimiterAllowsUnderLimit(t *testing.T) {
 }
 
 func TestLimiterBlocksOverLimit(t *testing.T) {
-	lim := New(3, time.Minute)
+	lim := New(3, time.Minute, 1)
 	for i := 0; i < 3; i++ {
 		lim.Allow("1.2.3.4")
 	}
@@ -28,7 +28,7 @@ func TestLimiterBlocksOverLimit(t *testing.T) {
 }
 
 func TestLimiterTracksIPsSeparately(t *testing.T) {
-	lim := New(1, time.Minute)
+	lim := New(1, time.Minute, 1)
 	if !lim.Allow("1.1.1.1") {
 		t.Fatal("first IP should be allowed")
 	}
@@ -41,7 +41,7 @@ func TestLimiterTracksIPsSeparately(t *testing.T) {
 }
 
 func TestLimiterRefillsAfterWindow(t *testing.T) {
-	lim := New(1, 50*time.Millisecond)
+	lim := New(1, 50*time.Millisecond, 1)
 	lim.Allow("1.2.3.4")
 	if lim.Allow("1.2.3.4") {
 		t.Fatal("should be blocked immediately")
@@ -53,7 +53,7 @@ func TestLimiterRefillsAfterWindow(t *testing.T) {
 }
 
 func TestMiddleware429(t *testing.T) {
-	lim := New(1, time.Minute)
+	lim := New(1, time.Minute, 1)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -74,7 +74,7 @@ func TestMiddleware429(t *testing.T) {
 }
 
 func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
-	lim := New(1, time.Minute)
+	lim := New(1, time.Minute, 1)
 	handler := lim.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -105,7 +105,7 @@ func TestMiddlewareRespectsXForwardedFor(t *testing.T) {
 }
 
 func TestEvictExpiredRemovesStaleEntries(t *testing.T) {
-	lim := New(1, 50*time.Millisecond)
+	lim := New(1, 50*time.Millisecond, 1)
 	lim.Allow("stale-ip")
 	time.Sleep(60 * time.Millisecond)
 	lim.evictExpired()

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -367,14 +367,13 @@ func (h *Hub) Register(number string, conn *Conn) error {
 			if old.WS != nil {
 				_ = old.WS.Close()
 			}
-			select {
-			case _, ok := <-old.Send:
-				if ok {
-					close(old.Send)
-				}
-			default:
-				close(old.Send)
-			}
+			// Close the old connection's send channel so its write pump exits
+			// (the pump returns on the !ok branch). Double-close is impossible:
+			// replacing the slot in place below makes the old conn invisible to
+			// any later Unregister, and every send into old.Send happens under
+			// h.mu, which we hold here. Draining first would silently drop a
+			// queued outbound frame, so we close unconditionally instead.
+			close(old.Send)
 			existing[i] = conn
 			replaced = true
 			break

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -75,19 +75,30 @@ func TestHubGetReturnsConnForOnline(t *testing.T) {
 	}
 }
 
-func TestRegisterHandlesAlreadyClosedSendChannel(t *testing.T) {
+func TestRegisterSameHardwareReplacesAndClosesOld(t *testing.T) {
 	hub := NewHub()
 	number := "3140001"
-	oldConn := &Conn{Send: make(chan []byte), HardwareID: "hw-001"}
-	close(oldConn.Send)
-	hub.conns[number] = []*Conn{oldConn}
-	hub.hwConns["hw-001"] = oldConn
+	oldConn := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-001"}
+	// Queue an outbound frame so the test would catch a regression that
+	// drains (and silently discards) the old connection's buffer instead of
+	// closing it and letting the write pump flush.
+	oldConn.Send <- []byte("queued")
+	_ = hub.Register(number, oldConn)
 
 	newConn := &Conn{Send: make(chan []byte, 1), HardwareID: "hw-001"}
 	_ = hub.Register(number, newConn)
 
 	if got := hub.Get(number); got != newConn {
 		t.Fatalf("expected new connection to be registered")
+	}
+
+	// The old channel must be closed (write pump exits on !ok) and any queued
+	// frame still readable before the close is observed.
+	if got := <-oldConn.Send; string(got) != "queued" {
+		t.Fatalf("queued frame lost: got %q", got)
+	}
+	if _, ok := <-oldConn.Send; ok {
+		t.Fatal("expected old connection's Send channel to be closed")
 	}
 }
 

--- a/server/internal/signaling/redis.go
+++ b/server/internal/signaling/redis.go
@@ -130,7 +130,13 @@ func (b *RedisBridge) Subscribe(ctx context.Context) <-chan *Envelope {
 				if env.PodID == b.podID {
 					continue
 				}
-				ch <- &env
+				// Guard the send so a stalled consumer (full buffer) cannot
+				// pin this goroutine open past context cancellation.
+				select {
+				case ch <- &env:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -332,6 +332,11 @@ type HandlerConfig struct {
 	// WSRateLimitPerMin overrides the default WebSocket upgrade rate limit
 	// (per IP, per minute). Zero uses the default (30).
 	WSRateLimitPerMin int
+	// TrustedProxies is the reverse-proxy hop count used to resolve the client
+	// IP from X-Forwarded-For for rate limiting (see httputil.ClientIP). It is
+	// passed verbatim to the rate limiters; the default of 1 is supplied by the
+	// config loader.
+	TrustedProxies int
 }
 
 // Deps bundles the stores, hub, and other collaborators the web Handler
@@ -514,12 +519,12 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 		linkStore:                deps.LinkStore,
 		inviteStore:              deps.InviteStore,
 		emailer:                  deps.Emailer,
-		authLimiter:              ratelimit.New(5, time.Minute),
-		magicVerifyLimiter:       ratelimit.New(10, time.Minute),
-		googleLoginLimiter:       ratelimit.New(10, time.Minute),
-		pairingLimiter:           ratelimit.New(5, time.Minute),
-		inviteLimiter:            ratelimit.New(5, time.Minute),
-		wsLimiter:                ratelimit.New(wsRateLimit(cfg), time.Minute),
+		authLimiter:              ratelimit.New(5, time.Minute, cfg.TrustedProxies),
+		magicVerifyLimiter:       ratelimit.New(10, time.Minute, cfg.TrustedProxies),
+		googleLoginLimiter:       ratelimit.New(10, time.Minute, cfg.TrustedProxies),
+		pairingLimiter:           ratelimit.New(5, time.Minute, cfg.TrustedProxies),
+		inviteLimiter:            ratelimit.New(5, time.Minute, cfg.TrustedProxies),
+		wsLimiter:                ratelimit.New(wsRateLimit(cfg), time.Minute, cfg.TrustedProxies),
 		metrics:                  deps.Metrics,
 	}, nil
 }


### PR DESCRIPTION
## What

Five verified code-review fixes in the signaling server: two security hardening fixes and three latent concurrency fixes.

**1. Client IP resolution (security).** `httputil.ClientIP` trusted `X-Forwarded-For` whenever `RemoteAddr` was private and returned the leftmost entry. Behind Traefik in the cluster, `RemoteAddr` is always the private proxy IP, so any client could send its own `X-Forwarded-For` and control the rate-limit key, defeating every limiter (magic-link, Google login, pairing, invite, WebSocket upgrade). `ClientIP` now takes a trusted-proxy hop count and walks that many entries from the right, since each trusted proxy appends the address it received the connection from. The rightmost-minus-hops entry is the only one the chain vouches for. Default is one hop (a single Traefik), overridable via `SIGNALD_TRUSTED_PROXIES`; zero ignores `X-Forwarded-For` entirely.

**2. Google OAuth email verification (security).** The OAuth callback never checked `verified_email`, then matched an existing user by email and linked the Google ID. An attacker could set a victim's address as an unverified email on their own Google account and take over the victim's magic-link account. The callback now parses `verified_email` and rejects the login with 403 when false, before any user lookup, link, or session creation.

**3. Conference snapshot (data race).** `ConferenceByPhone` returned the live `*Conference` pointer, which callers read after the tracker mutex was released while other methods mutate the same struct under lock. It now returns a deep copy, factored into a `snapshotLocked` helper shared with the existing `Snapshot`. All callers only read fields.

**4. Hub reconnect channel close (message loss).** On a same-hardware-ID reconnect, `Hub.Register` drained `old.Send` before closing it, discarding any queued outbound frame. The double-close the drain guarded against cannot happen: replacing the slot in place makes the old conn invisible to any later `Unregister`, and every send happens under `h.mu`. The channel is now closed unconditionally, so the write pump exits on its `!ok` branch after flushing what it has buffered.

**5. Redis subscriber goroutine leak.** The subscriber goroutine selected on `ctx.Done()` for the receive from Redis but used an unguarded blocking send to the consumer channel. A stalled consumer with a full buffer would leak the goroutine on shutdown. The send is now wrapped in a `select` with a `ctx.Done()` case.

## Why

Fixes 1 and 2 are exploitable account-takeover and rate-limit-bypass vectors in production. Fixes 3 through 5 are latent concurrency bugs (data race, silent message loss on reconnect, goroutine leak on shutdown).

## Test plan

- `make test`: pass
- `make test-integration`: pass (with `-race`, covering the conference snapshot and hub close fixes)
- `golangci-lint run ./...`: clean (no new issues)
- `make build`: pass

New and updated unit tests cover direct connections, single and multi trusted-proxy XFF resolution, spoofed leftmost entries being ignored, zero trusted proxies, the unverified-email rejection path, and same-hardware reconnect preserving a queued frame while closing the old channel.