### PR TITLE
docs: sync stale tool, mixer service, and CI workflow references

### DIFF
--- a/.claude/skills/deploy-phone/SKILL.md
+++ b/.claude/skills/deploy-phone/SKILL.md
@@ -14,7 +14,7 @@ Build and deploy Pi binaries to phone devices over SSH. Handles the read-only ro
 | `digitsd` | `pi/digitsd/` | `make build` | `bin/digitsd` | `/usr/local/bin/digitsd` | `digitsd` |
 | diagnostic tools | `pi/digitsd/` | `GOOS=linux GOARCH=arm64 go build -o bin/<name> ./cmd/<name>` | `bin/<name>` | `/tmp/<name>` | none |
 
-Diagnostic tools: `alsatest`, `latbench`, `latclient`, `memprofile`, `pipetest`, `dmixlat`, `clocksync`. Deploy to `/tmp/` -- they are throwaway debugging utilities, not permanent system binaries.
+Diagnostic tools: `alsatest`, `latclient`, `memprofile`, `dmixlat`. Deploy to `/tmp/` -- they are throwaway debugging utilities, not permanent system binaries. The full list with per-tool purpose lives in `pi/digitsd/cmd/README.md`.
 
 `digitsd` handles all modes via the `--mode` flag: `normal` (default), `recovery`, `setup`, and `gpclk0`. There is no separate `digits-setup` or `digits-recovery` binary.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ When `DEV_MODE=true`, signald serves `/static/*` from disk (`internal/web/static
 
 ## Linting
 
-golangci-lint v2 with `standard` defaults (`.golangci.yml` at repo root). Run `golangci-lint run ./...` from each module directory before pushing Go changes; CI enforces errcheck that `go vet` does not. Pre-commit hook: `git config core.hooksPath .githooks`.
+golangci-lint v2 with `standard` defaults (`.golangci.yml` at repo root). Run `golangci-lint run ./...` from each module directory before pushing Go changes; CI enforces errcheck that `go vet` does not. Shell scripts under `tools/`, `scripts/`, and `pi/image/` are gated by shellcheck (`-S warning -x`) in CI. Pre-commit hook (`git config core.hooksPath .githooks`) runs both on staged files.
 
 ## Production deployment
 
@@ -144,4 +144,6 @@ Small fixes, docs, dep bumps, and typo PRs do not need this pass; their plans ma
 GitHub Actions workflows in `.github/workflows/`:
 - `server-ci.yml`: build, test, vet (triggers on `server/` changes); required for merge.
 - `server-integration.yml`: integration tests (Postgres service containers); required for merge to main.
+- `fw-ci.yml`: host-side firmware unit tests, no Pico SDK needed (triggers on `firmware/` changes).
+- `shellcheck-ci.yml`: shellcheck `-S warning -x` over `tools/`, `scripts/`, and `pi/image/` (including shebang-detected `rootfs-overlay` executables).
 - `fw-release` / `pi-release` / `server-release`: tag-triggered release pipelines.

--- a/docs/build/wiring.md
+++ b/docs/build/wiring.md
@@ -210,11 +210,8 @@ These three MUST be OFF or audio has fade-in latency:
 | 39    | Headphone Gain Ramping Switch | off   |
 | 40    | Lineout Gain Ramping Switch | off     |
 
-Mixer state file: `/home/digits/digits_mixer.state`
-Restore script: `/home/digits/restore_mixer.sh`
-Systemd service: `digits-mixer.service` (runs on boot)
-
-Full mixer documentation: `pi/README-mixer.md`
+Mixer state file: `/data/digits_mixer.state`
+Restored on boot by `digitsd.service` (its `ExecStartPre` runs `alsactl restore`)
 
 ## Power Architecture
 
@@ -243,8 +240,7 @@ Full mixer documentation: `pi/README-mixer.md`
 
 | Service                    | Purpose                                   | Status   |
 |----------------------------|-------------------------------------------|----------|
-| `digitsd.service`          | Main daemon -- serial, tones, WebRTC, keepalive | Active |
-| `digits-mixer.service`    | Restore ALSA mixer state on boot          | Active   |
+| `digitsd.service`          | Main daemon -- serial, tones, mixer restore, WebRTC, keepalive | Active |
 | `digits-ap-check.service` | Boot-time check: AP mode vs normal boot   | Active (oneshot) |
 | `digits-ap.service`       | hostapd AP mode (setup only)              | Conditional |
 | `digits-dnsmasq-ap.service` | dnsmasq DHCP/DNS for AP mode            | Conditional |


### PR DESCRIPTION
## What

Daily cross-PR coherence pass over the last 24 hours of merges. Three committed docs still described things that #740, #741, and #742 removed or added. No code changes.

- **`.claude/skills/deploy-phone/SKILL.md`**: the diagnostic tools list still named `latbench`, `pipetest`, and `clocksync`, all deleted in #741. The list now matches the four tools that actually exist and points at `pi/digitsd/cmd/README.md` (added in #741) as the source of truth.
- **`docs/build/wiring.md`**: still documented `digits-mixer.service` as an active boot unit, but #740 deleted it because `digitsd.service`'s `ExecStartPre` already runs the `alsactl restore`. The surrounding mixer block was also wrong on every line: the state file lives at `/data/digits_mixer.state` (not `/home/digits/...`), there is no `restore_mixer.sh`, and the referenced `pi/README-mixer.md` never existed in repo history. The services table row is removed and the `digitsd.service` row now mentions mixer restore.
- **`CLAUDE.md`**: the CI section did not list the two quality gates added this window, `fw-ci.yml` (#742, host-side firmware tests) and `shellcheck-ci.yml` (#740). Both are listed now, and the Linting section mentions the shellcheck gate alongside golangci-lint since the pre-commit hook from #740 runs both.

## Why

Each of these PRs was correct on its own; the drift is that the docs describing the removed unit, removed tools, and new CI gates live outside the directories those PRs touched, so single-PR review never saw them.

## Motivated by

- #740 refactor(image): shell quality pass and shellcheck CI across image, tools, and scripts
- #741 refactor(digitsd): extract signaling dispatch from main and prune stale debug tools
- #742 refactor(firmware): add host test harness and remove dead code