### PR TITLE
fix(digitsd,image): deliver the dev-mode sudoers entry to OTA-updated devices

### DIFF
--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -23,7 +23,7 @@ import (
 
 // devModeHelperPath is the privileged helper that performs the root-level work
 // of toggling developer mode (SSH host keys, the dev user, ssh.service). It is
-// invoked via the single sudoers allowlist entry in /etc/sudoers.d/digits-updater.
+// invoked via the single sudoers allowlist entry in /etc/sudoers.d/digits-devmode.
 const devModeHelperPath = "/usr/local/bin/digits-devmode"
 
 // runDevModeHelper shells out to the privileged helper to enable or disable

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-devmode
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-devmode
@@ -1,0 +1,10 @@
+# Allow the digits service user to toggle developer mode (SSH + dev web UI) via
+# the digits-devmode helper, invoked by digitsd when the server sends a dev_mode
+# command.
+#
+# This is deliberately its own file, separate from digits-updater: it is NOT in
+# the digitsd OVERLAY_EXCLUDE list, so digitsd's asset extractor writes it on
+# update. That delivers the permission to devices that OTA-updated to a digitsd
+# carrying the helper but were flashed from an image predating it. (digits-updater
+# stays excluded because the extractor itself relies on it.)
+digits ALL=(root) NOPASSWD: /usr/local/bin/digits-devmode

--- a/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
+++ b/pi/image/rootfs-overlay/etc/sudoers.d/digits-updater
@@ -6,7 +6,11 @@
 #   - reload systemd unit definitions after the asset extractor rewrites them
 #   - reboot the device (remote restart, factory reset, or service code)
 #   - clear /data/wifi-configured flag for *#SETUP# Wi-Fi re-provisioning
-#   - toggle developer mode (SSH + dev web UI) via the digits-devmode helper
+#
+# NOTE: developer-mode toggling lives in a separate file, etc/sudoers.d/
+# digits-devmode, which (unlike this file) is NOT in the digitsd OVERLAY_EXCLUDE
+# list, so it ships to already-deployed devices via runtime asset extraction.
+# This file is build-time only because the asset extractor depends on it.
 digits ALL=(root) NOPASSWD: /usr/bin/mount -o remount\,rw /, /usr/bin/mount -o remount\,ro /
 digits ALL=(root) NOPASSWD: /usr/bin/mkdir -p *
 digits ALL=(root) NOPASSWD: /usr/bin/cp /tmp/asset-* *
@@ -19,4 +23,3 @@ digits ALL=(root) NOPASSWD: /usr/bin/openocd
 digits ALL=(root) NOPASSWD: /usr/bin/systemctl stop digitsd.service, /usr/bin/systemctl start digitsd.service, /usr/bin/systemctl daemon-reload
 digits ALL=(root) NOPASSWD: /usr/sbin/reboot
 digits ALL=(root) NOPASSWD: /usr/bin/journalctl -u digitsd *
-digits ALL=(root) NOPASSWD: /usr/local/bin/digits-devmode


### PR DESCRIPTION
## Summary

Disabling (or enabling) developer mode from the web UI times out with "Timed out waiting for the device to apply the change" on devices that OTA-updated digitsd but were flashed from an image predating the dev-mode feature.

**Root cause:** the `digits-devmode` helper ships via runtime asset extraction (it's in the overlay tree the digitsd binary embeds), but its sudoers grant was added to `etc/sudoers.d/digits-updater`, which is in the digitsd `OVERLAY_EXCLUDE` list and is therefore never extracted at runtime. So an OTA-updated device ends up with the helper present but no permission to run it. digitsd (user `digits`) runs `sudo /usr/local/bin/digits-devmode disable` and sudo rejects it:

```
sudo: digits : command not allowed ; COMMAND=/usr/local/bin/digits-devmode disable
dev mode: apply failed enable=false error="... a password is required"
```

The device never re-reports its state, so the UI poll times out. (Confirmed live on the V2 device via its digitsd journal.)

**Fix:** move the grant into its own `etc/sudoers.d/digits-devmode` file, which is **not** excluded, so the asset extractor writes it on update alongside the helper. New images get it via the overlay; already-deployed devices get it on the next OTA. `digits-updater` stays excluded because the extractor itself depends on it.

## Notes

- The OTA extractor normalizes `sudoers.d` files to 0440 (its `permOverride`); sudo also accepts the 0644 the overlay ships (it only rejects group/world-*writable* sudoers, and git can't store 0440 anyway).
- A single malformed sudoers file is skipped by sudo, not fatal, and the extractor does not depend on this new file, so there's no chicken-and-egg with `digits-updater`.
- The affected V2 bench device was patched by hand so the toggle works now; this PR is what fixes it fleet-wide on the next pi release.

## Test plan

- [x] `visudo -c` on both sudoers files; digitsd builds; assets test passes
- [x] `make embed` includes `digits-devmode` and excludes `digits-updater`
- [x] Live: after manually installing the new file on the V2 device, `sudo -u digits sudo -n /usr/local/bin/digits-devmode status` succeeds (was "command not allowed")
- [ ] Fleet: confirm an OTA-updated device gains the entry after the pi release (not run here)