### PR TITLE
feat(server,digitsd,image): add web-app developer-mode toggle (SSH + dev UI)

### DIFF
--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"errors"
@@ -13,10 +14,116 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 )
+
+// devModeHelperPath is the privileged helper that performs the root-level work
+// of toggling developer mode (SSH host keys, the dev user, ssh.service). It is
+// invoked via the single sudoers allowlist entry in /etc/sudoers.d/digits-updater.
+const devModeHelperPath = "/usr/local/bin/digits-devmode"
+
+// runDevModeHelper shells out to the privileged helper to enable or disable
+// developer mode. When enabling, the new SSH login password is piped on stdin
+// so it never appears in the process list.
+func runDevModeHelper(enable bool, password string) error {
+	sub := "disable"
+	if enable {
+		sub = "enable"
+	}
+	cmd := exec.Command("sudo", devModeHelperPath, sub)
+	if enable {
+		cmd.Stdin = strings.NewReader(password + "\n")
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("digits-devmode %s: %w: %s", sub, err, bytes.TrimSpace(out))
+	}
+	slog.Info("devmode: helper applied", "action", sub, "output", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// devModeManager owns the lifecycle of the on-device dev web UI listener and
+// the privileged enable/disable transitions. It lets the daemon flip dev mode
+// at runtime (in response to a server command) without a restart.
+//
+// apply performs the privileged work; it is a field so tests can inject a stub
+// in place of the real sudo invocation.
+type devModeManager struct {
+	cfg   *devModeConfig
+	apply func(enable bool, password string) error
+	start func(*devModeConfig) (net.Listener, error)
+
+	mu sync.Mutex
+	ln net.Listener
+}
+
+func newDevModeManager(cfg *devModeConfig) *devModeManager {
+	return &devModeManager{cfg: cfg, apply: runDevModeHelper, start: startDevModeServer}
+}
+
+func (m *devModeManager) startListenerLocked() error {
+	if m.ln != nil {
+		return nil
+	}
+	ln, err := m.start(m.cfg)
+	if err != nil {
+		return err
+	}
+	m.ln = ln
+	return nil
+}
+
+func (m *devModeManager) stopListenerLocked() {
+	if m.ln != nil {
+		_ = m.ln.Close()
+		m.ln = nil
+	}
+}
+
+// EnsureListener starts the dev web UI if it is not already running. Used at
+// boot when the dev-mode flag is already present.
+func (m *devModeManager) EnsureListener() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.startListenerLocked()
+}
+
+// Enable runs the privileged helper to turn dev mode on (creating the dev user,
+// setting its SSH password, starting ssh.service) and then starts the dev web
+// UI listener.
+func (m *devModeManager) Enable(password string) error {
+	if err := m.apply(true, password); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.startListenerLocked()
+}
+
+// Disable runs the privileged helper to turn dev mode off (stopping
+// ssh.service, locking the dev account, clearing the flag) and then stops the
+// dev web UI listener.
+func (m *devModeManager) Disable() error {
+	if err := m.apply(false, ""); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopListenerLocked()
+	return nil
+}
+
+// Close shuts down the listener without changing privileged state. Used on
+// daemon shutdown.
+func (m *devModeManager) Close() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopListenerLocked()
+}
 
 //go:embed devmode_static
 var devmodeStaticFS embed.FS

