### PR TITLE
fix(digitsd): reconnect off the main loop and resilience hardening

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1508,12 +1508,11 @@ func main() {
 			slog.Warn("could not load pairing tones", "error", err)
 		}
 	}
-	mixer.Start()
-	defer mixer.Stop()
-
 	// Debug: capture raw PCM output if CAPTURE_PCM is set. Bounded so a forgotten
 	// capture cannot fill /data (raw 48kHz stereo S16LE is ~345 MB/hr). Default
 	// cap 512 MB; override the megabyte limit with CAPTURE_PCM_MAX_MB (0 = off).
+	// Set up before Start() so the render goroutine observes the capture fields
+	// from its first iteration without any cross-goroutine write to race on.
 	if capPath := os.Getenv("CAPTURE_PCM"); capPath != "" {
 		maxBytes := int64(512) * 1024 * 1024
 		if v := os.Getenv("CAPTURE_PCM_MAX_MB"); v != "" {
@@ -1529,6 +1528,9 @@ func main() {
 			defer mixer.DisableCapture()
 		}
 	}
+
+	mixer.Start()
+	defer mixer.Stop()
 
 	deviceID, err := config.LoadOrCreateDeviceID()
 	if err != nil {

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -121,17 +121,17 @@ type daemonCallbacks struct {
 		candidates []string // local ICE candidates gathered during ring, sent on pickup
 		caller     string   // pendingCaller at time of preparation
 	}
-	iceServers            []owebrtc.ICEServerConfig // cached STUN/TURN servers from signald
-	debugMode             bool                      // read from DIGITS_DEBUG env at startup
-	paired                atomic.Bool
-	pairingCode           string      // current pairing code from server
-	pairingCodeExpiresAt  time.Time   // server-reported expiry of the current pairing code
-	callPeer              string      // number of the remote party during an active call
-	isCaller              bool        // true if we initiated the current call
-	callReturnOrigin      atomic.Bool // true when the current call was initiated via *69
-	isRestartingICE       bool        // true while an ICE restart is in progress
-	restartTimer          *time.Timer // timeout for ICE restart attempt
-	disconnectTimer       *time.Timer // debounce before reacting to pion Disconnected
+	iceServers           []owebrtc.ICEServerConfig // cached STUN/TURN servers from signald
+	debugMode            bool                      // read from DIGITS_DEBUG env at startup
+	paired               atomic.Bool
+	pairingCode          string      // current pairing code from server
+	pairingCodeExpiresAt time.Time   // server-reported expiry of the current pairing code
+	callPeer             string      // number of the remote party during an active call
+	isCaller             bool        // true if we initiated the current call
+	callReturnOrigin     atomic.Bool // true when the current call was initiated via *69
+	isRestartingICE      bool        // true while an ICE restart is in progress
+	restartTimer         *time.Timer // timeout for ICE restart attempt
+	disconnectTimer      *time.Timer // debounce before reacting to pion Disconnected
 
 	// Link-health reporter: spawned when a call reaches Connected, canceled on teardown.
 	// Protected by mu.
@@ -261,6 +261,16 @@ func sendSignal(sig *sigclient.Client, msg *sigclient.Message) {
 	}
 }
 
+// currentSig returns the active signaling client under cb.mu. The reconnect
+// goroutine swaps d.sig on every reconnect, so pion callbacks and FSM
+// goroutines must read it through this accessor rather than touching d.sig
+// directly, which would race with that writer.
+func (d *daemonCallbacks) currentSig() *sigclient.Client {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sig
+}
+
 // recoverGoroutine logs a panic with its stack trace so a single bad frame
 // doesn't crash an audio/WebRTC goroutine silently.
 func recoverGoroutine(name string) {
@@ -344,7 +354,7 @@ func (d *daemonCallbacks) EnableFlashDetection() {
 
 func (d *daemonCallbacks) OnCallReturn() {
 	d.callReturnOrigin.Store(true)
-	if err := d.sig.Send(&sigclient.Message{Type: sigclient.TypeCallReturn}); err != nil {
+	if err := d.currentSig().Send(&sigclient.Message{Type: sigclient.TypeCallReturn}); err != nil {
 		slog.Error("call_return: server unreachable", "error", err)
 		d.callReturnOrigin.Store(false)
 		d.mixer.PlayOnce("disconnected")
@@ -354,7 +364,7 @@ func (d *daemonCallbacks) OnCallReturn() {
 }
 
 func (d *daemonCallbacks) OnCallReturnCancel() {
-	if err := d.sig.Send(&sigclient.Message{Type: sigclient.TypeCallReturnCancel}); err != nil {
+	if err := d.currentSig().Send(&sigclient.Message{Type: sigclient.TypeCallReturnCancel}); err != nil {
 		slog.Error("call_return_cancel: server unreachable", "error", err)
 	}
 }
@@ -465,11 +475,12 @@ func publishVoicemailStateOnce(sender sigSender, store *voicemail.Store, last *i
 func (d *daemonCallbacks) publishVoicemailState() {
 	d.mu.Lock()
 	store := d.voicemailStore
+	sig := d.sig
 	d.mu.Unlock()
 
 	d.publishVMMu.Lock()
 	defer d.publishVMMu.Unlock()
-	publishVoicemailStateOnce(d.sig, store, &d.publishVMLast, false)
+	publishVoicemailStateOnce(sig, store, &d.publishVMLast, false)
 }
 
 // publishVoicemailStateInitial is the (re)connect wrapper. It sends the
@@ -479,11 +490,12 @@ func (d *daemonCallbacks) publishVoicemailState() {
 func (d *daemonCallbacks) publishVoicemailStateInitial() {
 	d.mu.Lock()
 	store := d.voicemailStore
+	sig := d.sig
 	d.mu.Unlock()
 
 	d.publishVMMu.Lock()
 	defer d.publishVMMu.Unlock()
-	publishVoicemailStateOnce(d.sig, store, &d.publishVMLast, true)
+	publishVoicemailStateOnce(sig, store, &d.publishVMLast, true)
 }
 
 // setVoicemailConfig replaces the local voicemail config under d.mu and
@@ -1499,9 +1511,19 @@ func main() {
 	mixer.Start()
 	defer mixer.Stop()
 
-	// Debug: capture raw PCM output if CAPTURE_PCM is set
+	// Debug: capture raw PCM output if CAPTURE_PCM is set. Bounded so a forgotten
+	// capture cannot fill /data (raw 48kHz stereo S16LE is ~345 MB/hr). Default
+	// cap 512 MB; override the megabyte limit with CAPTURE_PCM_MAX_MB (0 = off).
 	if capPath := os.Getenv("CAPTURE_PCM"); capPath != "" {
-		if err := mixer.EnableCapture(capPath); err != nil {
+		maxBytes := int64(512) * 1024 * 1024
+		if v := os.Getenv("CAPTURE_PCM_MAX_MB"); v != "" {
+			if mb, err := strconv.ParseInt(v, 10, 64); err == nil {
+				maxBytes = mb * 1024 * 1024
+			} else {
+				slog.Warn("CAPTURE_PCM_MAX_MB invalid, using default", "value", v)
+			}
+		}
+		if err := mixer.EnableCapture(capPath, maxBytes); err != nil {
 			slog.Warn("PCM capture failed", "error", err)
 		} else {
 			defer mixer.DisableCapture()
@@ -2004,8 +2026,26 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
+	// reconnected hands a freshly connected client back from the reconnect
+	// goroutine to the main loop. Buffered so the goroutine never blocks if
+	// the loop is momentarily busy. reconnecting is true while that goroutine
+	// is in flight: it gates sig.Done() out of the select so the loop neither
+	// spins on the dead client's already-closed done channel nor blocks on
+	// time.Sleep, leaving it free to service sp.Events() and quit throughout
+	// the backoff/connect.
+	reconnected := make(chan *sigclient.Client, 1)
+	reconnecting := false
+
 	// Main select loop
 	for {
+		// During reconnect, sig points at the dead client whose Done() is
+		// already closed; nil out doneCh so the select does not busy-loop on
+		// it. Completion arrives on the reconnected channel instead.
+		var doneCh <-chan struct{}
+		if !reconnecting {
+			doneCh = sig.Done()
+		}
+
 		select {
 		case <-quit:
 			slog.Info("digitsd shutting down")
@@ -2015,6 +2055,13 @@ func main() {
 				slog.Warn("sig close failed", "error", err)
 			}
 			return
+
+		case newSig := <-reconnected:
+			// The reconnect goroutine established a new client and ran the
+			// post-reconnect resume/teardown. Swap it in as the loop's active
+			// client; subsequent iterations select on its channels.
+			sig = newSig
+			reconnecting = false
 
 		case event := <-sp.Events():
 			// Confirmer intercept: when a sensitive op is awaiting "press *
@@ -2748,56 +2795,76 @@ func main() {
 				_ = sig.Close()
 			}
 
-		case <-sig.Done():
-			backoff := 3 * time.Second
-			first := true
-			for {
-				if first {
-					// Attempt the first reconnect immediately: no sleep on the
-					// first try so a transient blip resolves as fast as possible.
-					// This is especially important during an active call so the
-					// caller can re-deliver the ICE-restart offer before the peer's
-					// 25s recovery window expires.
-					first = false
-				} else {
-					// Active calls use a short fixed interval to stay within the
-					// recovery window. Idle paths use standard exponential backoff.
-					backoff = nextReconnectBackoff(backoff, ctrl.IsCallActive())
-					slog.Info("signal: connection lost, reconnecting", "backoff", backoff)
-					time.Sleep(backoff)
-				}
-				sig = sigclient.NewClient(effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken)
-				cb.mu.Lock()
-				cb.sig = sig
-				cb.mu.Unlock()
-				if err := sig.Connect(); err != nil {
-					slog.Warn("signal: reconnect failed", "error", err)
-					continue
-				}
-				slog.Info("signal: reconnected")
+		case <-doneCh:
+			// Reconnect off the main loop so the select keeps servicing UART
+			// events and quit during the backoff/connect. The goroutine runs
+			// the connect with backoff, performs the post-reconnect resume or
+			// teardown, then hands the live client back via reconnected.
+			reconnecting = true
+			go reconnectLoop(reconnected, cb, ctrl, effectiveServerURL, effectiveNumber, deviceID, cfg.DeviceToken, fwVersion, fwCommit)
+		}
+	}
+}
 
-				// A 2-party call whose media survived the WebSocket drop is
-				// resumed in place; if media also dropped, drive ICE recovery.
-				// Anything else (conference, voicemail, ringing) is torn down:
-				// the server already cleared its side or will after its grace
-				// window, and stale renegotiation would error.
-				if ctrl.State() != phone.StateIDLE {
-					if cb.tryResumeAfterReconnect(ctrl.State()) {
-						slog.Info("signal: resumed call after reconnect", "state", ctrl.State())
-					} else {
-						slog.Info("signal: tearing down stale call after reconnect", "state", ctrl.State())
-						cb.TearDownAllMeshPeers()
-						cb.HangupCall()
-						ctrl.Reset()
-					}
-				}
+// reconnectLoop re-establishes the signald WebSocket after a drop, applying
+// the active-call fast backoff vs idle exponential backoff, runs the resume or
+// teardown for any in-progress call, then hands the connected client back to
+// the main loop on done. It runs on its own goroutine so the main select loop
+// stays free to service UART events and shutdown during the backoff/connect.
+func reconnectLoop(
+	done chan<- *sigclient.Client,
+	cb *daemonCallbacks,
+	ctrl *phone.Controller,
+	serverURL, number, deviceID, deviceToken, fwVersion, fwCommit string,
+) {
+	backoff := 3 * time.Second
+	first := true
+	for {
+		if first {
+			// Attempt the first reconnect immediately: no sleep on the
+			// first try so a transient blip resolves as fast as possible.
+			// This is especially important during an active call so the
+			// caller can re-deliver the ICE-restart offer before the peer's
+			// 25s recovery window expires.
+			first = false
+		} else {
+			// Active calls use a short fixed interval to stay within the
+			// recovery window. Idle paths use standard exponential backoff.
+			backoff = nextReconnectBackoff(backoff, ctrl.IsCallActive())
+			slog.Info("signal: connection lost, reconnecting", "backoff", backoff)
+			time.Sleep(backoff)
+		}
+		sig := sigclient.NewClient(serverURL, number, deviceID, deviceToken)
+		cb.mu.Lock()
+		cb.sig = sig
+		cb.mu.Unlock()
+		if err := sig.Connect(); err != nil {
+			slog.Warn("signal: reconnect failed", "error", err)
+			continue
+		}
+		slog.Info("signal: reconnected")
 
-				sendDeviceInfo(sig, fwVersion, fwCommit)
-				cb.publishVoicemailState()
-				requestICEServers(sig)
-				break
+		// A 2-party call whose media survived the WebSocket drop is
+		// resumed in place; if media also dropped, drive ICE recovery.
+		// Anything else (conference, voicemail, ringing) is torn down:
+		// the server already cleared its side or will after its grace
+		// window, and stale renegotiation would error.
+		if ctrl.State() != phone.StateIDLE {
+			if cb.tryResumeAfterReconnect(ctrl.State()) {
+				slog.Info("signal: resumed call after reconnect", "state", ctrl.State())
+			} else {
+				slog.Info("signal: tearing down stale call after reconnect", "state", ctrl.State())
+				cb.TearDownAllMeshPeers()
+				cb.HangupCall()
+				ctrl.Reset()
 			}
 		}
+
+		sendDeviceInfo(sig, fwVersion, fwCommit)
+		cb.publishVoicemailState()
+		requestICEServers(sig)
+		done <- sig
+		return
 	}
 }
 

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -495,19 +496,51 @@ func clearRecoveryPhase(sp *phone.SerialPort) {
 	}
 }
 
-// clearRecoveryFlags mounts /data temporarily to clear the boot counter
-// and recovery-mode flag so the next boot proceeds normally.
+// dataMounted reports whether /data is already a mount point. The try-again
+// exits run with /data mounted by the recovery boot; the cold path (called via
+// doReboot from contexts where /data is not mounted) is not. clearRecoveryFlags
+// uses this to avoid stacking a second mount over an existing one and then
+// unmounting only one layer, which would leave the original mount live.
+func dataMounted() bool {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return false
+	}
+	return mountsContain(string(data), "/data")
+}
+
+// mountsContain reports whether the /proc/mounts content lists target as a
+// mount point. Split out so the parsing is unit-testable without /proc.
+func mountsContain(procMounts, target string) bool {
+	for _, line := range strings.Split(procMounts, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == target {
+			return true
+		}
+	}
+	return false
+}
+
+// clearRecoveryFlags clears the boot counter and recovery-mode flag so the next
+// boot proceeds normally. If /data is already mounted (the try-again exits), it
+// operates on the live mount and leaves it as-is. Only the cold path, where
+// /data is not mounted, mounts it temporarily and unmounts when done.
 func clearRecoveryFlags() {
-	_ = os.MkdirAll("/data", 0755)
-	if err := syscall.Mount("/dev/mmcblk0p4", "/data", "ext4", 0, ""); err != nil {
-		slog.Warn("recovery: mount /data for flag cleanup failed", "error", err)
-		return
+	if !dataMounted() {
+		_ = os.MkdirAll("/data", 0755)
+		if err := syscall.Mount("/dev/mmcblk0p4", "/data", "ext4", 0, ""); err != nil {
+			slog.Warn("recovery: mount /data for flag cleanup failed", "error", err)
+			return
+		}
+		defer func() {
+			syscall.Sync()
+			_ = syscall.Unmount("/data", 0)
+		}()
 	}
 	_ = bootcount.Clear(bootcount.DefaultPath)
 	_ = os.Remove("/data/digits/recovery-mode")
 	slog.Info("recovery: boot counter and recovery flag cleared")
 	syscall.Sync()
-	_ = syscall.Unmount("/data", 0)
 }
 
 // doReboot reboots the system. If running as PID 1 (init in initramfs),

--- a/pi/digitsd/cmd/digitsd/recovery_test.go
+++ b/pi/digitsd/cmd/digitsd/recovery_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestMountsContain(t *testing.T) {
+	const sample = `proc /proc proc rw,relatime 0 0
+/dev/mmcblk0p2 / ext4 ro,relatime 0 0
+/dev/mmcblk0p4 /data ext4 rw,relatime 0 0
+tmpfs /run tmpfs rw,nosuid 0 0
+`
+	tests := []struct {
+		name   string
+		mounts string
+		target string
+		want   bool
+	}{
+		{"data mounted", sample, "/data", true},
+		{"root mounted", sample, "/", true},
+		{"not mounted", sample, "/boot", false},
+		{"empty mounts", "", "/data", false},
+		{"prefix is not a match", "/dev/x /database ext4 rw 0 0\n", "/data", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mountsContain(tc.mounts, tc.target); got != tc.want {
+				t.Errorf("mountsContain(%q, %q) = %v, want %v", tc.mounts, tc.target, got, tc.want)
+			}
+		})
+	}
+}

--- a/pi/digitsd/cmd/digitsd/resilience_test.go
+++ b/pi/digitsd/cmd/digitsd/resilience_test.go
@@ -248,3 +248,33 @@ func TestNextReconnectBackoff(t *testing.T) {
 		}
 	}
 }
+
+func TestCurrentSigReturnsActiveClientUnderLock(t *testing.T) {
+	a := sigclient.NewClient("ws://127.0.0.1:0/a", "n", "hw", "tok")
+	b := sigclient.NewClient("ws://127.0.0.1:0/b", "n", "hw", "tok")
+	d := &daemonCallbacks{sig: a}
+
+	if got := d.currentSig(); got != a {
+		t.Fatalf("currentSig() = %p, want %p", got, a)
+	}
+
+	// Concurrent reader + writer: with -race this asserts the accessor and the
+	// reconnect-style writer agree on d.mu so the swap is not a data race.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			_ = d.currentSig()
+		}
+		close(done)
+	}()
+	for i := 0; i < 1000; i++ {
+		d.mu.Lock()
+		d.sig = b
+		d.mu.Unlock()
+	}
+	<-done
+
+	if got := d.currentSig(); got != b {
+		t.Fatalf("currentSig() after swap = %p, want %p", got, b)
+	}
+}

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -410,7 +410,7 @@ func (d *daemonCallbacks) VoicemailAutoAnswer() {
 	sdpSent := make(chan struct{})
 	d.peerMgr.OnICECandidate = func(candidate string) {
 		<-sdpSent
-		sendSignal(d.sig, &sigclient.Message{
+		sendSignal(d.currentSig(), &sigclient.Message{
 			Type:      sigclient.TypeICE,
 			To:        caller,
 			Candidate: candidate,

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -96,7 +96,7 @@ func (d *daemonCallbacks) InitiateCall(targetNumber string) error {
 	sdpSent := make(chan struct{})
 	d.peerMgr.OnICECandidate = func(candidate string) {
 		<-sdpSent
-		sendSignal(d.sig, &sigclient.Message{
+		sendSignal(d.currentSig(), &sigclient.Message{
 			Type:      sigclient.TypeICE,
 			To:        targetNumber,
 			Candidate: candidate,
@@ -180,7 +180,7 @@ func (d *daemonCallbacks) AnswerCall() {
 
 		// Any candidates still gathering after promotion should be sent directly.
 		pm.OnICECandidate = func(candidate string) {
-			sendSignal(d.sig, &sigclient.Message{
+			sendSignal(d.currentSig(), &sigclient.Message{
 				Type:      sigclient.TypeICE,
 				To:        caller,
 				Candidate: candidate,
@@ -230,7 +230,7 @@ func (d *daemonCallbacks) AnswerCall() {
 	sdpSent := make(chan struct{})
 	d.peerMgr.OnICECandidate = func(candidate string) {
 		<-sdpSent
-		sendSignal(d.sig, &sigclient.Message{
+		sendSignal(d.currentSig(), &sigclient.Message{
 			Type:      sigclient.TypeICE,
 			To:        caller,
 			Candidate: candidate,

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -32,10 +32,13 @@ type FrameWriter interface {
 // debugPCMFile is a raw PCM capture of everything sent to the DAC.
 // Set via EnableCapture/DisableCapture. Only written from render loop.
 type Mixer struct {
-	capturePath string   // if non-empty, render loop writes raw PCM here
-	captureFile *os.File // open file handle (nil when not capturing)
-	w      FrameWriter
-	period int
+	capturePath  string   // if non-empty, render loop writes raw PCM here
+	captureFile  *os.File // open file handle (nil when not capturing)
+	captureMax   int64    // stop writing once this many bytes are on disk (0 = unbounded)
+	captureBytes int64    // bytes written so far this session
+	captureFull  bool     // true once captureMax is hit; logged once, then writes stop
+	w            FrameWriter
+	period       int
 
 	mu      sync.Mutex
 	stopCh  chan struct{}
@@ -167,16 +170,27 @@ func (m *Mixer) renderLoop(stop, done chan struct{}) {
 		// 4. Write the mixed period to hardware (only this goroutine does this)
 		m.w.WriteFrame(buf) //nolint:errcheck
 
-		// 5. Capture raw PCM if enabled (same goroutine, no lock needed for file write)
-		if m.captureFile != nil {
-			binary.Write(m.captureFile, binary.LittleEndian, buf) //nolint:errcheck
+		// 5. Capture raw PCM if enabled (same goroutine, no lock needed for file
+		// write). Bounded by captureMax so a long-lived daemon cannot fill /data:
+		// once the cap is reached, stop writing and log the cutoff once.
+		if m.captureFile != nil && !m.captureFull {
+			if m.captureMax > 0 && m.captureBytes >= m.captureMax {
+				m.captureFull = true
+				slog.Warn("mixer: PCM capture size cap reached, stopping writes",
+					"path", m.capturePath, "bytes", m.captureBytes, "max", m.captureMax)
+			} else {
+				binary.Write(m.captureFile, binary.LittleEndian, buf) //nolint:errcheck
+				m.captureBytes += int64(len(buf)) * 2                 // int16 == 2 bytes
+			}
 		}
 	}
 }
 
 // clampAdd adds two int16 values with saturation (no overflow wrap-around).
-// EnableCapture starts writing raw S16LE PCM to path. Call from main, not render loop.
-func (m *Mixer) EnableCapture(path string) error {
+// EnableCapture starts writing raw S16LE PCM to path. Call from main, not render
+// loop. maxBytes caps the total written so a long-running debug capture cannot
+// fill /data; pass 0 for unbounded.
+func (m *Mixer) EnableCapture(path string, maxBytes int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	f, err := os.Create(path)
@@ -185,7 +199,10 @@ func (m *Mixer) EnableCapture(path string) error {
 	}
 	m.captureFile = f
 	m.capturePath = path
-	slog.Info("mixer: PCM capture enabled", "path", path)
+	m.captureMax = maxBytes
+	m.captureBytes = 0
+	m.captureFull = false
+	slog.Info("mixer: PCM capture enabled", "path", path, "max_bytes", maxBytes)
 	return nil
 }
 

--- a/pi/digitsd/internal/audio/mixer.go
+++ b/pi/digitsd/internal/audio/mixer.go
@@ -186,10 +186,10 @@ func (m *Mixer) renderLoop(stop, done chan struct{}) {
 	}
 }
 
-// clampAdd adds two int16 values with saturation (no overflow wrap-around).
-// EnableCapture starts writing raw S16LE PCM to path. Call from main, not render
-// loop. maxBytes caps the total written so a long-running debug capture cannot
-// fill /data; pass 0 for unbounded.
+// EnableCapture starts writing raw S16LE PCM to path. Call from main before
+// Start so the render loop observes the capture fields without racing their
+// initialization. maxBytes caps the total written so a long-running debug
+// capture cannot fill /data; pass 0 for unbounded.
 func (m *Mixer) EnableCapture(path string, maxBytes int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -220,6 +220,7 @@ func (m *Mixer) DisableCapture() {
 	}
 }
 
+// clampAdd adds two int16 values with saturation (no overflow wrap-around).
 func clampAdd(a, b int16) int16 {
 	sum := int32(a) + int32(b)
 	if sum > 32767 {

--- a/pi/digitsd/internal/audio/mixer_test.go
+++ b/pi/digitsd/internal/audio/mixer_test.go
@@ -40,13 +40,13 @@ func createMinimalWAV(t *testing.T, path string, samples []int16) {
 	binary.LittleEndian.PutUint32(header[4:8], uint32(riffSize))
 	copy(header[8:12], "WAVE")
 	copy(header[12:16], "fmt ")
-	binary.LittleEndian.PutUint32(header[16:20], 16)     // fmt chunk size
-	binary.LittleEndian.PutUint16(header[20:22], 1)      // PCM
-	binary.LittleEndian.PutUint16(header[22:24], 1)      // mono
-	binary.LittleEndian.PutUint32(header[24:28], 48000)  // sample rate
-	binary.LittleEndian.PutUint32(header[28:32], 96000)  // byte rate (48000 * 1 * 2)
-	binary.LittleEndian.PutUint16(header[32:34], 2)      // block align
-	binary.LittleEndian.PutUint16(header[34:36], 16)     // bits per sample
+	binary.LittleEndian.PutUint32(header[16:20], 16)    // fmt chunk size
+	binary.LittleEndian.PutUint16(header[20:22], 1)     // PCM
+	binary.LittleEndian.PutUint16(header[22:24], 1)     // mono
+	binary.LittleEndian.PutUint32(header[24:28], 48000) // sample rate
+	binary.LittleEndian.PutUint32(header[28:32], 96000) // byte rate (48000 * 1 * 2)
+	binary.LittleEndian.PutUint16(header[32:34], 2)     // block align
+	binary.LittleEndian.PutUint16(header[34:36], 16)    // bits per sample
 	copy(header[36:40], "data")
 	binary.LittleEndian.PutUint32(header[40:44], uint32(dataSize))
 	_, _ = f.Write(header)
@@ -72,6 +72,61 @@ func TestMixerWritesSilenceWhenIdle(t *testing.T) {
 				t.Fatalf("period %d sample %d: expected 0 (silence), got %d", i, j, s)
 			}
 		}
+	}
+}
+
+// --- PCM capture cap ---
+
+func TestMixerCaptureRespectsMaxBytes(t *testing.T) {
+	w := &mockWriter{}
+	mx := NewMixer(w)
+
+	path := t.TempDir() + "/capture.pcm"
+	// One frame is 960 int16 == 1920 bytes; cap at 3 frames worth so the loop
+	// writes a few frames, then stops.
+	maxBytes := int64(3 * 960 * 2)
+	if err := mx.EnableCapture(path, maxBytes); err != nil {
+		t.Fatalf("EnableCapture: %v", err)
+	}
+
+	mx.Start()
+	time.Sleep(150 * time.Millisecond) // many more than 3 frames at 20ms each
+	mx.Stop()
+	mx.DisableCapture()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat capture file: %v", err)
+	}
+	if info.Size() > maxBytes {
+		t.Fatalf("capture file %d bytes exceeds cap %d", info.Size(), maxBytes)
+	}
+	if info.Size() == 0 {
+		t.Fatal("capture file is empty; expected some frames written before the cap")
+	}
+}
+
+func TestMixerCaptureUnboundedWhenMaxZero(t *testing.T) {
+	w := &mockWriter{}
+	mx := NewMixer(w)
+
+	path := t.TempDir() + "/capture.pcm"
+	if err := mx.EnableCapture(path, 0); err != nil {
+		t.Fatalf("EnableCapture: %v", err)
+	}
+
+	mx.Start()
+	time.Sleep(100 * time.Millisecond)
+	mx.Stop()
+	mx.DisableCapture()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat capture file: %v", err)
+	}
+	// With no cap the file should hold several frames (well over one frame).
+	if info.Size() < int64(2*960*2) {
+		t.Fatalf("unbounded capture wrote only %d bytes; expected multiple frames", info.Size())
 	}
 }
 
@@ -391,13 +446,13 @@ func TestLoadWAV(t *testing.T) {
 	binary.LittleEndian.PutUint32(header[4:8], uint32(riffSize))
 	copy(header[8:12], "WAVE")
 	copy(header[12:16], "fmt ")
-	binary.LittleEndian.PutUint32(header[16:20], 16)     // fmt chunk size
-	binary.LittleEndian.PutUint16(header[20:22], 1)      // PCM
-	binary.LittleEndian.PutUint16(header[22:24], 1)      // mono
-	binary.LittleEndian.PutUint32(header[24:28], 48000)  // sample rate
-	binary.LittleEndian.PutUint32(header[28:32], 96000)  // byte rate
-	binary.LittleEndian.PutUint16(header[32:34], 2)      // block align
-	binary.LittleEndian.PutUint16(header[34:36], 16)     // bits per sample
+	binary.LittleEndian.PutUint32(header[16:20], 16)    // fmt chunk size
+	binary.LittleEndian.PutUint16(header[20:22], 1)     // PCM
+	binary.LittleEndian.PutUint16(header[22:24], 1)     // mono
+	binary.LittleEndian.PutUint32(header[24:28], 48000) // sample rate
+	binary.LittleEndian.PutUint32(header[28:32], 96000) // byte rate
+	binary.LittleEndian.PutUint16(header[32:34], 2)     // block align
+	binary.LittleEndian.PutUint16(header[34:36], 16)    // bits per sample
 	copy(header[36:40], "data")
 	binary.LittleEndian.PutUint32(header[40:44], uint32(dataSize))
 	_, _ = f.Write(header)

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -271,7 +271,13 @@ func (p *Pipeline) captureLoop() {
 
 		mono := ExtractChannel(stereo, 2, p.cfg.MicChannel)
 
-		mono = p.filters.Process(mono)
+		// On the default config the bandpass is off and p.filters is nil; skip
+		// the call so we do not allocate + copy a fresh buffer 50x/sec to no-op.
+		// ExtractChannel already returns a fresh slice, so the in-place denoiser
+		// below is safe operating on it directly.
+		if p.filters != nil {
+			mono = p.filters.Process(mono)
+		}
 
 		if p.denoiser != nil {
 			mono = p.denoiser.Process(mono)

--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -16,6 +17,41 @@ import (
 	"strings"
 	"time"
 )
+
+const (
+	// dialTimeout bounds TCP connection establishment.
+	dialTimeout = 15 * time.Second
+	// responseHeaderTimeout bounds how long we wait for the server to send
+	// response headers after the request is written. This catches a server
+	// that accepts the connection then stalls before replying, the classic
+	// half-open hang, without capping the time spent streaming a large body.
+	responseHeaderTimeout = 30 * time.Second
+	// downloadTimeout is the generous absolute deadline for a single artifact
+	// download. Large enough for a multi-megabyte binary over a slow link, but
+	// finite so a connection that goes silent mid-body cannot latch update
+	// state forever.
+	downloadTimeout = 10 * time.Minute
+)
+
+// newHTTPClient builds the shared client. It sets connection-setup and
+// response-header timeouts on the transport rather than a single
+// Client.Timeout, so legitimate large downloads are not killed by an absolute
+// cap while half-open connections still fail fast. Per-request deadlines are
+// supplied via context (see CheckVersion and Download).
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   dialTimeout,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   dialTimeout,
+			ResponseHeaderTimeout: responseHeaderTimeout,
+			ExpectContinueTimeout: 1 * time.Second,
+			IdleConnTimeout:       90 * time.Second,
+		},
+	}
+}
 
 type CheckResult struct {
 	PiAvailable bool
@@ -41,6 +77,9 @@ type Config struct {
 type Updater struct {
 	cfg    Config
 	client *http.Client
+	// downloadTimeout bounds a single Download. Defaults to the package
+	// downloadTimeout const; overridable in tests.
+	downloadTimeout time.Duration
 }
 
 func New(cfg Config) *Updater {
@@ -63,8 +102,9 @@ func New(cfg Config) *Updater {
 		cfg.FirmwarePath = "/data/digits/firmware.elf"
 	}
 	return &Updater{
-		cfg:    cfg,
-		client: &http.Client{},
+		cfg:             cfg,
+		client:          newHTTPClient(),
+		downloadTimeout: downloadTimeout,
 	}
 }
 
@@ -160,7 +200,16 @@ func (u *Updater) Download(url, localName, expectedSHA string) (string, error) {
 	}
 	destPath := filepath.Join(u.cfg.StagingDir, localName)
 
-	resp, err := u.client.Get(url)
+	// Bound the whole download so a connection that stalls mid-body cannot
+	// block io.Copy forever and latch update state. The deadline covers the
+	// body stream too: cancelling the context unblocks an in-flight Read.
+	ctx, cancel := context.WithTimeout(context.Background(), u.downloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", url, err)
+	}
+	resp, err := u.client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", url, err)
 	}

--- a/pi/digitsd/internal/updater/updater_test.go
+++ b/pi/digitsd/internal/updater/updater_test.go
@@ -1,10 +1,14 @@
 package updater
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 )
 
 func newTestServer(idx ReleaseIndex) *httptest.Server {
@@ -143,5 +147,62 @@ func TestCheckVersion_UnknownVersion(t *testing.T) {
 	_, err := u.CheckVersion("9.9.9", "")
 	if err == nil {
 		t.Error("expected error for unknown version")
+	}
+}
+
+func TestDownload_VerifiesAndWrites(t *testing.T) {
+	body := []byte("digitsd-binary-payload")
+	sum := sha256.Sum256(body)
+	wantSHA := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	u := New(Config{ServerBaseURL: srv.URL, StagingDir: t.TempDir()})
+
+	dest, err := u.Download(srv.URL+"/artifact", "digitsd", wantSHA)
+	if err != nil {
+		t.Fatalf("Download() error: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("downloaded content = %q, want %q", got, body)
+	}
+}
+
+func TestDownload_StalledBodyHitsDeadline(t *testing.T) {
+	// Server sends headers then stalls forever without sending the body. The
+	// per-request context deadline must abort the download instead of blocking
+	// io.Copy indefinitely.
+	block := make(chan struct{})
+	// srv.Close() (deferred first, so runs last) waits for in-flight handlers;
+	// unblock the handler before that by deferring close(block) afterwards so
+	// LIFO runs it first.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-block // never send the body until the test unblocks on cleanup
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	u := New(Config{ServerBaseURL: srv.URL, StagingDir: t.TempDir()})
+	u.downloadTimeout = 200 * time.Millisecond
+
+	start := time.Now()
+	_, err := u.Download(srv.URL+"/artifact", "digitsd", "")
+	if err == nil {
+		t.Fatal("expected error from stalled download, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Download took %v; deadline was not enforced", elapsed)
 	}
 }


### PR DESCRIPTION
## What

Fixes six verified code-review findings in the Pi daemon. The dominant fix moves WebSocket reconnection off the main select loop so it no longer blocks event servicing and shutdown. The rest harden the updater, recovery mount handling, debug capture, and the audio filter path, and close a data race on the signaling client pointer.

## Why

Per finding:

- **Reconnect blocked the main loop (HIGH).** `cmd/digitsd/main.go` ran an inner backoff loop with `time.Sleep` (exp backoff capped 60s) directly inside the main `select`. While sleeping the loop could not service `sp.Events()` (UART hook/key events) or `quit`, so events queued or dropped and `systemctl stop` blocked up to 60s. Reconnection now runs in `reconnectLoop` on its own goroutine; it does the backoff, connect, and post-reconnect resume/teardown, then hands the live client back over a buffered channel. A `reconnecting` flag nils the dead client's already-closed `Done()` out of the select so the loop neither busy-spins nor blocks and stays free to service events and shutdown. The active-call fast backoff vs idle exponential backoff (`nextReconnectBackoff`/`IsCallActive`), watchdog petting (already a separate goroutine), and clean shutdown are preserved.

- **Updater HTTP could hang forever (HIGH).** `internal/updater/updater.go` shared an `http.Client{}` with no timeout and `Download` used `client.Get` with no context, so a half-open connection blocked `io.Copy` forever and latched update state. The client now uses a transport with dial, TLS-handshake, and response-header timeouts (catching a server that stalls before replying without capping a legitimate large body), and `Download` gets a per-request context with a generous absolute deadline that also covers the body stream. `CheckVersion` keeps its own 30s context. Nothing else uses the client.

- **Unsynchronized reads of `daemonCallbacks.sig` (MEDIUM).** The reconnect path writes `d.sig` under `d.mu`; several reads ran from pion callbacks / FSM goroutines outside the lock (a data race). Added a `currentSig()` accessor that reads under `d.mu` and routed the racy reads (the `OnICECandidate` closures in `webrtc.go` and `voicemail.go`, `OnCallReturn`/`OnCallReturnCancel`, and `publishVoicemailState`/`publishVoicemailStateInitial`) through it. Reads already performed under `d.mu` (conference.go, link-health, the synchronous `InitiateCall`/`AnswerCall`/`HangupCall` sends) were left as-is since they are already synchronized against the same writer.

- **Recovery mount stacking (MEDIUM).** `clearRecoveryFlags` unconditionally mounted `/dev/mmcblk0p4` on `/data` then unmounted once. The try-again exits already run with `/data` mounted, so this stacked a second mount and left the original live. It now detects whether `/data` is already a mount point and operates on the live mount in that case; the cold path still mounts, clears, and unmounts.

- **Mixer ALSA consolidation (LOW, skipped).** `digits-mixer.service` carries a codec-readiness wait loop (`until [ -d /proc/asound/... ]`) that `digitsd.service`'s inline `alsactl restore` ExecStartPre does not, and the unit-enable path is applied outside the working-tree scripts. Folding them risked restoring mixer state before the codec node enumerates, which the finding explicitly warned against, so this was left alone.

- **Unbounded debug PCM capture (LOW).** With `CAPTURE_PCM` set, the render loop wrote every mixed frame including idle silence to disk with no cap (~345 MB/hr) for the daemon's lifetime. Added a size cap (default 512 MB, override with `CAPTURE_PCM_MAX_MB`, 0 = unbounded); once reached the loop stops writing and logs the cutoff once.

- **No-op filter pass (LOW).** `captureLoop` called `p.filters.Process` unconditionally; on the default config `p.filters` is nil and `Process` still allocated and copied a fresh buffer 50x/sec to no-op. Guarded with a nil check. `ExtractChannel` already returns a fresh slice, so the in-place denoiser downstream stays safe.

## Residual risk

The reconnect change shifts the post-reconnect resume/teardown (`tryResumeAfterReconnect`, `TearDownAllMeshPeers`, `HangupCall`, `ctrl.Reset`) from the main goroutine onto the reconnect goroutine. Those touch `ctrl` (mutex-guarded FSM) and `cb` (under `d.mu`), which are already accessed concurrently from pion callbacks, so the locking is correct, but the concurrency window is new and was not exercised against live hardware in this change. The logic and ordering are unchanged from the original inline loop; only the host goroutine differs.

## Test plan

- `make test`: all packages pass.
- `go test -race ./cmd/digitsd/... ./internal/audio/... ./internal/updater/...`: race-clean, including a new concurrent reader/writer test for `currentSig`.
- New tests: updater download success + stalled-body deadline enforcement, mixer capture size cap + unbounded, recovery `/proc/mounts` parsing.
- `golangci-lint run ./...`: 0 issues.
- `make build`: Docker cross-compile to linux/arm64 succeeds.