### PR TITLE
docs: fix stale sudoers and events-package references

### DIFF
--- a/pi/digitsd/README.md
+++ b/pi/digitsd/README.md
@@ -53,7 +53,7 @@ The build embeds assets from `pi/image/rootfs-overlay/` and `pi/tones/` into the
 
 `make embed` copies rootfs overlay files (systemd services, hostapd config, SWD config, boot scripts) and tone WAVs into `internal/assets/embed/`. These are compiled into the binary with `//go:embed` so digitsd can deploy them to the filesystem for OTA updates and factory resets.
 
-Some overlay files are excluded from embedding (boot fragments, sudoers) because they're only needed at image build time, not runtime.
+Some overlay files are excluded from embedding (boot fragments, the `digits-updater` sudoers file, the PCB revision marker) because they're only needed at image build time or, in the case of `digits-updater`, because the asset extractor's own permissions come from it. Other sudoers files such as `digits-devmode` are embedded on purpose so OTA updates deliver them to already-flashed devices.
 
 ## Runtime
 

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -65,7 +65,7 @@ type healthLifecycle interface {
 	EvictConference(confID uuid.UUID)
 }
 
-// dashNotifier is the subset of *dashboard/events.Broadcaster the Tracker
+// dashNotifier is the subset of *events.Broadcaster the Tracker
 // uses to wake dashboard SSE subscribers when active-call count changes.
 // Optional; nil disables notifications.
 type dashNotifier interface {

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -59,7 +59,7 @@ type Conn struct {
 	DevMode         bool
 }
 
-// dashNotifier is the subset of *dashboard/events.Broadcaster the Hub uses
+// dashNotifier is the subset of *events.Broadcaster the Hub uses
 // to wake dashboard SSE subscribers when the set of online lines changes.
 // Optional; nil disables notifications.
 type dashNotifier interface {


### PR DESCRIPTION
## What

Two stale references left behind by yesterday's merges, found by the daily cross-PR coherence pass:

- `server/internal/signaling/hub.go` and `server/internal/calls/tracker.go` documented their `dashNotifier` interfaces as "the subset of `*dashboard/events.Broadcaster`". #755 flattened `internal/dashboard/events` to `internal/events`, so that package path no longer exists; the comments now say `*events.Broadcaster`.
- `pi/digitsd/README.md` said overlay sudoers files are excluded from embedding because they are "only needed at image build time". #754's entire fix was the opposite: `digits-devmode` is deliberately embedded so the asset extractor delivers it to OTA-updated devices, and only `digits-updater` stays build-time (the extractor's own permissions come from it). The README now describes the split, matching the comments #754 put in the sudoers files themselves.

## Why

Both are reader traps: the comments point at a package path that no longer compiles in anyone's head, and the README contradicts both the `OVERLAY_EXCLUDE` list in `pi/digitsd/Makefile` and `docs/architecture/updates-and-recovery.md`, which correctly says sudoers config is embedded.

## Motivated by

- #754: fix(digitsd,image): deliver the dev-mode sudoers entry to OTA-updated devices
- #755: fix(server): address code-audit findings across correctness, hygiene, and tests

## Verification

Comment and README-only change. In both `server/` and `pi/digitsd/`: `go build ./...`, `go test ./...`, and `golangci-lint run ./...` (v2.12.2) all pass.