--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -94,25 +94,27 @@ func (m *devModeManager) EnsureListener() error {
 
 // Enable runs the privileged helper to turn dev mode on (creating the dev user,
 // setting its SSH password, starting ssh.service) and then starts the dev web
-// UI listener.
+// UI listener. The lock is held across apply so concurrent dev_mode commands
+// can't run two helper processes that race on the rootfs remount.
 func (m *devModeManager) Enable(password string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if err := m.apply(true, password); err != nil {
 		return err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return m.startListenerLocked()
 }
 
 // Disable runs the privileged helper to turn dev mode off (stopping
 // ssh.service, locking the dev account, clearing the flag) and then stops the
-// dev web UI listener.
+// dev web UI listener. The lock is held across apply for the same reason as
+// Enable: serialize the privileged transition.
 func (m *devModeManager) Disable() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if err := m.apply(false, ""); err != nil {
 		return err
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.stopListenerLocked()
 	return nil
 }

--- a/pi/digitsd/cmd/digitsd/devmode_test.go
+++ b/pi/digitsd/cmd/digitsd/devmode_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +13,99 @@ import (
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 )
+
+// newTestListener returns a real, closeable loopback listener for manager tests
+// so they never bind the fixed :8080 dev-UI port.
+func newTestListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln
+}
+
+func TestDevModeManager_EnablePassesPasswordAndStartsListener(t *testing.T) {
+	var gotEnable bool
+	var gotPassword string
+	startCalls := 0
+	m := &devModeManager{
+		cfg: &devModeConfig{},
+		apply: func(enable bool, password string) error {
+			gotEnable = enable
+			gotPassword = password
+			return nil
+		},
+		start: func(*devModeConfig) (net.Listener, error) {
+			startCalls++
+			return newTestListener(t), nil
+		},
+	}
+
+	if err := m.Enable("hunter2pw"); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if !gotEnable {
+		t.Error("apply called with enable=false, want true")
+	}
+	if gotPassword != "hunter2pw" {
+		t.Errorf("password = %q, want hunter2pw", gotPassword)
+	}
+	if startCalls != 1 {
+		t.Errorf("start calls = %d, want 1", startCalls)
+	}
+
+	// Re-enabling does not start a second listener.
+	if err := m.Enable("hunter2pw"); err != nil {
+		t.Fatalf("Enable (2nd): %v", err)
+	}
+	if startCalls != 1 {
+		t.Errorf("start calls after re-enable = %d, want 1", startCalls)
+	}
+	m.Close()
+}
+
+func TestDevModeManager_DisableStopsListener(t *testing.T) {
+	var gotEnable = true
+	m := &devModeManager{
+		cfg:   &devModeConfig{},
+		apply: func(enable bool, _ string) error { gotEnable = enable; return nil },
+		start: func(*devModeConfig) (net.Listener, error) { return newTestListener(t), nil },
+	}
+	if err := m.EnsureListener(); err != nil {
+		t.Fatalf("EnsureListener: %v", err)
+	}
+	if m.ln == nil {
+		t.Fatal("listener not started by EnsureListener")
+	}
+	if err := m.Disable(); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if gotEnable {
+		t.Error("apply called with enable=true on Disable, want false")
+	}
+	if m.ln != nil {
+		t.Error("listener not stopped by Disable")
+	}
+}
+
+func TestDevModeManager_ApplyErrorLeavesListenerUnchanged(t *testing.T) {
+	startCalls := 0
+	m := &devModeManager{
+		cfg:   &devModeConfig{},
+		apply: func(bool, string) error { return errors.New("helper boom") },
+		start: func(*devModeConfig) (net.Listener, error) { startCalls++; return newTestListener(t), nil },
+	}
+	if err := m.Enable("pw12345678"); err == nil {
+		t.Fatal("Enable: want error, got nil")
+	}
+	if startCalls != 0 {
+		t.Errorf("start calls = %d, want 0 (apply failed)", startCalls)
+	}
+	if m.ln != nil {
+		t.Error("listener started despite apply failure")
+	}
+}
 
 func TestDevModeStatusHandler(t *testing.T) {
 	dir := t.TempDir()

--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -430,6 +430,31 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 			slog.Info("ring test: stopped")
 		}()
 
+	case sigclient.TypeDevMode:
+		enable := msg.DevMode
+		password := msg.DevModePassword
+		slog.Info("dev mode: command received", "enable", enable)
+		if d.devMode == nil {
+			slog.Warn("dev mode: manager unavailable, ignoring command")
+			break
+		}
+		go func() {
+			var err error
+			if enable {
+				err = d.devMode.Enable(password)
+			} else {
+				err = d.devMode.Disable()
+			}
+			if err != nil {
+				slog.Error("dev mode: apply failed", "enable", enable, "error", err)
+				return
+			}
+			// Re-report device_info so the server reflects the new state;
+			// sendDeviceInfo reads the flag the helper just wrote.
+			fwVer, fwCom := d.getFirmwareVersion()
+			sendDeviceInfo(d.currentSig(), fwVer, fwCom)
+		}()
+
 	case sigclient.TypeLineSettings:
 		if msg.LineSettings == nil {
 			slog.Warn("line_settings message missing payload", "from", msg.From)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -172,6 +172,7 @@ type daemonCallbacks struct {
 	requeryFirmware func()          // re-query Pico firmware version off the main loop
 	contactsCache   *contacts.Cache // local contact list cache
 	pairingRefresh  *time.Timer     // pairing-code refresh timer (shared with run loop)
+	devMode         *devModeManager // dev-mode (SSH + dev web UI) lifecycle; nil outside normal mode
 
 	// Voicemail state. voicemailStore is opened once at startup and is nil
 	// when the feature is disabled or initialization failed. recorder is the
@@ -1970,55 +1971,57 @@ func main() {
 	phone.RestoreVolume()
 	slog.Info("digitsd ready")
 
-	// Dev-mode web UI on :8080 (only when the flag file is present).
+	// Dev-mode web UI on :8080. The manager is always constructed so a runtime
+	// dev_mode command can start it without a restart; the listener only comes
+	// up when the flag is present (now, at boot) or when enabled later.
+	//
+	// Snapshot the phase once at startup; it rarely changes during normal
+	// operation and querying UART on every HTTP poll is wasteful.
+	startupPhase := cachedPhase
+	devCfg := &devModeConfig{
+		FlagPath:           devmode.DefaultFlagPath,
+		SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,
+		SkipAutoUpdatePath: devmode.DefaultSkipAutoUpdatePath,
+		UARTLogPath:        uartLogPath,
+		CaptureDevice:      audio.CodecCaptureDevice(),
+		StatusFunc: func() devModeStatus {
+			fwVer, fwCom := cb.getFirmwareVersion()
+			return devModeStatus{
+				DigitsdVersion:   version.Version,
+				FirmwareVersion:  fwVer,
+				FirmwareCommit:   fwCom,
+				Phase:            startupPhase,
+				Online:           cb.paired.Load(),
+				PhoneNumber:      effectiveNumber,
+				ConfigAutoUpdate: cb.autoUpdateEnabled.Load(),
+			}
+		},
+	}
+	if flashCapable.Load() {
+		devCfg.FlashFunc = func(elfPath string) error {
+			// Move the uploaded ELF to the standard firmware path, then
+			// invoke the same flash script the OTA updater uses.
+			if err := os.Rename(elfPath, defaultFirmwarePath); err != nil {
+				return fmt.Errorf("stage firmware: %w", err)
+			}
+			cmd := exec.Command("setsid", "bash", defaultFlashScript, defaultFirmwarePath)
+			cmd.Env = append(os.Environ(), "SKIP_SERVICE_CONTROL=1")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("flash script: %w", err)
+			}
+			slog.Info("devmode: flash script succeeded")
+			requeryFirmware()
+			return nil
+		}
+	}
+	cb.devMode = newDevModeManager(devCfg)
+	defer cb.devMode.Close()
 	if devmode.Enabled(devmode.DefaultFlagPath) {
 		slog.Info("devmode: flag present, starting dev-mode web UI")
-		// Snapshot the phase once at startup; it rarely changes during
-		// normal operation and querying UART on every HTTP poll is wasteful.
-		startupPhase := cachedPhase
-		devCfg := &devModeConfig{
-			FlagPath:           devmode.DefaultFlagPath,
-			SkipFWReflashPath:  devmode.DefaultSkipFWReflashPath,
-			SkipAutoUpdatePath: devmode.DefaultSkipAutoUpdatePath,
-			UARTLogPath:        uartLogPath,
-			CaptureDevice:      audio.CodecCaptureDevice(),
-			StatusFunc: func() devModeStatus {
-				fwVer, fwCom := cb.getFirmwareVersion()
-				return devModeStatus{
-					DigitsdVersion:   version.Version,
-					FirmwareVersion:  fwVer,
-					FirmwareCommit:   fwCom,
-					Phase:            startupPhase,
-					Online:           cb.paired.Load(),
-					PhoneNumber:      effectiveNumber,
-					ConfigAutoUpdate: cb.autoUpdateEnabled.Load(),
-				}
-			},
-		}
-		if flashCapable.Load() {
-			devCfg.FlashFunc = func(elfPath string) error {
-				// Move the uploaded ELF to the standard firmware path, then
-				// invoke the same flash script the OTA updater uses.
-				if err := os.Rename(elfPath, defaultFirmwarePath); err != nil {
-					return fmt.Errorf("stage firmware: %w", err)
-				}
-				cmd := exec.Command("setsid", "bash", defaultFlashScript, defaultFirmwarePath)
-				cmd.Env = append(os.Environ(), "SKIP_SERVICE_CONTROL=1")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				if err := cmd.Run(); err != nil {
-					return fmt.Errorf("flash script: %w", err)
-				}
-				slog.Info("devmode: flash script succeeded")
-				requeryFirmware()
-				return nil
-			}
-		}
-		devLn, devErr := startDevModeServer(devCfg)
-		if devErr != nil {
-			slog.Warn("devmode: failed to start web UI", "error", devErr)
-		} else {
-			defer func() { _ = devLn.Close() }()
+		if err := cb.devMode.EnsureListener(); err != nil {
+			slog.Warn("devmode: failed to start web UI", "error", err)
 		}
 	}
 

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -51,6 +51,11 @@ const (
 	// TypeRingTest is sent by the server to briefly ring the bell for hardware verification.
 	TypeRingTest = "ring_test"
 
+	// TypeDevMode is sent by the server to enable or disable developer mode
+	// (SSH + the on-device dev web UI). DevMode carries the on/off intent and,
+	// when enabling, DevModePassword carries the new SSH login password.
+	TypeDevMode = "dev_mode"
+
 	// TypeLineSettings is sent by the server to push an updated Settings blob
 	// for the line this device is registered as. Applied live.
 	TypeLineSettings = "line_settings"
@@ -214,7 +219,12 @@ type Message struct {
 	UpdateDetail string `json:"update_detail,omitempty"` // human-readable detail
 
 	// DevMode indicates the device has dev-mode enabled (device_info messages)
+	// and, on dev_mode command messages, the requested on/off state.
 	DevMode bool `json:"dev_mode,omitempty"`
+
+	// DevModePassword is the new SSH login password carried on a dev_mode
+	// command when enabling. Server -> device only.
+	DevModePassword string `json:"dev_mode_password,omitempty"`
 
 	// Restart fields (restart messages)
 	RestartMode string `json:"restart_mode,omitempty"` // "service" or "reboot"

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -6,6 +6,7 @@
 #   - reload systemd unit definitions after the asset extractor rewrites them
 #   - reboot the device (remote restart, factory reset, or service code)
 #   - clear /data/wifi-configured flag for *#SETUP# Wi-Fi re-provisioning
+#   - toggle developer mode (SSH + dev web UI) via the digits-devmode helper
 digits ALL=(root) NOPASSWD: /usr/bin/mount -o remount\,rw /, /usr/bin/mount -o remount\,ro /
 digits ALL=(root) NOPASSWD: /usr/bin/mkdir -p *
 digits ALL=(root) NOPASSWD: /usr/bin/cp /tmp/asset-* *
@@ -18,3 +19,4 @@ digits ALL=(root) NOPASSWD: /usr/bin/openocd
 digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service, /usr/bin/systemctl daemon-reload
 digits ALL=(root) NOPASSWD: /usr/sbin/reboot
 digits ALL=(root) NOPASSWD: /usr/bin/journalctl -u digitsd *
+digits ALL=(root) NOPASSWD: /usr/local/bin/digits-devmode

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# digits-devmode: enable or disable developer mode on a Digits phone at runtime.
+#
+# Developer mode means: SSH login as user "dev" (password auth), the on-device
+# dev web UI on :8080 (gated by /data/digits/dev-mode), and passwordless sudo
+# for "dev". Release images ship with none of this; this script creates it on
+# demand and tears it back down. Every step is idempotent so re-running is safe.
+#
+# digitsd (running as the unprivileged "digits" user) invokes this via a single
+# sudoers allowlist entry. The enable password is read from stdin so it never
+# appears in the process list.
+#
+# Usage:
+#   digits-devmode enable   # reads the dev login password from stdin
+#   digits-devmode disable
+#   digits-devmode status
+set -euo pipefail
+
+DEV_USER="dev"
+FLAG=/data/digits/dev-mode
+SSH_KEY_DIR=/data/ssh
+SSHD_DROPIN=/etc/ssh/sshd_config.d/digits-dev.conf
+SUDOERS_DROPIN=/etc/sudoers.d/dev-nopasswd
+
+remount_rw() { mount -o remount,rw / ; }
+# The rootfs sometimes refuses an immediate ro transition (a just-written file's
+# page cache is still dirty). Mirror the OTA path: sync and retry a few times,
+# and never fail the whole operation if it stays rw -- the next boot mounts ro.
+remount_ro() {
+  local i
+  for i in 1 2 3 4; do
+    sync
+    if mount -o remount,ro / 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.3
+  done
+  echo "digits-devmode: WARNING: could not remount / read-only (will be ro on next boot)" >&2
+  return 0
+}
+
+ensure_host_keys() {
+  mkdir -p "$SSH_KEY_DIR"
+  if [[ ! -f "$SSH_KEY_DIR/ssh_host_ed25519_key" ]]; then
+    ssh-keygen -t ed25519 -f "$SSH_KEY_DIR/ssh_host_ed25519_key" -N '' -q
+  fi
+  if [[ ! -f "$SSH_KEY_DIR/ssh_host_rsa_key" ]]; then
+    ssh-keygen -t rsa -b 4096 -f "$SSH_KEY_DIR/ssh_host_rsa_key" -N '' -q
+  fi
+}
+
+ensure_ssh_symlinks() {
+  mkdir -p /etc/ssh
+  ln -sf "$SSH_KEY_DIR/ssh_host_rsa_key"         /etc/ssh/ssh_host_rsa_key
+  ln -sf "$SSH_KEY_DIR/ssh_host_rsa_key.pub"     /etc/ssh/ssh_host_rsa_key.pub
+  ln -sf "$SSH_KEY_DIR/ssh_host_ed25519_key"     /etc/ssh/ssh_host_ed25519_key
+  ln -sf "$SSH_KEY_DIR/ssh_host_ed25519_key.pub" /etc/ssh/ssh_host_ed25519_key.pub
+}
+
+ensure_password_auth() {
+  mkdir -p /etc/ssh/sshd_config.d
+  printf 'PasswordAuthentication yes\n' > "$SSHD_DROPIN"
+}
+
+ensure_dev_user() {
+  if ! id "$DEV_USER" >/dev/null 2>&1; then
+    useradd -m -s /bin/bash \
+      -G sudo,audio,video,dialout,gpio,i2c,spi "$DEV_USER"
+  fi
+  printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$DEV_USER" > "$SUDOERS_DROPIN"
+  chmod 0440 "$SUDOERS_DROPIN"
+}
+
+cmd_enable() {
+  # Read the new password from stdin (single line).
+  local password
+  IFS= read -r password || true
+  if [[ -z "$password" ]]; then
+    echo "digits-devmode: enable requires a password on stdin" >&2
+    exit 2
+  fi
+
+  remount_rw
+  mkdir -p /data/digits
+  touch "$FLAG"
+  ensure_host_keys
+  ensure_ssh_symlinks
+  ensure_password_auth
+  ensure_dev_user
+  printf '%s:%s\n' "$DEV_USER" "$password" | chpasswd
+  passwd -u "$DEV_USER" >/dev/null 2>&1 || true
+  remount_ro
+
+  # Raspbian masks/auto-generates host keys via this unit; we manage our own.
+  systemctl unmask ssh.service >/dev/null 2>&1 || true
+  systemctl enable --now ssh.service
+  echo "digits-devmode: enabled"
+}
+
+cmd_disable() {
+  systemctl disable --now ssh.service >/dev/null 2>&1 || true
+
+  remount_rw
+  passwd -l "$DEV_USER" >/dev/null 2>&1 || true
+  rm -f "$FLAG"
+  remount_ro
+  echo "digits-devmode: disabled"
+}
+
+cmd_status() {
+  if [[ -f "$FLAG" ]] && systemctl is-active --quiet ssh.service; then
+    echo "enabled"
+  else
+    echo "disabled"
+  fi
+}
+
+case "${1:-}" in
+  enable)  cmd_enable ;;
+  disable) cmd_disable ;;
+  status)  cmd_status ;;
+  *)
+    echo "usage: digits-devmode {enable|disable|status}" >&2
+    exit 64
+    ;;
+esac

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
@@ -27,14 +27,22 @@ FLAG=/data/digits/dev-mode
 SSH_KEY_DIR=/data/ssh
 SSHD_DROPIN=/etc/ssh/sshd_config.d/digits-dev.conf
 SUDOERS_DROPIN=/etc/sudoers.d/dev-nopasswd
+# Defense-in-depth floor, mirrors the server's validateDevModePassword. The
+# web handler is the primary gate; this guards any other producer of a
+# dev_mode command on the signaling channel.
+MIN_PASSWORD_LEN=8
+
+# Tracks whether the rootfs is currently remounted rw so the EXIT trap can
+# restore it on any early/error exit (set -e) without leaving / writable.
+_need_ro=0
+restore_ro_on_exit() { if [[ "$_need_ro" == 1 ]]; then remount_ro; fi; }
 
 remount_rw() { mount -o remount,rw / ; }
 # The rootfs sometimes refuses an immediate ro transition (a just-written file's
 # page cache is still dirty). Mirror the OTA path: sync and retry a few times,
 # and never fail the whole operation if it stays rw -- the next boot mounts ro.
 remount_ro() {
-  local i
-  for i in 1 2 3 4; do
+  for _ in 1 2 3 4; do
     sync
     if mount -o remount,ro / 2>/dev/null; then
       return 0
@@ -85,31 +93,58 @@ cmd_enable() {
     echo "digits-devmode: enable requires a password on stdin" >&2
     exit 2
   fi
+  if [[ "${#password}" -lt "$MIN_PASSWORD_LEN" ]]; then
+    echo "digits-devmode: password must be at least $MIN_PASSWORD_LEN characters" >&2
+    exit 2
+  fi
 
-  remount_rw
-  mkdir -p /data/digits
-  touch "$FLAG"
+  # All persistent rootfs changes happen in one rw window. The EXIT trap
+  # restores ro if any step fails under set -e, so a partial enable never
+  # leaves / writable, and the flag below is only set on full success.
+  trap restore_ro_on_exit EXIT
+  remount_rw; _need_ro=1
   ensure_host_keys
   ensure_ssh_symlinks
   ensure_password_auth
   ensure_dev_user
   printf '%s:%s\n' "$DEV_USER" "$password" | chpasswd
   passwd -u "$DEV_USER" >/dev/null 2>&1 || true
-  remount_ro
-
-  # Raspbian masks/auto-generates host keys via this unit; we manage our own.
+  # Raspbian's regenerate_ssh_host_keys.service would ssh-keygen into the
+  # read-only /etc/ssh and pollute it; we supply our own keys, so mask it
+  # (matches the --dev image build). `enable` (not --now) writes the rootfs
+  # symlink while we still hold rw; the service is started after remount-ro.
+  systemctl mask regenerate_ssh_host_keys.service >/dev/null 2>&1 || true
   systemctl unmask ssh.service >/dev/null 2>&1 || true
-  systemctl enable --now ssh.service
+  systemctl enable ssh.service
+  remount_ro; _need_ro=0
+  trap - EXIT
+
+  # Start outside the rw window (no rootfs writes) and confirm it actually
+  # came up before declaring success. The flag is written last, so the
+  # device only reports dev mode on once SSH is genuinely listening.
+  systemctl start ssh.service
+  systemctl is-active --quiet ssh.service
+  mkdir -p /data/digits
+  touch "$FLAG"
   echo "digits-devmode: enabled"
 }
 
 cmd_disable() {
   systemctl disable --now ssh.service >/dev/null 2>&1 || true
+  # Stopping the unit only blocks new logins; forked sshd children survive.
+  # Kill the dev user's live sessions so "off" actually ends SSH access.
+  pkill -KILL -u "$DEV_USER" >/dev/null 2>&1 || true
 
-  remount_rw
+  # Remove the standing-privilege artifacts enable created so "off" leaves no
+  # passwordless-sudo grant or global password-auth setting on disk.
+  trap restore_ro_on_exit EXIT
+  remount_rw; _need_ro=1
   passwd -l "$DEV_USER" >/dev/null 2>&1 || true
+  rm -f "$SUDOERS_DROPIN" "$SSHD_DROPIN"
+  remount_ro; _need_ro=0
+  trap - EXIT
+
   rm -f "$FLAG"
-  remount_ro
   echo "digits-devmode: disabled"
 }
 

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
@@ -130,15 +130,20 @@ cmd_enable() {
 }
 
 cmd_disable() {
-  systemctl disable --now ssh.service >/dev/null 2>&1 || true
-  # Stopping the unit only blocks new logins; forked sshd children survive.
-  # Kill the dev user's live sessions so "off" actually ends SSH access.
+  # Runtime teardown first (no rootfs writes): stop the listener and kill the
+  # dev user's live sessions so "off" actually ends SSH access immediately.
+  systemctl stop ssh.service >/dev/null 2>&1 || true
   pkill -KILL -u "$DEV_USER" >/dev/null 2>&1 || true
 
-  # Remove the standing-privilege artifacts enable created so "off" leaves no
-  # passwordless-sudo grant or global password-auth setting on disk.
+  # Persistent teardown inside the rw window. `systemctl disable` removes the
+  # boot-time wants-symlink under /etc, so it MUST run while the rootfs is rw
+  # (mirroring cmd_enable's `systemctl enable`); doing it before remount would
+  # silently fail and leave ssh.service enabled for the next boot. Also drop
+  # the standing-privilege artifacts so "off" leaves no passwordless-sudo grant
+  # or global password-auth setting on disk.
   trap restore_ro_on_exit EXIT
   remount_rw; _need_ro=1
+  systemctl disable ssh.service >/dev/null 2>&1 || true
   passwd -l "$DEV_USER" >/dev/null 2>&1 || true
   rm -f "$SUDOERS_DROPIN" "$SSHD_DROPIN"
   remount_ro; _need_ro=0

--- a/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
+++ b/pi/image/rootfs-overlay/usr/local/bin/digits-devmode
@@ -10,6 +10,12 @@
 # sudoers allowlist entry. The enable password is read from stdin so it never
 # appears in the process list.
 #
+# This mirrors, at runtime, what tools/build-image.sh does host-side for --dev
+# images (the "dev mode" step that creates the dev user, host keys, the SSH
+# password-auth drop-in, and the sudoers entry). Keep the two in sync: the
+# dropin path/contents, sudoers line, symlink targets, and group list below
+# must match that step.
+#
 # Usage:
 #   digits-devmode enable   # reads the dev login password from stdin
 #   digits-devmode disable

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -25,6 +25,7 @@ const (
 	TypeFactoryReset        = "factory_reset"         // Server → Phone: trigger factory reset
 	TypeRestart             = "restart"               // Server → Phone: restart service or reboot
 	TypeRingTest            = "ring_test"             // Server → Phone: brief ring for hardware verification
+	TypeDevMode             = "dev_mode"              // Server → Phone: enable/disable developer mode (SSH + dev web UI)
 	TypeLineSettings        = "line_settings"         // Server → Phone: per-line config update
 	TypeLinkHealth          = "link_health"           // Phone → Server: per-call stats snapshot
 	TypeRepair              = "repair"                // Phone → Server: invalidate pairing (used by *#0* before reboot)
@@ -203,7 +204,12 @@ type Message struct {
 	LineSettings *LineSettings `json:"line_settings,omitempty"`
 
 	// DevMode indicates the device has dev-mode enabled (device_info messages)
+	// and, on dev_mode command messages, the requested on/off state.
 	DevMode bool `json:"dev_mode,omitempty"`
+
+	// DevModePassword is the new SSH login password carried on a dev_mode
+	// command when enabling. Server -> device only.
+	DevModePassword string `json:"dev_mode_password,omitempty"`
 
 	// Extension pickup fields (POTS extension model).
 	// Extension is true when this SDP/ICE message belongs to an extension

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -612,6 +612,8 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/factory-reset", h.handlePhoneFactoryReset)
 	protected.HandleFunc("POST /phones/{number}/restart", h.handlePhoneRestart)
 	protected.HandleFunc("POST /phones/{number}/ring-test", h.handlePhoneRingTest)
+	protected.HandleFunc("POST /phones/{number}/dev-mode", h.handlePhoneDevMode)
+	protected.HandleFunc("GET /phones/{number}/dev-mode-status", h.handlePhoneDevModeStatus)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -36,9 +36,7 @@ func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Reque
 	if ln == nil {
 		return nil, nil
 	}
-	user := auth.UserFromContext(r.Context())
-	role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
-	if err != nil || role != "admin" {
+	if !h.isHouseholdAdmin(r, hh.ID) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return nil, nil
 	}

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -45,6 +45,19 @@ func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Reque
 	return ln, hh
 }
 
+// isHouseholdAdmin reports whether the request's user is an admin of the given
+// household. Best-effort: returns false on any lookup error or missing user.
+// Used to gate the rendering of admin-only UI (the result is advisory; the
+// POST handlers still enforce admin via requireLineOwnershipAdmin).
+func (h *Handler) isHouseholdAdmin(r *http.Request, householdID string) bool {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		return false
+	}
+	role, err := h.householdStore.GetRole(r.Context(), user.ID, householdID)
+	return err == nil && role == "admin"
+}
+
 // requireLineOwnershipWithHousehold is requireLineOwnership plus the matched
 // household value, for callers that need the household state (e.g., DND)
 // without an extra DB round-trip. On any failure it writes 404 and returns

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -168,8 +168,7 @@ func (h *Handler) handleLinksRevokePost(w http.ResponseWriter, r *http.Request) 
 	isAdmin := false
 	for _, hh := range households {
 		if hh.ID == link.HouseholdAID || (link.HouseholdBID != nil && hh.ID == *link.HouseholdBID) {
-			role, err := h.householdStore.GetRole(r.Context(), user.ID, hh.ID)
-			if err == nil && role == "admin" {
+			if h.isHouseholdAdmin(r, hh.ID) {
 				isAdmin = true
 				break
 			}

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -868,10 +868,13 @@ func validateDevModePassword(pw string) error {
 	if strings.TrimSpace(pw) == "" {
 		return errors.New("password is required")
 	}
-	if len(pw) < devModePasswordMin {
+	// Count runes, not bytes, so the "characters" bounds match what the user
+	// typed (and the browser's length check) for non-ASCII passwords.
+	n := utf8.RuneCountInString(pw)
+	if n < devModePasswordMin {
 		return errors.New("password must be at least 8 characters")
 	}
-	if len(pw) > devModePasswordMax {
+	if n > devModePasswordMax {
 		return errors.New("password must be at most 72 characters")
 	}
 	return nil

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -281,6 +281,7 @@ type lineDetailData struct {
 	FirmwareUpdateNotes   []updates.Release
 	OtherLines            []line.Line
 	NumberError           string
+	IsAdmin               bool
 }
 
 func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
@@ -366,6 +367,7 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		FirmwareUpdateNotes:   firmwareUpdateNotes,
 		OtherLines:            otherLines,
 		NumberError:           r.URL.Query().Get("number_error"),
+		IsAdmin:               h.isHouseholdAdmin(r, hh.ID),
 	})
 }
 
@@ -848,6 +850,85 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 		RestartMode: mode,
 	}
 	h.sendPhoneCommandAndRespond(w, r, number, msg, "restart command", "mode", mode)
+}
+
+// devModePasswordMin and devModePasswordMax bound the SSH login password set
+// when enabling developer mode. The lower bound is a basic strength floor; the
+// upper bound keeps parity with common password-field limits (chpasswd itself
+// has no hard cap).
+const (
+	devModePasswordMin = 8
+	devModePasswordMax = 72
+)
+
+// validateDevModePassword checks a proposed dev-mode SSH password. It does not
+// trim the password (leading/trailing characters may be intentional) but
+// rejects all-whitespace input and enforces the length bounds.
+func validateDevModePassword(pw string) error {
+	if strings.TrimSpace(pw) == "" {
+		return errors.New("password is required")
+	}
+	if len(pw) < devModePasswordMin {
+		return errors.New("password must be at least 8 characters")
+	}
+	if len(pw) > devModePasswordMax {
+		return errors.New("password must be at most 72 characters")
+	}
+	return nil
+}
+
+// handlePhoneDevMode enables or disables developer mode (SSH + the on-device
+// dev web UI) on the line's device. Admin-only. When enabling, an SSH login
+// password is required and is forwarded to the device over the authenticated
+// signaling channel.
+func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
+		return
+	}
+	if !parseForm(w, r) {
+		return
+	}
+	enabled := r.FormValue("enabled") == "true"
+
+	msg := &signaling.Message{
+		Type:    signaling.TypeDevMode,
+		DevMode: enabled,
+	}
+	if enabled {
+		pw := r.FormValue("password")
+		if err := validateDevModePassword(pw); err != nil {
+			jsonError(r.Context(), w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		msg.DevModePassword = pw
+	}
+	h.sendPhoneCommandAndRespond(w, r, number, msg, "dev mode command", "enabled", enabled)
+}
+
+// handlePhoneDevModeStatus reports the device's current developer-mode state so
+// the UI can confirm a toggle took effect. Owner scope. Returns only the
+// boolean and the fixed SSH username; the LAN IP is rendered in owner-scope
+// HTML on page reload, never in JSON (see DeviceInfoSnapshot.RemoteAddr).
+func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	if h.requireLineOwnership(w, r, number) == nil {
+		return
+	}
+	enabled := false
+	for _, info := range h.hub.AllDeviceInfo(number) {
+		if info.DevMode {
+			enabled = true
+			break
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"enabled":  enabled,
+		"ssh_user": "dev",
+	}); err != nil {
+		slog.ErrorContext(r.Context(), "dev mode status: json encode failed", "number", number, "err", err)
+	}
 }
 
 // sendPhoneCommandAndRespond pushes msg to the device, logs the outcome

--- a/server/internal/web/handler_phones_test.go
+++ b/server/internal/web/handler_phones_test.go
@@ -5,6 +5,36 @@ import (
 	"testing"
 )
 
+func TestValidateDevModePassword(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		{name: "ok", in: "hunter2pw"},
+		{name: "exactly min", in: "12345678"},
+		{name: "exactly max", in: strings.Repeat("a", 72)},
+		{name: "empty", in: "", wantErr: "password is required"},
+		{name: "whitespace only", in: "   \t  ", wantErr: "password is required"},
+		{name: "too short", in: "short", wantErr: "password must be at least 8 characters"},
+		{name: "too long", in: strings.Repeat("a", 73), wantErr: "password must be at most 72 characters"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDevModePassword(tc.in)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("want error %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestValidateLineName(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/server/internal/web/template_parse_test.go
+++ b/server/internal/web/template_parse_test.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"html/template"
+	"testing"
+)
+
+// TestTemplatePagesParse parses every page template the same way NewHandler
+// does. It runs without the integration build tag (no DB needed) so template
+// syntax errors are caught by the fast unit suite, not only at server startup.
+func TestTemplatePagesParse(t *testing.T) {
+	funcMap := TemplateFuncs()
+	pages := []string{
+		"dashboard.html",
+		"phones.html",
+		"phone-detail.html",
+		"calls.html",
+		"settings.html",
+		"onboard.html",
+		"links.html",
+	}
+	for _, page := range pages {
+		page := page
+		t.Run(page, func(t *testing.T) {
+			_, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
+				"templates/_partials.html",
+				"templates/_changelog.html",
+				"templates/layout-v2.html",
+				"templates/layout-dialup.html",
+				"templates/layout-answering-machine.html",
+				"templates/"+page,
+			)
+			if err != nil {
+				t.Fatalf("parse %s: %v", page, err)
+			}
+		})
+	}
+}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -511,6 +511,7 @@
   var piPollTimer = null;
   var fwPollTimer = null;
   var restartPollTimer = null;
+  var devModePollTimer = null;
   var restartMode = null;
 
   function doRingTest() {
@@ -768,20 +769,21 @@
     .catch(function(err) { devModeError('Network error: ' + err.message); });
   }
   function pollDevMode(target) {
+    if (devModePollTimer) clearInterval(devModePollTimer);
     var attempts = 0;
-    var timer = setInterval(function() {
+    devModePollTimer = setInterval(function() {
       attempts++;
-      if (attempts > 30) { clearInterval(timer); devModeError('Timed out waiting for the device to apply the change.'); return; }
+      if (attempts > 15) { clearInterval(devModePollTimer); devModeError('Timed out waiting for the device to apply the change.'); return; }
       fetch('/phones/' + phoneNumber + '/dev-mode-status')
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.enabled === target) {
-          clearInterval(timer);
+          clearInterval(devModePollTimer);
           devModeProgress('Done. Reloading...');
           setTimeout(function() { location.reload(); }, 1000);
         }
       }).catch(function() {});
-    }, 1000);
+    }, 2000);
   }
   </script>
 
@@ -1698,6 +1700,7 @@
 
     var amRestartMode = null;
     var amRestartPollTimer = null;
+    var amDevModePollTimer = null;
 
     window.amShowRestartConfirm = function(mode) {
       amRestartMode = mode;
@@ -1871,24 +1874,26 @@
       .catch(function(err) { amDevModeError('Network error: ' + err.message); });
     }
     function amPollDevMode(target) {
+      if (amDevModePollTimer) clearInterval(amDevModePollTimer);
       var attempts = 0;
-      var timer = setInterval(function() {
+      amDevModePollTimer = setInterval(function() {
         attempts++;
-        if (attempts > 30) { clearInterval(timer); amDevModeError('Timed out waiting for the device to apply the change.'); return; }
+        if (attempts > 15) { clearInterval(amDevModePollTimer); amDevModeError('Timed out waiting for the device to apply the change.'); return; }
         fetch('/phones/' + phoneNumber + '/dev-mode-status')
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.enabled === target) {
-            clearInterval(timer);
+            clearInterval(amDevModePollTimer);
             amDevModeProgress('Done. Reloading...');
             setTimeout(function() { location.reload(); }, 1000);
           }
         }).catch(function() {});
-      }, 1000);
+      }, 2000);
     }
 
     window.addEventListener('pagehide', function() {
       if (amRestartPollTimer) clearInterval(amRestartPollTimer);
+      if (amDevModePollTimer) clearInterval(amDevModePollTimer);
       Object.keys(pollers).forEach(function(p) { if (pollers[p]) clearInterval(pollers[p]); });
     });
   })();

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -371,6 +371,46 @@
             </div>
           </div>
 
