### PR TITLE
refactor(server): add writeJSON helper for JSON success responses

### DIFF
--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"crypto/subtle"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 
@@ -71,8 +70,7 @@ func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]any{
+	if err := writeJSON(w, map[string]any{
 		"total_users":      totalUsers,
 		"total_households": totalHouseholds,
 		"total_lines":      lineCount,
@@ -105,8 +103,7 @@ func (h *Handler) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]any{
+	if err := writeJSON(w, map[string]any{
 		"total_lines":  len(lineRows),
 		"online_lines": onlineCount,
 		"active_calls": activeCount,
@@ -134,8 +131,7 @@ func (h *Handler) handleAPIActiveCalls(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(pairs); err != nil {
+	if err := writeJSON(w, pairs); err != nil {
 		slog.ErrorContext(r.Context(), "active calls: json encode failed", "err", err)
 	}
 }
@@ -152,15 +148,13 @@ func (h *Handler) handleAPINumberAvailable(w http.ResponseWriter, r *http.Reques
 		jsonError(r.Context(), w, "internal server error", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]bool{"available": !exists}); err != nil {
+	if err := writeJSON(w, map[string]bool{"available": !exists}); err != nil {
 		slog.ErrorContext(r.Context(), "number available: json encode failed", "err", err)
 	}
 }
 
 func (h *Handler) handleAPIVersion(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]string{
+	if err := writeJSON(w, map[string]string{
 		"version": version.Version,
 		"commit":  version.Commit,
 	}); err != nil {

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -3,7 +3,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -62,8 +61,7 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 
 	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+	if err := writeJSON(w, resp); err != nil {
 		slog.ErrorContext(r.Context(), "conference_link_health encode failed", "conf_id", confID, "err", err)
 	}
 }

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -462,6 +462,14 @@ func jsonError(ctx context.Context, w http.ResponseWriter, msg string, code int)
 	}
 }
 
+// writeJSON sets the JSON content type and encodes v to the response body with
+// an implicit 200 status. It is the success-path counterpart to jsonError;
+// callers log the returned error with their own request context.
+func writeJSON(w http.ResponseWriter, v any) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(v)
+}
+
 func renderWith(ctx context.Context, w http.ResponseWriter, t *template.Template, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := t.ExecuteTemplate(w, name, data); err != nil {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -3,7 +3,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"html"
 	"io"
@@ -99,8 +98,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := LinkHealthResp{CallID: call.ID, StartedAt: call.StartedAt, Caller: caller, Callee: callee}
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+	if err := writeJSON(w, resp); err != nil {
 		slog.ErrorContext(r.Context(), "link_health encode failed", "call_id", callID, "err", err)
 	}
 }

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -387,8 +387,7 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 		}{online})
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]bool{"online": online}); err != nil {
+	if err := writeJSON(w, map[string]bool{"online": online}); err != nil {
 		slog.ErrorContext(r.Context(), "encode online status failed", "err", err)
 	}
 }
@@ -757,14 +756,13 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 		return
 	}
 	status := h.hub.GetUpdateStatus(number)
-	w.Header().Set("Content-Type", "application/json")
 	if status == nil {
-		if err := json.NewEncoder(w).Encode(map[string]string{"status": ""}); err != nil {
+		if err := writeJSON(w, map[string]string{"status": ""}); err != nil {
 			slog.ErrorContext(r.Context(), "update status: json encode failed", "err", err)
 		}
 		return
 	}
-	if err := json.NewEncoder(w).Encode(status); err != nil {
+	if err := writeJSON(w, status); err != nil {
 		slog.ErrorContext(r.Context(), "update status: json encode failed", "err", err)
 	}
 }
@@ -890,8 +888,7 @@ func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Reques
 			break
 		}
 	}
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]any{
+	if err := writeJSON(w, map[string]any{
 		"enabled":  enabled,
 		"ssh_user": "dev",
 	}); err != nil {

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -262,8 +262,7 @@ func (h *Handler) handleTestStartCall(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+	_ = writeJSON(w, map[string]any{"id": id})
 }
 
 // handleTestStartConference is a DEV_MODE test-harness endpoint that seeds
@@ -305,8 +304,7 @@ func (h *Handler) handleTestStartConference(w http.ResponseWriter, r *http.Reque
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"conf_id": conf.ID.String()})
+	_ = writeJSON(w, map[string]any{"conf_id": conf.ID.String()})
 }
 
 // handleDevSeedFirmware registers a fake hub entry for a line number with the


