### PR TITLE
refactor(server): consolidate household-admin settings POST handlers

### DIFF
--- a/server/docs/metrics.md
+++ b/server/docs/metrics.md
@@ -7,9 +7,9 @@ the operator (the listener is expected to be private; binding it to
 `127.0.0.1` is supported for single-node Docker deployments and is the
 recommended default for a host-network compose setup).
 
-The metric design is bound by the digits anti-surveillance pitch (see
-`docs/mission.md` and `docs/why-digits.md`). Reviewers should treat any
-new label as a privacy decision, not a routine refactor.
+The metric design is bound by the digits anti-surveillance pitch (see the
+repo-root `docs/mission.md` and `docs/why-digits.md`). Reviewers should treat
+any new label as a privacy decision, not a routine refactor.
 
 ## Listener config
 

--- a/server/internal/web/handler_settings.go
+++ b/server/internal/web/handler_settings.go
@@ -62,7 +62,13 @@ func (h *Handler) handleSettings(w http.ResponseWriter, r *http.Request) {
 	renderWith(r.Context(), w, h.tmplSettings, layoutFor(r), data)
 }
 
-func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Request) {
+// handleHouseholdAdminPost shares the boilerplate between the simple
+// household-admin settings handlers: require an admin session, parse the form,
+// persist via save. On any failure it redirects back to /settings; on success
+// it redirects to /settings?saved=1 so the page can flash a confirmation. op
+// names the operation for the error log. This mirrors handleUserPrefPost for
+// the user-level preference handlers.
+func (h *Handler) handleHouseholdAdminPost(w http.ResponseWriter, r *http.Request, op string, save func(ctx context.Context, hh *household.Household) error) {
 	_, hh, ok := h.requireHouseholdAdmin(w, r)
 	if !ok {
 		return
@@ -70,32 +76,29 @@ func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Req
 	if !parseForm(w, r) {
 		return
 	}
-	name := strings.TrimSpace(r.FormValue("name"))
-	if name != "" {
-		if err := h.householdStore.UpdateName(r.Context(), hh.ID, name); err != nil {
-			slog.ErrorContext(r.Context(), "update household name failed", "household_id", hh.ID, "err", err)
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
-			return
-		}
-	}
-	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
-}
-
-func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Request) {
-	_, hh, ok := h.requireHouseholdAdmin(w, r)
-	if !ok {
-		return
-	}
-	if !parseForm(w, r) {
-		return
-	}
-	enabled := r.FormValue("enabled") == "true"
-	if err := h.householdStore.SetCallHistoryEnabled(r.Context(), hh.ID, enabled); err != nil {
-		slog.ErrorContext(r.Context(), "set call history failed", "err", err)
+	if err := save(r.Context(), hh); err != nil {
+		slog.ErrorContext(r.Context(), op+" failed", "err", err, "household_id", hh.ID)
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 		return
 	}
 	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
+}
+
+func (h *Handler) handleSettingsHouseholdPost(w http.ResponseWriter, r *http.Request) {
+	h.handleHouseholdAdminPost(w, r, "update household name", func(ctx context.Context, hh *household.Household) error {
+		name := strings.TrimSpace(r.FormValue("name"))
+		if name == "" {
+			return nil
+		}
+		return h.householdStore.UpdateName(ctx, hh.ID, name)
+	})
+}
+
+func (h *Handler) handleSettingsCallHistory(w http.ResponseWriter, r *http.Request) {
+	h.handleHouseholdAdminPost(w, r, "set call history", func(ctx context.Context, hh *household.Household) error {
+		enabled := r.FormValue("enabled") == "true"
+		return h.householdStore.SetCallHistoryEnabled(ctx, hh.ID, enabled)
+	})
 }
 
 func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Request) {
@@ -134,22 +137,13 @@ func (h *Handler) handleSettingsDoNotDisturb(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) handleSettingsTimezone(w http.ResponseWriter, r *http.Request) {
-	_, hh, ok := h.requireHouseholdAdmin(w, r)
-	if !ok {
-		return
-	}
-	if !parseForm(w, r) {
-		return
-	}
-	tz := strings.TrimSpace(r.FormValue("timezone"))
-	if tz != "" {
-		if err := h.householdStore.SetTimezone(r.Context(), hh.ID, tz); err != nil {
-			slog.ErrorContext(r.Context(), "set timezone failed", "err", err)
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
-			return
+	h.handleHouseholdAdminPost(w, r, "set timezone", func(ctx context.Context, hh *household.Household) error {
+		tz := strings.TrimSpace(r.FormValue("timezone"))
+		if tz == "" {
+			return nil
 		}
-	}
-	http.Redirect(w, r, "/settings?saved=1", http.StatusSeeOther)
+		return h.householdStore.SetTimezone(ctx, hh.ID, tz)
+	})
 }
 
 // handleUserPrefPost shares the boilerplate between the theme/CRT/appearance


### PR DESCRIPTION
## What

A small server-folder cleanliness pass. Two changes:

1. Extract a `handleHouseholdAdminPost` helper in `internal/web/handler_settings.go` so the household-name, call-history, and timezone POST handlers stop repeating the same guard/parse/persist/redirect boilerplate. The helper mirrors the existing `handleUserPrefPost` pattern, and each handler now expresses only its persist closure.
2. Clarify a path in `docs/metrics.md`: the referenced `mission.md` and `why-digits.md` live at the repo-root `docs/`, not under `server/docs/`.

The do-not-disturb handler is deliberately left untouched: it has HTMX-aware rendering and a per-line silence fan-out that don't fit the shared shape.

## Why

The full server folder was audited for cleanliness, idiomatic Go, stale/unreferenced code, project layout, and test coverage. It is in excellent shape: `go build`, `go vet`, the full unit suite, and `golangci-lint` (standard preset, including staticcheck/unused/errcheck) all pass clean; `deadcode` is clean across every entry point; `go.mod` is tidy; no orphaned static assets or templates; and shipped product copy (templates, Go strings, JS) contains zero em dashes. The low unit-coverage numbers on DB-backed packages are integration-gated by build tags, not real gaps.

The one genuinely actionable code finding was the duplicated settings-handler boilerplate. The codebase already abstracts the same shape for user-level preferences via `handleUserPrefPost`, so extending that established pattern to the household-admin handlers is a low-risk, in-character consolidation rather than new churn.

### Grade

- **Before: 93/100.** Already clean and well-maintained; the only deductions were the three duplicated settings handlers and a slightly imprecise doc path.
- **After: 95/100.** Duplication removed, doc path clarified. The remaining headroom is inherent to a project of this size (large `internal/web` and `internal/signaling` packages), not defects.

## Test plan

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` (full unit suite) passes
- `golangci-lint run ./...` reports 0 issues
- Behavior preserved exactly: same admin guard, same empty-input handling (no-op save still redirects to `?saved=1`), same error-redirect to `/settings`. Error logs now also carry `household_id` for the call-history and timezone cases, which previously omitted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTSF4A1tnVSNoXRkCdFLQC)_