### PR TITLE
refactor(server): drop the dead settings key/value table

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -78,10 +78,6 @@ func (d *Database) migrate() error {
 			ended_at    TIMESTAMPTZ,
 			duration_s  INTEGER DEFAULT 0
 		)`,
-		`CREATE TABLE IF NOT EXISTS settings (
-			key   TEXT PRIMARY KEY,
-			value TEXT NOT NULL
-		)`,
 		// v2: user accounts + auth
 		`CREATE TABLE IF NOT EXISTS users (
 			id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -493,6 +489,10 @@ END $$;`,
 		// v29: remove household-level do_not_disturb flag. "Silence All" is
 		// now derived from per-line silent_mode settings.
 		`ALTER TABLE households DROP COLUMN IF EXISTS do_not_disturb`,
+		// v30: drop the settings key/value table, a v1 SQLite-port artifact
+		// that no code ever read or wrote. Its CREATE is gone from v1 above
+		// so fresh databases never get it; this drop covers existing ones.
+		`DROP TABLE IF EXISTS settings`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {


### PR DESCRIPTION
The `settings` key/value table came over in the v1 SQLite port and no code has ever read or written it: `git log -S 'FROM settings'` and `-S 'INTO settings'` find nothing in the repo's history, and the only reference today is the `CREATE TABLE` itself. Every deployment carries an empty dead table.

Two changes, following the v6 precedent of dropping superseded tables:

- Remove the `CREATE TABLE settings` from the v1 block, so fresh databases never get it. The early migrations are plain idempotent statements (only the `DO $$` blocks are version-gated), so removing a statement from the list is safe.
- Append a v30 `DROP TABLE IF EXISTS settings` for databases that already have it.

Verified against a local Postgres 16: the full integration suite passes (`go test -tags=integration -race -count=1 -p 1 ./...`, 24 packages ok), a database migrated with a pre-existing populated `settings` table ends up without it, and `TestMigrateIsIdempotent` covers the re-run path. Unit tests and golangci-lint also pass.