### PR TITLE
refactor(firmware): table-drive the STATE:SET phase handlers

### DIFF
--- a/firmware/src/phone_fsm.c
+++ b/firmware/src/phone_fsm.c
@@ -258,22 +258,27 @@ static void process_pi_command(const char *cmd) {
         // a stale prefix.
         clear_dialing_buffer();
         uart_proto_send("DIAL:RESET:OK");
-    } else if (strcmp(cmd, "STATE:SET:PAIRED") == 0) {
-        phase_write(PHASE_PAIRED);
-        if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
-        uart_proto_send("STATE:SET:OK");
-    } else if (strcmp(cmd, "STATE:SET:UNPAIRED") == 0) {
-        phase_write(PHASE_UNPAIRED);
-        if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
-        uart_proto_send("STATE:SET:OK");
-    } else if (strcmp(cmd, "STATE:SET:SETUP") == 0) {
-        phase_write(PHASE_SETUP);
-        if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
-        uart_proto_send("STATE:SET:OK");
-    } else if (strcmp(cmd, "STATE:SET:RECOVERY") == 0) {
-        phase_write(PHASE_RECOVERY);
-        if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
-        uart_proto_send("STATE:SET:OK");
+    } else if (strncmp(cmd, "STATE:SET:", 10) == 0) {
+        static const struct {
+            const char *name;
+            uint8_t phase;
+        } phase_names[] = {
+            {"PAIRED", PHASE_PAIRED},
+            {"UNPAIRED", PHASE_UNPAIRED},
+            {"SETUP", PHASE_SETUP},
+            {"RECOVERY", PHASE_RECOVERY},
+        };
+        // Unknown phase names fall through silently, matching the chain's
+        // behavior for any other unrecognized command.
+        for (size_t i = 0; i < sizeof(phase_names) / sizeof(phase_names[0]); ++i) {
+            if (strcmp(cmd + 10, phase_names[i].name) == 0) {
+                phase_write(phase_names[i].phase);
+                // Re-resolve the idle LED pattern, which is phase-dependent.
+                if (s_state == PHONE_STATE_IDLE) fsm_led_set(LED_MODE_OFF);
+                uart_proto_send("STATE:SET:OK");
+                break;
+            }
+        }
     } else if (strcmp(cmd, "PHASE?") == 0) {
         char buf[16];
         snprintf(buf, sizeof(buf), "PHASE:0x%02X", phase_read());

--- a/firmware/test/test_fsm.c
+++ b/firmware/test/test_fsm.c
@@ -284,6 +284,34 @@ static void test_fsm_idle_led_follows_phase(void) {
     CHECK_EQ(fake_led_mode(), LED_MODE_DOUBLE_PULSE);
 }
 
+static void test_fsm_state_set_writes_phase_and_acks(void) {
+    fsm_reset_idle();
+
+    static const struct {
+        const char *cmd;
+        uint8_t phase;
+    } cases[] = {
+        {"STATE:SET:UNPAIRED", PHASE_UNPAIRED},
+        {"STATE:SET:SETUP", PHASE_SETUP},
+        {"STATE:SET:RECOVERY", PHASE_RECOVERY},
+        {"STATE:SET:PAIRED", PHASE_PAIRED},
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+        fake_uart_tx_reset();
+        send_cmd(cases[i].cmd);
+        run_for_ms(20);
+        CHECK_EQ(phase_read(), cases[i].phase);
+        CHECK_EQ(fake_uart_tx_count_lines_with_prefix("STATE:SET:OK"), 1);
+    }
+
+    // An unrecognized phase name neither writes the phase nor acks.
+    fake_uart_tx_reset();
+    send_cmd("STATE:SET:BOGUS");
+    run_for_ms(20);
+    CHECK_EQ(phase_read(), PHASE_PAIRED);
+    CHECK_EQ(fake_uart_tx_count_lines_with_prefix("STATE:SET:"), 0);
+}
+
 static void test_fsm_state_name_mapping(void) {
     CHECK_STREQ(phone_fsm_state_name(PHONE_STATE_IDLE), "IDLE");
     CHECK_STREQ(phone_fsm_state_name(PHONE_STATE_DIAL_TONE), "DIAL_TONE");
@@ -309,6 +337,7 @@ static const test_case_t k_fsm_tests[] = {
     TEST_CASE(test_fsm_dialtone_timeout_to_busy),
     TEST_CASE(test_fsm_reset_command_returns_idle),
     TEST_CASE(test_fsm_idle_led_follows_phase),
+    TEST_CASE(test_fsm_state_set_writes_phase_and_acks),
     TEST_CASE(test_fsm_state_name_mapping),
 };
 


### PR DESCRIPTION
## What

The Pi-command dispatcher in `phone_fsm.c` handled `STATE:SET:PAIRED`, `STATE:SET:UNPAIRED`, `STATE:SET:SETUP`, and `STATE:SET:RECOVERY` as four copy-pasted branches, each repeating the same write-phase, refresh-idle-LED, send-ack sequence with only the phase constant varying. This folds them into a single `STATE:SET:` prefix branch with a name-to-phase lookup table.

Behavior is unchanged, including the edge case: an unrecognized phase name (`STATE:SET:BOGUS`) still neither writes the phase nor acks, exactly as it did when it fell through the whole else-if chain.

## Why

The phase-change side effects (LED idle-pattern refresh, the `STATE:SET:OK` ack) now live in one place instead of four, so they cannot drift apart, and adding a phase is one table row instead of a fourth pasted branch in a 38-command dispatcher.

The four handlers also had no direct host-test coverage (only the LED side effect was asserted, for two of the four phases). The new `test_fsm_state_set_writes_phase_and_acks` covers all four phase writes, the ack, and the unknown-name ignore path.

## Validation

`make firmware-test` passes: 36 tests, 142 checks, 0 failures. The host suite compiles `phone_fsm.c` itself, so the changed code is fully exercised; this sandbox has no Docker daemon for the cross-compile, but the change is plain C (`strncmp`/`strcmp`/static table) with nothing SDK-specific, and `fw-ci.yml` runs this same suite.