### PR TITLE
refactor(server): check auth before parseForm in updateLineSetting handlers

### DIFF
--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -504,6 +504,10 @@ func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Request) {
+	ln := h.requireLineOwnership(w, r, r.PathValue("number"))
+	if ln == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
@@ -512,27 +516,35 @@ func (h *Handler) handlePhoneVoiceStylePost(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "missing voice_style", http.StatusBadRequest)
 		return
 	}
-	h.updateLineSetting(w, r, "voice-style-section", "am-voice-style-section", func(s *line.Settings) {
+	h.updateLineSetting(w, r, ln, "voice-style-section", "am-voice-style-section", func(s *line.Settings) {
 		s.VoiceStyle = raw
 	})
 }
 
 func (h *Handler) handlePhoneSilentModePost(w http.ResponseWriter, r *http.Request) {
+	ln := h.requireLineOwnership(w, r, r.PathValue("number"))
+	if ln == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
 	silent := strings.TrimSpace(r.FormValue("silent_mode")) == "on"
-	h.updateLineSetting(w, r, "silent-mode-section", "am-silent-mode-section", func(s *line.Settings) {
+	h.updateLineSetting(w, r, ln, "silent-mode-section", "am-silent-mode-section", func(s *line.Settings) {
 		s.SilentMode = silent
 	})
 }
 
 func (h *Handler) handlePhoneAutoUpdatePost(w http.ResponseWriter, r *http.Request) {
+	ln := h.requireLineOwnership(w, r, r.PathValue("number"))
+	if ln == nil {
+		return
+	}
 	if !parseForm(w, r) {
 		return
 	}
 	autoUpdate := strings.TrimSpace(r.FormValue("auto_update")) == "on"
-	h.updateLineSetting(w, r, "auto-update-section", "am-auto-update-section", func(s *line.Settings) {
+	h.updateLineSetting(w, r, ln, "auto-update-section", "am-auto-update-section", func(s *line.Settings) {
 		s.AutoUpdate = autoUpdate
 	})
 }
@@ -677,17 +689,13 @@ func parseClampedInt(w http.ResponseWriter, r *http.Request, name string, min, m
 	return v, true
 }
 
-// updateLineSetting applies a mutation to the Settings of the line identified
-// by the {number} path value, persists and pushes it if anything changed, and
-// then renders the theme-appropriate partial (or redirects to the phone detail
-// page for non-htmx callers). Handlers are expected to have already called
-// ParseForm and extracted the field they need before invoking this helper.
-func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, intercom, am string, mutate func(*line.Settings)) {
-	number := r.PathValue("number")
-	ln := h.requireLineOwnership(w, r, number)
-	if ln == nil {
-		return
-	}
+// updateLineSetting applies a mutation to the Settings of ln, persists and
+// pushes it if anything changed, and then renders the theme-appropriate
+// partial (or redirects to the phone detail page for non-htmx callers).
+// Handlers are expected to have already verified ownership (ln comes from
+// requireLineOwnership), then called ParseForm and extracted the field they
+// need before invoking this helper.
+func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, ln *line.Line, intercom, am string, mutate func(*line.Settings)) {
 	next := ln.Settings
 	mutate(&next)
 	next = next.Normalize()
@@ -700,7 +708,7 @@ func (h *Handler) updateLineSetting(w http.ResponseWriter, r *http.Request, inte
 		}{Line: *ln})
 		return
 	}
-	http.Redirect(w, r, "/phones/"+number, http.StatusSeeOther)
+	http.Redirect(w, r, "/phones/"+ln.Number, http.StatusSeeOther)
 }
 
 // applyLineSettings persists `next` and pushes it to the connected device if


### PR DESCRIPTION
## Summary

Completes the auth-before-parseForm convention across `handler_phones.go`. PR #716 established the ordering (ownership check first, then body parsing), and #722 extended it to six more handlers in this file but explicitly left three behind: `handlePhoneVoiceStylePost`, `handlePhoneSilentModePost`, and `handlePhoneAutoUpdatePost` all delegate to `updateLineSetting`, which owned the ownership check internally, so the form had to be parsed before the helper ran.

This PR reshapes the helper: `requireLineOwnership` is hoisted into the three callers, ahead of `parseForm`, and the resolved `*line.Line` is passed into `updateLineSetting`. The helper no longer re-reads the `{number}` path value; the non-htmx redirect uses `ln.Number`. Every mutating handler in the file now follows the same order, and an unauthorized request no longer gets its body parsed and allocated first.

#728 rewrote much of this file the same day and preserved the #722 ordering in everything it kept, so this closes the last gap in the sequence.

## Motivated by (merged in the last 24h)

- #722 `refactor(server): check auth before parseForm in phone handlers`, which named this exact trio as the remaining departure
- #728 `feat(server): merge Lines into Overview`, which preserved the convention through its rewrite

## Test plan

- [x] `go build ./...` in `server/`
- [x] `go test ./...` in `server/`
- [x] `go vet ./...` in `server/`
- [x] `golangci-lint run ./...` (v2.12.2): 0 issues