### PR TITLE
fix(server): correct email template width and tidy server internals

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -227,7 +227,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("parse login template: %w", err)
 	}
 	if cfg.DevMode {
-		slog.Warn("dev mode enabled — magic link URLs will be logged to stdout")
+		slog.Warn("dev mode enabled: magic link URLs will be logged to stdout")
 	}
 	authHandlers := auth.NewHandlers(authStore, googleAuth, emailSender, cfg.BaseURL, cfg.CookieDomain, loginTmpl, cfg.DevMode)
 

--- a/server/internal/auth/handlers.go
+++ b/server/internal/auth/handlers.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -95,16 +94,9 @@ func (h *Handlers) HandleMagicLinkVerify(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Find or create user
-	user, err := h.store.GetUserByEmail(r.Context(), emailAddr)
-	if errors.Is(err, ErrUserNotFound) {
-		user, err = h.store.CreateUser(r.Context(), emailAddr, "", nil)
-		if err != nil {
-			http.Error(w, "failed to create user", http.StatusInternalServerError)
-			return
-		}
-	} else if err != nil {
-		slog.ErrorContext(r.Context(), "magic link verify: lookup user", "err", err)
+	user, _, err := h.store.GetOrCreateUserByEmail(r.Context(), emailAddr)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "magic link verify: get or create user", "err", err)
 		http.Error(w, "failed to look up user", http.StatusInternalServerError)
 		return
 	}
@@ -148,14 +140,13 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 
 	slog.InfoContext(r.Context(), "dev-session requested", "email", emailAddr)
 
-	// Find or create user (same pattern as HandleMagicLinkVerify)
-	user, err := h.store.GetUserByEmail(r.Context(), emailAddr)
-	if errors.Is(err, ErrUserNotFound) {
-		user, err = h.store.CreateUser(r.Context(), emailAddr, "", nil)
-		if err != nil {
-			http.Error(w, "failed to create user", http.StatusInternalServerError)
-			return
-		}
+	user, created, err := h.store.GetOrCreateUserByEmail(r.Context(), emailAddr)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "dev-session: get or create user", "err", err)
+		http.Error(w, "failed to look up user", http.StatusInternalServerError)
+		return
+	}
+	if created {
 		// Skip /welcome for fresh dev-session users so e2e tests don't have to
 		// click through the theme picker on every run. The picker can still be
 		// exercised locally by flipping theme_chosen back to false in SQL.
@@ -164,10 +155,6 @@ func (h *Handlers) HandleDevSession(w http.ResponseWriter, r *http.Request) {
 		} else {
 			user.ThemeChosen = true
 		}
-	} else if err != nil {
-		slog.ErrorContext(r.Context(), "dev-session: lookup user", "err", err)
-		http.Error(w, "failed to look up user", http.StatusInternalServerError)
-		return
 	}
 
 	if err := h.store.UpdateLastLogin(r.Context(), user.ID); err != nil {

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -111,6 +111,27 @@ func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error)
 	return s.queryUser(ctx, `email = $1`, email)
 }
 