+          {{if .IsAdmin}}
+          <!-- Developer mode -->
+          <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+            <div class="field__label" style="margin-bottom: 6px;">Developer mode</div>
+            {{if and .DeviceInfo .DeviceInfo.DevMode}}
+            <p class="muted" style="font-size: 12.5px; margin: 0 0 8px;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code class="num">{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
+            <div id="devmode-on-default">
+              <button type="button" onclick="showDevModeDisableConfirm()" class="btn btn--danger">Disable developer mode</button>
+            </div>
+            <div id="devmode-disable-confirm" class="hidden">
+              <p style="font-size: 13.5px; color: var(--ink); margin: 8px 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
+              <div class="hstack" style="gap: 8px;">
+                <button type="button" onclick="doDevModeDisable()" class="btn btn--danger">Confirm</button>
+                <button type="button" onclick="cancelDevModeDisable()" class="btn">Cancel</button>
+              </div>
+            </div>
+            {{else}}
+            <p class="muted" style="font-size: 12.5px; margin: 0 0 8px;">Enables SSH (user <code>dev</code>) and the on-device admin panel. Set an SSH password to turn it on.</p>
+            <div id="devmode-off-default">
+              <button type="button" onclick="showDevModeEnableForm()" class="btn">Enable developer mode</button>
+            </div>
+            <div id="devmode-enable-form" class="hidden">
+              <label for="devmode-password" class="field__label" style="display: block; margin: 8px 0 4px;">SSH password</label>
+              <input type="password" id="devmode-password" class="field__input" autocomplete="new-password" style="max-width: 280px;" placeholder="At least 8 characters">
+              <span class="muted" style="display: block; font-size: 11px; margin-top: 4px;">8 to 72 characters. Used to log in as <code>dev</code> over SSH.</span>
+              <div class="hstack" style="gap: 8px; margin-top: 10px;">
+                <button type="button" onclick="doDevModeEnable()" class="btn btn--primary">Enable</button>
+                <button type="button" onclick="cancelDevModeEnable()" class="btn">Cancel</button>
+              </div>
+            </div>
+            {{end}}
+            <div id="devmode-progress" class="hidden" style="margin-top: 10px;">
+              <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+                <div id="devmode-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+                <span id="devmode-text" style="font-size: 13px; color: var(--ink);">Sending command...</span>
+              </div>
+            </div>
+          </div>
+          {{end}}
+
         </div>
       </section>
       {{end}}
