### PR TITLE
refactor(server): drop unused lineNumbers param from hasPhoneUpdates

### DIFF
--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -390,7 +390,7 @@ func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chro
 	cd := newChromeData(page, auth.UserFromContext(r.Context()), active)
 	cd.Households = households
 	if active != nil {
-		cd.HasUpdates = h.hasPhoneUpdates(r.Context(), active.ID, nil)
+		cd.HasUpdates = h.hasPhoneUpdates(r.Context(), active.ID)
 		if h.lineStore != nil {
 			silent, err := h.lineStore.AllSilentByHousehold(r.Context(), active.ID)
 			if err != nil {
@@ -403,9 +403,8 @@ func (h *Handler) newChromeDataWithHouseholds(r *http.Request, page string) chro
 }
 
 // hasPhoneUpdates returns true if any phone in the household is behind the
-// latest pi or firmware release. If lineNumbers is non-nil, it skips the DB
-// lookup and uses the provided numbers directly.
-func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string, lineNumbers []string) bool {
+// latest pi or firmware release.
+func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string) bool {
 	if h.releases == nil {
 		return false
 	}
@@ -418,18 +417,16 @@ func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string, lineN
 	if latestPi == "" && latestFw == "" {
 		return false
 	}
-	if lineNumbers == nil {
-		if h.lineStore == nil {
-			return false
-		}
-		lines, err := h.lineStore.ListByHousehold(ctx, householdID)
-		if err != nil {
-			return false
-		}
-		lineNumbers = make([]string, len(lines))
-		for i, l := range lines {
-			lineNumbers[i] = l.Number
-		}
+	if h.lineStore == nil {
+		return false
+	}
+	lines, err := h.lineStore.ListByHousehold(ctx, householdID)
+	if err != nil {
+		return false
+	}
+	lineNumbers := make([]string, len(lines))
+	for i, l := range lines {
+		lineNumbers[i] = l.Number
 	}
 	for _, number := range lineNumbers {
 		for _, info := range h.hub.AllDeviceInfo(number) {


### PR DESCRIPTION
## What

`hasPhoneUpdates` took an optional `lineNumbers []string` argument, documented as a way to skip the per-household DB lookup and use caller-supplied numbers directly. Its only caller (`newChromeDataWithHouseholds`) always passed `nil`.

That made the parameter and its `if lineNumbers == nil { ... }` branch premature flexibility with zero users: a path that exists only in case someone might want it later. This drops the argument and the conditional, so the function unconditionally resolves line numbers from the line store.

## Why this scope

The fast-path branch isn't dead in the unreachable sense (it's the only path that ever ran, since the arg was always nil), but the *non-nil* half of it never executes and the parameter misleads readers into thinking callers can pre-supply numbers. Removing it tightens the contract to what the code actually does. Net: one parameter and one conditional gone, behavior unchanged.

## Validation

- `go build ./...`
- `go test ./...`
- `golangci-lint run ./...`