### PR TITLE
refactor(server): tidy NewHandler template parsing and refresh stale docs

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -310,19 +310,24 @@ cmd/signald/             Entry point -- wires all components
 
 internal/
   auth/                  User authentication (magic links, Google OAuth, sessions)
+  autodeploy/            GHCR pull + compose rollout for the prod autodeploy timer
   calls/                 Call lifecycle tracking and history
   config/                Environment variable config loading
   db/                    Postgres connection and schema migrations
   dbutil/                Database utilities
   device/                Physical device persistence and pairing
   email/                 SMTP email sender (magic link delivery)
+  events/                Dashboard event fan-out (in-memory and Redis pub/sub)
   household/             Household CRUD, membership, onboarding
   httputil/              HTTP helpers (healthz)
   line/                  Phone number CRUD, call authorization
   logging/               Structured logging setup (slog + tint)
+  metrics/               Prometheus metrics and privacy-safe route bucketing
   pairing/               Pairing code generation and claim flow
+  profiling/             Pyroscope continuous-profiling integration
   ratelimit/             IP-based token bucket rate limiter
   signaling/             WebSocket hub, message relay, protocol types
+  tracing/               OpenTelemetry trace setup and DB instrumentation
   turn/                  TURN credential generation (HMAC-SHA1)
   updates/               GitHub release index fetching and caching
   version/               Build-time version info

--- a/server/docs/tracing.md
+++ b/server/docs/tracing.md
@@ -76,7 +76,7 @@ slow query can run `EXPLAIN` against the database directly.
 What `otelsql` still records:
 
 - `db.system: postgresql`
-- `db.name`: `digits` or `digits_admin`
+- `db.name`: the database from `DATABASE_URL` (`digits` in prod, `digits_test` under integration tests)
 - operation kind (connection, query, prepare) and duration
 - error attribute on failed calls
 
@@ -173,9 +173,8 @@ side by side. Routing:
   log records.
 
 The k8s deployment manifests in `homelab-k8s/manifests/digits/` set the
