### PR TITLE
refactor(digitsd): fold subsystem topoLayers enabled-set into regByName

### DIFF
--- a/pi/digitsd/internal/subsystem/manager.go
+++ b/pi/digitsd/internal/subsystem/manager.go
@@ -186,11 +186,12 @@ func (m *Manager) logSummary(ctx context.Context) {
 // Disabled modules are excluded from the output layers; their names are also
 // excluded from the dep graph so that dependents can still resolve.
 func topoLayers(regs []Registration) ([][]Registration, error) {
-	// Build index of enabled modules by name.
-	enabled := make(map[string]bool, len(regs))
+	// Index enabled modules by name. Doubles as the enabled-membership set
+	// for dependency resolution: a name is enabled iff it has an entry here.
+	regByName := make(map[string]Registration, len(regs))
 	for _, r := range regs {
 		if !r.Disabled {
-			enabled[r.Module.Name()] = true
+			regByName[r.Module.Name()] = r
 		}
 	}
 
@@ -207,20 +208,12 @@ func topoLayers(regs []Registration) ([][]Registration, error) {
 			inDegree[name] = 0
 		}
 		for _, dep := range r.Deps {
-			if !enabled[dep] {
-				// disabled dep: ignore it
+			if _, ok := regByName[dep]; !ok {
+				// disabled (or unknown) dep: ignore it
 				continue
 			}
 			deps[dep] = append(deps[dep], name)
 			inDegree[name]++
-		}
-	}
-
-	// Collect enabled regs by name for layer construction.
-	regByName := make(map[string]Registration, len(regs))
-	for _, r := range regs {
-		if !r.Disabled {
-			regByName[r.Module.Name()] = r
 		}
 	}
 


### PR DESCRIPTION
## Motivation

`topoLayers` (Kahn's algorithm over the module dependency graph) built two maps over the same filtered key set:

- `enabled` (`map[string]bool`), used only to test whether a dependency name refers to an active module
- `regByName` (`map[string]Registration`), used to assemble the output layers

Both are populated by the identical `for r := range regs { if !r.Disabled { m[r.Module.Name()] = ... } }` loop, so they always carry the same keys. That made them a hand-maintained invariant (add a filter condition to one, you must add it to the other) for no benefit: the bool map carries strictly less information than the registration map already does.

## Change

Build `regByName` up front and use its membership (`_, ok := regByName[dep]`) for the disabled-dependency check, dropping the separate `enabled` map and its construction loop. The membership semantics are identical, so the topological sort still ignores disabled and unknown deps exactly as before.

## Validation

`go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` suite pass in `pi/digitsd`. (golangci-lint could not run in this environment due to a toolchain version mismatch; CI runs the pinned version.)