### PR TITLE
refactor(server): code-cleanliness audit (wire constants, README cmd list)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -306,7 +306,10 @@ After SDP/ICE exchange, audio flows peer-to-peer via WebRTC DTLS-SRTP.
 ## Architecture
 
 ```
-cmd/signald/             Entry point -- wires all components
+cmd/
+  signald/               Entry point -- wires all components
+  autodeploy/            CLI for the prod autodeploy timer (GHCR pull + compose rollout)
+  devseed/               Local dev database seeder
 
 internal/
   auth/                  User authentication (magic links, Google OAuth, sessions)

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -41,6 +41,14 @@ const (
 	TypeVoicemailState = "voicemail_state" // Phone → Server: per-handset unheard voicemail count snapshot
 )
 
+// Update status values reported by phones during OTA updates. The full wire
+// vocabulary is downloading, applying, rebooting, success, failed (consumed by
+// the phone-detail UI); these are the values the server itself acts on.
+const (
+	UpdateStatusRebooting = "rebooting" // device is rebooting to apply an update
+	UpdateStatusSuccess   = "success"   // update applied, device reconnected
+)
+
 // Extension pickup types (POTS extension model: pick up a second handset mid-call)
 const (
 	TypeExtensionPickup  = "extension_pickup"  // Phone → Server: device is picking up during active call on its line

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -240,9 +240,9 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 				"local_addr", msg.LocalAddr)
 		}
 		// If device reconnects after a rebooting update, mark it as success
-		if status := r.Hub.GetUpdateStatus(from); status != nil && status.Status == "rebooting" {
-			r.Hub.SetUpdateStatus(from, "success", "Updated to "+msg.PiVersion)
-			slog.InfoContext(ctx, "update_status", "number", from, "status", "success",
+		if status := r.Hub.GetUpdateStatus(from); status != nil && status.Status == UpdateStatusRebooting {
+			r.Hub.SetUpdateStatus(from, UpdateStatusSuccess, "Updated to "+msg.PiVersion)
+			slog.InfoContext(ctx, "update_status", "number", from, "status", UpdateStatusSuccess,
 				"detail", "device reconnected with "+msg.PiVersion)
 		}
 		return // No relay: server consumes this


### PR DESCRIPTION
## Summary

Audited the `server/` folder for code cleanliness, idiomatic Go, stale/unreferenced code, project layout, and test coverage. The module is in excellent shape, so this PR lands only the two small, concrete improvements the audit surfaced. Everything else checked out and was deliberately left alone.

## Changes

**`refactor(server)`: name update-status wire values as constants.** The reconnect-after-update path in `relay.go` compared and set OTA status with bare `"rebooting"` / `"success"` string literals. They are now named constants (`UpdateStatusRebooting`, `UpdateStatusSuccess`) declared in `protocol.go` alongside the existing `Type*` wire vocabulary, so the values the server acts on are declared once and referenced, matching how every other protocol token is already handled. No wire behavior changes.

**`docs`: list all cmd entrypoints in the README architecture block.** The block listed only `cmd/signald`, omitting `cmd/autodeploy` and `cmd/devseed`, which are real, built binaries (autodeploy has its own make target and README section). All three are now listed under a `cmd/` heading.

## What was audited and left unchanged

The codebase is well-maintained, and most checks came back clean:

- **Build / static analysis:** `go build`, `go vet`, `staticcheck`, and `golangci-lint` (standard config) all pass with zero issues. `go mod tidy` is a no-op.
- **Tests:** full unit suite green. Integration and e2e tiers are correctly gated behind `//go:build integration` / `e2e` tags; lower default-run coverage on web/auth/household reflects those tiers needing Postgres, not missing tests.
- **Stale code:** a `deadcode` reachability sweep plus a module-wide audit of every exported symbol, struct field, config option, static asset (CSS/JS/fonts/audio/images), and HTML template found nothing dead. The single `deadcode` hit (`emailtest`) is a legitimate test helper, a known false positive.
- **Layout:** clean `cmd/` + `internal/` split, 23 cohesive packages, consistent `handler_*.go` naming, and docs (`README`, `TESTING.md`, `docs/`) that match reality. Makefile targets and docker-compose service references all resolve.
- **Idiom:** consistent receiver names, `context.Context` threaded as the first parameter and never stored in structs, lowercase unpunctuated error strings, correct `%w` wrapping, and small justified interfaces. The handful of `panic` sites are all impossible-marshal or exhaustive-switch invariant guards.

Two further nits were considered and skipped as not worth the churn: renaming a couple of `internal/household` test files (the integration-vs-unit `_test.go` naming is inconsistent repo-wide and `TESTING.md` already acknowledges it; renaming two files would not fix the pattern), and moving the `clockParts` helper out of `handler.go` (subjective, low value).

## Grade

**Before: 93 / 100. After: 96 / 100.**

The codebase already scores high: clean static analysis, no dead code, disciplined layout, idiomatic Go, and CI that keeps cruft from accumulating. Deductions were minor: a documentation-completeness gap and a small patch of magic strings in the wire protocol. Both are addressed here. The remaining gap to 100 is the repo-wide integration-test filename inconsistency, intentionally not churned in this PR.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./...` reports 0 issues
- `staticcheck ./...` clean
- `go test ./...` all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ5mf6dLoM1ZAyVqssL6T5)_