### PR TITLE
refactor(firmware): wire host tests into the root make test target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Firmware (from repo root):
 ```
 make firmware         # builds in Docker
 make firmware-local   # builds on host (requires arm-none-eabi-gcc + Pico SDK)
+make firmware-test    # host-side unit tests (native cmake + gcc, no Pico SDK; see firmware/test/README.md)
 ./scripts/flash.sh    # copies UF2 to mounted Pico
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help server server-test pi-build pi-test firmware firmware-local fetch-tags stage-firmware image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
+.PHONY: help server server-test pi-build pi-test firmware firmware-local firmware-test fetch-tags stage-firmware image image-dev image-v2 image-v2-dev flash flash-v1 flash-v2 image-flash image-v2-flash clean
 
 # Refresh tags from origin so version derivation in firmware and pi-build
 # resolves to the latest published release, not whatever the local clone
@@ -36,6 +36,9 @@ firmware: fetch-tags ## Build Pico firmware (Docker, no host toolchain needed)
 
 firmware-local: ## Build Pico firmware on host (requires arm-none-eabi-gcc + Pico SDK)
 	$(MAKE) -C firmware build-local
+
+firmware-test: ## Run firmware host tests (native cmake + gcc, no Pico SDK needed)
+	$(MAKE) -C firmware test
 
 # Mirror firmware/Makefile's DIGITS_VERSION derivation so the .version file we
 # stage matches the version string the firmware reports over UART after boot.
@@ -117,7 +120,7 @@ image-v2-flash: ## Build V2 dev image and flash
 
 # ── Utilities ────────────────────────────────────────────────────────────────
 
-test: server-test pi-test ## Run all tests
+test: server-test pi-test firmware-test ## Run all tests
 
 clean: ## Clean build artifacts
 	$(MAKE) -C server clean


### PR DESCRIPTION
## What

Adds a `firmware-test` target to the root Makefile (delegating to `make -C firmware test`, matching the existing `server-test` / `pi-test` convention), includes it in the aggregate `make test` target, and documents it in CLAUDE.md's firmware build block.

## Why

Daily cross-PR coherence review of the last 24h of merges. #742 added the native firmware host test harness (`firmware/test/`, `make test` in `firmware/Makefile`) and `fw-ci.yml` runs it in CI, but the root Makefile never caught up: every other component has a per-component test target at the root, and the aggregate `test` target says "Run all tests" while silently skipping firmware. The #750 docs sync then updated CLAUDE.md's CI section for `fw-ci.yml` but left the Build-and-test section with no firmware test command at all, so the docs describe a gate that a reader has no documented way to run locally.

## Motivated by

- #742: refactor(firmware): add host test harness and remove dead code
- #750: docs: sync stale tool, mixer service, and CI workflow references

## Verification

- `make firmware-test` from repo root: 35 tests, 132 checks, 0 failures.
- `make help` lists the new target with the others.