### PR TITLE
refactor(server): name the link-health SSE event types

### DIFF
--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -156,7 +156,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	// between the ownership check and the Subscribe, the cross-pod evict
 	// has already passed and this session would never receive EndedKind.
 	if cur, err := h.tracker.GetConferenceByID(r.Context(), confID); err == nil && cur != nil && cur.EndedAt != nil {
-		_ = writeSSE(w, "ended", renderEndedConferenceFragment(""))
+		_ = writeSSE(w, sseEventEnded, renderEndedConferenceFragment(""))
 		flusher.Flush()
 		return
 	}
@@ -168,7 +168,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 		slog.ErrorContext(r.Context(), "SSE conference stream: initial render failed", "conf_id", confID, "err", err)
 		return
 	}
-	if werr := writeSSE(w, "sample", fragment); werr != nil {
+	if werr := writeSSE(w, sseEventSample, fragment); werr != nil {
 		return
 	}
 	flusher.Flush()
@@ -182,7 +182,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 			return
 		case ev, okEv := <-sub.C:
 			if !okEv {
-				_ = writeSSE(w, "ended", renderEndedConferenceFragment(""))
+				_ = writeSSE(w, sseEventEnded, renderEndedConferenceFragment(""))
 				flusher.Flush()
 				return
 			}
@@ -191,7 +191,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 				return
 			}
 		case <-heartbeat.C:
-			if err := writeSSE(w, "heartbeat", "{}"); err != nil {
+			if err := writeSSE(w, sseEventHeartbeat, "{}"); err != nil {
 				return
 			}
 			flusher.Flush()
@@ -207,15 +207,15 @@ func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher
 		if err != nil {
 			return err
 		}
-		if err := writeSSE(w, "sample", fragment); err != nil {
+		if err := writeSSE(w, sseEventSample, fragment); err != nil {
 			return err
 		}
 	case calls.EndedKind:
-		if err := writeSSE(w, "ended", renderEndedConferenceFragment("")); err != nil {
+		if err := writeSSE(w, sseEventEnded, renderEndedConferenceFragment("")); err != nil {
 			return err
 		}
 	case calls.DisconnectKind:
-		if err := writeSSE(w, "disconnect", renderEndedConferenceFragment(ev.EndedBy)); err != nil {
+		if err := writeSSE(w, sseEventDisconnect, renderEndedConferenceFragment(ev.EndedBy)); err != nil {
 			return err
 		}
 	}

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -196,7 +196,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 	// this session would never receive EndedKind. The DB status is
 	// authoritative; flip straight to the terminal state.
 	if cur, err := h.tracker.GetCall(r.Context(), callID); err == nil && cur.Status == calls.CallStatusEnded {
-		_ = writeSSE(w, "ended", renderEndedFragment(""))
+		_ = writeSSE(w, sseEventEnded, renderEndedFragment(""))
 		flusher.Flush()
 		return
 	}
@@ -211,7 +211,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 		case ev, ok := <-sub.C:
 			if !ok {
 				// Channel closed by Evict. Send one final ended event and return.
-				_ = writeSSE(w, "ended", renderEndedFragment(""))
+				_ = writeSSE(w, sseEventEnded, renderEndedFragment(""))
 				flusher.Flush()
 				return
 			}
@@ -220,7 +220,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 				return
 			}
 		case <-heartbeat.C:
-			if err := writeSSE(w, "heartbeat", "{}"); err != nil {
+			if err := writeSSE(w, sseEventHeartbeat, "{}"); err != nil {
 				return
 			}
 			flusher.Flush()
@@ -249,6 +249,20 @@ func startSSE(w http.ResponseWriter, r *http.Request) (http.Flusher, bool) {
 	return flusher, true
 }
 
+// SSE event names emitted by the link-health streams. These are a wire
+// contract: the htmx sse-swap attributes in call-live-detail.html and
+// conference-live-detail.html subscribe to "sample", "ended", and "disconnect"
+// by these exact names, so a typo here silently breaks the client swap with no
+// compile error. The two stream handlers (2-party and conference) must agree on
+// the vocabulary, which is why it lives in one place. "heartbeat" keeps the
+// connection warm and has no client swap.
+const (
+	sseEventSample     = "sample"
+	sseEventEnded      = "ended"
+	sseEventDisconnect = "disconnect"
+	sseEventHeartbeat  = "heartbeat"
+)
+
 // writeSSE emits one SSE event frame: "event: <name>\ndata: <data>\n\n".
 func writeSSE(w io.Writer, event, data string) error {
 	if _, err := fmt.Fprintf(w, "event: %s\n", event); err != nil {
@@ -276,7 +290,7 @@ func (h *Handler) writeSampleEvent(ctx context.Context, w io.Writer, flusher htt
 	if err != nil {
 		return err
 	}
-	if err := writeSSE(w, "sample", fragment); err != nil {
+	if err := writeSSE(w, sseEventSample, fragment); err != nil {
 		return err
 	}
 	flusher.Flush()
@@ -289,11 +303,11 @@ func (h *Handler) writeSampleEvent(ctx context.Context, w io.Writer, flusher htt
 func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event) (bool, error) {
 	switch ev.Kind {
 	case calls.EndedKind:
-		if err := writeSSE(w, "ended", renderEndedFragment("")); err != nil {
+		if err := writeSSE(w, sseEventEnded, renderEndedFragment("")); err != nil {
 			return true, err
 		}
 	case calls.DisconnectKind:
-		if err := writeSSE(w, "disconnect", renderEndedFragment(ev.EndedBy)); err != nil {
+		if err := writeSSE(w, sseEventDisconnect, renderEndedFragment(ev.EndedBy)); err != nil {
 			return true, err
 		}
 	default:


### PR DESCRIPTION
## Motivation

The two link-health SSE handlers, `handler_linkhealth.go` (2-party) and `handler_conference_linkhealth.go` (conference), each hardcoded the event names `"sample"`, `"ended"`, `"disconnect"`, and `"heartbeat"` as bare string literals across 13 `writeSSE` call sites.

These names are a wire contract, not an internal detail. The htmx `sse-swap` attributes in `call-live-detail.html` and `conference-live-detail.html` both subscribe with `sse-swap="sample,disconnect,ended"`, matching by exact string. A typo on the server (`"ended"` -> `"endeded"`) compiles fine and silently breaks the client swap, and the two handlers have to keep the same vocabulary in lockstep with each other and the templates.

## Change

Define a single const block next to `writeSSE`:

```go
const (
	sseEventSample     = "sample"
	sseEventEnded      = "ended"
	sseEventDisconnect = "disconnect"
	sseEventHeartbeat  = "heartbeat"
)
```

and route all 13 call sites in both handlers through it. The vocabulary now lives in one place that both stream handlers reference, so they cannot drift, and a future rename is a single edit plus the template.

Scope note: the dashboard stream's separate `"status"` event is left alone. It appears once, in one file, with no cross-handler duplication, so it has none of the drift risk this PR addresses.

## Tests

No behavior change. `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass for the server module.