### PR DESCRIPTION
## Summary

This PR is the result of a full code-cleanliness audit of the `server/` module covering idiomatic Go, dead/unreferenced code, project layout, and test coverage. The headline finding is that the module is already in excellent shape. The single concrete improvement worth shipping is a small consistency fix, included here.

## Audit method

Established a clean baseline, then ran targeted audits across staleness, idioms/layout, and test coverage. Each candidate finding was verified by hand before acting.

Baseline (all clean):

- `go build ./...`: passes
- `go vet ./...`: passes
- `gofmt -l`: no files
- `go mod tidy`: no changes
- `go test ./...`: 24 packages pass

## What the audit found

The module scores high across every axis:

- **Dead code.** None. Every exported symbol, handler route, and helper is referenced. Zero `TODO`/`FIXME` markers in production code.
- **Idiomatic Go.** Consumer-side interfaces (the two `dashNotifier` interfaces live in their respective consumer packages, which is the idiomatic pattern, not duplication), `Must`-style panics confined to statically-known data, exhaustiveness-guard panics over internal closed enums with untrusted input routed through error-returning parsers, and fully consistent receiver names (0 inconsistencies module-wide).
- **Error handling.** Errors are wrapped with `%w`; ignored returns are limited to deferred `Close` and best-effort response writes.
- **Logging.** Consistent use of the context-aware `slog` variants in request paths; plain variants only in startup/background goroutines where no request context exists.
- **Transactions.** Composite writes (household create plus admin member, conference create plus members plus call updates) are correctly wrapped in `dbutil.WithTx`.
- **Layout.** Clean `cmd/` plus `internal/` split with cohesive, well-named packages.
- **Tests.** The test suite is larger than the production code. Apparent low unit-coverage numbers in some packages (`web`, `pairing`) are an artifact of the integration suite being build-tag gated behind `TEST_DATABASE_URL`, not a real gap.

Several initial candidate findings (interface "duplication", panic usage, receiver naming, missing transaction boundaries, missing tests for `CompareSemver`/`StripGroomedSentinel`) were investigated and confirmed to be false positives.

## What this PR changes

There is a `jsonError` helper for JSON error responses but no counterpart for the success path, so the `Content-Type: application/json` header plus `json.NewEncoder(w).Encode(...)` pair was hand-rolled at roughly a dozen sites. This adds `writeJSON` to mirror `jsonError` and routes the JSON 200 responses through it.

- Adds `writeJSON(w, v) error` next to `jsonError` in `handler_helpers.go`.
- Converts the matching success-path encode sites in `handler_api.go`, `handler_phones.go`, `handler_ws.go`, `handler_linkhealth.go`, and `handler_conference_linkhealth.go`.
- Drops the now-unused `encoding/json` import from three files.

Behavior is unchanged: the helper performs the same two statements in the same order, and callers keep their own per-site error log messages. Two categories are intentionally left as-is: the raw `w.Write([]byte("{}"))` no-op writes (encoding would add a trailing newline) and `respondPhoneCommandResult` (it interleaves `WriteHeader`, which the single-purpose helper does not cover).

Net change: 21 insertions, 28 deletions across 6 files.

## Verification

`go build`, `go vet`, `gofmt`, and the full `go test ./...` suite all pass after the change. A `/simplify` pass across reuse, simplification, altitude, and efficiency returned no actionable findings.

## Grade

| | Score | Notes |
|---|---|---|
| Before | 93 / 100 | Already clean, idiomatic, well-tested, well-organized. Minor success-path JSON-write duplication. |
| After | 94 / 100 | Duplication removed; success/error response helpers now symmetric. |

The codebase was healthy going in; this is polish rather than remediation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RskpsU2ATDcFgZ228128rs)_