### PR TITLE
docs(server): document SIGNALD_TRUSTED_PROXIES in the env var table

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -91,6 +91,7 @@ Visit `http://localhost:8443` for the web UI. New users are prompted to create a
 | `DATABASE_URL` | (required)                       | Postgres connection string            |
 | `BASE_URL`     | `https://app.digits.family`      | Public base URL for links and OAuth   |
 | `ADMIN_SECRET` | (required)                       | Shared secret for internal stats API  |
+| `SIGNALD_TRUSTED_PROXIES` | `1`                   | Reverse-proxy hops between signald and clients, used to resolve the real client IP from `X-Forwarded-For` for rate limiting. The default fits one proxy in front (Caddy or Traefik). Set to `0` when signald is exposed directly; raise it when another proxy (CDN, load balancer) sits in front of yours. |
 
 ### TLS (optional)
 


### PR DESCRIPTION
## Summary

PR #726 changed client-IP resolution to walk a configurable trusted-proxy hop count from the right of `X-Forwarded-For` and introduced `SIGNALD_TRUSTED_PROXIES` to set that count, defaulting to 1. The README's environment variable section, which is the reference self-hosters configure from, never picked the knob up; it was documented only in `internal/config/config.go` comments and the commit message.

The knob is security-relevant in both directions. A deployment with no proxy should set `0` so `X-Forwarded-For` is ignored entirely, and a deployment with two hops (say a CDN in front of Caddy) needs `2` or every client gets keyed to the edge proxy's address and rate limits misfire. The default of `1` silently matches the documented Caddy and Traefik topologies, which is exactly why it deserves a visible row.

Adds one row to the Core table in `server/README.md` with the deployment guidance from the config doc comment.

## Motivated by (merged in the last 24h)

- #726 `fix(server): harden client-IP resolution and Google OAuth, plus latent concurrency fixes`

## Test plan

Docs-only change; no code touched.