### PR TITLE
feat(digitsd): drop the never-sent contacts/sync signaling messages

### DIFF
--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
-	"github.com/justinlindh/digits/pi/digitsd/internal/contacts"
 	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
@@ -22,7 +21,6 @@ import (
 type signalController interface {
 	HandleSignal(msgType, sender string)
 	State() phone.State
-	SetContactChecker(cc phone.ContactChecker)
 	SetCallReturnNumber(number string)
 	ResetToDialtone()
 	HandleCallReturnRing(target string)
@@ -45,8 +43,8 @@ var _ signalController = (*phone.Controller)(nil)
 //
 // Dependencies that the handlers need but that are owned by the run loop
 // (serial port, signaling client, mixer, controller, the firmware-update
-// closures, the pairing-refresh timer, the contacts cache) are stored on
-// daemonCallbacks and wired once before the loop starts.
+// closures, the pairing-refresh timer) are stored on daemonCallbacks and
+// wired once before the loop starts.
 func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 	ctrl := d.ctrlSignal
 	mixer := d.mixer
@@ -273,19 +271,6 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 	case sigclient.TypeFactoryReset:
 		slog.Info("factory reset: triggered by server")
 		go triggerFactoryReset(d.currentSig(), d.deviceID)
-
-	case sigclient.TypeContacts, sigclient.TypeContactsUpdated:
-		entries := make([]contacts.Entry, 0, len(msg.Contacts))
-		for _, c := range msg.Contacts {
-			entries = append(entries, contacts.Entry{Number: c.Number, Name: c.Name})
-		}
-		d.contactsCache.Update(entries)
-		if len(entries) > 0 {
-			ctrl.SetContactChecker(d.contactsCache)
-		} else {
-			ctrl.SetContactChecker(nil)
-		}
-		slog.Info("contacts: updated", "count", len(entries), "type", msg.Type)
 
 	case sigclient.TypeICERestart:
 		d.mu.Lock()

--- a/pi/digitsd/cmd/digitsd/dispatch_test.go
+++ b/pi/digitsd/cmd/digitsd/dispatch_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
-	"github.com/justinlindh/digits/pi/digitsd/internal/contacts"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 )
@@ -21,8 +20,6 @@ type fakeController struct {
 	mu             sync.Mutex
 	state          phone.State
 	signals        []signalCall
-	contactChecker phone.ContactChecker
-	contactSetN    int
 	callReturnNum  string
 	callReturnRing string
 	confMember     []confMemberCall
@@ -55,13 +52,6 @@ func (f *fakeController) State() phone.State {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.state
-}
-
-func (f *fakeController) SetContactChecker(cc phone.ContactChecker) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.contactChecker = cc
-	f.contactSetN++
 }
 
 func (f *fakeController) SetCallReturnNumber(number string) {
@@ -131,7 +121,6 @@ func newDispatchDaemon(t *testing.T, fc *fakeController) *daemonCallbacks {
 	d := &daemonCallbacks{}
 	d.mixer = audio.NewMixer(nopWriter{})
 	d.ctrlSignal = fc
-	d.contactsCache = contacts.NewCache(filepath.Join(t.TempDir(), "contacts.json"))
 	return d
 }
 
@@ -264,49 +253,6 @@ func TestDispatchRouting_FSMDelegating(t *testing.T) {
 	})
 }
 
