### PR TITLE
refactor(digitsd): drop unreachable responder branch in AddMeshPeer

### DIFF
--- a/pi/digitsd/cmd/digitsd/conference.go
+++ b/pi/digitsd/cmd/digitsd/conference.go
@@ -246,27 +246,22 @@ func (d *daemonCallbacks) AddMeshPeer(phone string, initiator bool) {
 
 	pm.OnConnectionState = d.meshReporterOnConnected(pm, phone)
 
-	if initiator {
-		// Initiator creates and sends the SDP offer to the peer.
-		offer, err := pm.CreateOffer()
-		if err != nil {
-			slog.Error("conference: create offer failed", "phone", phone, "err", err)
-			close(sdpSent)
-			return
-		}
-		sendSignal(sig, &sigclient.Message{
-			Type:   sigclient.TypeSDP,
-			To:     phone,
-			ConfID: confID,
-			SDP:    offer,
-		})
+	// Past the early return above, this is always the initiator path: create
+	// and send the SDP offer to the peer. The responder never reaches here.
+	offer, err := pm.CreateOffer()
+	if err != nil {
+		slog.Error("conference: create offer failed", "phone", phone, "err", err)
 		close(sdpSent)
-		slog.Info("conference: sent SDP offer to peer", "phone", phone, "conf_id", confID)
-	} else {
-		// Responder waits for the initiator's offer (handled in TypeSDP dispatch).
-		// Ungate ICE candidates immediately since we don't send an offer here.
-		close(sdpSent)
+		return
 	}
+	sendSignal(sig, &sigclient.Message{
+		Type:   sigclient.TypeSDP,
+		To:     phone,
+		ConfID: confID,
+		SDP:    offer,
+	})
+	close(sdpSent)
+	slog.Info("conference: sent SDP offer to peer", "phone", phone, "conf_id", confID)
 }
 
 func (d *daemonCallbacks) RemoveMeshPeer(phone string) {


### PR DESCRIPTION
## What

`AddMeshPeer(phone string, initiator bool)` returns early for the responder case at the top:

```go
if !initiator {
    slog.Info("conference: responder waiting for initiator SDP", "phone", phone)
    return
}
```

So every line past that guard runs only when `initiator == true`. Yet the function ended with a redundant `if initiator { ... } else { ... }` re-checking the same constant. The `else` arm only closed `sdpSent` with a comment claiming "Responder waits for the initiator's offer", but the responder can never reach it: that path is `setupMeshResponder`, dispatched separately.

This collapses the conditional to the unconditional initiator path (create and send the SDP offer), so the control flow matches what actually executes.

## Why this scope

The dead `else` is the kind of leftover that misleads: a reader sees a responder branch here and assumes both roles flow through `AddMeshPeer`, when the early return already split them. Removing it is behavior-preserving (the offer path is unchanged) and removes a false signpost. The `initiator` parameter stays, since the early-return guard still uses it.

## Validation

- `go build ./...`
- `go test ./...`
- `golangci-lint run ./...`