### PR TITLE
docs: add link-health Redis fan-out to the multi-replica docs

### DIFF
--- a/charts/digits/README.md
+++ b/charts/digits/README.md
@@ -110,12 +110,15 @@ those env vars. Redis then carries:
 - device presence (which pod owns each connected device);
 - active-call and conference state (so any pod can answer "is this number
   busy?" or list live calls);
-- dashboard SSE events (so `/api/dashboard/stream` re-renders on any pod).
+- dashboard SSE events (so `/api/dashboard/stream` re-renders on any pod);
+- link-health telemetry fan-out (so live call-quality screens stay complete
+  when the caller and callee hold WebSockets on different pods).
 
 When `redis.enabled` is false, all of the above is local-only. Replica
 counts above 1 then silently break: calls whose target is on another pod
-get dropped, devices on other pods appear offline here, and dashboard
-counters reflect just the local pod.
+get dropped, devices on other pods appear offline here, dashboard
+counters reflect just the local pod, and live call-quality screens show
+one silent side whenever a call spans two pods.
 
 To bring your own Redis instead of the bundled StatefulSet, leave
 `redis.enabled: false` and inject `REDIS_URL` (and, for sentinel mode,

--- a/server/README.md
+++ b/server/README.md
@@ -143,7 +143,7 @@ around what is and is not collected.
 
 | Variable                | Description                                                    |
 |-------------------------|----------------------------------------------------------------|
-| `REDIS_URL`             | Redis connection URL (`redis://host:port` or `rediss://...`), or a comma-separated list of Sentinel addresses for failover mode. When set, signald enables both cross-pod signaling (pub/sub) and shared cluster state (device presence, active calls and conferences, dashboard SSE events). Empty disables Redis (single-instance mode). |
+| `REDIS_URL`             | Redis connection URL (`redis://host:port` or `rediss://...`), or a comma-separated list of Sentinel addresses for failover mode. When set, signald enables both cross-pod signaling (pub/sub) and shared cluster state (device presence, active calls and conferences, dashboard SSE events, link-health telemetry). Empty disables Redis (single-instance mode). |
 | `REDIS_SENTINEL_MASTER` | Sentinel master name. When set together with a comma-separated `REDIS_URL`, the client switches to failover-aware mode. Leave empty for a direct connection. |
 
 Without `REDIS_URL`, behavior is identical to the single-instance default
@@ -160,10 +160,17 @@ into Redis so multi-pod queries see a consistent view:
 - **Dashboard events:** the SSE broadcaster fans out across pods via Redis
   pub/sub so `/api/dashboard/stream` re-renders counters regardless of which
   pod the SSE client connected to.
+- **Link-health telemetry:** each pod ingests its own phones' call-quality
+  samples and fans them out over the `digits:linkhealth` channel, so the
+  in-memory windows behind `/call/live` screens and link-health SSE streams
+  stay complete even when the caller and callee hold WebSockets on
+  different pods.
 
 Running multiple replicas without Redis silently breaks all of these:
-calls land on the wrong pod, devices appear offline to other pods, and
-dashboard counters reflect only the local pod's events.
+calls land on the wrong pod, devices appear offline to other pods,
+dashboard counters reflect only the local pod's events, and live
+call-quality screens show one silent side whenever the two phones in a
+call connected to different pods.
 
 ### Tracing and Profiling
 


### PR DESCRIPTION
## What

Adds link-health telemetry to the two docs that enumerate what Redis carries in multi-replica mode:

- `server/README.md` (Multi-replica signaling): new bullet for the `digits:linkhealth` fan-out in the cluster-state list, mention in the `REDIS_URL` row, and the one-silent-side symptom in the "without Redis silently breaks" paragraph.
- `charts/digits/README.md` ("Redis then carries:"): same bullet and failure-mode addition.

## Why

#729 made link-health telemetry the fourth Redis-backed multi-pod surface: each pod ingests its own phones' call-quality samples and fans them out over the `digits:linkhealth` pub/sub channel, the same pattern as the dashboard events broadcaster. Both READMEs still listed only device presence, call/conference state, and dashboard events, so an operator sizing a multi-replica deployment (or debugging one without Redis) would not learn from the docs that live call-quality screens show one silent side whenever a call spans two pods, which is exactly the bug #729 fixed.

Found by the daily cross-PR coherence review of the last 24h of merges (#722-#734).