### PR TITLE
fix(server): record link health from every signald replica

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -168,6 +168,11 @@ func run(ctx context.Context) error {
 	}
 	healthStore := calls.NewHealthStore(database, healthOpts...)
 	tracker.SetHealthStore(healthStore)
+	if redisBridge != nil {
+		healthStore.SetRedis(redisBridge.Client(), redisBridge.PodID())
+		go healthStore.RunRedis(ctx)
+		slog.Info("redis fan-out enabled for cross-pod link health")
+	}
 
 	healthDone := make(chan struct{})
 	go func() {

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -84,6 +84,12 @@ type sessionRings struct {
 	mu          sync.Mutex
 	byEndpoint  map[endpointKey]*ring
 	subscribers map[*subscriber]struct{} // nil until first Subscribe
+	// lastActivity is the wall-clock time of the most recent init, sample
+	// append, or subscribe. The idle sweep in Run evicts sessions whose
+	// lastActivity is older than idleSessionTTL and that have no live
+	// subscribers, bounding memory when an end event never reaches this
+	// pod (it may have been handled by a different replica).
+	lastActivity time.Time
 }
 
 type subscriber struct {
@@ -117,11 +123,24 @@ func (r *ring) latest() *Sample {
 // accepted by the constructor for use by the periodic DB flusher; when
 // nil the store operates in memory-only mode. Zero-value is NOT valid; use
 // NewHealthStore.
+//
+// Multi-replica operation: sessions and rings are pod-local memory. When
+// Redis is configured via SetRedis, every locally ingested sample and every
+// locally triggered evict/disconnect is also published on a shared channel;
+// RunRedis applies events from other pods to the local rings and
+// subscribers. This keeps the live observation deck and the in-memory
+// windows complete on every pod even though each phone's WebSocket (and
+// therefore its link_health ingest) lands on exactly one pod.
 type HealthStore struct {
 	db            *sql.DB
 	mu            sync.Mutex
 	sessions      map[SessionKey]*sessionRings
 	flushDisabled bool
+	now           func() time.Time // injectable for idle-sweep tests
+
+	rmu    sync.Mutex
+	client redisPublisher
+	podID  string
 }
 
 // HealthStoreOption configures a HealthStore at construction time.
@@ -142,6 +161,7 @@ func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 	s := &HealthStore{
 		db:       unwrapDB(d),
 		sessions: make(map[SessionKey]*sessionRings),
+		now:      time.Now,
 	}
 	for _, o := range opts {
 		o(s)
@@ -152,16 +172,34 @@ func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 // initSession creates an empty rings entry for the given session key.
 // Idempotent: no-op if the key already exists.
 func (s *HealthStore) initSession(key SessionKey) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.sessions[key]; ok {
-		return
-	}
-	s.sessions[key] = &sessionRings{byEndpoint: make(map[endpointKey]*ring)}
+	s.getOrCreateSession(key)
 }
 
-// recordSession appends a sample for the given session key and endpoint pair.
-// No-op if the session was not initialized or has been evicted.
+// getOrCreateSession returns the rings entry for key, creating it if absent,
+// and stamps lastActivity. Sessions are created lazily because the
+// "call started" hook (Tracker.StartCall -> Init) runs only on the pod that
+// handled the caller's signaling message; samples and subscribers on the
+// other replicas must not depend on it. The idle sweep bounds the lifetime
+// of sessions whose end event never reaches this pod.
+func (s *HealthStore) getOrCreateSession(key SessionKey) *sessionRings {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sr, ok := s.sessions[key]
+	if !ok {
+		sr = &sessionRings{byEndpoint: make(map[endpointKey]*ring)}
+		s.sessions[key] = sr
+	}
+	sr.mu.Lock()
+	sr.lastActivity = s.now()
+	sr.mu.Unlock()
+	return sr
+}
+
+// recordSession appends a sample for the given session key and endpoint
+// pair, creating the session if this pod has not seen it yet. remote marks
+// samples applied from the Redis fan-out: they update the rings and local
+// subscribers but advance lastFlushed so only the ingesting pod writes the
+// sample to the database, and they are not re-published.
 //
 // Race note: between releasing the top-level map lock and acquiring the
 // per-session lock, a concurrent evictSession can remove the sessionRings
@@ -169,24 +207,26 @@ func (s *HealthStore) initSession(key SessionKey) {
 // (the struct is not freed) but is no longer reachable from the map; the
 // sample appended to it will be silently dropped -- never flushed, eventually
 // GC'd. This is intentional telemetry loss on a racing session-end.
-func (s *HealthStore) recordSession(key SessionKey, from, peer string, sample Sample) {
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		return
-	}
+func (s *HealthStore) recordSession(key SessionKey, from, peer string, sample Sample, remote bool) {
+	sr := s.getOrCreateSession(key)
 
 	epKey := endpointKey{From: from, Peer: peer}
 	sr.mu.Lock()
-	defer sr.mu.Unlock()
 	r, ok := sr.byEndpoint[epKey]
 	if !ok {
 		r = &ring{}
 		sr.byEndpoint[epKey] = r
 	}
 	r.append(sample)
+	if remote && sample.TS.After(r.lastFlushed) {
+		r.lastFlushed = sample.TS
+	}
 	sr.broadcastLocked(Event{Kind: SampleKind, Endpoint: from, Peer: peer, Sample: sample})
+	sr.mu.Unlock()
+
+	if !remote {
+		s.publishSample(key, from, peer, sample)
+	}
 }
 
 // windowSession returns a copy of the retained sample ring for the given
@@ -210,8 +250,14 @@ func (s *HealthStore) windowSession(key SessionKey, from, peer string) []Sample 
 }
 
 // evictSession drops all in-memory state for a session. Broadcasts EndedKind
-// to every live subscriber and closes their channels. Idempotent.
-func (s *HealthStore) evictSession(key SessionKey) {
+// to every live subscriber and closes their channels. Idempotent. When
+// publish is true the eviction also fans out to other pods so their
+// subscribers see the call end too; remote-applied and sweep-driven evicts
+// pass false.
+func (s *HealthStore) evictSession(key SessionKey, publish bool) {
+	if publish {
+		s.publishLifecycle(wireKindEvict, key, "")
+	}
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	delete(s.sessions, key)
@@ -238,18 +284,13 @@ func (s *HealthStore) evictSession(key SessionKey) {
 	sr.subscribers = nil
 }
 
-// subscribeSession opens an event stream for a session. If the session is not
-// currently initialized (or has been evicted), returns a Subscription whose
-// channel is already closed.
+// subscribeSession opens an event stream for a session, creating the
+// session if this pod has not seen it yet. Callers gate on the call being
+// active (the SSE handlers 404 ended calls before subscribing), so lazy
+// creation cannot resurrect a finished call for longer than the idle sweep
+// allows.
 func (s *HealthStore) subscribeSession(key SessionKey) *Subscription {
-	s.mu.Lock()
-	sr, ok := s.sessions[key]
-	s.mu.Unlock()
-	if !ok {
-		ch := make(chan Event)
-		close(ch)
-		return &Subscription{C: ch, close: func() {}}
-	}
+	sr := s.getOrCreateSession(key)
 
 	sub := &subscriber{ch: make(chan Event, subscriberBufferSize)}
 
@@ -275,19 +316,21 @@ func (s *HealthStore) subscribeSession(key SessionKey) *Subscription {
 }
 
 // Init creates an empty rings entry for a call. Called by Tracker on
-// OnCallInitiated so that subsequent Record calls have a place to land
-// without needing auto-creation (which would resurrect evicted calls).
-// Safe to call multiple times; idempotent.
+// OnCallInitiated so subscribers attaching before the first sample find a
+// live session. Record and Subscribe also create sessions lazily, so Init
+// is an optimization, not a precondition. Safe to call multiple times;
+// idempotent.
 func (s *HealthStore) Init(callID int64) {
 	s.initSession(SessionKey{CallID: callID})
 }
 
-// Record appends a sample for the given call and endpoint. Safe for
-// concurrent use. No-op if Init was not called for this callID first
-// or if the call has been Evicted -- this matches the tracker-authoritative
-// lifecycle and prevents post-Evict resurrection of map entries.
+// Record appends a sample for the given call and endpoint, creating the
+// session if this pod has not seen the call (with multiple replicas, call
+// setup usually ran on a different pod). Safe for concurrent use. A sample
+// racing the call's eviction can recreate the session; the idle sweep in
+// Run bounds the lifetime of such stragglers.
 func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
-	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample)
+	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample, false)
 }
 
 // Window returns a copy of the retained sample ring for an endpoint, oldest
@@ -302,7 +345,7 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 //
 // Called by Tracker on call end via the SetHealthStore-registered interface.
 func (s *HealthStore) Evict(callID int64) {
-	s.evictSession(SessionKey{CallID: callID})
+	s.evictSession(SessionKey{CallID: callID}, true)
 }
 
 // InitConference registers a conference for in-memory sample retention.
@@ -312,11 +355,10 @@ func (s *HealthStore) InitConference(confID uuid.UUID) {
 }
 
 // RecordEdge appends a per-edge sample for a conference. from is the
-// phone that emitted the sample; peer is the remote endpoint the
-// sample describes. No-op if InitConference was not called for this
-// conference (mirrors Record's behavior for unknown callID).
+// phone that emitted the sample; peer is the remote endpoint the sample
+// describes. Creates the session lazily, mirroring Record.
 func (s *HealthStore) RecordEdge(confID uuid.UUID, from, peer string, sample Sample) {
-	s.recordSession(SessionKey{ConfID: confID}, from, peer, sample)
+	s.recordSession(SessionKey{ConfID: confID}, from, peer, sample, false)
 }
 
 // WindowEdge returns a copy of the retained sample ring for a conference
@@ -328,7 +370,7 @@ func (s *HealthStore) WindowEdge(confID uuid.UUID, from, peer string) []Sample {
 // EvictConference drops in-memory state for a conference and broadcasts
 // EndedKind to subscribers.
 func (s *HealthStore) EvictConference(confID uuid.UUID) {
-	s.evictSession(SessionKey{ConfID: confID})
+	s.evictSession(SessionKey{ConfID: confID}, true)
 }
 
 // SubscribeConference returns an event stream for a conference's samples,
@@ -364,10 +406,11 @@ func (s *Subscription) Close() {
 // consumer on a LAN.
 const subscriberBufferSize = 16
 
-// Subscribe opens a stream of telemetry events for a call. If the call is
-// not currently Init'd (or has already been Evicted), returns a Subscription
-// whose channel is already closed -- callers see this the same way as a
-// mid-stream Evict and can treat it uniformly.
+// Subscribe opens a stream of telemetry events for a call, creating the
+// session if this pod has not seen the call yet. Callers must gate on the
+// call being active first (the SSE handlers 404 ended calls before
+// subscribing); the idle sweep reaps sessions a stray subscriber created
+// for a dead call.
 func (s *HealthStore) Subscribe(callID int64) *Subscription {
 	return s.subscribeSession(SessionKey{CallID: callID})
 }
@@ -379,7 +422,7 @@ func (s *HealthStore) Subscribe(callID int64) *Subscription {
 //
 // No-op for unknown callIDs.
 func (s *HealthStore) NotifyDisconnected(callID int64, endedBy string) {
-	s.notifyDisconnectedSession(SessionKey{CallID: callID}, endedBy)
+	s.notifyDisconnectedSession(SessionKey{CallID: callID}, endedBy, true)
 }
 
 // NotifyDisconnectedConference broadcasts a DisconnectKind event to every
@@ -389,10 +432,16 @@ func (s *HealthStore) NotifyDisconnected(callID int64, endedBy string) {
 //
 // No-op for unknown conference IDs.
 func (s *HealthStore) NotifyDisconnectedConference(confID uuid.UUID, endedBy string) {
-	s.notifyDisconnectedSession(SessionKey{ConfID: confID}, endedBy)
+	s.notifyDisconnectedSession(SessionKey{ConfID: confID}, endedBy, true)
 }
 
-func (s *HealthStore) notifyDisconnectedSession(key SessionKey, endedBy string) {
+// notifyDisconnectedSession broadcasts DisconnectKind to local subscribers.
+// When publish is true it also fans out to other pods; remote-applied
+// notifications pass false.
+func (s *HealthStore) notifyDisconnectedSession(key SessionKey, endedBy string, publish bool) {
+	if publish {
+		s.publishLifecycle(wireKindDisconnect, key, endedBy)
+	}
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	s.mu.Unlock()
@@ -551,26 +600,65 @@ func nullableString(s string) any {
 	return s
 }
 
-// Run blocks until ctx is canceled, flushing every flushInterval. On ctx
-// cancellation it runs one final flush before returning (bounded at 2s so
-// a graceful shutdown doesn't hang). If flushDisabled is true, Run still
-// blocks until ctx is canceled but skips all DB writes (periodic and final).
+// Run blocks until ctx is canceled, flushing and sweeping every
+// flushInterval. On ctx cancellation it runs one final flush before
+// returning (bounded at 2s so a graceful shutdown doesn't hang). If
+// flushDisabled is true (or the store is memory-only), DB writes are
+// skipped but the idle sweep still runs so lazily created sessions cannot
+// accumulate.
 func (s *HealthStore) Run(ctx context.Context) {
-	if s.db == nil || s.flushDisabled {
-		<-ctx.Done()
-		return
-	}
+	flush := s.db != nil && !s.flushDisabled
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_ = s.FlushOnce(shutdownCtx)
-			cancel()
+			if flush {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				_ = s.FlushOnce(shutdownCtx)
+				cancel()
+			}
 			return
 		case <-t.C:
-			_ = s.FlushOnce(ctx)
+			if flush {
+				_ = s.FlushOnce(ctx)
+			}
+			s.sweepIdleSessions()
+		}
+	}
+}
+
+// idleSessionTTL bounds how long a session with no new samples and no live
+// subscribers survives in memory. End events normally evict promptly; the
+// TTL covers sessions whose end was handled by another replica before
+// cross-pod eviction existed, plus stragglers recreated by late samples.
+const idleSessionTTL = 15 * time.Minute
+
+// sweepIdleSessions evicts sessions idle for longer than idleSessionTTL
+// that have no live subscribers. Sweep evictions are pod-local: every pod
+// runs its own sweep, so nothing is published.
+func (s *HealthStore) sweepIdleSessions() {
+	cutoff := s.now().Add(-idleSessionTTL)
+
+	s.mu.Lock()
+	keys := make([]SessionKey, 0, len(s.sessions))
+	for k := range s.sessions {
+		keys = append(keys, k)
+	}
+	s.mu.Unlock()
+
+	for _, k := range keys {
+		s.mu.Lock()
+		sr := s.sessions[k]
+		s.mu.Unlock()
+		if sr == nil {
+			continue
+		}
+		sr.mu.Lock()
+		idle := sr.lastActivity.Before(cutoff) && len(sr.subscribers) == 0
+		sr.mu.Unlock()
+		if idle {
+			s.evictSession(k, false)
 		}
 	}
 }

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -437,7 +437,9 @@ func (s *HealthStore) NotifyDisconnectedConference(confID uuid.UUID, endedBy str
 }
 
 // notifyDisconnectedSession broadcasts DisconnectKind to local subscribers.
-// Pod-local: the public Notify methods fan out to other pods first.
+// Pod-local: the public Notify methods fan out to other pods first. Unlike
+// Record/Subscribe this does NOT lazily create the session: a disconnect
+// only matters where a subscriber (hence a session) already exists.
 func (s *HealthStore) notifyDisconnectedSession(key SessionKey, endedBy string) {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
@@ -627,15 +629,26 @@ func (s *HealthStore) Run(ctx context.Context) {
 
 // idleSessionTTL bounds how long a session with no new samples and no live
 // subscribers survives in memory. End events normally evict promptly; the
-// TTL covers sessions whose end was handled by another replica before
-// cross-pod eviction existed, plus stragglers recreated by late samples.
+// TTL covers stragglers recreated by late samples and sessions whose end
+// event predates this pod's subscription (e.g. a pod restart mid-call).
 const idleSessionTTL = 15 * time.Minute
 
+// subscribedSessionTTL is the self-heal bound for sessions that hold live
+// subscribers but see no samples. The SSE handlers re-check call liveness
+// after subscribing, so a phantom "live" session on an ended call should
+// not occur; if one slips through anyway, the sweep closes its streams
+// with EndedKind after this much silence. Real calls report every couple
+// of seconds, so an hour of total silence means the deck is dead weight.
+const subscribedSessionTTL = 4 * idleSessionTTL
+
 // sweepIdleSessions evicts sessions idle for longer than idleSessionTTL
-// that have no live subscribers. Sweep evictions are pod-local: every pod
-// runs its own sweep, so nothing is published.
+// that have no live subscribers, and sessions idle past
+// subscribedSessionTTL regardless of subscribers. Sweep evictions are
+// pod-local: every pod runs its own sweep, so nothing is published.
 func (s *HealthStore) sweepIdleSessions() {
-	cutoff := s.now().Add(-idleSessionTTL)
+	now := s.now()
+	cutoff := now.Add(-idleSessionTTL)
+	stuckCutoff := now.Add(-subscribedSessionTTL)
 
 	s.mu.Lock()
 	keys := make([]SessionKey, 0, len(s.sessions))
@@ -653,8 +666,9 @@ func (s *HealthStore) sweepIdleSessions() {
 		}
 		sr.mu.Lock()
 		idle := sr.lastActivity.Before(cutoff) && len(sr.subscribers) == 0
+		stuck := sr.lastActivity.Before(stuckCutoff)
 		sr.mu.Unlock()
-		if idle {
+		if idle || stuck {
 			s.evictSession(k)
 		}
 	}

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -169,12 +169,6 @@ func NewHealthStore(d *db.Database, opts ...HealthStoreOption) *HealthStore {
 	return s
 }
 
-// initSession creates an empty rings entry for the given session key.
-// Idempotent: no-op if the key already exists.
-func (s *HealthStore) initSession(key SessionKey) {
-	s.getOrCreateSession(key)
-}
-
 // getOrCreateSession returns the rings entry for key, creating it if absent,
 // and stamps lastActivity. Sessions are created lazily because the
 // "call started" hook (Tracker.StartCall -> Init) runs only on the pod that
@@ -199,7 +193,10 @@ func (s *HealthStore) getOrCreateSession(key SessionKey) *sessionRings {
 // pair, creating the session if this pod has not seen it yet. remote marks
 // samples applied from the Redis fan-out: they update the rings and local
 // subscribers but advance lastFlushed so only the ingesting pod writes the
-// sample to the database, and they are not re-published.
+// sample to the database. Advancing on every remote sample is safe because
+// a given endpoint's samples come from a single publisher (the pod holding
+// that phone's WebSocket), and Redis pub/sub preserves per-publisher order;
+// the unique indexes behind writeSample's ON CONFLICT are the backstop.
 //
 // Race note: between releasing the top-level map lock and acquiring the
 // per-session lock, a concurrent evictSession can remove the sessionRings
@@ -223,10 +220,6 @@ func (s *HealthStore) recordSession(key SessionKey, from, peer string, sample Sa
 	}
 	sr.broadcastLocked(Event{Kind: SampleKind, Endpoint: from, Peer: peer, Sample: sample})
 	sr.mu.Unlock()
-
-	if !remote {
-		s.publishSample(key, from, peer, sample)
-	}
 }
 
 // windowSession returns a copy of the retained sample ring for the given
@@ -250,14 +243,10 @@ func (s *HealthStore) windowSession(key SessionKey, from, peer string) []Sample 
 }
 
 // evictSession drops all in-memory state for a session. Broadcasts EndedKind
-// to every live subscriber and closes their channels. Idempotent. When
-// publish is true the eviction also fans out to other pods so their
-// subscribers see the call end too; remote-applied and sweep-driven evicts
-// pass false.
-func (s *HealthStore) evictSession(key SessionKey, publish bool) {
-	if publish {
-		s.publishLifecycle(wireKindEvict, key, "")
-	}
+// to every live subscriber and closes their channels. Idempotent. Pod-local:
+// the public Evict methods fan the eviction out to other pods; remote
+// applies and the idle sweep call this directly.
+func (s *HealthStore) evictSession(key SessionKey) {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	delete(s.sessions, key)
@@ -321,7 +310,7 @@ func (s *HealthStore) subscribeSession(key SessionKey) *Subscription {
 // is an optimization, not a precondition. Safe to call multiple times;
 // idempotent.
 func (s *HealthStore) Init(callID int64) {
-	s.initSession(SessionKey{CallID: callID})
+	s.getOrCreateSession(SessionKey{CallID: callID})
 }
 
 // Record appends a sample for the given call and endpoint, creating the
@@ -330,7 +319,9 @@ func (s *HealthStore) Init(callID int64) {
 // racing the call's eviction can recreate the session; the idle sweep in
 // Run bounds the lifetime of such stragglers.
 func (s *HealthStore) Record(callID int64, endpoint string, sample Sample) {
-	s.recordSession(SessionKey{CallID: callID}, endpoint, "", sample, false)
+	key := SessionKey{CallID: callID}
+	s.recordSession(key, endpoint, "", sample, false)
+	s.publishSample(key, endpoint, "", sample)
 }
 
 // Window returns a copy of the retained sample ring for an endpoint, oldest
@@ -345,20 +336,24 @@ func (s *HealthStore) Window(callID int64, endpoint string) []Sample {
 //
 // Called by Tracker on call end via the SetHealthStore-registered interface.
 func (s *HealthStore) Evict(callID int64) {
-	s.evictSession(SessionKey{CallID: callID}, true)
+	key := SessionKey{CallID: callID}
+	s.publishLifecycle(wireKindEvict, key, "")
+	s.evictSession(key)
 }
 
 // InitConference registers a conference for in-memory sample retention.
 // Mirrors Init for 2-party calls. Safe to call multiple times.
 func (s *HealthStore) InitConference(confID uuid.UUID) {
-	s.initSession(SessionKey{ConfID: confID})
+	s.getOrCreateSession(SessionKey{ConfID: confID})
 }
 
 // RecordEdge appends a per-edge sample for a conference. from is the
 // phone that emitted the sample; peer is the remote endpoint the sample
 // describes. Creates the session lazily, mirroring Record.
 func (s *HealthStore) RecordEdge(confID uuid.UUID, from, peer string, sample Sample) {
-	s.recordSession(SessionKey{ConfID: confID}, from, peer, sample, false)
+	key := SessionKey{ConfID: confID}
+	s.recordSession(key, from, peer, sample, false)
+	s.publishSample(key, from, peer, sample)
 }
 
 // WindowEdge returns a copy of the retained sample ring for a conference
@@ -370,7 +365,9 @@ func (s *HealthStore) WindowEdge(confID uuid.UUID, from, peer string) []Sample {
 // EvictConference drops in-memory state for a conference and broadcasts
 // EndedKind to subscribers.
 func (s *HealthStore) EvictConference(confID uuid.UUID) {
-	s.evictSession(SessionKey{ConfID: confID}, true)
+	key := SessionKey{ConfID: confID}
+	s.publishLifecycle(wireKindEvict, key, "")
+	s.evictSession(key)
 }
 
 // SubscribeConference returns an event stream for a conference's samples,
@@ -422,7 +419,9 @@ func (s *HealthStore) Subscribe(callID int64) *Subscription {
 //
 // No-op for unknown callIDs.
 func (s *HealthStore) NotifyDisconnected(callID int64, endedBy string) {
-	s.notifyDisconnectedSession(SessionKey{CallID: callID}, endedBy, true)
+	key := SessionKey{CallID: callID}
+	s.publishLifecycle(wireKindDisconnect, key, endedBy)
+	s.notifyDisconnectedSession(key, endedBy)
 }
 
 // NotifyDisconnectedConference broadcasts a DisconnectKind event to every
@@ -432,16 +431,14 @@ func (s *HealthStore) NotifyDisconnected(callID int64, endedBy string) {
 //
 // No-op for unknown conference IDs.
 func (s *HealthStore) NotifyDisconnectedConference(confID uuid.UUID, endedBy string) {
-	s.notifyDisconnectedSession(SessionKey{ConfID: confID}, endedBy, true)
+	key := SessionKey{ConfID: confID}
+	s.publishLifecycle(wireKindDisconnect, key, endedBy)
+	s.notifyDisconnectedSession(key, endedBy)
 }
 
 // notifyDisconnectedSession broadcasts DisconnectKind to local subscribers.
-// When publish is true it also fans out to other pods; remote-applied
-// notifications pass false.
-func (s *HealthStore) notifyDisconnectedSession(key SessionKey, endedBy string, publish bool) {
-	if publish {
-		s.publishLifecycle(wireKindDisconnect, key, endedBy)
-	}
+// Pod-local: the public Notify methods fan out to other pods first.
+func (s *HealthStore) notifyDisconnectedSession(key SessionKey, endedBy string) {
 	s.mu.Lock()
 	sr, ok := s.sessions[key]
 	s.mu.Unlock()
@@ -658,7 +655,7 @@ func (s *HealthStore) sweepIdleSessions() {
 		idle := sr.lastActivity.Before(cutoff) && len(sr.subscribers) == 0
 		sr.mu.Unlock()
 		if idle {
-			s.evictSession(k, false)
+			s.evictSession(k)
 		}
 	}
 }

--- a/server/internal/calls/linkhealth_integration_test.go
+++ b/server/internal/calls/linkhealth_integration_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
 	"github.com/justinlindh/digits/server/internal/db"
 )
 
@@ -530,5 +533,67 @@ func TestFlushOnceWritesConferenceRows(t *testing.T) {
 	want := []string{"+15555550001|+15555550002", "+15555550002|+15555550001"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("edges: got %v want %v", got, want)
+	}
+}
+
+// TestFlusherSkipsRemoteSamples covers the multi-replica split: a sample
+// ingested on pod A fans out to pod B over Redis for live views, but only
+// pod A writes it to the database. Pod B's flusher must treat the
+// remote-applied sample as already flushed.
+func TestFlusherSkipsRemoteSamples(t *testing.T) {
+	d := setupTestDB(t)
+	mr := miniredis.RunT(t)
+	clientA := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	clientB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = clientA.Close(); _ = clientB.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	a := NewHealthStore(d)
+	a.SetRedis(clientA, "pod-a")
+	go a.RunRedis(ctx)
+	b := NewHealthStore(d)
+	b.SetRedis(clientB, "pod-b")
+	go b.RunRedis(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	callID := insertCall(t, d, "555-1111", "555-2222")
+	loss := float32(0.4)
+	a.Record(callID, "555-1111", Sample{TS: time.Now(), LossPct: &loss})
+
+	// Wait for the fan-out to land on B.
+	deadline := time.Now().Add(2 * time.Second)
+	for len(b.Window(callID, "555-1111")) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for cross-pod sample")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	countRows := func() int {
+		var n int
+		if err := d.DB.QueryRow(
+			"SELECT count(*) FROM call_link_health WHERE call_id = $1", callID,
+		).Scan(&n); err != nil {
+			t.Fatalf("count rows: %v", err)
+		}
+		return n
+	}
+
+	// The remote pod flushes first: it must not write the sample.
+	if err := b.FlushOnce(ctx); err != nil {
+		t.Fatalf("flush B: %v", err)
+	}
+	if n := countRows(); n != 0 {
+		t.Fatalf("remote pod wrote %d rows, want 0", n)
+	}
+
+	// The ingesting pod owns the write.
+	if err := a.FlushOnce(ctx); err != nil {
+		t.Fatalf("flush A: %v", err)
+	}
+	if n := countRows(); n != 1 {
+		t.Fatalf("ingest pod rows = %d, want 1", n)
 	}
 }

--- a/server/internal/calls/linkhealth_redis.go
+++ b/server/internal/calls/linkhealth_redis.go
@@ -150,9 +150,9 @@ func (s *HealthStore) RunRedis(ctx context.Context) {
 	}
 }
 
-// applyRemote dispatches one cross-pod event into the local store. Remote
-// events never re-publish (the publish flag is false on every path), so
-// there is no echo loop.
+// applyRemote dispatches one cross-pod event into the local store. It calls
+// the pod-local session operations directly, never the publishing public
+// methods, so there is no echo loop.
 func (s *HealthStore) applyRemote(env *healthEnvelope) {
 	key, ok := sessionKeyFromEnvelope(env)
 	if !ok {
@@ -166,9 +166,9 @@ func (s *HealthStore) applyRemote(env *healthEnvelope) {
 		}
 		s.recordSession(key, env.From, env.Peer, env.Sample.toSample(), true)
 	case wireKindDisconnect:
-		s.notifyDisconnectedSession(key, env.EndedBy, false)
+		s.notifyDisconnectedSession(key, env.EndedBy)
 	case wireKindEvict:
-		s.evictSession(key, false)
+		s.evictSession(key)
 	default:
 		slog.Warn("link_health: unknown redis event kind", "kind", env.Kind)
 	}
@@ -198,11 +198,12 @@ func (s *HealthStore) publishLifecycle(kind uint8, key SessionKey, endedBy strin
 func (s *HealthStore) publish(env *healthEnvelope) {
 	s.rmu.Lock()
 	client := s.client
-	env.PodID = s.podID
+	podID := s.podID
 	s.rmu.Unlock()
 	if client == nil {
 		return
 	}
+	env.PodID = podID
 	payload, err := json.Marshal(env)
 	if err != nil {
 		slog.Error("link_health: marshal redis envelope failed", "err", err)

--- a/server/internal/calls/linkhealth_redis.go
+++ b/server/internal/calls/linkhealth_redis.go
@@ -1,0 +1,214 @@
+package calls
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// linkHealthChannel is the shared Redis pub/sub channel for cross-pod
+// link-health fan-out. Every pod publishes its locally ingested samples and
+// locally triggered lifecycle events here and applies everyone else's, so
+// the in-memory rings and live SSE subscribers stay complete on every
+// replica regardless of which pod each phone's WebSocket landed on.
+const linkHealthChannel = "digits:linkhealth"
+
+// redisPublisher is the subset of redis.UniversalClient the HealthStore
+// uses. Narrowed for testability.
+type redisPublisher interface {
+	Publish(ctx context.Context, channel string, message interface{}) *redis.IntCmd
+	Subscribe(ctx context.Context, channels ...string) *redis.PubSub
+}
+
+// Wire event kinds. Distinct from EventKind: EndedKind is never sent on the
+// wire; it is produced locally by applying an evict.
+const (
+	wireKindSample uint8 = iota
+	wireKindDisconnect
+	wireKindEvict
+)
+
+// healthEnvelope is the JSON wire format for one cross-pod link-health
+// event. Exactly one of CallID / ConfID is set, mirroring SessionKey.
+type healthEnvelope struct {
+	PodID   string      `json:"pod"`
+	Kind    uint8       `json:"kind"`
+	CallID  int64       `json:"call_id,omitempty"`
+	ConfID  string      `json:"conf_id,omitempty"`
+	From    string      `json:"from,omitempty"`
+	Peer    string      `json:"peer,omitempty"`
+	EndedBy string      `json:"ended_by,omitempty"`
+	Sample  *wireSample `json:"sample,omitempty"`
+}
+
+// wireSample is Sample with a unix-millisecond timestamp for compact JSON.
+type wireSample struct {
+	TS       int64    `json:"ts"`
+	LossPct  *float32 `json:"loss,omitempty"`
+	JitterMs *float32 `json:"jitter,omitempty"`
+	RttMs    *float32 `json:"rtt,omitempty"`
+	ConnType string   `json:"conn,omitempty"`
+	BytesIn  *int64   `json:"bytes_in,omitempty"`
+	BytesOut *int64   `json:"bytes_out,omitempty"`
+}
+
+func toWireSample(s Sample) *wireSample {
+	return &wireSample{
+		TS:       s.TS.UnixMilli(),
+		LossPct:  s.LossPct,
+		JitterMs: s.JitterMs,
+		RttMs:    s.RttMs,
+		ConnType: s.ConnType,
+		BytesIn:  s.BytesIn,
+		BytesOut: s.BytesOut,
+	}
+}
+
+func (w *wireSample) toSample() Sample {
+	return Sample{
+		TS:       time.UnixMilli(w.TS),
+		LossPct:  w.LossPct,
+		JitterMs: w.JitterMs,
+		RttMs:    w.RttMs,
+		ConnType: w.ConnType,
+		BytesIn:  w.BytesIn,
+		BytesOut: w.BytesOut,
+	}
+}
+
+// sessionKeyFromEnvelope rebuilds the SessionKey. ok is false when the
+// envelope carries neither a call id nor a parseable conference id.
+func sessionKeyFromEnvelope(env *healthEnvelope) (SessionKey, bool) {
+	if env.CallID != 0 {
+		return SessionKey{CallID: env.CallID}, true
+	}
+	if env.ConfID != "" {
+		id, err := uuid.Parse(env.ConfID)
+		if err != nil {
+			return SessionKey{}, false
+		}
+		return SessionKey{ConfID: id}, true
+	}
+	return SessionKey{}, false
+}
+
+func envelopeForKey(key SessionKey) healthEnvelope {
+	if key.IsConf() {
+		return healthEnvelope{ConfID: key.ConfID.String()}
+	}
+	return healthEnvelope{CallID: key.CallID}
+}
+
+// SetRedis configures Redis pub/sub for cross-pod link-health fan-out.
+// Pass nil to disable (single-instance mode). podID identifies this
+// process so RunRedis can skip its own publications.
+func (s *HealthStore) SetRedis(client redisPublisher, podID string) {
+	s.rmu.Lock()
+	s.client = client
+	s.podID = podID
+	s.rmu.Unlock()
+}
+
+// RunRedis subscribes to the link-health channel and applies events from
+// other pods to the local store. Returns when ctx is cancelled or the
+// subscription channel closes. No-op if SetRedis was not called.
+func (s *HealthStore) RunRedis(ctx context.Context) {
+	s.rmu.Lock()
+	client := s.client
+	podID := s.podID
+	s.rmu.Unlock()
+	if client == nil {
+		return
+	}
+
+	sub := client.Subscribe(ctx, linkHealthChannel)
+	defer func() { _ = sub.Close() }()
+
+	ch := sub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var env healthEnvelope
+			if err := json.Unmarshal([]byte(msg.Payload), &env); err != nil {
+				slog.Warn("link_health: bad redis envelope", "err", err)
+				continue
+			}
+			if env.PodID == podID {
+				continue
+			}
+			s.applyRemote(&env)
+		}
+	}
+}
+
+// applyRemote dispatches one cross-pod event into the local store. Remote
+// events never re-publish (the publish flag is false on every path), so
+// there is no echo loop.
+func (s *HealthStore) applyRemote(env *healthEnvelope) {
+	key, ok := sessionKeyFromEnvelope(env)
+	if !ok {
+		slog.Warn("link_health: redis envelope without session key", "kind", env.Kind)
+		return
+	}
+	switch env.Kind {
+	case wireKindSample:
+		if env.Sample == nil {
+			return
+		}
+		s.recordSession(key, env.From, env.Peer, env.Sample.toSample(), true)
+	case wireKindDisconnect:
+		s.notifyDisconnectedSession(key, env.EndedBy, false)
+	case wireKindEvict:
+		s.evictSession(key, false)
+	default:
+		slog.Warn("link_health: unknown redis event kind", "kind", env.Kind)
+	}
+}
+
+// publishSample fans a locally ingested sample out to the other pods.
+// Best-effort: a publish failure loses cross-pod liveness for that sample
+// but never the local ring or the DB flush.
+func (s *HealthStore) publishSample(key SessionKey, from, peer string, sample Sample) {
+	env := envelopeForKey(key)
+	env.Kind = wireKindSample
+	env.From = from
+	env.Peer = peer
+	env.Sample = toWireSample(sample)
+	s.publish(&env)
+}
+
+// publishLifecycle fans a locally triggered evict or disconnect out to the
+// other pods so their subscribers observe the call end too.
+func (s *HealthStore) publishLifecycle(kind uint8, key SessionKey, endedBy string) {
+	env := envelopeForKey(key)
+	env.Kind = kind
+	env.EndedBy = endedBy
+	s.publish(&env)
+}
+
+func (s *HealthStore) publish(env *healthEnvelope) {
+	s.rmu.Lock()
+	client := s.client
+	env.PodID = s.podID
+	s.rmu.Unlock()
+	if client == nil {
+		return
+	}
+	payload, err := json.Marshal(env)
+	if err != nil {
+		slog.Error("link_health: marshal redis envelope failed", "err", err)
+		return
+	}
+	if err := client.Publish(context.Background(), linkHealthChannel, payload).Err(); err != nil {
+		slog.Error("link_health: redis publish failed", "err", err)
+	}
+}

--- a/server/internal/calls/linkhealth_redis_test.go
+++ b/server/internal/calls/linkhealth_redis_test.go
@@ -1,0 +1,177 @@
+package calls
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// twoStores wires two HealthStores ("pods") to one miniredis and starts
+// both RunRedis loops. The returned cancel stops the loops.
+func twoStores(t *testing.T) (a, b *HealthStore) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	clientA := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	clientB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = clientA.Close(); _ = clientB.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	a = NewHealthStore(nil)
+	a.SetRedis(clientA, "pod-a")
+	go a.RunRedis(ctx)
+
+	b = NewHealthStore(nil)
+	b.SetRedis(clientB, "pod-b")
+	go b.RunRedis(ctx)
+
+	// Give both subscriptions time to attach before tests publish.
+	time.Sleep(100 * time.Millisecond)
+	return a, b
+}
+
+// waitForWindow polls until the store's window for (callID, endpoint) is
+// non-empty or the deadline passes.
+func waitForWindow(t *testing.T, s *HealthStore, callID int64, endpoint string) []Sample {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if w := s.Window(callID, endpoint); len(w) > 0 {
+			return w
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for window on call %d endpoint %s", callID, endpoint)
+	return nil
+}
+
+func TestHealthStoreRedisFanOutSample(t *testing.T) {
+	a, b := twoStores(t)
+
+	loss := float32(1.5)
+	ts := time.Now().Truncate(time.Millisecond)
+	a.Record(7, "555-1111", Sample{TS: ts, LossPct: &loss, ConnType: "srflx"})
+
+	w := waitForWindow(t, b, 7, "555-1111")
+	if len(w) != 1 {
+		t.Fatalf("remote window len = %d, want 1", len(w))
+	}
+	got := w[0]
+	if !got.TS.Equal(ts) || got.LossPct == nil || *got.LossPct != loss || got.ConnType != "srflx" {
+		t.Fatalf("remote sample mismatch: %+v", got)
+	}
+}
+
+func TestHealthStoreRedisFanOutToSubscriber(t *testing.T) {
+	a, b := twoStores(t)
+
+	// Viewer subscribes on pod B before pod A has ingested anything.
+	sub := b.Subscribe(9)
+	defer sub.Close()
+
+	jit := float32(3)
+	a.Record(9, "555-2222", Sample{TS: time.Now(), JitterMs: &jit})
+
+	select {
+	case ev, ok := <-sub.C:
+		if !ok {
+			t.Fatal("subscription closed before delivering the remote sample")
+		}
+		if ev.Kind != SampleKind || ev.Endpoint != "555-2222" {
+			t.Fatalf("got event %+v, want remote SampleKind from 555-2222", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cross-pod sample event")
+	}
+}
+
+func TestHealthStoreRedisFanOutEvictClosesRemoteSubscribers(t *testing.T) {
+	a, b := twoStores(t)
+
+	sub := b.Subscribe(11)
+	defer sub.Close()
+
+	a.Evict(11)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				return // channel closed by the remote-applied evict: success
+			}
+			if ev.Kind == EndedKind {
+				continue // EndedKind precedes the close
+			}
+			t.Fatalf("unexpected event before close: %+v", ev)
+		case <-deadline:
+			t.Fatal("timeout waiting for cross-pod evict to close the subscription")
+		}
+	}
+}
+
+func TestHealthStoreRedisFanOutDisconnectNotify(t *testing.T) {
+	a, b := twoStores(t)
+
+	sub := b.Subscribe(13)
+	defer sub.Close()
+
+	a.NotifyDisconnected(13, "Justin")
+
+	select {
+	case ev, ok := <-sub.C:
+		if !ok {
+			t.Fatal("subscription closed unexpectedly")
+		}
+		if ev.Kind != DisconnectKind || ev.EndedBy != "Justin" {
+			t.Fatalf("got event %+v, want DisconnectKind by Justin", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for cross-pod disconnect event")
+	}
+}
+
+func TestHealthStoreRedisFanOutConferenceEdge(t *testing.T) {
+	a, b := twoStores(t)
+
+	confID := uuid.New()
+	rtt := float32(40)
+	a.RecordEdge(confID, "555-1111", "555-2222", Sample{TS: time.Now(), RttMs: &rtt})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if w := b.WindowEdge(confID, "555-1111", "555-2222"); len(w) == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timeout waiting for cross-pod conference edge sample")
+}
+
+func TestHealthStoreRedisSkipsOwnEvents(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	s := NewHealthStore(nil)
+	s.SetRedis(client, "pod-a")
+	go s.RunRedis(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	loss := float32(0.5)
+	s.Record(21, "555-1111", Sample{TS: time.Now(), LossPct: &loss})
+	// Give the subscriber loop a moment; a self-applied echo would append
+	// a duplicate sample to the ring.
+	time.Sleep(200 * time.Millisecond)
+	if w := s.Window(21, "555-1111"); len(w) != 1 {
+		t.Fatalf("window len = %d, want 1 (own published event must be skipped)", len(w))
+	}
+}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -551,3 +551,44 @@ func TestHealthStoreRecordLazilyCreatesSession(t *testing.T) {
 		t.Fatalf("Record without Init should lazily create the session: got %d samples", len(w))
 	}
 }
+
+func TestHealthStoreSweepReapsStuckSubscribedSession(t *testing.T) {
+	s := NewHealthStore(nil)
+
+	// Race shape from the multi-pod world: the call ended on another pod
+	// (its evict already fanned out and no-op'd here), then a viewer
+	// subscribed, lazily creating a session that will never receive an
+	// EndedKind from the call lifecycle.
+	sub := s.Subscribe(31)
+	defer sub.Close()
+
+	// Under the normal idle TTL the subscriber protects the session.
+	base := time.Now()
+	s.now = func() time.Time { return base.Add(idleSessionTTL + time.Minute) }
+	s.sweepIdleSessions()
+	select {
+	case _, ok := <-sub.C:
+		if !ok {
+			t.Fatal("session with subscriber swept before subscribedSessionTTL")
+		}
+	default:
+	}
+
+	// Past the subscribed backstop the sweep closes the stream.
+	s.now = func() time.Time { return base.Add(subscribedSessionTTL + time.Minute) }
+	s.sweepIdleSessions()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				return // closed: phantom session self-healed
+			}
+			if ev.Kind != EndedKind {
+				t.Fatalf("unexpected event before close: %+v", ev)
+			}
+		case <-deadline:
+			t.Fatal("sweep did not close the stuck subscribed session")
+		}
+	}
+}

--- a/server/internal/calls/linkhealth_test.go
+++ b/server/internal/calls/linkhealth_test.go
@@ -170,18 +170,50 @@ func TestHealthStoreConcurrentCallsAndEndpoints(t *testing.T) {
 	}
 }
 
-func TestHealthStoreRecordIsNoOpAfterEvict(t *testing.T) {
+func TestHealthStoreRecordAfterEvictIsReapedBySweep(t *testing.T) {
 	s := NewHealthStore(nil)
 	s.Init(1)
 	s.Record(1, "A", sample(100, 0.5))
 	s.Evict(1)
-	s.Record(1, "A", sample(200, 0.9)) // should NOT resurrect map entry
-	if win := s.Window(1, "A"); len(win) != 0 {
-		t.Fatalf("post-evict Record must not create entry; got window len %d", len(win))
+	// A late sample (e.g. in flight while another replica handled the
+	// hangup) lazily recreates the session rather than vanishing.
+	s.Record(1, "A", sample(200, 0.9))
+	if win := s.Window(1, "A"); len(win) != 1 {
+		t.Fatalf("post-evict Record should lazily recreate the session; got window len %d", len(win))
 	}
-	a, b := s.latest(1, "A", "B")
-	if a != nil || b != nil {
-		t.Fatalf("post-evict Record must not resurrect rings; got (%v,%v)", a, b)
+	// The idle sweep reaps it once it goes quiet.
+	s.now = func() time.Time { return time.Now().Add(idleSessionTTL + time.Minute) }
+	s.sweepIdleSessions()
+	if win := s.Window(1, "A"); len(win) != 0 {
+		t.Fatalf("idle sweep should evict the recreated session; got window len %d", len(win))
+	}
+}
+
+func TestHealthStoreSweepSparesActiveAndSubscribed(t *testing.T) {
+	s := NewHealthStore(nil)
+
+	s.Init(1) // fresh session: activity is now
+	s.Init(2) // will go idle but holds a subscriber
+	sub := s.Subscribe(2)
+	defer sub.Close()
+
+	// Both sessions sit past the TTL except session 1, which records a
+	// sample "now" to refresh its activity.
+	base := time.Now()
+	s.now = func() time.Time { return base.Add(idleSessionTTL + time.Minute) }
+	s.Record(1, "A", sample(100, 0.5))
+	s.sweepIdleSessions()
+
+	if win := s.Window(1, "A"); len(win) != 1 {
+		t.Fatalf("recently active session must survive the sweep; got window len %d", len(win))
+	}
+	select {
+	case _, ok := <-sub.C:
+		if !ok {
+			t.Fatal("sweep must not evict a session with live subscribers")
+		}
+	default:
+		// no event delivered: still subscribed, as expected
 	}
 }
 
@@ -294,17 +326,24 @@ func TestHealthStoreEvictClosesSubscribers(t *testing.T) {
 	}
 }
 
-func TestHealthStoreSubscribeOnMissingCallReturnsClosedChannel(t *testing.T) {
+func TestHealthStoreSubscribeOnUnseenCallReceivesLaterSamples(t *testing.T) {
 	s := NewHealthStore(nil)
+	// No Init: with multiple replicas the viewer's pod may not have seen
+	// any state for the call yet. Subscribe must still attach.
 	sub := s.Subscribe(999)
 	defer sub.Close()
+
+	s.Record(999, "A", sample(100, 0.5))
 	select {
-	case _, ok := <-sub.C:
-		if ok {
-			t.Fatal("expected closed channel, got event")
+	case ev, ok := <-sub.C:
+		if !ok {
+			t.Fatal("subscription closed unexpectedly")
+		}
+		if ev.Kind != SampleKind || ev.Endpoint != "A" {
+			t.Fatalf("got event %+v, want SampleKind from A", ev)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("expected closed channel, got block")
+		t.Fatal("timeout waiting for sample on lazily created session")
 	}
 }
 
@@ -494,11 +533,21 @@ func TestHealthStoreConferenceSubscribeReceivesPeer(t *testing.T) {
 	}
 }
 
-func TestHealthStoreRecordEdgeDropsIfNotInit(t *testing.T) {
+func TestHealthStoreRecordEdgeLazilyCreatesSession(t *testing.T) {
 	s := NewHealthStore(nil)
-	confID := uuid.New() // never InitConference'd
+	confID := uuid.New() // never InitConference'd: ingest pod may differ from setup pod
 	s.RecordEdge(confID, "A", "B", Sample{TS: time.Unix(0, 1)})
-	if w := s.WindowEdge(confID, "A", "B"); len(w) != 0 {
-		t.Fatalf("RecordEdge without InitConference should be a no-op: got %d", len(w))
+	if w := s.WindowEdge(confID, "A", "B"); len(w) != 1 {
+		t.Fatalf("RecordEdge without InitConference should lazily create the session: got %d samples", len(w))
+	}
+}
+
+func TestHealthStoreRecordLazilyCreatesSession(t *testing.T) {
+	s := NewHealthStore(nil)
+	// No Init: with multiple replicas the ingesting pod is often not the
+	// pod that handled call setup.
+	s.Record(42, "A", Sample{TS: time.Unix(0, 1)})
+	if w := s.Window(42, "A"); len(w) != 1 {
+		t.Fatalf("Record without Init should lazily create the session: got %d samples", len(w))
 	}
 }

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -153,6 +153,16 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	sub := h.healthStore.SubscribeConference(confID)
 	defer sub.Close()
 
+	// Re-check liveness AFTER subscribing. SubscribeConference lazily
+	// creates the session, so if the conference ended on another pod
+	// between the ownership check and the Subscribe, the cross-pod evict
+	// has already passed and this session would never receive EndedKind.
+	if cur, err := h.tracker.GetConferenceByID(r.Context(), confID); err == nil && cur != nil && cur.EndedAt != nil {
+		_ = writeSSE(w, "ended", renderEndedConferenceFragment(""))
+		flusher.Flush()
+		return
+	}
+
 	// Initial snapshot.
 	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -192,6 +192,17 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 	sub := h.healthStore.Subscribe(callID)
 	defer sub.Close()
 
+	// Re-check liveness AFTER subscribing. Subscribe lazily creates the
+	// session, so if the call ended on another pod between the ownership
+	// check and the Subscribe, the cross-pod evict has already passed and
+	// this session would never receive EndedKind. The DB status is
+	// authoritative; flip straight to the terminal state.
+	if cur, err := h.tracker.GetCall(r.Context(), callID); err == nil && cur.Status == calls.CallStatusEnded {
+		_ = writeSSE(w, "ended", renderEndedFragment(""))
+		flusher.Flush()
+		return
+	}
+
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
 


### PR DESCRIPTION
## Bug

On `/call/live` screens only one side of a call had telemetry (example: prod call 76297, where the caller logged 7 samples and the callee logged zero despite a 64s call). Prod data shows the pattern exactly: since the week of 2026-05-04 the asymmetric calls are **always caller-only, never callee-only**, and both-sides coverage dropped to ~1/3 of answered calls. That week is when prod moved to k8s with three signald replicas.

## Root cause

`HealthStore` sessions are pod-local memory:

- `Tracker.StartCall` ran `HealthStore.Init(callID)` only on the pod handling the caller's `call` message, which is always the caller's own WebSocket pod.
- `recordSession` silently dropped samples for sessions the local pod never initialized.
- The callee's WebSocket lands on the same pod as the caller's only ~1/3 of the time with three replicas; the other 2/3 of its `link_health` samples were discarded before ever reaching Postgres.
- Same hole for the live view: the SSE stream subscribes to the serving pod's in-memory store, and `Evict` only ran on the pod that handled the hangup, leaking sessions elsewhere.

## Fix

Mirrors the cross-pod pattern the dashboard `events.Broadcaster` already uses:

- **Lazy sessions.** `Record`, `RecordEdge`, and `Subscribe` create the session if the pod hasn't seen it, so each pod ingests and flushes its own phones' samples no matter which replica set the call up. This alone fixes the persisted data.
- **Redis fan-out.** Locally ingested samples and locally triggered evict/disconnect events publish on a `digits:linkhealth` channel; every pod applies the others' events to its rings and live SSE subscribers. Remote-applied samples advance `lastFlushed`, so only the ingesting pod writes to Postgres (the v20 unique indexes remain the backstop). Publishes happen at the public API boundary; session internals stay transport-free.
- **Lifecycle.** Cross-pod evicts close remote subscribers promptly; a 15-minute idle sweep (skips sessions with live subscribers) bounds sessions whose end event predates a pod restart or was recreated by a late sample.

Single-replica deployments are unaffected: with no Redis configured the publishes are no-ops and behavior reduces to lazy creation plus the sweep.

## Tests

- miniredis unit tests: cross-pod sample fan-out (2-party + conference edge), delivery to remote subscribers, evict closing remote subscriptions, disconnect notify, self-event skip.
- Postgres integration test: the remote pod's flusher writes nothing; the ingesting pod writes the row.
- Updated the unit tests that encoded the old drop-when-uninitialized contract, plus new sweep coverage (reaps idle, spares active/subscribed).

## Verification plan

After merge and the ArgoCD rollout, confirm on prod that the next real calls have `call_link_health` rows from **both** endpoints, and spot-check a `/call/live` page.
