### PR TITLE
test(server): cover device, household, pairing, and auth store gaps

### DIFF
--- a/server/internal/auth/store_test.go
+++ b/server/internal/auth/store_test.go
@@ -75,6 +75,50 @@ func TestCreateAndGetUser(t *testing.T) {
 	}
 }
 
+func TestGetOrCreateUserByEmail_Creates(t *testing.T) {
+	s := testDB(t)
+
+	u, created, err := s.GetOrCreateUserByEmail(context.Background(), "fresh@example.com")
+	if err != nil {
+		t.Fatalf("GetOrCreateUserByEmail: %v", err)
+	}
+	if !created {
+		t.Error("expected created=true for a brand-new email")
+	}
+	if u.Email != "fresh@example.com" {
+		t.Errorf("email = %q, want fresh@example.com", u.Email)
+	}
+	if u.Name != "" {
+		t.Errorf("name = %q, want empty for auto-created user", u.Name)
+	}
+	if u.GoogleID != nil {
+		t.Errorf("GoogleID = %v, want nil for auto-created user", u.GoogleID)
+	}
+}
+
+func TestGetOrCreateUserByEmail_ReturnsExisting(t *testing.T) {
+	s := testDB(t)
+
+	existing, err := s.CreateUser(context.Background(), "existing@example.com", "Existing User", nil)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	got, created, err := s.GetOrCreateUserByEmail(context.Background(), "existing@example.com")
+	if err != nil {
+		t.Fatalf("GetOrCreateUserByEmail: %v", err)
+	}
+	if created {
+		t.Error("expected created=false when the user already exists")
+	}
+	if got.ID != existing.ID {
+		t.Errorf("ID = %s, want existing %s", got.ID, existing.ID)
+	}
+	if got.Name != "Existing User" {
+		t.Errorf("name = %q, want Existing User (should not overwrite)", got.Name)
+	}
+}
+
 func TestGetUserByEmail_NotFound(t *testing.T) {
 	s := testDB(t)
 	_, err := s.GetUserByEmail(context.Background(), "nobody@example.com")

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -240,3 +240,126 @@ func TestReassign_NotFound(t *testing.T) {
 		t.Error("expected error for non-existent device")
 	}
 }