+// GetOrCreateUserByEmail returns the user for email, creating one (with an empty
+// name and no Google ID) if none exists. The bool reports whether a new user was
+// created. A lookup failure other than ErrUserNotFound is returned unchanged so
+// callers can tell a transient DB error apart from a missing user and avoid
+// silently creating a duplicate account.
+func (s *Store) GetOrCreateUserByEmail(ctx context.Context, email string) (*User, bool, error) {
+	user, err := s.GetUserByEmail(ctx, email)
+	switch {
+	case err == nil:
+		return user, false, nil
+	case errors.Is(err, ErrUserNotFound):
+		user, err = s.CreateUser(ctx, email, "", nil)
+		if err != nil {
+			return nil, false, err
+		}
+		return user, true, nil
+	default:
+		return nil, false, err
+	}
+}
+
 // GetUserByGoogleID looks up a user by their Google OAuth subject ID.
 func (s *Store) GetUserByGoogleID(ctx context.Context, googleID string) (*User, error) {
 	return s.queryUser(ctx, `google_id = $1`, googleID)

--- a/server/internal/autodeploy/config.go
+++ b/server/internal/autodeploy/config.go
@@ -69,8 +69,8 @@ func LoadConfig(path string) (Config, error) {
 		ComposeFile:    raw["COMPOSE_FILE"],
 		ComposeProject: raw["COMPOSE_PROJECT"],
 		ComposeEnvFile: raw["COMPOSE_ENV_FILE"],
-		Services:       splitFields(raw["SERVICES"]),
-		HealthURLs:     splitFields(raw["HEALTH_URLS"]),
+		Services:       strings.Fields(raw["SERVICES"]),
+		HealthURLs:     strings.Fields(raw["HEALTH_URLS"]),
 		GHCRUsername:   raw["GHCR_USERNAME"],
 		StateFile:      raw["STATE_FILE"],
 		SMTPHost:       raw["SMTP_HOST"],
@@ -152,5 +152,3 @@ func LoadConfig(path string) (Config, error) {
 	}
 	return c, nil
 }
-
-func splitFields(s string) []string { return strings.Fields(s) }

--- a/server/internal/autodeploy/runner.go
+++ b/server/internal/autodeploy/runner.go
@@ -1,6 +1,8 @@
-// Package autodeploy implements the automatic binary update loop for the
-// autodeploy command. It polls GitHub Releases for new pi/ tags, downloads
-// the matching arm64 binary, and hot-swaps the running signald process.
+// Package autodeploy implements the automatic update loop for the autodeploy
+// command. It polls GitHub Releases for new tags and, on a new release, drives
+// a Docker Compose deploy (login, pull, up, health-check verify) of the signald
+// stack, reverting to the previous version if the new release fails its health
+// check.
 package autodeploy
 
 import (

--- a/server/internal/calls/history.go
+++ b/server/internal/calls/history.go
@@ -199,19 +199,16 @@ func (t *Tracker) recentConferencesForHistory(ctx context.Context, phones []stri
 	limitIdx := len(args)
 
 	query := fmt.Sprintf(`
-		SELECT c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at,
-		       c.end_reason,
-		       COALESCE(EXTRACT(EPOCH FROM (c.ended_at - c.created_at))::INT, 0) AS duration_s,
-		       array_agg(m.phone ORDER BY CASE WHEN m.phone = c.host_phone THEN 0 ELSE 1 END, m.phone) AS members
+		SELECT %s
 		FROM conferences c
 		JOIN conference_members m ON m.conference_id = c.id
 		WHERE EXISTS (
 		  SELECT 1 FROM conference_members cm
 		  WHERE cm.conference_id = c.id AND cm.phone = ANY($1)
 		)%s
-		GROUP BY c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at, c.end_reason
+		GROUP BY %s
 		ORDER BY c.created_at DESC, c.id DESC
-		LIMIT $%d`, cursorSQL, limitIdx)
+		LIMIT $%d`, conferenceSummaryColumns, cursorSQL, conferenceSummaryGroupBy, limitIdx)
 
 	rows, err := t.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -221,19 +218,10 @@ func (t *Tracker) recentConferencesForHistory(ctx context.Context, phones []stri
 
 	var confs []ConferenceSummary
 	for rows.Next() {
-		var cs ConferenceSummary
-		var endReason *string
-		var members pq.StringArray
-		if err := rows.Scan(
-			&cs.ID, &cs.Host, &cs.OriginatingCallID, &cs.CreatedAt, &cs.EndedAt,
-			&endReason, &cs.DurationS, &members,
-		); err != nil {
+		cs, err := scanConferenceSummary(rows)
+		if err != nil {
 			return nil, err
 		}
-		if endReason != nil {
-			cs.EndReason = *endReason
-		}
-		cs.Members = []string(members)
 		confs = append(confs, cs)
 	}
 	return confs, rows.Err()

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -862,7 +862,7 @@ func (t *Tracker) RecentForPhones(ctx context.Context, phoneNumbers []string, li
 		return nil, nil
 	}
 
-	// Build IN clause — reuse same $1..$N placeholders for both caller and callee
+	// Build IN clause: reuse same $1..$N placeholders for both caller and callee
 	n := len(phoneNumbers)
 	ph := dbutil.Placeholders(n)
 	query := fmt.Sprintf(

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -527,13 +527,8 @@ const conferenceSummaryColumns = `c.id, c.host_phone, c.originating_call_id, c.c
 
 const conferenceSummaryGroupBy = `c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at, c.end_reason`
 
-// rowScanner is satisfied by both *sql.Row and *sql.Rows.
-type rowScanner interface {
-	Scan(dest ...any) error
-}
-
 // scanConferenceSummary scans one row selected with conferenceSummaryColumns.
-func scanConferenceSummary(row rowScanner) (ConferenceSummary, error) {
+func scanConferenceSummary(row dbutil.RowScanner) (ConferenceSummary, error) {
 	var cs ConferenceSummary
 	var endReason *string
 	var members pq.StringArray

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -517,6 +517,39 @@ func scanCallRows(rows *sql.Rows) ([]Call, error) {
 	return calls, rows.Err()
 }
 
+// conferenceSummaryColumns is the SELECT list for queries that scan into a
+// ConferenceSummary via scanConferenceSummary; conferenceSummaryGroupBy is the
+// matching GROUP BY list. Keep both in sync with the scan there.
+const conferenceSummaryColumns = `c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at,
+	c.end_reason,
+	COALESCE(EXTRACT(EPOCH FROM (c.ended_at - c.created_at))::INT, 0) AS duration_s,
+	array_agg(m.phone ORDER BY CASE WHEN m.phone = c.host_phone THEN 0 ELSE 1 END, m.phone) AS members`
+
+const conferenceSummaryGroupBy = `c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at, c.end_reason`
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanConferenceSummary scans one row selected with conferenceSummaryColumns.
+func scanConferenceSummary(row rowScanner) (ConferenceSummary, error) {
+	var cs ConferenceSummary
+	var endReason *string
+	var members pq.StringArray
+	if err := row.Scan(
+		&cs.ID, &cs.Host, &cs.OriginatingCallID, &cs.CreatedAt, &cs.EndedAt,
+		&endReason, &cs.DurationS, &members,
+	); err != nil {
+		return cs, err
+	}
+	if endReason != nil {
+		cs.EndReason = *endReason
+	}
+	cs.Members = []string(members)
+	return cs, nil
+}
+
 // MarkForceEnded records which user force-ended a call. Returns nil error
 // even if no rows matched (idempotent against racing peer hangups).
 func (t *Tracker) MarkForceEnded(ctx context.Context, callID int64, userID string) error {
@@ -677,33 +710,20 @@ func (t *Tracker) RecordKick(ctx context.Context, confID uuid.UUID, kickedPhone,
 // GetConferenceByID returns a conference summary from the DB by ID. Returns
 // (nil, nil) if not found. Handles both active and ended conferences.
 func (t *Tracker) GetConferenceByID(ctx context.Context, confID uuid.UUID) (*ConferenceSummary, error) {
-	const query = `
-		SELECT c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at,
-		       c.end_reason,
-		       COALESCE(EXTRACT(EPOCH FROM (c.ended_at - c.created_at))::INT, 0) AS duration_s,
-		       array_agg(m.phone ORDER BY CASE WHEN m.phone = c.host_phone THEN 0 ELSE 1 END, m.phone) AS members
+	query := fmt.Sprintf(`
+		SELECT %s
 		FROM conferences c
 		JOIN conference_members m ON m.conference_id = c.id
 		WHERE c.id = $1
-		GROUP BY c.id, c.host_phone, c.originating_call_id, c.created_at, c.ended_at, c.end_reason`
+		GROUP BY %s`, conferenceSummaryColumns, conferenceSummaryGroupBy)
 
-	var cs ConferenceSummary
-	var endReason *string
-	var members pq.StringArray
-	err := t.db.QueryRowContext(ctx, query, confID).Scan(
-		&cs.ID, &cs.Host, &cs.OriginatingCallID, &cs.CreatedAt, &cs.EndedAt,
-		&endReason, &cs.DurationS, &members,
-	)
+	cs, err := scanConferenceSummary(t.db.QueryRowContext(ctx, query, confID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get conference %s: %w", confID, err)
 	}
-	if endReason != nil {
-		cs.EndReason = *endReason
-	}
-	cs.Members = []string(members)
 	return &cs, nil
 }
 

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -13,7 +13,7 @@ func brandedWrap(content string) string {
 <body style="margin:0; padding:0; background-color:#0f1117; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
 <table width="100%%" cellpadding="0" cellspacing="0" style="background-color:#0f1117; padding:40px 20px;">
 <tr><td align="center">
-<table width="480" cellpadding="0" cellspacing="0" style="max-width:480px; width:100%%.">
+<table width="480" cellpadding="0" cellspacing="0" style="max-width:480px; width:100%%">
 
 <!-- Header -->
 <tr><td style="padding:0 0 24px 0;">

--- a/server/internal/logging/logging.go
+++ b/server/internal/logging/logging.go
@@ -66,19 +66,16 @@ func (h *traceContextHandler) Enabled(ctx context.Context, level slog.Level) boo
 // canonical hex encoding (32 chars for trace, 16 for span) so they line
 // up with the values Tempo and Loki use for correlation queries.
 func (h *traceContextHandler) Handle(ctx context.Context, r slog.Record) error {
-	span := trace.SpanFromContext(ctx)
-	if span != nil {
-		sc := span.SpanContext()
-		// Only add the fields when a real, non-zero span context is
-		// present. SpanFromContext returns a noop span for callers that
-		// log outside a traced flow; that span has an all-zero context,
-		// and adding 32 zeros to every log line would be noise.
-		if sc.IsValid() {
-			r.AddAttrs(
-				slog.String("trace_id", sc.TraceID().String()),
-				slog.String("span_id", sc.SpanID().String()),
-			)
-		}
+	// Only add the fields when a real, non-zero span context is present.
+	// SpanFromContext returns a noop span (never nil) for callers that log
+	// outside a traced flow; that span has an all-zero context, and adding 32
+	// zeros to every log line would be noise.
+	sc := trace.SpanFromContext(ctx).SpanContext()
+	if sc.IsValid() {
+		r.AddAttrs(
+			slog.String("trace_id", sc.TraceID().String()),
+			slog.String("span_id", sc.SpanID().String()),
+		)
 	}
 	return h.inner.Handle(ctx, r)
 }

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -245,14 +245,14 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 			slog.InfoContext(ctx, "update_status", "number", from, "status", "success",
 				"detail", "device reconnected with "+msg.PiVersion)
 		}
-		return // No relay — server consumes this
+		return // No relay: server consumes this
 	case TypeUpdateStatus:
 		slog.InfoContext(ctx, "update_status", "number", from,
 			"status", msg.UpdateStatus, "detail", msg.UpdateDetail)
 		r.Hub.SetUpdateStatus(from, msg.UpdateStatus, msg.UpdateDetail)
-		return // No relay — server consumes this
+		return // No relay: server consumes this
 	case TypeRestart:
-		return // Server → device only; ignore if echoed back
+		return // Server to device only; ignore if echoed back
 	case TypeLinkHealth:
 		r.handleLinkHealth(ctx, from, msg)
 		return

--- a/server/internal/updates/store.go
+++ b/server/internal/updates/store.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // Component selectors used by SortedReleases and RangeReleases.
@@ -17,14 +16,12 @@ const (
 
 // Release describes a single versioned artifact (Pi binary or firmware).
 type Release struct {
-	Version    string    `json:"version"`
-	Commit     string    `json:"commit,omitempty"`
-	SHA256     string    `json:"sha256,omitempty"`
-	URL        string    `json:"url"`
-	Date       string    `json:"date"`
-	Notes      string    `json:"notes,omitempty"`
-	AudioURL   string    `json:"audio_url,omitempty"`
-	ReleasedAt time.Time `json:"-"`
+	Version  string `json:"version"`
+	SHA256   string `json:"sha256,omitempty"`
+	URL      string `json:"url"`
+	Date     string `json:"date"`
+	Notes    string `json:"notes,omitempty"`
+	AudioURL string `json:"audio_url,omitempty"`
 }
 
 // ReleaseIndex is the structure served at /api/updates/releases.

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -239,7 +239,7 @@ type Handler struct {
 	linkStore   *household.LinkStore
 	inviteStore *household.InviteStore
 	emailer     email.Sender
-	// Rate limiters. All four are Handler fields so Router() has a single
+	// Rate limiters. All are Handler fields so Router() has a single
 	// construction pattern; previously the magic-link verify and Google
 	// login limiters were instantiated inline inside Router(), which made
 	// them harder to spot and impossible to share across request types.
@@ -535,15 +535,15 @@ func (h *Handler) SetReleases(r *updates.GitHubReleases) {
 func (h *Handler) Router() http.Handler {
 	mux := http.NewServeMux()
 
-	// Static assets — no auth required. In DevMode, serve from disk so
+	// Static assets: no auth required. In DevMode, serve from disk so
 	// CSS/JS edits don't require a rebuild; otherwise serve the embedded
 	// FS so the production binary is self-contained.
 	mux.Handle("GET /static/", staticFileServer(h.cfg.DevMode, h.cfg.DevStaticDir))
 
-	// Health check — no auth required
+	// Health check: no auth required
 	mux.HandleFunc("GET /healthz", httputil.Healthz(version.Version))
 
-	// Public routes — no auth required
+	// Public routes: no auth required
 	mux.HandleFunc("GET /auth/login", h.authHandlers.HandleLoginPage)
 	mux.Handle("POST /auth/magic", h.authLimiter.Middleware(http.HandlerFunc(h.authHandlers.HandleMagicLinkRequest)))
 	mux.Handle("GET /auth/magic/{token}", h.magicVerifyLimiter.Middleware(http.HandlerFunc(h.authHandlers.HandleMagicLinkVerify)))
@@ -557,7 +557,7 @@ func (h *Handler) Router() http.Handler {
 	mux.HandleFunc("GET /internal/stats", h.handleInternalStats)
 	mux.Handle("GET /ws", h.wsLimiter.Middleware(http.HandlerFunc(h.handleWS)))
 
-	// Update release index endpoint (unauthenticated — phones fetch this)
+	// Update release index endpoint (unauthenticated; phones fetch this)
 	if h.releases != nil {
 		mux.HandleFunc("GET /api/updates/releases", h.releases.ServeReleases())
 		mux.HandleFunc("GET /api/release-audio/{component}/{version}", h.releases.ServeAudio())
@@ -583,7 +583,7 @@ func (h *Handler) Router() http.Handler {
 		mux.HandleFunc("POST /dev/seed-firmware", h.handleDevSeedFirmware)
 	}
 
-	// Protected routes — require valid session
+	// Protected routes: require valid session
 	protected := http.NewServeMux()
 	protected.HandleFunc("GET /", h.handleDashboard)
 	protected.HandleFunc("GET /connecting", h.handleConnecting)

--- a/server/internal/web/handler_changelog.go
+++ b/server/internal/web/handler_changelog.go
@@ -43,15 +43,15 @@ func (h *Handler) handleChangelog(w http.ResponseWriter, r *http.Request) {
 
 	var data changelogData
 	if idx != nil {
-		data.Server = buildChangelogSection(idx, updates.ComponentServer, nil, h)
-		data.Software = buildChangelogSection(idx, updates.ComponentPi, lines, h)
-		data.Firmware = buildChangelogSection(idx, updates.ComponentFirmware, lines, h)
+		data.Server = h.buildChangelogSection(idx, updates.ComponentServer, nil)
+		data.Software = h.buildChangelogSection(idx, updates.ComponentPi, lines)
+		data.Firmware = h.buildChangelogSection(idx, updates.ComponentFirmware, lines)
 	}
 
 	renderWith(r.Context(), w, h.tmplChangelog, "changelog-content", data)
 }
 
-func buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []string, h *Handler) []changelogRelease {
+func (h *Handler) buildChangelogSection(idx *updates.ReleaseIndex, component string, lines []string) []changelogRelease {
 	releases := idx.SortedReleases(component)
 	out := make([]changelogRelease, 0, len(releases))
 

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -84,7 +84,7 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Display-name resolution — same helpers as /calls page. No new data exposure.
+	// Display-name resolution: same helpers as /calls page. No new data exposure.
 	// Linked-household names are shown for peers that the user already sees in
 	// their call log; the underlying auth check does not grant read access to
 	// calls the user was not part of.


### PR DESCRIPTION
## What this is

A code cleanliness pass over the `server/` module: a review of idiomatic Go, dead/stale code, project layout, and test coverage, followed by fixes for the concrete findings. Includes one genuine user-visible fix (email rendering) alongside several internal refactors.

## Grade: 88 before, 93 after

### Why 88 before

The module was already in strong shape: `go build`, `go vet`, `golangci-lint` (standard) and the full test suite all pass clean, `deadcode` is clean, there are no TODO/FIXME markers, the layout is standard (`cmd/` thin mains over `internal/` packages, embedded templates and static assets), and the code is idiomatic throughout (errors wrapped with `%w`, `errors.Is`/`errors.As` against sentinels, rows closed with `rows.Err()` checked, no naked returns in long functions, no else-after-return chains). Test coverage is broad across unit, integration (build-tagged), and Playwright e2e tiers.

The deductions were for a handful of real issues:

- A conference summary `SELECT` plus its scan-into-struct was copy-pasted across two files, with the column list and scan that must stay in lockstep being exactly the duplicated parts (drift risk).
- The find-or-create-user sequence, including the security-sensitive distinction between a missing user and a transient DB error, was hand-copied across two handlers.
- Em dashes in source comments and a log string, against the project's own hard no-em-dashes rule.
- Dead code: never-populated `Release.Commit` / `Release.ReleasedAt` fields, an always-true `if span != nil` guard, a no-value `splitFields` wrapper.
- Stale comments: an "All four" rate-limiter count (there are six) and an `autodeploy` package doc describing an arm64 binary download and process hot-swap the package does not do.
- A broken `width:100%.` declaration in the email template (the stray period makes clients drop the rule, losing responsive width).

### What changed (and why 93 after)

| Commit | Change |
| --- | --- |
| `refactor` | Consolidate the duplicated conference summary query and scan into `conferenceSummaryColumns`/`conferenceSummaryGroupBy` consts and a `scanConferenceSummary` helper, mirroring the existing `callColumns`/`scanCallRows` pattern. |
| `refactor` | Move find-or-create-user into `Store.GetOrCreateUserByEmail`, which also reports whether a user was created so dev-session can mark the theme chosen. The Google callback keeps its own three-way lookup (it links by Google ID and creates with the OAuth name). |
| `refactor` | Make `buildChangelogSection` a `*Handler` method instead of threading `*Handler` as a trailing argument, matching its peers. |
| `fix` | Remove the stray period from the email table `width:100%` so the responsive width applies on narrow screens. |
| `refactor` | Remove dead code (dead nil guard, unused `Release` fields and the `time` import, the `splitFields` wrapper) and fix stale comments and em dashes in source. |
| `refactor` | Use the shared `dbutil.RowScanner` for the conference scan instead of a local redeclaration (found by the `/simplify` pass). |

After the pass: `build`, `vet`, `golangci-lint`, and the full test suite still pass clean, the duplication and drift risk are gone, production Go source is em-dash-clean, and the stale docs match the code.

### Deliberately not in scope

- `/healthz` on the metrics listener still inlines `{"status":"ok"}` rather than reusing `httputil.Healthz`: switching it would change that ops endpoint's response body (the shared helper adds a version field), a behavior change to a probe target.
- `events.Broadcaster.Notify` / `notifyLocal` share a fan-out loop: left as is, since deduping it touches lock ordering for a roughly six-line saving.
- `household.LinkStore` returns ad-hoc `errors.New` for not-found and conflict cases while the sibling `InviteStore` uses sentinels: no caller distinguishes them via `errors.Is` today (they are rendered as text), so adding sentinels now would be speculative API surface (YAGNI).
- Em dashes remain in test files and in CSS/HTML comments (and the dev-only test client): these are comment and dev-tooling punctuation with no Go-code-quality or functional signal, and template copy risks e2e assertions, so they are out of scope for this production-source pass.

## Testing

- `go build ./...`, `go vet ./...`: clean.
- `golangci-lint run ./...` (standard linters): 0 issues.
- `go test ./...`: all packages pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YU4M1N81pWAzpPzWDP3h35)_