@@ -669,6 +709,79 @@
       text.textContent = 'Error: ' + err.message;
       text.style.color = 'var(--rust)';
     });
+  }
+
+  function showDevModeEnableForm() {
+    document.getElementById('devmode-off-default').classList.add('hidden');
+    document.getElementById('devmode-enable-form').classList.remove('hidden');
+    document.getElementById('devmode-password').focus();
+  }
+  function cancelDevModeEnable() {
+    document.getElementById('devmode-enable-form').classList.add('hidden');
+    document.getElementById('devmode-off-default').classList.remove('hidden');
+  }
+  function showDevModeDisableConfirm() {
+    document.getElementById('devmode-on-default').classList.add('hidden');
+    document.getElementById('devmode-disable-confirm').classList.remove('hidden');
+  }
+  function cancelDevModeDisable() {
+    document.getElementById('devmode-disable-confirm').classList.add('hidden');
+    document.getElementById('devmode-on-default').classList.remove('hidden');
+  }
+  function devModeProgress(msg) {
+    var p = document.getElementById('devmode-progress');
+    if (p) p.classList.remove('hidden');
+    var t = document.getElementById('devmode-text');
+    if (t) { t.textContent = msg; t.style.color = 'var(--ink)'; }
+  }
+  function devModeError(msg) {
+    var spinner = document.getElementById('devmode-spinner');
+    if (spinner) spinner.classList.add('hidden');
+    var t = document.getElementById('devmode-text');
+    if (t) { t.textContent = msg; t.style.color = 'var(--rust)'; }
+  }
+  function doDevModeEnable() {
+    var pw = document.getElementById('devmode-password').value;
+    if (pw.length < 8 || pw.length > 72) { devModeError('Password must be 8 to 72 characters.'); return; }
+    document.getElementById('devmode-enable-form').classList.add('hidden');
+    devModeProgress('Enabling developer mode...');
+    var body = new URLSearchParams({enabled: 'true', password: pw});
+    sendDevMode(body, true);
+  }
+  function doDevModeDisable() {
+    document.getElementById('devmode-disable-confirm').classList.add('hidden');
+    devModeProgress('Disabling developer mode...');
+    sendDevMode(new URLSearchParams({enabled: 'false'}), false);
+  }
+  function sendDevMode(body, target) {
+    fetch('/phones/' + phoneNumber + '/dev-mode', {
+      method: 'POST',
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+      body: body.toString()
+    })
+    .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+    .then(function(res) {
+      if (!res.ok) { devModeError('Failed: ' + (res.data.error || 'request rejected')); return; }
+      devModeProgress(target ? 'Waiting for device to enable SSH...' : 'Waiting for device to disable SSH...');
+      pollDevMode(target);
+    })
+    .catch(function(err) { devModeError('Network error: ' + err.message); });
+  }
+  function pollDevMode(target) {
+    var attempts = 0;
+    var timer = setInterval(function() {
+      attempts++;
+      if (attempts > 30) { clearInterval(timer); devModeError('Timed out waiting for the device to apply the change.'); return; }
+      fetch('/phones/' + phoneNumber + '/dev-mode-status')
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        if (d.enabled === target) {
+          clearInterval(timer);
+          devModeProgress('Done. Reloading...');
+          setTimeout(function() { location.reload(); }, 1000);
+        }
+      }).catch(function() {});
+    }, 1000);
   }
   </script>
 
