### PR TITLE
refactor(digitsd): centralize auto-update gate in one method

### DIFF
--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -264,7 +264,7 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 
 	case sigclient.TypeReleaseAvailable:
 		slog.Info("signal: release_available", "pi", msg.LatestPiVersion, "fw", msg.LatestFWVersion)
-		if d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+		if d.autoUpdateAllowed() {
 			go d.triggerAutoUpdate()
 		}
 

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -270,6 +270,14 @@ func (d *daemonCallbacks) setFirmwareVersion(version, commit string) {
 	d.fwCom = commit
 }
 
+// autoUpdateAllowed reports whether an automatic update may run right now:
+// the line's auto-update setting is on AND the dev-mode skip-auto-update flag
+// is not present. Every place that decides to trigger an update gates on this
+// so the two-part policy stays in one spot.
+func (d *daemonCallbacks) autoUpdateAllowed() bool {
+	return d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath)
+}
+
 // sendSignal sends a signaling message and logs failures.
 func sendSignal(sig *sigclient.Client, msg *sigclient.Message) {
 	if err := sig.Send(msg); err != nil {
@@ -1891,7 +1899,7 @@ func main() {
 		fwVer, _ := cb.getFirmwareVersion()
 		runAutoUpdate(cb, effectiveServerURL, version.Version, fwVer, flashCapable.Load(), requeryFirmware)
 	}
-	if cb.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+	if cb.autoUpdateAllowed() {
 		slog.Info("auto-update: enabled, checking for updates on startup")
 		go cb.triggerAutoUpdate()
 	} else if devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
-	"github.com/justinlindh/digits/pi/digitsd/internal/devmode"
 	"github.com/justinlindh/digits/pi/digitsd/internal/phone"
 	sigclient "github.com/justinlindh/digits/pi/digitsd/internal/signal"
 	owebrtc "github.com/justinlindh/digits/pi/digitsd/internal/webrtc"
@@ -388,7 +387,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.publishVoicemailState()
 	}
 
-	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateAllowed() {
 		slog.Info("auto-update: call ended, running deferred update")
 		if d.triggerAutoUpdate != nil {
 			go d.triggerAutoUpdate()


### PR DESCRIPTION
## Motivation

The decision to trigger an automatic update gates on two conditions: the line's auto-update setting being on, and the dev-mode skip-auto-update flag being absent. That pair was spelled out verbatim at three call sites:

- startup (`main.go`)
- the `release_available` signal handler (`dispatch.go`)
- the deferred post-call update (`webrtc.go`)

Three identical copies of a security-relevant guard is a latent bug: adding a future gate, or simply forgetting the dev-mode half in one spot, silently lets an update run when the operator has pinned the device with the skip flag.

## Change

Extract `daemonCallbacks.autoUpdateAllowed()` and route all three sites through it. The `devmode` import in `webrtc.go` was only there for the inlined check, so it drops out.

The standalone `SkipAutoUpdate` checks that serve other purposes are intentionally left alone: the startup suppression log (which needs to distinguish "off" from "skipped") and the config reconciliation in `dispatch.go` (which compares against the live setting, not the trigger gate).

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `pi/digitsd`.