### PR TITLE
refactor(image): extract chroot_setup/chroot_teardown helpers in build-image.sh

### DIFF
--- a/tools/build-image.sh
+++ b/tools/build-image.sh
@@ -343,6 +343,26 @@ detach_loop() {
     fi
 }
 
+# Prepare $ROOTFS_MNT for chroot: install the qemu interpreter and bind the
+# pseudo-filesystems chrooted commands expect.
+chroot_setup() {
+    cp "$(which qemu-aarch64-static)" "${ROOTFS_MNT}/usr/bin/"
+    mount -t proc proc "${ROOTFS_MNT}/proc"
+    mount -t sysfs sys "${ROOTFS_MNT}/sys"
+    mount --bind /dev "${ROOTFS_MNT}/dev"
+    mount --bind /dev/pts "${ROOTFS_MNT}/dev/pts"
+    mount --bind /dev/shm "${ROOTFS_MNT}/dev/shm" 2>/dev/null || true
+}
+
+# Undo chroot_setup. Callers must not invoke this with an empty/unset
+# ROOTFS_MNT (the cleanup trap has its own guarded unmount loop).
+chroot_teardown() {
+    for mp in dev/pts dev/shm dev proc sys; do
+        umount "${ROOTFS_MNT}/${mp}" 2>/dev/null || true
+    done
+    rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
+}
+
 trap cleanup EXIT
 
 # ── host-side helper: add user to passwd/shadow/group ────────────────────────
@@ -568,15 +588,7 @@ mount "$P4" "$DATA_MNT"
 
 info "Preparing chroot environment (for apt-get operations only)..."
 
-# Copy qemu-user-static into the chroot
-cp "$(which qemu-aarch64-static)" "${ROOTFS_MNT}/usr/bin/"
-
-# Mount necessary filesystems for chroot
-mount -t proc proc "${ROOTFS_MNT}/proc"
-mount -t sysfs sys "${ROOTFS_MNT}/sys"
-mount --bind /dev "${ROOTFS_MNT}/dev"
-mount --bind /dev/pts "${ROOTFS_MNT}/dev/pts"
-mount --bind /dev/shm "${ROOTFS_MNT}/dev/shm" 2>/dev/null || true
+chroot_setup
 
 # Prevent services from starting during chroot operations
 cat > "${ROOTFS_MNT}/usr/sbin/policy-rc.d" << 'POLICY'
@@ -618,12 +630,8 @@ chroot "$ROOTFS_MNT" /bin/bash -c "
 
 info "Tearing down chroot (all remaining work is host-side)..."
 
-for mp in dev/pts dev/shm dev proc sys; do
-    umount "${ROOTFS_MNT}/${mp}" 2>/dev/null || true
-done
-
+chroot_teardown
 rm -f "${ROOTFS_MNT}/usr/sbin/policy-rc.d"
-rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
 
 # Restore resolv.conf (will be replaced with NM symlink later)
 if [[ -f "${ROOTFS_MNT}/etc/resolv.conf.bak" ]]; then
@@ -933,12 +941,7 @@ install -m 755 "$BOOT_CHECK_SRC"   "${ROOTFS_MNT}/etc/initramfs-tools/scripts/in
 install -m 755 "$RECOVERY_ROOT_SRC" "${ROOTFS_MNT}/etc/initramfs-tools/scripts/local-bottom/recovery-root"
 
 # Set up chroot for tool path resolution, library copying, and initramfs rebuild
-cp "$(which qemu-aarch64-static)" "${ROOTFS_MNT}/usr/bin/"
-mount -t proc proc "${ROOTFS_MNT}/proc"
-mount -t sysfs sys "${ROOTFS_MNT}/sys"
-mount --bind /dev "${ROOTFS_MNT}/dev"
-mount --bind /dev/pts "${ROOTFS_MNT}/dev/pts"
-mount --bind /dev/shm "${ROOTFS_MNT}/dev/shm" 2>/dev/null || true
+chroot_setup
 
 # Copy required tools from rootfs into recovery partition bin/
 info "  Copying required tools to recovery/bin/..."
@@ -1139,10 +1142,7 @@ ln -sf /run "${RECOVERY_MNT}/var/run"
 info "  Rebuilding initramfs (chroot)..."
 chroot "$ROOTFS_MNT" /bin/bash -c "update-initramfs -u"
 
-for mp in dev/pts dev/shm dev proc sys; do
-    umount "${ROOTFS_MNT}/${mp}" 2>/dev/null || true
-done
-rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
+chroot_teardown
 
 info "  Unmounting recovery partition..."
 umount "$RECOVERY_MNT"


### PR DESCRIPTION
## What

`build-image.sh` enters a qemu chroot twice: once for the apt-get phase (purge + install) and once for the initramfs rebuild. The setup sequence (copy `qemu-aarch64-static`, bind-mount `proc`/`sys`/`dev`/`dev/pts`/`dev/shm`) and the matching teardown (umount loop + qemu removal) were pasted verbatim at both sites. This extracts them into `chroot_setup` / `chroot_teardown` helpers, defined next to the other mount-lifecycle functions (`ensure_partitions`, `detach_loop`).

## What deliberately stays where it is

- The apt-specific pieces (`policy-rc.d` install/removal, `resolv.conf` swap) remain inline at the first site; the second chroot only runs `update-initramfs` and never needed them.
- The `cleanup` EXIT trap keeps its own guarded unmount loop rather than calling `chroot_teardown`: the trap can fire with `ROOTFS_MNT` unset, and the helper intentionally has no emptiness guard (an empty `ROOTFS_MNT` would make it unmount host paths). The helper's comment states this contract.

## Why

The bind-mount set is exactly the kind of thing that gets extended in one place and not the other (the existing copies already carry a subtle shared workaround: the `dev/shm` mount is allowed to fail). One definition makes the next change land in both chroot phases by construction.

Behavior is unchanged: both sites execute the identical command sequence as before, in the same order.

## Validation

`bash -n` passes; `shellcheck -S warning` reports exactly the same two pre-existing findings before and after (SC2043/SC2010, both untouched by this change). Pure command-for-command extraction, no logic edits.