@@ -1305,6 +1418,61 @@
           </div>
         </div>
       </div>
+      {{if .IsAdmin}}
+      <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+        <span class="am-plate__label">Developer mode</span>
+        {{if and .DeviceInfo .DeviceInfo.DevMode}}
+        <p class="am-hint" style="margin: 6px 0 8px;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code>{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
+        <div id="am-devmode-on-default">
+          <button type="button" onclick="amShowDevModeDisable()" class="am-key am-key--red">
+            <span class="am-key__symbol">&#x26D4;</span>
+            <span class="am-key__label">Disable dev mode</span>
+          </button>
+        </div>
+        <div id="am-devmode-disable-confirm" class="hidden" style="margin-top: 10px;">
+          <p class="am-hint" style="margin: 0 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
+          <div class="am-handset__actions-row" style="gap: 8px;">
+            <button type="button" onclick="amDoDevModeDisable()" class="am-key am-key--red">
+              <span class="am-key__symbol">&#x2713;</span>
+              <span class="am-key__label">Confirm</span>
+            </button>
+            <button type="button" onclick="amCancelDevModeDisable()" class="am-key">
+              <span class="am-key__symbol">&#x2715;</span>
+              <span class="am-key__label">Cancel</span>
+            </button>
+          </div>
+        </div>
+        {{else}}
+        <p class="am-hint" style="margin: 6px 0 8px;">Enables SSH (user <code>dev</code>) and the on-device admin panel. Set an SSH password to turn it on.</p>
+        <div id="am-devmode-off-default">
+          <button type="button" onclick="amShowDevModeEnable()" class="am-key">
+            <span class="am-key__symbol">&#x1F527;</span>
+            <span class="am-key__label">Enable dev mode</span>
+          </button>
+        </div>
+        <div id="am-devmode-enable-form" class="hidden" style="margin-top: 10px;">
+          <label for="am-devmode-password" class="am-hint" style="display: block; margin: 0 0 4px;">SSH password (8 to 72 characters)</label>
+          <input type="password" id="am-devmode-password" autocomplete="new-password" class="field__input" style="max-width: 280px;" placeholder="At least 8 characters">
+          <div class="am-handset__actions-row" style="gap: 8px; margin-top: 10px;">
+            <button type="button" onclick="amDoDevModeEnable()" class="am-key am-key--accent">
+              <span class="am-key__symbol">&#x2713;</span>
+              <span class="am-key__label">Enable</span>
+            </button>
+            <button type="button" onclick="amCancelDevModeEnable()" class="am-key">
+              <span class="am-key__symbol">&#x2715;</span>
+              <span class="am-key__label">Cancel</span>
+            </button>
+          </div>
+        </div>
+        {{end}}
+        <div id="am-devmode-progress" class="hidden" style="margin-top: 10px;">
+          <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+            <span id="am-devmode-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+            <span id="am-devmode-text" class="am-led">Sending command...</span>
+          </div>
+        </div>
+      </div>
+      {{end}}
     </section>
     {{end}}
 