-env vars; the docker prod deployment is unchanged for now (the
-exporter stays disabled until cutover, per `CLAUDE.local.md`'s
-"Parallel k8s deployment" note).
+env vars; the docker prod deployment is unchanged for now, with the
+exporter staying disabled until the k8s cutover.
 
 ## Tests
 

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -365,7 +365,7 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	// parsePage closes over the layout + shared-partials file list so each
 	// page only names itself. Adding a new layout or partial touches one line.
 	parsePage := func(page string) (*template.Template, error) {
-		return template.New("").Funcs(funcMap).ParseFS(templateFS,
+		t, err := template.New("").Funcs(funcMap).ParseFS(templateFS,
 			"templates/_partials.html",
 			"templates/_changelog.html",
 			"templates/layout-v2.html",
@@ -373,19 +373,30 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 			"templates/layout-answering-machine.html",
 			"templates/"+page,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", page, err)
+		}
+		return t, nil
+	}
+	// parsePageWith parses a page and then folds in extra partials, so their
+	// {{template "..."}} references resolve inside the page's template tree.
+	parsePageWith := func(page string, partials ...string) (*template.Template, error) {
+		t, err := parsePage(page)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := t.ParseFS(templateFS, partials...); err != nil {
+			return nil, fmt.Errorf("parse partials %v into %s: %w", partials, page, err)
+		}
+		return t, nil
 	}
 
-	tmplDashboard, err := parsePage("dashboard.html")
+	tmplDashboard, err := parsePageWith("dashboard.html",
+		"templates/dnd-toggle.html",
+		"templates/_dashboard-am-status.html",
+	)
 	if err != nil {
 		return nil, err
-	}
-	if _, err := tmplDashboard.ParseFS(templateFS, "templates/dnd-toggle.html"); err != nil {
-		return nil, fmt.Errorf("parse dnd-toggle partial into dashboard: %w", err)
-	}
-	// Merge the AM status partial so {{template "dashboard-am-status"}} resolves
-	// inside the dashboard page.
-	if _, err := tmplDashboard.ParseFS(templateFS, "templates/_dashboard-am-status.html"); err != nil {
-		return nil, fmt.Errorf("parse dashboard-am-status partial into dashboard: %w", err)
 	}
 	tmplDashboardAMStatus, err := template.New("dashboard-am-status").Funcs(funcMap).ParseFS(templateFS, "templates/_dashboard-am-status.html")
 	if err != nil {
@@ -435,21 +446,13 @@ func NewHandler(deps Deps, cfg HandlerConfig) (*Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse conference-live-panel: %w", err)
 	}
-	tmplCallLiveDetail, err := parsePage("call-live-detail.html")
+	tmplCallLiveDetail, err := parsePageWith("call-live-detail.html", "templates/_call-live-panel.html")
 	if err != nil {
-		return nil, fmt.Errorf("parse call-live-detail: %w", err)
+		return nil, err
 	}
-	// Merge the panel partial so {{template "call-live-panel"}} resolves inside the detail page.
-	if _, err := tmplCallLiveDetail.ParseFS(templateFS, "templates/_call-live-panel.html"); err != nil {
-		return nil, fmt.Errorf("parse call-live-panel partial into detail: %w", err)
-	}
-	tmplConferenceLiveDetail, err := parsePage("conference-live-detail.html")
+	tmplConferenceLiveDetail, err := parsePageWith("conference-live-detail.html", "templates/_conference-live-panel.html")
 	if err != nil {
-		return nil, fmt.Errorf("parse conference-live-detail: %w", err)
-	}
-	// Merge the panel partial so {{template "conference-live-panel"}} resolves inside the detail page.
-	if _, err := tmplConferenceLiveDetail.ParseFS(templateFS, "templates/_conference-live-panel.html"); err != nil {
-		return nil, fmt.Errorf("parse conference-live-panel partial into detail: %w", err)
+		return nil, err
 	}
 	tmplChangelog, err := template.New("changelog").Funcs(funcMap).ParseFS(templateFS,
 		"templates/_partials.html",


### PR DESCRIPTION
## Summary

A cleanliness pass over the `server/` module. The package was already in strong shape, so this is a small, targeted set of fixes rather than a rewrite.

## What I checked

Baseline tooling was already clean and stays clean after these changes:

- `go build ./...`, `go vet ./...`: clean
- `golangci-lint run ./...` (standard config): 0 issues
- `staticcheck ./...`: 0 issues
- `deadcode ./...`: nothing reachable-but-unused (the one hit, `emailtest`, is a test helper used by tests)
- Full `go test ./...`: all 24 packages pass

I also audited every static asset and template for references: all 30 static files and 23 templates are used. No stale assets found.

## Changes

**1. Unify template parse error wrapping in `NewHandler` (`internal/web/handler.go`).**
The constructor parsed ~14 templates, but error handling was inconsistent: the `parsePage` closure returned a bare error while some call sites wrapped with `fmt.Errorf("parse X: %w", ...)` and others did not, so a parse failure could surface with or without the offending template name depending on which line broke. Moved the page-name context into `parsePage` itself so every failure names its template, and added a small `parsePageWith(page, partials...)` helper that folds extra partials into a page. That collapsed the three duplicated "parse page then merge partial" blocks (dashboard, call-live, conference-live) and removed their now-redundant per-site wrapping. Net: fewer lines, one consistent error shape.

**2. Refresh the README architecture map (`server/README.md`).**
The `internal/` package list documented 18 packages but the tree has 23. Added the five that were silently missing: `autodeploy`, `events`, `metrics`, `profiling`, and `tracing`. Three of those are core observability packages, so the omission understated the system's surface.

**3. Fix two dead references in `docs/tracing.md`.**
- `db.name: digits or digits_admin` cited a `digits_admin` database that does not exist (the server opens a single connection from `DATABASE_URL`); replaced with the real `DATABASE_URL`-derived value.
- A note cited `CLAUDE.local.md` for the "Parallel k8s deployment" plan, but no such file exists in the repo. Reworded to keep the meaning without the dangling citation.

## Verification

`go build`, `go vet`, `golangci-lint`, and the full `go test ./...` suite all pass after the changes. The template parse refactor is exercised by the existing `template_parse_test.go` and the web handler tests.

## Grade

**Before: 92 / 100.** Excellent structure and tooling hygiene, comprehensive tests, well-documented code. Held back only by a minor error-handling inconsistency in one constructor, an out-of-date architecture list, and two stale doc references.

**After: 96 / 100.** Those blemishes are resolved. The remaining gap is unit-test coverage in store-heavy packages (`device`, `household`, `auth`), which is largely covered by the build-tagged integration suite rather than unit tests, so it is a reporting artifact more than a real hole. Left untouched here to keep this change focused and low-risk.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdEH1uDA22Lu3TiTKU9wpa)_