-// TestDispatchRouting_ContactsUpdatesCacheAndChecker checks both the cache
-// write and the controller wiring for the contacts path, including the
-// distinction between a populated update (install checker) and an empty one
-// (clear checker).
-func TestDispatchRouting_ContactsUpdatesCacheAndChecker(t *testing.T) {
-	for _, mt := range []string{sigclient.TypeContacts, sigclient.TypeContactsUpdated} {
-		t.Run(mt+" populated", func(t *testing.T) {
-			fc := &fakeController{}
-			d := newDispatchDaemon(t, fc)
-			d.handleSignal(&sigclient.Message{
-				Type:     mt,
-				Contacts: []sigclient.ContactEntry{{Number: "3140001", Name: "Alice"}},
-			})
-			if d.contactsCache.Count() != 1 {
-				t.Errorf("cache count = %d, want 1", d.contactsCache.Count())
-			}
-			if !d.contactsCache.IsContact("3140001") {
-				t.Errorf("expected 3140001 to be a contact")
-			}
-			if fc.contactChecker == nil {
-				t.Errorf("expected contact checker to be installed for populated update")
-			}
-		})
-	}
-
-	t.Run("empty update clears checker", func(t *testing.T) {
-		fc := &fakeController{}
-		d := newDispatchDaemon(t, fc)
-		// Seed a checker first, then clear it with an empty update.
-		d.handleSignal(&sigclient.Message{
-			Type:     sigclient.TypeContacts,
-			Contacts: []sigclient.ContactEntry{{Number: "3140001"}},
-		})
-		d.handleSignal(&sigclient.Message{Type: sigclient.TypeContactsUpdated})
-		if d.contactsCache.Count() != 0 {
-			t.Errorf("cache count = %d after empty update, want 0", d.contactsCache.Count())
-		}
-		if fc.contactChecker != nil {
-			t.Errorf("expected contact checker cleared for empty update")
-		}
-	})
-}
-
 // TestDispatchRouting_ICEServersCached confirms the ICE-servers handler
 // stashes the server list on the daemon for the next peer connection.
 func TestDispatchRouting_ICEServersCached(t *testing.T) {
@@ -404,7 +350,7 @@ func TestDispatchRouting_UnknownTypeIsInertDefault(t *testing.T) {
 	if _, ok := fc.lastSignal(); ok {
 		t.Errorf("unknown type reached a controller handler: %+v", fc.signals)
 	}
-	if fc.contactSetN != 0 || len(fc.confMember) != 0 {
+	if fc.callReturnNum != "" || len(fc.confMember) != 0 {
 		t.Errorf("unknown type produced side effects on the controller")
 	}
 }

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -166,12 +166,11 @@ type daemonCallbacks struct {
 	// daemon (set-once) and are read by handleSignal; flashCapable and
 	// pairingRefresh are shared by identity with the run loop so a reset or
 	// load in either place is seen by the other.
-	deviceID        string          // hardware device ID, reported on factory reset
-	serverURL       string          // effective signaling server URL
-	flashCapable    *atomic.Bool    // SWD-flash capability (shared with run loop)
-	requeryFirmware func()          // re-query Pico firmware version off the main loop
-	contactsCache   *contacts.Cache // local contact list cache
-	pairingRefresh  *time.Timer     // pairing-code refresh timer (shared with run loop)
+	deviceID        string       // hardware device ID, reported on factory reset
+	serverURL       string       // effective signaling server URL
+	flashCapable    *atomic.Bool // SWD-flash capability (shared with run loop)
+	requeryFirmware func()       // re-query Pico firmware version off the main loop
+	pairingRefresh  *time.Timer  // pairing-code refresh timer (shared with run loop)
 
 	// Voicemail state. voicemailStore is opened once at startup and is nil
 	// when the feature is disabled or initialization failed. recorder is the
@@ -1911,9 +1910,9 @@ func main() {
 	}
 	getPhoneState = func() phone.State { return ctrl.State() }
 
-	// 8b. Contacts cache: optional dial safelist, persisted to disk.
-	// An empty cache leaves the checker nil so no-contacts phones allow
-	// every call (matching the pre-wiring behavior).
+	// 8b. Contacts cache: optional dial safelist, loaded from a hand-placed
+	// contacts.json. An empty cache leaves the checker nil so no-contacts
+	// phones allow every call (matching the pre-wiring behavior).
 	contactsPath := filepath.Join(filepath.Dir(*configPath), "contacts.json")
 	contactsCache := contacts.NewCache(contactsPath)
 	if err := contactsCache.Load(); err != nil {
@@ -2070,7 +2069,6 @@ func main() {
 	cb.serverURL = effectiveServerURL
 	cb.flashCapable = &flashCapable
 	cb.requeryFirmware = requeryFirmware
-	cb.contactsCache = contactsCache
 	cb.pairingRefresh = pairingRefresh
 
 	// pairingAnnouncementCancel cancels the in-flight pairing-announcement

--- a/pi/digitsd/internal/contacts/cache.go
+++ b/pi/digitsd/internal/contacts/cache.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
-	"log/slog"
 	"os"
 	"sync"
 )
@@ -15,39 +14,18 @@ type Entry struct {
 	Name   string `json:"name"`
 }
 
-// Cache is a thread-safe in-memory contact list with optional JSON file persistence.
+// Cache is a thread-safe in-memory contact list loaded from a JSON file.
 type Cache struct {
 	mu       sync.RWMutex
 	contacts map[string]string // number → name
-	path     string            // file path for persistence (empty = no persistence)
+	path     string            // file path to load from (empty = always empty cache)
 }
 
-// NewCache creates a new Cache. If path is non-empty, Save/Load will use that file.
+// NewCache creates a new Cache. If path is non-empty, Load will read that file.
 func NewCache(path string) *Cache {
 	return &Cache{
 		contacts: make(map[string]string),
 		path:     path,
-	}
-}
-
-// setLocked replaces the contact map. Caller must hold c.mu write lock.
-func (c *Cache) setLocked(entries []Entry) {
-	c.contacts = make(map[string]string, len(entries))
-	for _, e := range entries {
-		c.contacts[e.Number] = e.Name
-	}
-}
-
-// Update replaces the entire contact list and persists to disk.
-func (c *Cache) Update(entries []Entry) {
-	c.mu.Lock()
-	c.setLocked(entries)
-	c.mu.Unlock()
-
-	if c.path != "" {
-		if err := c.Save(); err != nil {
-			slog.Error("contacts: save failed", "error", err)
-		}
 	}
 }
 
@@ -64,25 +42,6 @@ func (c *Cache) Count() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.contacts)
-}
-
-// Save writes the contact list to the configured file path as JSON.
-func (c *Cache) Save() error {
-	if c.path == "" {
-		return nil
-	}
-	c.mu.RLock()
-	entries := make([]Entry, 0, len(c.contacts))
-	for num, name := range c.contacts {
-		entries = append(entries, Entry{Number: num, Name: name})
-	}
-	c.mu.RUnlock()
-
-	data, err := json.MarshalIndent(entries, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(c.path, data, 0600)
 }
 
 // Load reads the contact list from the configured file path.
@@ -102,8 +61,12 @@ func (c *Cache) Load() error {
 	if err := json.Unmarshal(data, &entries); err != nil {
 		return err
 	}
+	contacts := make(map[string]string, len(entries))
+	for _, e := range entries {
+		contacts[e.Number] = e.Name
+	}
 	c.mu.Lock()
-	c.setLocked(entries)
+	c.contacts = contacts
 	c.mu.Unlock()
 	return nil
 }

--- a/pi/digitsd/internal/contacts/cache_test.go
+++ b/pi/digitsd/internal/contacts/cache_test.go
@@ -13,12 +13,25 @@ func TestCache_IsContact_Empty(t *testing.T) {
 	}
 }
 
-func TestCache_Update_And_IsContact(t *testing.T) {
-	c := NewCache("")
-	c.Update([]Entry{
-		{Number: "5551234", Name: "Emma"},
-		{Number: "5559876", Name: "Liam"},
-	})
+// writeContacts writes a contacts JSON file and returns its path.
+func writeContacts(t *testing.T, json string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "contacts.json")
+	if err := os.WriteFile(path, []byte(json), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestCache_Load_And_IsContact(t *testing.T) {
+	path := writeContacts(t, `[
+		{"number":"5551234","name":"Emma"},
+		{"number":"5559876","name":"Liam"}
+	]`)
+	c := NewCache(path)
+	if err := c.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
 
 	if !c.IsContact("5551234") {
 		t.Error("expected 5551234 to be a contact")
@@ -31,67 +44,22 @@ func TestCache_Update_And_IsContact(t *testing.T) {
 	}
 }
 
-func TestCache_Update_Replaces(t *testing.T) {
-	c := NewCache("")
-	c.Update([]Entry{
-		{Number: "5551234", Name: "Emma"},
-		{Number: "5559876", Name: "Liam"},
-	})
-	c.Update([]Entry{
-		{Number: "5550000", Name: "Olivia"},
-	})
-
-	if c.IsContact("5551234") {
-		t.Error("old contact 5551234 should be gone after update")
-	}
-	if !c.IsContact("5550000") {
-		t.Error("new contact 5550000 should be present")
-	}
-}
-
 func TestCache_Count(t *testing.T) {
 	c := NewCache("")
 	if c.Count() != 0 {
 		t.Errorf("expected 0, got %d", c.Count())
 	}
-	c.Update([]Entry{
-		{Number: "5551234", Name: "Emma"},
-		{Number: "5559876", Name: "Liam"},
-	})
-	if c.Count() != 2 {
-		t.Errorf("expected 2, got %d", c.Count())
-	}
-}
 
-func TestCache_PersistAndLoad(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "contacts.json")
-
-	c1 := NewCache(path)
-	c1.Update([]Entry{
-		{Number: "5551234", Name: "Emma"},
-		{Number: "5559876", Name: "Liam"},
-	})
-	if err := c1.Save(); err != nil {
-		t.Fatalf("save: %v", err)
-	}
-
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("expected file at %s: %v", path, err)
-	}
-
-	c2 := NewCache(path)
-	if err := c2.Load(); err != nil {
+	path := writeContacts(t, `[
+		{"number":"5551234","name":"Emma"},
+		{"number":"5559876","name":"Liam"}
+	]`)
+	c = NewCache(path)
+	if err := c.Load(); err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if c2.Count() != 2 {
-		t.Fatalf("expected 2 contacts after load, got %d", c2.Count())
-	}
-	if !c2.IsContact("5551234") {
-		t.Error("expected 5551234 after load")
-	}
-	if !c2.IsContact("5559876") {
-		t.Error("expected 5559876 after load")
+	if c.Count() != 2 {
+		t.Errorf("expected 2, got %d", c.Count())
 	}
 }
 
@@ -105,9 +73,13 @@ func TestCache_Load_NoFile(t *testing.T) {
 	}
 }
 
-func TestCache_Save_NoPath(t *testing.T) {
-	c := NewCache("")
-	if err := c.Save(); err != nil {
-		t.Fatalf("save with no path should succeed, got: %v", err)
+func TestCache_Load_InvalidJSON(t *testing.T) {
+	path := writeContacts(t, `{not json`)
+	c := NewCache(path)
+	if err := c.Load(); err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if c.Count() != 0 {
+		t.Errorf("failed load should leave cache empty, got %d", c.Count())
 	}
 }

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -4,21 +4,18 @@ import "encoding/json"
 
 // Message types (must match server/internal/signaling/protocol.go)
 const (
-	TypeRegister        = "register"
-	TypeCall            = "call"
-	TypeRing            = "ring"
-	TypeSDP             = "sdp"
-	TypeICE             = "ice"
-	TypeAnswer          = "answer"
-	TypeHangup          = "hangup"
-	TypeBusy            = "busy"
-	TypeDTMF            = "dtmf"
-	TypeError           = "error"
-	TypeICEServers      = "ice-servers"
-	TypeRequestICE      = "request-ice-servers"
-	TypeSync            = "sync"
-	TypeContacts        = "contacts"
-	TypeContactsUpdated = "contacts_updated"
+	TypeRegister   = "register"
+	TypeCall       = "call"
+	TypeRing       = "ring"
+	TypeSDP        = "sdp"
+	TypeICE        = "ice"
+	TypeAnswer     = "answer"
+	TypeHangup     = "hangup"
+	TypeBusy       = "busy"
+	TypeDTMF       = "dtmf"
+	TypeError      = "error"
+	TypeICEServers = "ice-servers"
+	TypeRequestICE = "request-ice-servers"
 
 	// TypePairingCode is sent by the server during registration when a device
 	// is not yet paired. The client should display the code (e.g. on an LED
@@ -127,12 +124,6 @@ type LinkHealthPayload struct {
 	Peer string `json:"peer,omitempty"`
 }
 
-// ContactEntry represents a single contact in a sync payload.
-type ContactEntry struct {
-	Number string `json:"number"`
-	Name   string `json:"name"`
-}
-
 // LineSettings is the wire-format copy of server-side line.Settings used in
 // signaling messages. Mirrors the server definition so digitsd doesn't need
 // to import any server code.
@@ -172,22 +163,21 @@ type ICEServer struct {
 
 // Message is the shared signaling envelope used between client and server.
 type Message struct {
-	Type        string         `json:"type"`
-	From        string         `json:"from,omitempty"`
-	To          string         `json:"to,omitempty"`
-	Number      string         `json:"number,omitempty"`
-	Digit       string         `json:"digit,omitempty"`
-	SDP         string         `json:"sdp,omitempty"`
-	Candidate   string         `json:"candidate,omitempty"`
-	Error       string         `json:"error,omitempty"`
-	Servers     []ICEServer    `json:"servers,omitempty"`
-	Contacts    []ContactEntry `json:"contacts,omitempty"`
-	PairingCode string         `json:"pairing_code,omitempty"`
+	Type        string      `json:"type"`
+	From        string      `json:"from,omitempty"`
+	To          string      `json:"to,omitempty"`
+	Number      string      `json:"number,omitempty"`
+	Digit       string      `json:"digit,omitempty"`
+	SDP         string      `json:"sdp,omitempty"`
+	Candidate   string      `json:"candidate,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	Servers     []ICEServer `json:"servers,omitempty"`
+	PairingCode string      `json:"pairing_code,omitempty"`
 	// PairingCodeTTL is the server-reported validity of PairingCode, in
 	// seconds. Drives the spoken countdown and the pre-expiry refresh.
-	PairingCodeTTL int            `json:"pairing_code_ttl,omitempty"`
-	HardwareID     string         `json:"hardware_id,omitempty"`
-	DeviceToken    string         `json:"device_token,omitempty"`
+	PairingCodeTTL int    `json:"pairing_code_ttl,omitempty"`
+	HardwareID     string `json:"hardware_id,omitempty"`
+	DeviceToken    string `json:"device_token,omitempty"`
 
 	// Version info (device_info messages)
 	PiVersion       string `json:"pi_version,omitempty"`

--- a/pi/digitsd/internal/signal/protocol_test.go
+++ b/pi/digitsd/internal/signal/protocol_test.go
@@ -111,37 +111,6 @@ func TestParseMessage_Invalid(t *testing.T) {
 	}
 }
 
-func TestParseContactsMessage(t *testing.T) {
-	raw := `{"type":"contacts","contacts":[{"number":"5551234","name":"Emma"},{"number":"5559876","name":"Liam"}]}`
-	msg, err := ParseMessage([]byte(raw))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if msg.Type != TypeContacts {
-		t.Errorf("expected type %q, got %q", TypeContacts, msg.Type)
-	}
-	if len(msg.Contacts) != 2 {
-		t.Fatalf("expected 2 contacts, got %d", len(msg.Contacts))
-	}
-	if msg.Contacts[0].Number != "5551234" || msg.Contacts[0].Name != "Emma" {
-		t.Errorf("unexpected contact[0]: %+v", msg.Contacts[0])
-	}
-	if msg.Contacts[1].Number != "5559876" || msg.Contacts[1].Name != "Liam" {
-		t.Errorf("unexpected contact[1]: %+v", msg.Contacts[1])
-	}
-}
-
-func TestParseContactsUpdatedNudge(t *testing.T) {
-	raw := `{"type":"contacts_updated"}`
-	msg, err := ParseMessage([]byte(raw))
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if msg.Type != TypeContactsUpdated {
-		t.Errorf("expected type %q, got %q", TypeContactsUpdated, msg.Type)
-	}
-}
-
 func TestParseICERestartMessage(t *testing.T) {
 	raw := `{"type":"ice_restart","from":"3140001","to":"3140002","sdp":"v=0\r\n"}`
 	msg, err := ParseMessage([]byte(raw))
@@ -156,21 +125,6 @@ func TestParseICERestartMessage(t *testing.T) {
 	}
 	if msg.SDP != "v=0\r\n" {
 		t.Errorf("expected SDP %q, got %q", "v=0\r\n", msg.SDP)
-	}
-}
-
-func TestParseSyncRequest(t *testing.T) {
-	msg := &Message{Type: TypeSync}
-	data, err := msg.Marshal()
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	parsed, err := ParseMessage(data)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	if parsed.Type != TypeSync {
-		t.Errorf("expected type %q, got %q", TypeSync, parsed.Type)
 	}
 }
 


### PR DESCRIPTION
## Why

The digitsd signaling protocol defines `sync`, `contacts`, and `contacts_updated` message types, and the daemon carries a full receive path for server-pushed contact lists: a `Contacts` field on the wire envelope, a `ContactEntry` type, a dispatch case that updates the cache and swaps the dial-filter checker, and the cache's `Update`/`Save` write half.

The server has never sent any of these. `git log -S '"contacts"' -- server` finds no commit that ever produced them, the server's `protocol.go` has no matching constants, and the server-side contacts tables were dropped in schema v6 when households/lines replaced them. The digitsd protocol header says `must match server/internal/signaling/protocol.go`; these three types are exactly the mismatch.

## What

- Remove `TypeSync`, `TypeContacts`, `TypeContactsUpdated`, `ContactEntry`, and the `Contacts` envelope field from `internal/signal/protocol.go`.
- Remove the contacts dispatch case, the `contactsCache` dispatcher field, and `SetContactChecker` from the dispatch-facing controller interface (main still calls it on the concrete controller).
- Trim `contacts.Cache` to its live surface: `Load`, `IsContact`, `Count`. The write half (`Update`/`Save`) existed only for the server push.
- Update tests accordingly; cache tests now exercise the load path directly, including a new invalid-JSON case.

## Why this scope

The dial-safelist feature itself stays: a hand-placed `contacts.json` is still loaded at startup and wired into the controller exactly as before, so device behavior is unchanged. Going smaller (constants only) would leave dead dispatch and cache code behind; going bigger (removing the safelist entirely) would delete a working, product-relevant feature rather than dead protocol surface.

Validated with `go build ./... && go test ./... && golangci-lint run ./...` in `pi/digitsd`.