@@ -1641,6 +1809,83 @@
         text.textContent = 'Error: ' + err.message;
       });
     };
+
+    window.amShowDevModeEnable = function() {
+      document.getElementById('am-devmode-off-default').classList.add('hidden');
+      document.getElementById('am-devmode-enable-form').classList.remove('hidden');
+      document.getElementById('am-devmode-password').focus();
+    };
+    window.amCancelDevModeEnable = function() {
+      document.getElementById('am-devmode-enable-form').classList.add('hidden');
+      document.getElementById('am-devmode-off-default').classList.remove('hidden');
+    };
+    window.amShowDevModeDisable = function() {
+      document.getElementById('am-devmode-on-default').classList.add('hidden');
+      document.getElementById('am-devmode-disable-confirm').classList.remove('hidden');
+    };
+    window.amCancelDevModeDisable = function() {
+      document.getElementById('am-devmode-disable-confirm').classList.add('hidden');
+      document.getElementById('am-devmode-on-default').classList.remove('hidden');
+    };
+    function amDevModeProgress(msg) {
+      document.getElementById('am-devmode-progress').classList.remove('hidden');
+      var lamp = document.getElementById('am-devmode-lamp');
+      lamp.classList.remove('am-lamp--on-red');
+      lamp.classList.add('am-lamp--on-amber');
+      var t = document.getElementById('am-devmode-text');
+      t.classList.remove('am-led--red');
+      t.textContent = msg;
+    }
+    function amDevModeError(msg) {
+      var lamp = document.getElementById('am-devmode-lamp');
+      lamp.classList.remove('am-lamp--on-amber');
+      lamp.classList.add('am-lamp--on-red');
+      var t = document.getElementById('am-devmode-text');
+      t.classList.add('am-led--red');
+      t.textContent = msg;
+    }
+    window.amDoDevModeEnable = function() {
+      var pw = document.getElementById('am-devmode-password').value;
+      if (pw.length < 8 || pw.length > 72) { amDevModeProgress(''); amDevModeError('Password must be 8 to 72 characters.'); return; }
+      document.getElementById('am-devmode-enable-form').classList.add('hidden');
+      amDevModeProgress('Enabling developer mode...');
+      amSendDevMode(new URLSearchParams({enabled: 'true', password: pw}), true);
+    };
+    window.amDoDevModeDisable = function() {
+      document.getElementById('am-devmode-disable-confirm').classList.add('hidden');
+      amDevModeProgress('Disabling developer mode...');
+      amSendDevMode(new URLSearchParams({enabled: 'false'}), false);
+    };
+    function amSendDevMode(body, target) {
+      fetch('/phones/' + phoneNumber + '/dev-mode', {
+        method: 'POST',
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: body.toString()
+      })
+      .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+      .then(function(res) {
+        if (!res.ok) { amDevModeError('Failed: ' + (res.data.error || 'request rejected')); return; }
+        amDevModeProgress(target ? 'Waiting for device to enable SSH...' : 'Waiting for device to disable SSH...');
+        amPollDevMode(target);
+      })
+      .catch(function(err) { amDevModeError('Network error: ' + err.message); });
+    }
+    function amPollDevMode(target) {
+      var attempts = 0;
+      var timer = setInterval(function() {
+        attempts++;
+        if (attempts > 30) { clearInterval(timer); amDevModeError('Timed out waiting for the device to apply the change.'); return; }
+        fetch('/phones/' + phoneNumber + '/dev-mode-status')
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+          if (d.enabled === target) {
+            clearInterval(timer);
+            amDevModeProgress('Done. Reloading...');
+            setTimeout(function() { location.reload(); }, 1000);
+          }
+        }).catch(function() {});
+      }, 1000);
+    }
 
     window.addEventListener('pagehide', function() {
       if (amRestartPollTimer) clearInterval(amRestartPollTimer);

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -785,6 +785,13 @@
       }).catch(function() {});
     }, 2000);
   }
