### PR TITLE
refactor(digitsd): extract resolveTargetRelease in CheckVersion

### DIFF
--- a/pi/digitsd/internal/updater/updater.go
+++ b/pi/digitsd/internal/updater/updater.go
@@ -157,39 +157,47 @@ func (u *Updater) CheckVersion(targetPi, targetFW string) (*CheckResult, error) 
 
 	result := &CheckResult{}
 
-	// Resolve Pi target
-	piTarget := targetPi
-	if piTarget == "" {
-		piTarget = idx.Pi.Latest
+	piRel, err := resolveTargetRelease("pi", targetPi, u.cfg.CurrentPiVersion, idx.Pi)
+	if err != nil {
+		return nil, err
 	}
-	if piTarget != "" && piTarget != u.cfg.CurrentPiVersion {
-		rel, ok := idx.Pi.Releases[piTarget]
-		if !ok {
-			return nil, fmt.Errorf("pi version %s not found in release index", piTarget)
-		}
+	if piRel != nil {
 		result.PiAvailable = true
-		result.PiVersion = rel.Version
-		result.PiSHA256 = rel.SHA256
-		result.PiURL = rel.URL
+		result.PiVersion = piRel.Version
+		result.PiSHA256 = piRel.SHA256
+		result.PiURL = piRel.URL
 	}
 
-	// Resolve FW target
-	fwTarget := targetFW
-	if fwTarget == "" {
-		fwTarget = idx.Firmware.Latest
+	fwRel, err := resolveTargetRelease("firmware", targetFW, u.cfg.CurrentFWVersion, idx.Firmware)
+	if err != nil {
+		return nil, err
 	}
-	if fwTarget != "" && fwTarget != u.cfg.CurrentFWVersion {
-		rel, ok := idx.Firmware.Releases[fwTarget]
-		if !ok {
-			return nil, fmt.Errorf("firmware version %s not found in release index", fwTarget)
-		}
+	if fwRel != nil {
 		result.FWAvailable = true
-		result.FWVersion = rel.Version
-		result.FWSHA256 = rel.SHA256
-		result.FWURL = rel.URL
+		result.FWVersion = fwRel.Version
+		result.FWSHA256 = fwRel.SHA256
+		result.FWURL = fwRel.URL
 	}
 
 	return result, nil
+}
+
+// resolveTargetRelease picks the release a component should move to. An empty
+// target means "use the component's Latest". Returns (nil, nil) when no update
+// is needed (no target known, or the resolved target equals current). Returns
+// an error only when an explicit target is set but missing from the index.
+func resolveTargetRelease(label, target, current string, comp ComponentIndex) (*Release, error) {
+	if target == "" {
+		target = comp.Latest
+	}
+	if target == "" || target == current {
+		return nil, nil
+	}
+	rel, ok := comp.Releases[target]
+	if !ok {
+		return nil, fmt.Errorf("%s version %s not found in release index", label, target)
+	}
+	return rel, nil
 }
 
 // Download downloads an artifact from a URL, verifies SHA256, and writes it


### PR DESCRIPTION
## Summary

The Pi and FW target-resolution blocks in `Updater.CheckVersion` were structurally identical: each picked `Latest` when the explicit target was empty, skipped when no target was known or the component was already current, and errored when an explicit target was missing from the index. They had to be kept in lockstep, which is exactly the kind of duplication that drifts.

Pulled the shared logic into a small `resolveTargetRelease` helper so each per-component section in `CheckVersion` now reads as "resolve target, copy fields if available" rather than a ten-line block that mirrors the one above it.

Behavior is unchanged. The existing tests (`TestCheckVersion_TargetedUpdate`, `_EmptyTargetsUsesLatest`, `_AlreadyCurrent`, `_UnknownVersion`) continue to pass and exercise all four branches of the helper.

## Test plan
- [x] `go build ./...` in `pi/digitsd/`
- [x] `go test ./internal/updater/...` in `pi/digitsd/`
- [x] `go vet ./internal/updater/...` in `pi/digitsd/`