### PR TITLE
fix(digitsd): resync Pico state after runtime firmware flash

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -854,8 +854,8 @@ type picoStateResyncer interface {
 }
 
 // resetPicoHardware clears any residual ring or LED state on the Pico in case
-// the Pi rebooted mid-call. Safe no-op on clean boots where none of these
-// hardware states were active.
+// the Pi or Pico rebooted mid-call. Safe no-op on clean boots where none of
+// these hardware states were active.
 func resetPicoHardware(sp picoStateResyncer) {
 	slog.Info("pico: clearing residual hardware state")
 	sp.StopRing()

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -843,13 +843,46 @@ func runTargetedUpdate(serverURL, piVersion, fwVersion, targetPi, targetFW strin
 	}
 }
 
+// picoStateResyncer is the subset of *phone.SerialPort that the Pico
+// hardware-reset and state-resync helpers need. Declaring it as an interface
+// lets tests fake the serial boundary and record the commands emitted, the same
+// way linkhealth fakes its sigSender.
+type picoStateResyncer interface {
+	StopRing()
+	LED(mode string)
+	StateSet(state string)
+}
+
 // resetPicoHardware clears any residual ring or LED state on the Pico in case
 // the Pi rebooted mid-call. Safe no-op on clean boots where none of these
 // hardware states were active.
