### PR TITLE
refactor(digitsd): collapse repeated DTMF key-tone playback

### DIFF
--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -111,12 +111,10 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 			slog.Warn("dtmf: empty digit in message")
 			break
 		}
-		dtmfName := dtmfToneName(msg.Digit)
-		if dtmfName == "" {
+		if !playKeyTone(mixer, msg.Digit) {
 			slog.Warn("dtmf: unrecognized digit", "digit", msg.Digit)
 			break
 		}
-		mixer.PlayOnce(dtmfName)
 	case sigclient.TypeError:
 		slog.Warn("signal error", "error", msg.Error)
 		// ADD_CALLING: route through the controller so state transitions

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -2250,10 +2250,7 @@ func main() {
 					pairingAnnouncementCancel = nil
 					mixer.StopAll()
 				}
-				dtmfName := dtmfToneName(key)
-				if dtmfName != "" {
-					mixer.PlayOnce(dtmfName)
-				}
+				playKeyTone(mixer, key)
 				// Forward DTMF to the remote peer if a call is connected.
 				state := ctrl.State()
 				if state == phone.StateCONNECTED {
@@ -2567,4 +2564,16 @@ func dtmfToneName(key string) string {
 	default:
 		return ""
 	}
+}
+
+// playKeyTone plays the keypad feedback beep for a pressed key and reports
+// whether a tone was played. Keys that map to no tone (anything but 0-9, *, #)
+// are a no-op and return false.
+func playKeyTone(mixer *audio.Mixer, key string) bool {
+	tone := dtmfToneName(key)
+	if tone == "" {
+		return false
+	}
+	mixer.PlayOnce(tone)
+	return true
 }

--- a/pi/digitsd/cmd/digitsd/voice_prompt.go
+++ b/pi/digitsd/cmd/digitsd/voice_prompt.go
@@ -56,8 +56,7 @@ func voicePromptSession(events <-chan string, mixer *audio.Mixer, cfg voicePromp
 			}
 			if key != "" {
 				mixer.StopAll()
-				if tone := dtmfToneName(key); tone != "" {
-					mixer.PlayOnce(tone)
+				if playKeyTone(mixer, key) {
 					waitForOnceComplete(mixer, 500*time.Millisecond)
 				}
 				if cfg.OnKey != nil && cfg.OnKey(key) {
@@ -80,8 +79,7 @@ func voicePromptSession(events <-chan string, mixer *audio.Mixer, cfg voicePromp
 				if strings.HasPrefix(ev, "KEY:") {
 					key := ev[4:]
 					mixer.StopAll()
-					if tone := dtmfToneName(key); tone != "" {
-						mixer.PlayOnce(tone)
+					if playKeyTone(mixer, key) {
 						waitForOnceComplete(mixer, 500*time.Millisecond)
 					}
 					if cfg.OnKey != nil && cfg.OnKey(key) {


### PR DESCRIPTION
## Motivation

Four call sites in `cmd/digitsd` turned a pressed key into its WAV name with `dtmfToneName` and then conditionally played it, each repeating the same lookup + empty-string guard + `PlayOnce` triple:

- the main keypad handler (`main.go`),
- the inbound DTMF dispatch branch (`dispatch.go`),
- both key handlers in the voice-prompt loop (`voice_prompt.go`).

The shared shape was always "map key to tone; if it maps to something, play it." Spelling that out four times means the keypad-to-tone contract lives in four places.

## Change

Extract one helper next to `dtmfToneName`:

```go
// playKeyTone plays the keypad feedback beep for a pressed key and reports
// whether a tone was played. Keys that map to no tone (anything but 0-9, *, #)
// are a no-op and return false.
func playKeyTone(mixer *audio.Mixer, key string) bool {
	tone := dtmfToneName(key)
	if tone == "" {
		return false
	}
	mixer.PlayOnce(tone)
	return true
}
```

and route the four sites through it. The returned bool carries the "did it map to a tone" signal each site already needed:

- `dispatch.go` keys its `unrecognized digit` warning off `!playKeyTone(...)`.
- both `voice_prompt.go` handlers gate `waitForOnceComplete` on the result.
- the main keypad handler just calls it for feedback.

Behavior is unchanged at every site.

## Scope note

The recovery factory-reset confirm handler (`recovery.go`) keeps its inline form on purpose: it interleaves `dbg.add` trace lines that name the specific tone between the lookup and the play, so it does not fit the helper without losing that debug granularity.

## Tests

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass for the digitsd module.