+
+func TestListByLines(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Batch Household")
+	lineA := createTestLine(t, database, "5550003331", hhID)
+	lineB := createTestLine(t, database, "5550003332", hhID)
+	lineC := createTestLine(t, database, "5550003333", hhID)
+
+	insertTestDevice(t, database, lineA, "hw-batch-a1")
+	insertTestDevice(t, database, lineA, "hw-batch-a2")
+	insertTestDevice(t, database, lineB, "hw-batch-b1")
+
+	got, err := s.ListByLines(context.Background(), []int64{lineA, lineB, lineC})
+	if err != nil {
+		t.Fatalf("ListByLines: %v", err)
+	}
+	if len(got[lineA]) != 2 {
+		t.Errorf("lineA = %d devices, want 2", len(got[lineA]))
+	}
+	if len(got[lineB]) != 1 {
+		t.Errorf("lineB = %d devices, want 1", len(got[lineB]))
+	}
+	// A line with no devices should be absent from the map, not present with an
+	// empty slice.
+	if _, ok := got[lineC]; ok {
+		t.Errorf("lineC should be absent from the map, got %v", got[lineC])
+	}
+}
+
+func TestListByLines_Empty(t *testing.T) {
+	s, _ := testStore(t)
+
+	got, err := s.ListByLines(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListByLines(nil): %v", err)
+	}
+	if got != nil {
+		t.Errorf("ListByLines(nil) = %v, want nil", got)
+	}
+}
+
+func TestUnpair(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Unpair Household")
+	lineID := createTestLine(t, database, "5550004441", hhID)
+	insertTestDevice(t, database, lineID, "hw-unpair-001")
+	pairTestDevice(t, database, "hw-unpair-001", "a-real-token")
+
+	// Sanity: device starts paired with a valid token.
+	paired, valid, err := s.AuthStatus(context.Background(), "hw-unpair-001", "a-real-token")
+	if err != nil {
+		t.Fatalf("AuthStatus before unpair: %v", err)
+	}
+	if !paired || !valid {
+		t.Fatalf("before unpair: paired=%v valid=%v, want both true", paired, valid)
+	}
+
+	if err := s.Unpair(context.Background(), "hw-unpair-001"); err != nil {
+		t.Fatalf("Unpair: %v", err)
+	}
+
+	// After unpair the device is no longer paired and the token is cleared.
+	paired, valid, err = s.AuthStatus(context.Background(), "hw-unpair-001", "a-real-token")
+	if err != nil {
+		t.Fatalf("AuthStatus after unpair: %v", err)
+	}
+	if paired || valid {
+		t.Errorf("after unpair: paired=%v valid=%v, want both false", paired, valid)
+	}
+}
+
+func TestUnpair_UnknownHardware(t *testing.T) {
+	s, _ := testStore(t)
+
+	// Unpairing a hardware ID with no device row is a no-op, not an error.
+	if err := s.Unpair(context.Background(), "hw-does-not-exist"); err != nil {
+		t.Errorf("Unpair for unknown hardware: %v", err)
+	}
+}
+
+func TestBoundLineNumber(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Bound Household")
+	lineID := createTestLine(t, database, "5550005551", hhID)
+	insertTestDevice(t, database, lineID, "hw-bound-001")
+	pairTestDevice(t, database, "hw-bound-001", "bound-token")
+
+	number, err := s.BoundLineNumber(context.Background(), "hw-bound-001")
+	if err != nil {
+		t.Fatalf("BoundLineNumber: %v", err)
+	}
+	if number != "5550005551" {
+		t.Errorf("BoundLineNumber = %q, want 5550005551", number)
+	}
+}
+
+func TestBoundLineNumber_Unpaired(t *testing.T) {
+	s, database := testStore(t)
+	hhID := createTestHousehold(t, database, "Unbound Household")
+	lineID := createTestLine(t, database, "5550006661", hhID)
+	// Device is assigned to a line but never paired (paired_at IS NULL).
+	insertTestDevice(t, database, lineID, "hw-unbound-001")
+
+	number, err := s.BoundLineNumber(context.Background(), "hw-unbound-001")
+	if err != nil {
+		t.Fatalf("BoundLineNumber: %v", err)
+	}
+	if number != "" {
+		t.Errorf("BoundLineNumber for unpaired device = %q, want empty", number)
+	}
+}
+
+func TestBoundLineNumber_UnknownHardware(t *testing.T) {
+	s, _ := testStore(t)
+
+	number, err := s.BoundLineNumber(context.Background(), "hw-nope")
+	if err != nil {
+		t.Fatalf("BoundLineNumber: %v", err)
+	}
+	if number != "" {
+		t.Errorf("BoundLineNumber for unknown hardware = %q, want empty", number)
+	}
+}

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -412,3 +412,132 @@ func TestStore_Delete_NotFound(t *testing.T) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
+
+func TestGetMembersWithUsers(t *testing.T) {
+	s, database := testStore(t)
+	ctx := context.Background()
+	ownerID := createTestUser(t, database, "members-owner@example.com")
+	memberID := createTestUser(t, database, "members-member@example.com")
+
+	h, err := s.Create(ctx, "Members Family", ownerID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.AddMember(ctx, memberID, h.ID, "member"); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+
+	members, err := s.GetMembersWithUsers(ctx, h.ID)
+	if err != nil {
+		t.Fatalf("GetMembersWithUsers: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+
+	byEmail := make(map[string]MemberWithUser, len(members))
+	for _, m := range members {
+		byEmail[m.Email] = m
+	}
+	owner, ok := byEmail["members-owner@example.com"]
+	if !ok {
+		t.Fatal("owner missing from members")
+	}
+	if owner.Role != "admin" {
+		t.Errorf("owner role = %q, want admin", owner.Role)
+	}
+	if owner.UserID != ownerID {
+		t.Errorf("owner UserID = %q, want %q", owner.UserID, ownerID)
+	}
+	if member, ok := byEmail["members-member@example.com"]; !ok || member.Role != "member" {
+		t.Errorf("member entry = %+v, ok=%v, want role member", member, ok)
+	}
+}
+
+func TestIsMemberByEmail(t *testing.T) {
+	s, database := testStore(t)
+	ctx := context.Background()
+	ownerID := createTestUser(t, database, "Mixed.Case@Example.com")
+
+	h, err := s.Create(ctx, "Email Family", ownerID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Lookup is case-insensitive on both sides.
+	ok, err := s.IsMemberByEmail(ctx, h.ID, "mixed.case@example.com")
+	if err != nil {
+		t.Fatalf("IsMemberByEmail: %v", err)
+	}
+	if !ok {
+		t.Error("expected case-insensitive match for existing member")
+	}
+
+	ok, err = s.IsMemberByEmail(ctx, h.ID, "stranger@example.com")
+	if err != nil {
+		t.Fatalf("IsMemberByEmail: %v", err)
+	}
+	if ok {
+		t.Error("expected non-member to report false")
+	}
+}
+
+func TestCountHouseholds(t *testing.T) {
+	s, database := testStore(t)
+	ctx := context.Background()
+
+	before, err := s.CountHouseholds(ctx)
+	if err != nil {
+		t.Fatalf("CountHouseholds: %v", err)
+	}
+
+	ownerID := createTestUser(t, database, "count-owner@example.com")
+	if _, err := s.Create(ctx, "Count A", ownerID); err != nil {
+		t.Fatalf("Create A: %v", err)
+	}
+	if _, err := s.Create(ctx, "Count B", ownerID); err != nil {
+		t.Fatalf("Create B: %v", err)
+	}
+
+	after, err := s.CountHouseholds(ctx)
+	if err != nil {
+		t.Fatalf("CountHouseholds: %v", err)
+	}
+	if after != before+2 {
+		t.Errorf("CountHouseholds = %d, want %d", after, before+2)
+	}
+}
+
+func TestSetCallHistoryEnabled(t *testing.T) {
+	s, database := testStore(t)
+	ctx := context.Background()
+	ownerID := createTestUser(t, database, "callhist-owner@example.com")
+
+	h, err := s.Create(ctx, "Call History Family", ownerID)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	readFlag := func() bool {
+		t.Helper()
+		got, err := s.GetByID(ctx, h.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		return got.CallHistoryEnabled
+	}
+
+	if err := s.SetCallHistoryEnabled(ctx, h.ID, false); err != nil {
+		t.Fatalf("SetCallHistoryEnabled(false): %v", err)
+	}
+	if readFlag() {
+		t.Error("expected call_history_enabled to be false")
+	}
+
+	if err := s.SetCallHistoryEnabled(ctx, h.ID, true); err != nil {
+		t.Fatalf("SetCallHistoryEnabled(true): %v", err)
+	}
+	if !readFlag() {
+		t.Error("expected call_history_enabled to be true")
+	}
+}

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/lib/pq"
 
 	"github.com/justinlindh/digits/server/internal/db"
+	"github.com/justinlindh/digits/server/internal/line"
 )
 
 func setupStore(t *testing.T) *Store {
@@ -67,6 +68,99 @@ func seedHousehold(t *testing.T, s *Store) string {
 		t.Fatalf("seed household: %v", err)
 	}
 	return id
+}
+
+// seedLine inserts a line in the given household and returns its ID.
+func seedLine(t *testing.T, s *Store, number, householdID string) int64 {
+	t.Helper()
+	var id int64
+	if err := s.db.QueryRow(
+		`INSERT INTO lines (number, household_id) VALUES ($1, $2) RETURNING id`,
+		number, householdID,
+	).Scan(&id); err != nil {
+		t.Fatalf("seed line %s: %v", number, err)
+	}
+	return id
+}
+
+func TestClaimDeviceToLine_Success(t *testing.T) {
+	s := setupStore(t)
+	hhID := seedHousehold(t, s)
+	lineID := seedLine(t, s, "5550200", hhID)
+	code, err := s.GenerateCode(context.Background(), "test-hw-claim-line-1")
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	token, hwID, err := s.ClaimDeviceToLine(context.Background(), code, lineID, "Den Phone", hhID)
+	if err != nil {
+		t.Fatalf("ClaimDeviceToLine: %v", err)
+	}
+	if len(token) != 64 {
+		t.Errorf("expected 64-char hex token, got %d chars", len(token))
+	}
+	if hwID != "test-hw-claim-line-1" {
+		t.Errorf("hardwareID = %q, want test-hw-claim-line-1", hwID)
+	}
+	if !isPaired(t, s, "test-hw-claim-line-1") {
+		t.Error("expected device to be paired after ClaimDeviceToLine")
+	}
+
+	// Device should now be bound to the existing line, not a freshly created one.
+	var boundLineID int64
+	if err := s.db.QueryRow(
+		`SELECT line_id FROM devices WHERE hardware_id = $1`, "test-hw-claim-line-1",
+	).Scan(&boundLineID); err != nil {
+		t.Fatalf("read bound line: %v", err)
+	}
+	if boundLineID != lineID {
+		t.Errorf("bound line = %d, want %d", boundLineID, lineID)
+	}
+}
+
+func TestClaimDeviceToLine_WrongHousehold(t *testing.T) {
+	s := setupStore(t)
+	ownerHH := seedHousehold(t, s)
+	lineID := seedLine(t, s, "5550201", ownerHH)
+	code, err := s.GenerateCode(context.Background(), "test-hw-claim-line-2")
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	// Claim against a different household than the one that owns the line.
+	otherHH := seedHousehold(t, s)
+	_, _, err = s.ClaimDeviceToLine(context.Background(), code, lineID, "Intruder Phone", otherHH)
+	if !errors.Is(err, ErrLineNotOwned) {
+		t.Errorf("expected ErrLineNotOwned, got %v", err)
+	}
+	if isPaired(t, s, "test-hw-claim-line-2") {
+		t.Error("device should not be paired when the line is not owned")
+	}
+}
+
+func TestClaimDeviceToLine_MissingLine(t *testing.T) {
+	s := setupStore(t)
+	hhID := seedHousehold(t, s)
+	code, err := s.GenerateCode(context.Background(), "test-hw-claim-line-3")
+	if err != nil {
+		t.Fatalf("GenerateCode: %v", err)
+	}
+
+	_, _, err = s.ClaimDeviceToLine(context.Background(), code, 999999, "Ghost Phone", hhID)
+	if !errors.Is(err, line.ErrNotFound) {
+		t.Errorf("expected line.ErrNotFound, got %v", err)
+	}
+}
+
+func TestClaimDeviceToLine_InvalidCode(t *testing.T) {
+	s := setupStore(t)
+	hhID := seedHousehold(t, s)
+	lineID := seedLine(t, s, "5550202", hhID)
+
+	_, _, err := s.ClaimDeviceToLine(context.Background(), "999999", lineID, "No Code Phone", hhID)
+	if !errors.Is(err, ErrInvalidCode) {
+		t.Errorf("expected ErrInvalidCode, got %v", err)
+	}
 }
 
 func TestGenerateCode_Returns6Digits(t *testing.T) {


### PR DESCRIPTION
## Summary

This started as a code-quality audit of the `server/` module against cleanliness, idiomatic Go, stale/unreferenced code, project layout, and test coverage. The module is in excellent shape, so the only actionable lever was a handful of store methods that had no test coverage in any tier. This PR closes those gaps with 17 new integration tests; no production code changed.

## Audit findings

Tooling run across the whole module (`go build`, `go vet`, `staticcheck`, `golangci-lint` with the project config, `deadcode`):

- **Cleanliness / idiomatic Go.** `golangci-lint`, `staticcheck`, and `go vet` all report **0 issues**. Errors are returned not panicked, raw SQL via `database/sql`, consistent `handler_*.go` naming.
- **Stale / unreferenced code.** `deadcode` flags only the `emailtest` helpers (reachable from tests only, expected). No TODO/FIXME debt, no commented-out blocks, no orphaned files.
- **Project layout.** Clean `cmd/` + `internal/` split with well-separated packages and no cross-layer or circular imports.
- **Test coverage.** Strong overall (full unit + 37 integration test files pass). The one weak spot: several store methods were exercised by neither unit nor integration tests.

## What changed

Integration tests modeled on the existing harness in each package:

- **device.** `ListByLines` (batch grouping plus empty input), `Unpair` (clears `paired_at`/token, no-op for unknown hardware), `BoundLineNumber` (paired, unpaired, and unknown-hardware cases).
- **household.** `GetMembersWithUsers`, `IsMemberByEmail` (case-insensitive), `CountHouseholds`, `SetCallHistoryEnabled` (verified through the public `GetByID`).
- **pairing.** `ClaimDeviceToLine` (success binds to the existing line, wrong household, missing line, invalid code).
- **auth.** `GetOrCreateUserByEmail` (creates a new user, returns an existing one without overwriting its name).

## Verification

- Full unit suite: `go test ./...` passes.
- Full integration suite: `go test -tags=integration -race -count=1 -p 1 ./...` passes against a local Postgres 16 (all 26 packages green).
- `golangci-lint run --build-tags=integration` on the changed packages: 0 issues.
- `/simplify` run on the diff: the one genuine finding (raw-SQL verification in `SetCallHistoryEnabled`) was applied by reading state through the public `GetByID`, matching the sibling `TestSetTimezone`. Other findings were false positives from misreading a purely additive diff.

## Grade

| | Before | After |
|---|---|---|
| Cleanliness / idiomatic Go | 95 | 95 |
| Stale / unreferenced code | 98 | 98 |
| Project layout | 95 | 95 |
| Test coverage | 84 | 90 |
| **Overall** | **92** | **94** |

The module was already high quality; the gain is concentrated in test coverage, where named store methods went from zero coverage to direct, behavior-level tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSGqZWQpmbMNwpu65rYFjb)_