### PR TITLE
refactor(digitsd): make ContactChecker a func type

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1927,7 +1927,7 @@ func main() {
 	if err := contactsCache.Load(); err != nil {
 		slog.Warn("contacts: load failed", "path", contactsPath, "error", err)
 	} else if n := contactsCache.Count(); n > 0 {
-		ctrl.SetContactChecker(contactsCache)
+		ctrl.SetContactChecker(contactsCache.IsContact)
 		slog.Info("contacts: loaded safelist", "path", contactsPath, "count", n)
 	} else {
 		slog.Info("contacts: no local list, filter disabled", "path", contactsPath)

--- a/pi/digitsd/internal/phone/controller.go
+++ b/pi/digitsd/internal/phone/controller.go
@@ -127,11 +127,9 @@ type Callbacks interface {
 	VoicemailKey(digit string)                                    // DTMF key during playback (7=delete, 9=mark heard, #=skip, *=replay)
 }
 
-// ContactChecker determines whether a number is in the local contact list.
+// ContactChecker reports whether a number is in the local contact list.
 // When nil, all numbers are allowed (backward compatibility).
-type ContactChecker interface {
-	IsContact(number string) bool
-}
+type ContactChecker func(number string) bool
 
 type Controller struct {
 	mu             sync.Mutex
@@ -666,7 +664,7 @@ func (c *Controller) onDial(number string) {
 
 	// Contact filter: if checker is set and number is not a contact,
 	// play rejection sequence (mimics unreachable number) instead of calling.
-	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
+	if c.contactChecker != nil && !c.contactChecker(number) {
 		slog.Info("phone: number not in contacts, rejecting", "number", number)
 		c.state = StateCALLING
 		c.cb.SendTone(ToneRingback)
@@ -753,7 +751,7 @@ func (c *Controller) dialThirdParty(number string) {
 	}
 
 	// Contact filter: reject if number is not in the allowed contact list.
-	if c.contactChecker != nil && !c.contactChecker.IsContact(number) {
+	if c.contactChecker != nil && !c.contactChecker(number) {
 		slog.Info("phone: dialThirdParty number not in contacts, rejecting", "number", number)
 		c.state = StateADD_INTERCEPT
 		c.cb.SendTone(ToneIntercept)

--- a/pi/digitsd/internal/phone/controller_test.go
+++ b/pi/digitsd/internal/phone/controller_test.go
@@ -657,20 +657,20 @@ func TestController_BusySignal(t *testing.T) {
 	}
 }
 
-// mockContactChecker implements ContactChecker for testing.
-type mockContactChecker struct {
-	allowed map[string]bool
-}
-
-func (m *mockContactChecker) IsContact(number string) bool {
-	return m.allowed[number]
+// allowContacts builds a ContactChecker that admits only the given numbers.
+func allowContacts(numbers ...string) ContactChecker {
+	allowed := make(map[string]bool, len(numbers))
+	for _, n := range numbers {
+		allowed[n] = true
+	}
+	return func(number string) bool { return allowed[number] }
 }
 
 // Test: dialing an allowed contact proceeds normally
 func TestController_DialAllowedContact(t *testing.T) {
 	cb := &mockCallbacks{}
 	c := newTestController(cb, "")
-	c.SetContactChecker(&mockContactChecker{allowed: map[string]bool{"5551234": true}})
+	c.SetContactChecker(allowContacts("5551234"))
 
 	c.HandleEvent("HOOK:OFF")
 	c.HandleEvent("KEY:5")
@@ -689,7 +689,7 @@ func TestController_DialAllowedContact(t *testing.T) {
 func TestController_DialBlockedContact(t *testing.T) {
 	cb := &mockCallbacks{}
 	c := newTestController(cb, "")
-	c.SetContactChecker(&mockContactChecker{allowed: map[string]bool{"5559999": true}})
+	c.SetContactChecker(allowContacts("5559999"))
 
 	c.HandleEvent("HOOK:OFF")
 	c.HandleEvent("KEY:5")
@@ -1613,7 +1613,7 @@ func TestController_DialThirdPartyRejectsBlockedContact(t *testing.T) {
 	mock := &mockCallbacks{}
 	c := newTestController(mock, "5550001")
 	// Only 5550002 is allowed; 5550004 is blocked.
-	c.SetContactChecker(&mockContactChecker{allowed: map[string]bool{"5550002": true}})
+	c.SetContactChecker(allowContacts("5550002"))
 	c.setStateForTest(StateADD_DIALTONE)
 	c.setHeldPeerForTest("5550002")
 


### PR DESCRIPTION
## Motivation

`ContactChecker` in `internal/phone/controller.go` was a single-method interface:

```go
type ContactChecker interface {
	IsContact(number string) bool
}
```

It had exactly one production implementation (`contacts.Cache`, via its `IsContact` method) and a test-only `mockContactChecker` struct. The controller never holds it as anything richer than an optional predicate: both call sites are `if c.contactChecker != nil && !c.contactChecker.IsContact(number)`, and the field is wired once at startup or left nil (nil meaning "allow every number").

A one-method predicate interface with a single real implementation is exactly the case a function type expresses more directly, the same way `http.HandlerFunc` does.

## Change

`ContactChecker` becomes `type ContactChecker func(number string) bool`. The knock-on edits:

- The two `controller.go` call sites drop `.IsContact`, calling the value directly.
- Production wiring passes the bound method value: `ctrl.SetContactChecker(contactsCache.IsContact)`.
- The `mockContactChecker` struct is gone; tests build checkers from a small `allowContacts(numbers ...string)` helper that returns a closure.

`contacts.Cache.IsContact` is untouched: it remains a normal method, now also usable as a `ContactChecker`. Behavior is identical, including the nil-means-allow-all path.

## Tests

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass for the digitsd module.