### PR TITLE
refactor(digitsd): extract shared countPhraseClips voicemail helper

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -38,21 +38,29 @@ func (d *daemonCallbacks) playAnnouncementSequence(tones ...string) {
 	}
 }
 
+// countPhraseClips composes "You have N <suffix>", choosing the singular clip
+// for a count of one and the plural clip otherwise. Counts above 9 are capped
+// at the "9" clip since there is no clip to voice the exact number. A
+// non-positive count yields no clips.
+func countPhraseClips(count int, singular, plural string) []string {
+	if count <= 0 {
+		return nil
+	}
+	seq := []string{"vm_you_have", fmt.Sprintf("spoken_%d", min(count, 9))}
+	if count == 1 {
+		return append(seq, singular)
+	}
+	return append(seq, plural)
+}
+
 // announceMessageCount composes "You have N new message(s)" from individual
-// clips. Counts above 9 are capped at "9" in the spoken announcement since
-// there is no clip to voice the exact number.
+// clips, voicing "no messages" for an empty mailbox.
 func (d *daemonCallbacks) announceMessageCount(count int) {
 	if count <= 0 {
 		d.playAnnouncementSequence("vm_no_messages")
 		return
 	}
-	seq := []string{"vm_you_have", fmt.Sprintf("spoken_%d", min(count, 9))}
-	if count == 1 {
-		seq = append(seq, "vm_new_message")
-	} else {
-		seq = append(seq, "vm_new_messages")
-	}
-	d.playAnnouncementSequence(seq...)
+	d.playAnnouncementSequence(countPhraseClips(count, "vm_new_message", "vm_new_messages")...)
 }
 
 // messageNumberClips returns the clip sequence for the spoken "Message N"
@@ -82,26 +90,10 @@ func (d *daemonCallbacks) announceMessageNumber(number int) {
 	d.playAnnouncementSequence(clips...)
 }
 
-// savedCountClips returns the clip sequence for "You have N saved message(s)",
-// announced when *98 retrieval crosses from the new messages into the saved
-// ones. It mirrors announceMessageCount: a non-positive count yields no clips,
-// and counts above 9 are capped at "9" in the spoken announcement since there
-// is no clip to voice the exact number.
-func savedCountClips(count int) []string {
-	if count <= 0 {
-		return nil
-	}
-	seq := []string{"vm_you_have", fmt.Sprintf("spoken_%d", min(count, 9))}
-	if count == 1 {
-		return append(seq, "vm_saved_message")
-	}
-	return append(seq, "vm_saved_messages")
-}
-
 // announceSavedCount speaks "You have N saved messages" at the transition
 // from the new-message phase into the saved-message review phase.
 func (d *daemonCallbacks) announceSavedCount(count int) {
-	clips := savedCountClips(count)
+	clips := countPhraseClips(count, "vm_saved_message", "vm_saved_messages")
 	if len(clips) == 0 {
 		return
 	}

--- a/pi/digitsd/cmd/digitsd/voicemail_test.go
+++ b/pi/digitsd/cmd/digitsd/voicemail_test.go
@@ -29,7 +29,8 @@ func TestMessageNumberClips(t *testing.T) {
 	}
 }
 
-func TestSavedCountClips(t *testing.T) {
+func TestCountPhraseClips(t *testing.T) {
+	const singular, plural = "vm_saved_message", "vm_saved_messages"
 	tests := []struct {
 		name  string
 		count int
@@ -37,17 +38,17 @@ func TestSavedCountClips(t *testing.T) {
 	}{
 		{"zero yields no clips", 0, nil},
 		{"negative yields no clips", -1, nil},
-		{"one saved message is singular", 1, []string{"vm_you_have", "spoken_1", "vm_saved_message"}},
-		{"several saved messages are plural", 4, []string{"vm_you_have", "spoken_4", "vm_saved_messages"}},
-		{"highest digit clip", 9, []string{"vm_you_have", "spoken_9", "vm_saved_messages"}},
-		{"above nine caps at 9", 10, []string{"vm_you_have", "spoken_9", "vm_saved_messages"}},
-		{"well above nine caps at 9", 50, []string{"vm_you_have", "spoken_9", "vm_saved_messages"}},
+		{"one message is singular", 1, []string{"vm_you_have", "spoken_1", singular}},
+		{"several messages are plural", 4, []string{"vm_you_have", "spoken_4", plural}},
+		{"highest digit clip", 9, []string{"vm_you_have", "spoken_9", plural}},
+		{"above nine caps at 9", 10, []string{"vm_you_have", "spoken_9", plural}},
+		{"well above nine caps at 9", 50, []string{"vm_you_have", "spoken_9", plural}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := savedCountClips(tt.count)
+			got := countPhraseClips(tt.count, singular, plural)
 			if !slices.Equal(got, tt.want) {
-				t.Errorf("savedCountClips(%d) = %v, want %v", tt.count, got, tt.want)
+				t.Errorf("countPhraseClips(%d) = %v, want %v", tt.count, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

`announceMessageCount` and `savedCountClips` independently composed the same spoken phrase: `vm_you_have` + `spoken_N` (capped at the `spoken_9` clip when the count exceeds nine, since there is no clip to voice the exact number) + a singular/plural suffix. The two copies differed only in the suffix clips. The cap-at-9 rule, the non-positive guard, and the singular/plural branch all had to be kept in sync by hand across both functions.

## Change

Extract `countPhraseClips(count, singular, plural)` and route both callers through it:

- `announceMessageCount` keeps its distinct empty-mailbox behavior (it voices `vm_no_messages` rather than nothing) and delegates the non-empty case to the helper.
- `announceSavedCount` calls the helper directly, which lets the single-purpose `savedCountClips` wrapper go away.

`messageNumberClips` is intentionally left alone: it caps differently (above nine it emits only the bare `vm_message` word, with no spoken digit), so it does not share the new helper.

## Tests

`TestSavedCountClips` becomes `TestCountPhraseClips`, exercising the shared helper directly with the same count cases. `go build`, `go test ./...`, and `golangci-lint run ./...` all pass for the digitsd module.