+
+  window.addEventListener('pagehide', function() {
+    if (piPollTimer) clearInterval(piPollTimer);
+    if (fwPollTimer) clearInterval(fwPollTimer);
+    if (restartPollTimer) clearInterval(restartPollTimer);
+    if (devModePollTimer) clearInterval(devModePollTimer);
+  });
   </script>
 
 </div>


### PR DESCRIPTION
## Summary

Adds an admin-only "Developer mode" toggle on the line detail page that turns SSH and the on-device dev web UI on or off at runtime, no reflash required. Enabling prompts for an SSH password; disabling stops SSH and tears down the standing privilege it created.

- **server**: new `dev_mode` signaling command + `DevModePassword` field; admin-only `POST /phones/{number}/dev-mode` and owner-scope `GET /phones/{number}/dev-mode-status`; a "Developer mode" card in both the intercom and answering-machine themes (off: set an SSH password to enable; on: shows `ssh dev@<lan-ip>`, keeps the `:8080` admin-panel link, and a disable button). Card is gated to household admins.
- **digitsd**: handles the `dev_mode` command, applies it via a single privileged helper, manages the `:8080` dev-UI listener at runtime (no restart), and re-reports `device_info` so the UI reflects the new state. The dev-mode lifecycle is refactored into a small `devModeManager`.
- **image**: new `/usr/local/bin/digits-devmode` helper behind one sudoers allowlist entry. It owns all root work: SSH host keys, the `dev` user + password, `ssh.service`, and the password-auth drop-in. `enable` writes the on-flag last (only after `ssh.service` is confirmed active) inside a single rw window guarded by an EXIT trap; `disable` removes the passwordless-sudo and password-auth drop-ins and kills the dev user's live sessions, so "off" leaves no standing privilege. The helper is embedded into the digitsd binary (extracted at runtime on update); the sudoers entry ships with the next image build.

How it works end to end: admin submits the password form -> server sends `dev_mode` over the authenticated signaling channel (Redis fan-out reaches the device on any replica) -> digitsd runs `sudo digits-devmode enable`, starts `:8080`, re-reports `device_info` -> the UI polls `dev-mode-status` and reloads once the device confirms.

## Notes

- The SSH password crosses server->device over the already-authenticated WSS channel and, on the cross-replica path, transits the in-cluster Redis bridge (the same channel that already carries device tokens and pairing codes). It is passed to the helper on stdin, never argv.
- Release scopes: `server` (web toggle) and `digitsd` (handler + embedded helper) both need releases; `image` carries the sudoers entry, which ships with the next image build.

## Test plan

- [x] `make test-integration` + `golangci-lint` (server), `make test` + `golangci-lint` (digitsd), `shellcheck -S warning` (helper)
- [x] unit tests: `devModeManager` enable/disable/listener lifecycle, password validation, template parse
- [ ] Live on a real phone via the prod UI (post-deploy): enable -> SSH in as `dev` + `:8080` reachable; disable -> SSH refused + `:8080` gone; both themes. Screenshots to follow.