-func resetPicoHardware(sp *phone.SerialPort) {
-	slog.Info("pico: clearing residual hardware state on startup")
+func resetPicoHardware(sp picoStateResyncer) {
+	slog.Info("pico: clearing residual hardware state")
 	sp.StopRing()
 	sp.LED("UNLOCK")
+}
+
+// picoStateForToken derives the persisted Pico phase from the pairing state the
+// same way the startup path does: an empty device token means the phone is not
+// yet paired. Kept as a pure function so the mapping has a single source of
+// truth shared by startup and the post-flash resync.
+func picoStateForToken(deviceToken string) string {
+	if deviceToken == "" {
+		return "UNPAIRED"
+	}
+	return "PAIRED"
+}
+
+// resyncPicoState restores the Pico's residual hardware state and persisted
+// phase byte, mirroring exactly what the startup path does after POST. The Pico
+// boots PHASE_PAIRED as LED_MODE_BREATHING and relies on the Pi to clear it; a
+// runtime firmware flash reboots the chip without a daemon restart, so without
+// this the LED is left breathing at idle. deviceToken is read live (pairing can
+// change it at runtime) and mapped through picoStateForToken so this stays in
+// lockstep with the startup StateSet.
+func resyncPicoState(sp picoStateResyncer, deviceToken string) {
+	resetPicoHardware(sp)
+	sp.StateSet(picoStateForToken(deviceToken))
 }
 
 // playPairingAnnouncement queues one full pairing-voice sequence on mixer:
@@ -1455,12 +1488,7 @@ func main() {
 
 	// Clear any residual Pico hardware state from before the last reboot.
 	if postOk {
-		resetPicoHardware(sp)
-		if cfg.DeviceToken == "" {
-			sp.StateSet("UNPAIRED")
-		} else {
-			sp.StateSet("PAIRED")
-		}
+		resyncPicoState(sp, cfg.DeviceToken)
 	}
 
 	// 2. Open ALSA playback. V1 uses plughw direct to the codec; V2 routes
@@ -2236,6 +2264,25 @@ func main() {
 				cb.publishVoicemailStateInitial()
 			} else {
 				slog.Info("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
+			}
+
+			// A successful version re-query proves the Pico finished rebooting
+			// and is answering UART again. Any reboot (runtime firmware flash,
+			// external SWD, power cycle) leaves the chip booted into
+			// PHASE_PAIRED as LED_MODE_BREATHING, expecting the Pi to clear it.
+			// Startup does this after POST; without it here, a runtime
+			// firmware-only OTA (no daemon restart) leaves the LED breathing at
+			// idle. Skip while a call is active so a mid-call Pico power cycle
+			// does not stomp the call LED; the OTA path is already idle-gated by
+			// runAutoUpdate, so this only guards the external-reboot case.
+			cb.mu.Lock()
+			inCall := cb.callPeer != ""
+			cb.mu.Unlock()
+			if inCall {
+				slog.Info("pico: skipping state resync after reboot, call in progress")
+			} else {
+				slog.Info("pico: resyncing state after reboot")
+				resyncPicoState(sp, cfg.DeviceToken)
 			}
 
 		case msg := <-sig.Inbox():

--- a/pi/digitsd/cmd/digitsd/postflash_resync_test.go
+++ b/pi/digitsd/cmd/digitsd/postflash_resync_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// fakePicoResyncer records the commands resyncPicoState emits so tests can
+// assert the exact serial sequence without a real *phone.SerialPort.
+type fakePicoResyncer struct {
+	cmds []string
+}
+
+func (f *fakePicoResyncer) StopRing()             { f.cmds = append(f.cmds, "STOP_RING") }
+func (f *fakePicoResyncer) LED(mode string)       { f.cmds = append(f.cmds, "LED:"+mode) }
+func (f *fakePicoResyncer) StateSet(state string) { f.cmds = append(f.cmds, "STATE:SET:"+state) }
+
+func TestPicoStateForToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceToken string
+		want        string
+	}{
+		{name: "empty token is unpaired", deviceToken: "", want: "UNPAIRED"},
+		{name: "non-empty token is paired", deviceToken: "tok-abc123", want: "PAIRED"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := picoStateForToken(tc.deviceToken); got != tc.want {
+				t.Fatalf("picoStateForToken(%q) = %q, want %q", tc.deviceToken, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResyncPicoState verifies the post-flash resync emits the same hardware
+// reset plus STATE:SET sequence the startup path does, deriving the persisted
+// phase from the live device token. This is the behavior missing on the runtime
+// firmware-flash path that left the fleet breathing at idle.
+func TestResyncPicoState(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceToken string
+		want        []string
+	}{
+		{
+			name:        "paired device resyncs to PAIRED",
+			deviceToken: "tok-abc123",
+			want:        []string{"STOP_RING", "LED:UNLOCK", "STATE:SET:PAIRED"},
+		},
+		{
+			name:        "unpaired device resyncs to UNPAIRED",
+			deviceToken: "",
+			want:        []string{"STOP_RING", "LED:UNLOCK", "STATE:SET:UNPAIRED"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakePicoResyncer{}
+			resyncPicoState(f, tc.deviceToken)
+			if !reflect.DeepEqual(f.cmds, tc.want) {
+				t.Fatalf("resyncPicoState commands = %v, want %v", f.cmds, tc.want)
+			}
+		})
+	}
+}
+
+// TestResetPicoHardware locks in that the hardware reset clears ring and LED and
+// never touches the persisted phase, so resyncPicoState is the only path that
+// emits STATE:SET.
+func TestResetPicoHardware(t *testing.T) {
+	f := &fakePicoResyncer{}
+	resetPicoHardware(f)
+	want := []string{"STOP_RING", "LED:UNLOCK"}
+	if !reflect.DeepEqual(f.cmds, want) {
+		t.Fatalf("resetPicoHardware commands = %v, want %v", f.cmds, want)
+	}
+}


### PR DESCRIPTION
## The bug

When digitsd's runtime auto-updater applies a firmware-only update (`release_available` -> updater flashes the Pico via `flash-pico.sh`), the Pico reboots. Its firmware boots into `PHASE_PAIRED`, which `firmware/src/main.c` maps to `LED_MODE_BREATHING` at boot by design, expecting the Pi to clear it.

The STARTUP path clears it (`cmd/digitsd/main.go`): after POST it runs `resetPicoHardware(sp)` then `StateSet("PAIRED")`/`("UNPAIRED")`. But the RUNTIME updater path never re-synced Pico state after a flash. The post-flash VERSION re-query (the `requeryFirmware` closure feeding `fwVersionCh`) updated the firmware version and sent `device_info`, then stopped. No `STATE:SET`, no LED command.

## Production evidence

Last night the whole fleet took a firmware-only OTA (`fw/v1.14.1`, with pi already current at `1.42.11`). The journal on every phone showed, after `Flash complete`: a successful `VERSION` re-query, a `device_info` send to signald, and then nothing serial-bound. No `STATE:SET` and no LED command were ever emitted, so every phone stayed on the breathing idle LED. Previous firmware OTAs always rode along with a pi update whose daemon restart cleared the LED via the startup path, which is why this never surfaced before.

## The fix

Re-sync Pico state in the `fwVersionCh` consumer, the existing post-flash VERSION re-query handler. A successful re-query already proves the Pico finished rebooting and is answering UART again, which is exactly the liveness signal the resync needs. It now runs `resetPicoHardware` + `StateSet`, deriving the phase the same way startup does (`DeviceToken == "" ? "UNPAIRED" : "PAIRED"`) through a shared `picoStateForToken` helper so the two paths stay in lockstep.

Seam choice: the resync lives in `cmd/digitsd` where the serial port and live config are in scope, not in `internal/updater`. The updater already signals post-flash liveness through its existing `afterFirmwareUpdated` -> `requeryFirmware` -> `fwVersionCh` chain, so no new wiring was needed and the updater package stays free of serial dependencies.

Scope and safety:

- The resync runs on every Pico reboot re-query, not only firmware OTAs. That is intentional and matches startup, which resyncs unconditionally after POST: any reboot (runtime flash, external SWD, power cycle) leaves the chip breathing and needs the same clear. It is harmless on the pi-binary-only update path because that path restarts the daemon and the startup resync covers it.
- It skips while a call is active (`callPeer != ""`) so a mid-call Pico power cycle cannot stomp the call LED. The OTA flash path is already idle-gated by `runAutoUpdate` (which defers when in a call), so this guard is non-redundant only for the external-reboot case and does not duplicate the OTA gate.
- No recovery/setup regression: the resync only runs in normal mode (the other modes do not consume `fwVersionCh`), and it derives the phase from the device token exactly as normal-mode startup does.

## Test coverage

`cmd/digitsd/postflash_resync_test.go` fakes the serial boundary (the same recording-fake pattern as `linkhealth_test.go`) and asserts:

- `picoStateForToken` maps empty token to `UNPAIRED` and a non-empty token to `PAIRED`.
- `resyncPicoState` emits exactly `STOP_RING`, `LED:UNLOCK`, `STATE:SET:<state>` for both pairing states.
- `resetPicoHardware` clears ring and LED and never emits `STATE:SET`.

## Why fix-typed

The device behavior changes: phones that were stuck breathing now return to the correct idle LED after a firmware OTA. Fix-typed also intentionally triggers a pi release; that release rolling out to the fleet is itself the remediation that clears the currently-stuck LEDs on remote devices.

## Verification

From `pi/digitsd`, all green:

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `golangci-lint run ./...` (0 issues)
- `go test -race ./cmd/digitsd/`