### PR TITLE
refactor(server): unify line.Settings wire projection

### DIFF
--- a/server/internal/signaling/linestore_adapter.go
+++ b/server/internal/signaling/linestore_adapter.go
@@ -18,8 +18,21 @@ func NewLineStoreAdapter(s *line.Store) LineStore {
 	return &lineStoreAdapter{inner: s}
 }
 
-// VoicemailFromLine projects a line.Voicemail into its wire representation.
-func VoicemailFromLine(v line.Voicemail) *Voicemail {
+// LineSettingsFromLine projects a line.Settings into the wire LineSettings the
+// device consumes. It is the single source of truth for which line fields ride
+// the wire (note QuietHours is deliberately not among them), so registration
+// pushes and on-change pushes can never drift to different field sets.
+func LineSettingsFromLine(s line.Settings) *LineSettings {
+	return &LineSettings{
+		VoiceStyle: s.VoiceStyle,
+		SilentMode: s.SilentMode,
+		AutoUpdate: s.AutoUpdate,
+		Voicemail:  voicemailFromLine(s.Voicemail),
+	}
+}
+
+// voicemailFromLine projects a line.Voicemail into its wire representation.
+func voicemailFromLine(v line.Voicemail) *Voicemail {
 	return &Voicemail{
 		Enabled:            v.Enabled,
 		RingTimeoutSeconds: v.RingTimeoutSeconds,
@@ -31,12 +44,7 @@ func (a *lineStoreAdapter) EffectiveLineSettings(ctx context.Context, number str
 	if err != nil {
 		return nil, err
 	}
-	return &LineSettings{
-		VoiceStyle: settings.VoiceStyle,
-		SilentMode: settings.SilentMode,
-		AutoUpdate: settings.AutoUpdate,
-		Voicemail:  VoicemailFromLine(settings.Voicemail),
-	}, nil
+	return LineSettingsFromLine(settings), nil
 }
 
 func (a *lineStoreAdapter) LineIdentifiers(ctx context.Context, number string) (int64, string, error) {

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -714,14 +714,9 @@ func (h *Handler) applyLineSettings(w http.ResponseWriter, r *http.Request, ln *
 // settings via the registration push in relay.OnRegistered.
 func (h *Handler) pushLineSettings(number string, settings line.Settings) error {
 	err := h.hub.SendTo(number, &signaling.Message{
-		Type: signaling.TypeLineSettings,
-		To:   number,
-		LineSettings: &signaling.LineSettings{
-			VoiceStyle: settings.VoiceStyle,
-			SilentMode: settings.SilentMode,
-			AutoUpdate: settings.AutoUpdate,
-			Voicemail:  signaling.VoicemailFromLine(settings.Voicemail),
-		},
+		Type:         signaling.TypeLineSettings,
+		To:           number,
+		LineSettings: signaling.LineSettingsFromLine(settings),
 	})
 	if errors.Is(err, signaling.ErrNotConnected) {
 		return nil


### PR DESCRIPTION
## Motivation

Two call sites mapped a `line.Settings` into the wire `signaling.LineSettings` field by field:

- the registration push in the LineStore adapter (`signaling/linestore_adapter.go`)
- the on-change push in `pushLineSettings` (`web/handler_phones.go`)

Both had to agree on exactly which line fields cross the wire (`QuietHours` deliberately stays server-side). A new setting added to one path but not the other would be silently dropped from that push, and the divergence would not surface in either build or tests.

## Change

Collapse both onto a single `signaling.LineSettingsFromLine` constructor that owns the wire field set. `VoicemailFromLine` had exactly this one cross-package caller, so it folds into the new helper and becomes unexported (`voicemailFromLine`).

This keeps the existing dependency-isolation shape: the `internal/line` import stays confined to the adapter file where the projection already lived.

## Validation

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass in `server`.