### PR TITLE
feat(server): toggle between devices joined to a line

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -74,7 +74,7 @@ type Hub struct {
 	mu           sync.RWMutex
 	conns        map[string][]*Conn               // phone number -> connections (multiple devices per line)
 	hwConns      map[string]*Conn                 // hardware ID -> connection
-	updateStatus map[string]*UpdateStatusSnapshot // phone number -> last update status
+	updateStatus map[string]*UpdateStatusSnapshot // hardware id -> last update status
 	// voicemailUnheard tracks the per-handset unheard-voicemail count last
 	// reported by each device. Outer key is the phone number; inner key is
 	// the originating handset's hardware ID. Per-handset because voicemail
@@ -467,10 +467,6 @@ func (h *Hub) RekeyNumber(oldNumber, newNumber string) {
 		h.conns[newNumber] = cs
 		delete(h.conns, oldNumber)
 	}
-	if us, ok := h.updateStatus[oldNumber]; ok {
-		h.updateStatus[newNumber] = us
-		delete(h.updateStatus, oldNumber)
-	}
 	if vm, ok := h.voicemailUnheard[oldNumber]; ok {
 		h.voicemailUnheard[newNumber] = vm
 		delete(h.voicemailUnheard, oldNumber)
@@ -760,10 +756,10 @@ func (h *Hub) AllDeviceInfo(number string) []DeviceInfoSnapshot {
 	return snapshots
 }
 
-// SetUpdateStatus stores the latest update status for a phone.
-func (h *Hub) SetUpdateStatus(number, status, detail string) {
+// SetUpdateStatus stores the latest update status for a device identified by hardware ID.
+func (h *Hub) SetUpdateStatus(hardwareID, status, detail string) {
 	h.mu.Lock()
-	h.updateStatus[number] = &UpdateStatusSnapshot{
+	h.updateStatus[hardwareID] = &UpdateStatusSnapshot{
 		Status:    status,
 		Detail:    detail,
 		UpdatedAt: time.Now(),
@@ -771,31 +767,31 @@ func (h *Hub) SetUpdateStatus(number, status, detail string) {
 	ds := h.state
 	h.mu.Unlock()
 	if ds != nil {
-		ds.SetUpdateStatus(context.Background(), number, status, detail)
+		ds.SetUpdateStatus(context.Background(), hardwareID, status, detail)
 	}
 }
 
-// GetUpdateStatus returns the latest update status for a phone, or nil.
-func (h *Hub) GetUpdateStatus(number string) *UpdateStatusSnapshot {
+// GetUpdateStatus returns the latest update status for a device by hardware ID, or nil.
+func (h *Hub) GetUpdateStatus(hardwareID string) *UpdateStatusSnapshot {
 	h.mu.RLock()
 	ds := h.state
 	h.mu.RUnlock()
 	if ds != nil {
-		return ds.GetUpdateStatus(context.Background(), number)
+		return ds.GetUpdateStatus(context.Background(), hardwareID)
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.updateStatus[number]
+	return h.updateStatus[hardwareID]
 }
 
-// ClearUpdateStatus removes update status for a phone.
-func (h *Hub) ClearUpdateStatus(number string) {
+// ClearUpdateStatus removes update status for a device by hardware ID.
+func (h *Hub) ClearUpdateStatus(hardwareID string) {
 	h.mu.Lock()
-	delete(h.updateStatus, number)
+	delete(h.updateStatus, hardwareID)
 	ds := h.state
 	h.mu.Unlock()
 	if ds != nil {
-		ds.ClearUpdateStatus(context.Background(), number)
+		ds.ClearUpdateStatus(context.Background(), hardwareID)
 	}
 }
 

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -979,6 +979,17 @@ func (h *Hub) IsOnline(number string) bool {
 	return h.Get(number) != nil
 }
 
+// IsHardwareOnline reports whether the device with this hardware id has an
+// active hub connection on this pod.
+func (h *Hub) IsHardwareOnline(hardwareID string) bool {
+	if hardwareID == "" {
+		return false
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.hwConns[hardwareID] != nil
+}
+
 func (h *Hub) LocalConnectionCount() int {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -979,11 +979,19 @@ func (h *Hub) IsOnline(number string) bool {
 	return h.Get(number) != nil
 }
 
-// IsHardwareOnline reports whether the device with this hardware id has an
-// active hub connection on this pod.
+// IsHardwareOnline reports whether the device with this hardware id is
+// connected. When a shared device-state store is configured it answers
+// cross-pod from Redis, matching IsOnline and AllDeviceInfo; otherwise it
+// falls back to this pod's local connection map.
 func (h *Hub) IsHardwareOnline(hardwareID string) bool {
 	if hardwareID == "" {
 		return false
+	}
+	h.mu.RLock()
+	ds := h.state
+	h.mu.RUnlock()
+	if ds != nil {
+		return ds.IsHardwareOnline(context.Background(), hardwareID)
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -502,3 +502,23 @@ func TestSendToDoesNotInvokeDropHookOnSuccessfulSend(t *testing.T) {
 		t.Errorf("drop hook called %d times on successful send, want 0", drops)
 	}
 }
+
+func TestUpdateStatus_PerHardware(t *testing.T) {
+	h := NewHub()
+	h.SetUpdateStatus("hwA", "downloading", "10%")
+	h.SetUpdateStatus("hwB", "applying", "")
+
+	if got := h.GetUpdateStatus("hwA"); got == nil || got.Status != "downloading" {
+		t.Fatalf("hwA: got %+v", got)
+	}
+	if got := h.GetUpdateStatus("hwB"); got == nil || got.Status != "applying" {
+		t.Fatalf("hwB: got %+v", got)
+	}
+	h.ClearUpdateStatus("hwA")
+	if got := h.GetUpdateStatus("hwA"); got != nil {
+		t.Fatalf("hwA should be cleared, got %+v", got)
+	}
+	if got := h.GetUpdateStatus("hwB"); got == nil {
+		t.Fatalf("hwB should survive clearing hwA")
+	}
+}

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -522,3 +522,16 @@ func TestUpdateStatus_PerHardware(t *testing.T) {
 		t.Fatalf("hwB should survive clearing hwA")
 	}
 }
+
+func TestIsHardwareOnline(t *testing.T) {
+	h := NewHub()
+	if h.IsHardwareOnline("hw-absent") {
+		t.Fatal("absent hardware should be offline")
+	}
+	// Register a conn for hw-1
+	conn := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-1"}
+	_ = h.Register("3140001", conn)
+	if !h.IsHardwareOnline("hw-1") {
+		t.Fatal("hw-1 should be online")
+	}
+}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -240,16 +240,16 @@ func (r *Relay) HandleMessage(ctx context.Context, from string, msg *Message) {
 				"local_addr", msg.LocalAddr)
 		}
 		// If device reconnects after a rebooting update, mark it as success
-		if status := r.Hub.GetUpdateStatus(from); status != nil && status.Status == UpdateStatusRebooting {
-			r.Hub.SetUpdateStatus(from, UpdateStatusSuccess, "Updated to "+msg.PiVersion)
-			slog.InfoContext(ctx, "update_status", "number", from, "status", UpdateStatusSuccess,
-				"detail", "device reconnected with "+msg.PiVersion)
+		if status := r.Hub.GetUpdateStatus(msg.HardwareID); status != nil && status.Status == UpdateStatusRebooting {
+			r.Hub.SetUpdateStatus(msg.HardwareID, UpdateStatusSuccess, "Updated to "+msg.PiVersion)
+			slog.InfoContext(ctx, "update_status", "number", from, "hardware_id", msg.HardwareID,
+				"status", UpdateStatusSuccess, "detail", "device reconnected with "+msg.PiVersion)
 		}
 		return // No relay: server consumes this
 	case TypeUpdateStatus:
-		slog.InfoContext(ctx, "update_status", "number", from,
+		slog.InfoContext(ctx, "update_status", "number", from, "hardware_id", msg.HardwareID,
 			"status", msg.UpdateStatus, "detail", msg.UpdateDetail)
-		r.Hub.SetUpdateStatus(from, msg.UpdateStatus, msg.UpdateDetail)
+		r.Hub.SetUpdateStatus(msg.HardwareID, msg.UpdateStatus, msg.UpdateDetail)
 		return // No relay: server consumes this
 	case TypeRestart:
 		return // Server to device only; ignore if echoed back

--- a/server/internal/signaling/state_redis.go
+++ b/server/internal/signaling/state_redis.go
@@ -269,8 +269,8 @@ func (s *DeviceState) LastSeenAt(ctx context.Context, number string) *time.Time 
 	return &latest
 }
 
-func (s *DeviceState) SetUpdateStatus(ctx context.Context, number, status, detail string) {
-	key := updateStatusPrefix + number
+func (s *DeviceState) SetUpdateStatus(ctx context.Context, hardwareID, status, detail string) {
+	key := updateStatusPrefix + hardwareID
 	now := strconv.FormatInt(time.Now().Unix(), 10)
 
 	fields := map[string]any{
@@ -283,15 +283,15 @@ func (s *DeviceState) SetUpdateStatus(ctx context.Context, number, status, detai
 	pipe.HSet(ctx, key, fields)
 	pipe.Expire(ctx, key, updateStatusTTL)
 	if _, err := pipe.Exec(ctx); err != nil {
-		slog.ErrorContext(ctx, "redis: SetUpdateStatus failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: SetUpdateStatus failed", "hardware_id", hardwareID, "err", err)
 	}
 }
 
-func (s *DeviceState) GetUpdateStatus(ctx context.Context, number string) *UpdateStatusSnapshot {
-	key := updateStatusPrefix + number
+func (s *DeviceState) GetUpdateStatus(ctx context.Context, hardwareID string) *UpdateStatusSnapshot {
+	key := updateStatusPrefix + hardwareID
 	vals, err := s.client.HGetAll(ctx, key).Result()
 	if err != nil {
-		slog.ErrorContext(ctx, "redis: GetUpdateStatus failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: GetUpdateStatus failed", "hardware_id", hardwareID, "err", err)
 		return nil
 	}
 	if len(vals) == 0 {
@@ -312,10 +312,10 @@ func (s *DeviceState) GetUpdateStatus(ctx context.Context, number string) *Updat
 	}
 }
 
-func (s *DeviceState) ClearUpdateStatus(ctx context.Context, number string) {
-	key := updateStatusPrefix + number
+func (s *DeviceState) ClearUpdateStatus(ctx context.Context, hardwareID string) {
+	key := updateStatusPrefix + hardwareID
 	if err := s.client.Del(ctx, key).Err(); err != nil {
-		slog.ErrorContext(ctx, "redis: ClearUpdateStatus failed", "number", number, "err", err)
+		slog.ErrorContext(ctx, "redis: ClearUpdateStatus failed", "hardware_id", hardwareID, "err", err)
 	}
 }
 

--- a/server/internal/signaling/state_redis.go
+++ b/server/internal/signaling/state_redis.go
@@ -105,6 +105,19 @@ func (s *DeviceState) IsOnline(ctx context.Context, number string) bool {
 	return n > 0
 }
 
+// IsHardwareOnline reports whether the device with this hardware id is
+// connected to any pod. The per-device presence hash exists exactly while the
+// device is connected (SetOnline writes it, SetOffline deletes it, heartbeats
+// refresh its TTL), so its existence is the cross-pod online signal.
+func (s *DeviceState) IsHardwareOnline(ctx context.Context, hardwareID string) bool {
+	n, err := s.client.Exists(ctx, deviceKeyPrefix+hardwareID).Result()
+	if err != nil {
+		slog.ErrorContext(ctx, "redis: IsHardwareOnline failed", "hardware_id", hardwareID, "err", err)
+		return false
+	}
+	return n > 0
+}
+
 func (s *DeviceState) OnlineNumbers(ctx context.Context) []string {
 	var numbers []string
 	pattern := lineDevicesPrefix + "*"

--- a/server/internal/signaling/state_redis_test.go
+++ b/server/internal/signaling/state_redis_test.go
@@ -41,6 +41,34 @@ func TestDeviceStateSetOnlineAndIsOnline(t *testing.T) {
 	}
 }
 
+func TestDeviceStateIsHardwareOnline(t *testing.T) {
+	ds, _ := newTestDeviceState(t)
+	ctx := context.Background()
+
+	if ds.IsHardwareOnline(ctx, "hw-abc") {
+		t.Fatal("expected hardware to be offline before SetOnline")
+	}
+
+	ds.SetOnline(ctx, "5551234", DevicePresence{PodID: "pod-1", HardwareID: "hw-abc"})
+	ds.SetOnline(ctx, "5551234", DevicePresence{PodID: "pod-2", HardwareID: "hw-def"})
+
+	if !ds.IsHardwareOnline(ctx, "hw-abc") {
+		t.Fatal("hw-abc should be online after SetOnline")
+	}
+	if !ds.IsHardwareOnline(ctx, "hw-def") {
+		t.Fatal("hw-def should be online after SetOnline")
+	}
+
+	// One device going offline does not affect its sibling, even cross-pod.
+	ds.SetOffline(ctx, "5551234", "hw-abc")
+	if ds.IsHardwareOnline(ctx, "hw-abc") {
+		t.Fatal("hw-abc should be offline after SetOffline")
+	}
+	if !ds.IsHardwareOnline(ctx, "hw-def") {
+		t.Fatal("hw-def should still be online")
+	}
+}
+
 func TestDeviceStateSetOffline(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()

--- a/server/internal/signaling/state_redis_test.go
+++ b/server/internal/signaling/state_redis_test.go
@@ -22,11 +22,11 @@ func TestDeviceStateSetOnlineAndIsOnline(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	if ds.IsOnline(ctx, "5551234") {
+	if ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("expected device to be offline before SetOnline")
 	}
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:           "pod-1",
 		HardwareID:      "hw-abc",
 		PiVersion:       "1.0.0",
@@ -36,7 +36,7 @@ func TestDeviceStateSetOnlineAndIsOnline(t *testing.T) {
 		RemoteAddr:      "192.168.1.10",
 	})
 
-	if !ds.IsOnline(ctx, "5551234") {
+	if !ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("expected device to be online after SetOnline")
 	}
 }
@@ -45,14 +45,14 @@ func TestDeviceStateSetOffline(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:      "pod-1",
 		HardwareID: "hw-abc",
 	})
 
-	ds.SetOffline(ctx, "5551234", "hw-abc")
+	ds.SetOffline(ctx, "hw-5551234", "hw-abc")
 
-	if ds.IsOnline(ctx, "5551234") {
+	if ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("expected device to be offline after SetOffline")
 	}
 }
@@ -84,7 +84,7 @@ func TestDeviceStateDeviceInfo(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:           "pod-1",
 		HardwareID:      "hw-abc",
 		PiVersion:       "1.2.0",
@@ -94,7 +94,7 @@ func TestDeviceStateDeviceInfo(t *testing.T) {
 		RemoteAddr:      "10.0.0.5",
 	})
 
-	all := ds.AllDeviceInfo(ctx, "5551234")
+	all := ds.AllDeviceInfo(ctx, "hw-5551234")
 	if len(all) == 0 {
 		t.Fatal("expected a DeviceInfoSnapshot")
 	}
@@ -129,7 +129,7 @@ func TestDeviceStateUpdateDeviceInfo(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:           "pod-1",
 		HardwareID:      "hw-abc",
 		PiVersion:       "1.0.0",
@@ -141,7 +141,7 @@ func TestDeviceStateUpdateDeviceInfo(t *testing.T) {
 		RemoteAddr: "192.168.1.50",
 	})
 
-	all := ds.AllDeviceInfo(ctx, "5551234")
+	all := ds.AllDeviceInfo(ctx, "hw-5551234")
 	if len(all) == 0 {
 		t.Fatal("expected a DeviceInfoSnapshot")
 	}
@@ -161,16 +161,16 @@ func TestDeviceStateTouchLastSeen(t *testing.T) {
 	ds, mr := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:      "pod-1",
 		HardwareID: "hw-abc",
 	})
 
 	mr.FastForward(60 * time.Second)
 
-	ds.TouchLastSeen(ctx, "5551234", "hw-abc")
+	ds.TouchLastSeen(ctx, "hw-5551234", "hw-abc")
 
-	ts := ds.LastSeenAt(ctx, "5551234")
+	ts := ds.LastSeenAt(ctx, "hw-5551234")
 	if ts == nil {
 		t.Fatal("expected non-nil LastSeenAt after TouchLastSeen")
 	}
@@ -194,9 +194,9 @@ func TestDeviceStateUpdateStatus(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetUpdateStatus(ctx, "5551234", "downloading", "50%")
+	ds.SetUpdateStatus(ctx, "hw-5551234", "downloading", "50%")
 
-	snap := ds.GetUpdateStatus(ctx, "5551234")
+	snap := ds.GetUpdateStatus(ctx, "hw-5551234")
 	if snap == nil {
 		t.Fatal("expected non-nil UpdateStatusSnapshot")
 	}
@@ -210,9 +210,9 @@ func TestDeviceStateUpdateStatus(t *testing.T) {
 		t.Error("UpdatedAt should not be zero")
 	}
 
-	ds.ClearUpdateStatus(ctx, "5551234")
+	ds.ClearUpdateStatus(ctx, "hw-5551234")
 
-	snap = ds.GetUpdateStatus(ctx, "5551234")
+	snap = ds.GetUpdateStatus(ctx, "hw-5551234")
 	if snap != nil {
 		t.Fatalf("expected nil after ClearUpdateStatus, got %+v", snap)
 	}
@@ -222,18 +222,18 @@ func TestDeviceStateTTLExpiry(t *testing.T) {
 	ds, mr := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:      "pod-1",
 		HardwareID: "hw-abc",
 	})
 
-	if !ds.IsOnline(ctx, "5551234") {
+	if !ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("expected online before expiry")
 	}
 
 	mr.FastForward(91 * time.Second)
 
-	if ds.IsOnline(ctx, "5551234") {
+	if ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("expected offline after TTL expiry")
 	}
 }
@@ -242,20 +242,20 @@ func TestDeviceStateAllDeviceInfoMultiDevice(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:           "pod-1",
 		HardwareID:      "hw-aaa",
 		PiVersion:       "1.0.0",
 		FirmwareVersion: "0.5.0",
 	})
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID:           "pod-1",
 		HardwareID:      "hw-bbb",
 		PiVersion:       "1.2.0",
 		FirmwareVersion: "0.8.0",
 	})
 
-	infos := ds.AllDeviceInfo(ctx, "5551234")
+	infos := ds.AllDeviceInfo(ctx, "hw-5551234")
 	if len(infos) != 2 {
 		t.Fatalf("expected 2 devices, got %d", len(infos))
 	}
@@ -273,20 +273,20 @@ func TestDeviceStateSetOfflineRemovesOneDevice(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID: "pod-1", HardwareID: "hw-aaa", PiVersion: "1.0.0",
 	})
-	ds.SetOnline(ctx, "5551234", DevicePresence{
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{
 		PodID: "pod-1", HardwareID: "hw-bbb", PiVersion: "1.2.0",
 	})
 
-	ds.SetOffline(ctx, "5551234", "hw-aaa")
+	ds.SetOffline(ctx, "hw-5551234", "hw-aaa")
 
-	if !ds.IsOnline(ctx, "5551234") {
+	if !ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("line should still be online with one remaining device")
 	}
 
-	infos := ds.AllDeviceInfo(ctx, "5551234")
+	infos := ds.AllDeviceInfo(ctx, "hw-5551234")
 	if len(infos) != 1 {
 		t.Fatalf("expected 1 device after removing one, got %d", len(infos))
 	}
@@ -299,14 +299,14 @@ func TestDeviceStateEmptyHardwareIDSkipped(t *testing.T) {
 	ds, _ := newTestDeviceState(t)
 	ctx := context.Background()
 
-	ds.SetOnline(ctx, "5551234", DevicePresence{PodID: "pod-1"})
+	ds.SetOnline(ctx, "hw-5551234", DevicePresence{PodID: "pod-1"})
 
-	if ds.IsOnline(ctx, "5551234") {
+	if ds.IsOnline(ctx, "hw-5551234") {
 		t.Fatal("device with empty hardware ID should not register in Redis")
 	}
 
-	ds.SetOffline(ctx, "5551234", "")
+	ds.SetOffline(ctx, "hw-5551234", "")
 
-	ds.TouchLastSeen(ctx, "5551234", "")
+	ds.TouchLastSeen(ctx, "hw-5551234", "")
 	ds.UpdateDeviceInfo(ctx, "", DevicePresence{PiVersion: "1.0.0"})
 }

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -617,6 +617,7 @@ func (h *Handler) Router() http.Handler {
 	protected.HandleFunc("POST /phones/{number}/ring-test", h.handlePhoneRingTest)
 	protected.HandleFunc("POST /phones/{number}/dev-mode", h.handlePhoneDevMode)
 	protected.HandleFunc("GET /phones/{number}/dev-mode-status", h.handlePhoneDevModeStatus)
+	protected.HandleFunc("GET /phones/{number}/operator", h.handlePhoneOperator)
 	protected.HandleFunc("GET /calls", h.handleCalls)
 	protected.HandleFunc("GET /settings", h.handleSettings)
 	protected.HandleFunc("POST /settings/household", h.handleSettingsHouseholdPost)

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -404,12 +404,17 @@ func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *househol
 	// aggregate: on a multi-device line the line aggregate would show the most
 	// recently active sibling's time, which is wrong for the selected device.
 	// The throttled last-seen writer keeps the row fresh while the device is
-	// connected.
+	// connected. The empty-id fallback (legacy/unpaired connection with no row)
+	// has no per-device row, so it uses the line-level last-seen.
 	var lastSeenAt *time.Time
-	for _, d := range devices {
-		if d.HardwareID == hardwareID {
-			lastSeenAt = d.LastSeenAt
-			break
+	if hardwareID == "" {
+		lastSeenAt = h.hub.LastSeenAt(ln.Number)
+	} else {
+		for _, d := range devices {
+			if d.HardwareID == hardwareID {
+				lastSeenAt = d.LastSeenAt
+				break
+			}
 		}
 	}
 	if lastSeenAt != nil {

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -424,12 +424,110 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// buildOperatorData assembles the per-device operator view for hardwareID.
+// It is shared between handlePhoneDetail (full page) and handlePhoneOperator
+// (partial swap) so a toggle swap produces identical fields to a full reload.
+func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *household.Household, hardwareID string) lineDetailData {
+	var latestPi, latestFw string
+	var piReleases, fwReleases []updates.Release
+	var idx *updates.ReleaseIndex
+	if h.releases != nil {
+		idx = h.releases.ReleaseIndex()
+	}
+	if idx != nil {
+		latestPi = idx.Pi.Latest
+		latestFw = idx.Firmware.Latest
+		piReleases = idx.SortedReleases(updates.ComponentPi)
+		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
+	}
+
+	allInfos := h.hub.AllDeviceInfo(ln.Number)
+	var devInfo *signaling.DeviceInfoSnapshot
+	for i := range allInfos {
+		if allInfos[i].HardwareID == hardwareID {
+			devInfo = &allInfos[i]
+			break
+		}
+	}
+
+	online := h.hub.IsHardwareOnline(hardwareID)
+
+	var lastSeenAt *time.Time
+	if online {
+		lastSeenAt = h.hub.LastSeenAt(ln.Number)
+	} else if h.deviceStore != nil {
+		devices, _ := h.deviceStore.ListByLine(r.Context(), ln.ID)
+		for _, d := range devices {
+			if d.HardwareID == hardwareID && d.LastSeenAt != nil {
+				lastSeenAt = d.LastSeenAt
+				break
+			}
+		}
+	}
+
+	loc := hh.Location()
+	if lastSeenAt != nil {
+		t := lastSeenAt.In(loc)
+		lastSeenAt = &t
+	}
+
+	var oneSnapshot []signaling.DeviceInfoSnapshot
+	if devInfo != nil {
+		oneSnapshot = []signaling.DeviceInfoSnapshot{*devInfo}
+	}
+	piUpdateNotes, firmwareUpdateNotes := updateNotes(idx, oneSnapshot, latestPi, latestFw)
+
+	return lineDetailData{
+		Line:                  *ln,
+		Online:                online,
+		DeviceInfo:            devInfo,
+		LastSeenAt:            lastSeenAt,
+		LatestPiVersion:       latestPi,
+		LatestFirmwareVersion: latestFw,
+		PiReleases:            piReleases,
+		FWReleases:            fwReleases,
+		PiUpdateNotes:         piUpdateNotes,
+		FirmwareUpdateNotes:   firmwareUpdateNotes,
+		IsAdmin:               h.isHouseholdAdmin(r, hh.ID),
+		SelectedHardwareID:    hardwareID,
+	}
+}
+
+func (h *Handler) handlePhoneOperator(w http.ResponseWriter, r *http.Request) {
+	number := r.PathValue("number")
+	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
+	if ln == nil {
+		return
+	}
+	if !parseForm(w, r) {
+		return
+	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
+	data := h.buildOperatorData(r, ln, hh, hwID)
+	data.chromeData = h.newChromeDataWithHouseholds(r, "phones")
+	renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "operator-panel", "am-operator-panel"), data)
+}
+
 func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
 	if h.requireLineOwnership(w, r, number) == nil {
 		return
 	}
-	online := h.hub.IsOnline(number)
+	if !parseForm(w, r) {
+		return
+	}
+	// Per-device online check when hardware_id is provided; line-level otherwise.
+	// The HTMX header-badge path stays line-level so the badge reflects any device on the line.
+	hwID := strings.TrimSpace(r.FormValue("hardware_id"))
+	var online bool
+	if hwID != "" && !isHTMX(r) {
+		online = h.hub.IsHardwareOnline(hwID)
+	} else {
+		online = h.hub.IsOnline(number)
+	}
 	if isHTMX(r) {
 		renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "phone-status", "am-phone-status"), struct {
 			Online bool
@@ -774,32 +872,44 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings) error 
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
+	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	if ln == nil {
 		return
 	}
 	if !parseForm(w, r) {
 		return
 	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
 	targetPi := strings.TrimSpace(r.FormValue("target_pi_version"))
 	targetFW := strings.TrimSpace(r.FormValue("target_fw_version"))
 
-	// Clear any stale status before sending new trigger
-	h.hub.ClearUpdateStatus(number)
+	h.hub.ClearUpdateStatus(hwID)
 
 	msg := &signaling.Message{
 		Type:            signaling.TypeUpdateTrigger,
 		TargetPiVersion: targetPi,
 		TargetFWVersion: targetFW,
 	}
-	h.sendPhoneCommandAndRespond(w, r, number, msg, "update trigger", "target_pi", targetPi, "target_fw", targetFW)
+	h.sendDeviceCommandAndRespond(w, r, number, hwID, msg, "update trigger", "target_pi", targetPi, "target_fw", targetFW)
 }
 
 func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
 		return
 	}
-	status := h.hub.GetUpdateStatus(number)
+	if !parseForm(w, r) {
+		return
+	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
+	status := h.hub.GetUpdateStatus(hwID)
 	if status == nil {
 		if err := writeJSON(w, map[string]string{"status": ""}); err != nil {
 			slog.ErrorContext(r.Context(), "update status: json encode failed", "err", err)
@@ -813,33 +923,48 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
 		return
 	}
-
+	if !parseForm(w, r) {
+		return
+	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
 	msg := &signaling.Message{
 		Type: signaling.TypeRingTest,
 	}
-	h.sendPhoneCommandAndRespond(w, r, number, msg, "ring test")
+	h.sendDeviceCommandAndRespond(w, r, number, hwID, msg, "ring test")
 }
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
+	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	if ln == nil {
 		return
 	}
-
-	h.hub.ClearUpdateStatus(number)
+	if !parseForm(w, r) {
+		return
+	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
+	h.hub.ClearUpdateStatus(hwID)
 
 	msg := &signaling.Message{
 		Type: signaling.TypeFactoryReset,
 	}
-	h.sendPhoneCommandAndRespond(w, r, number, msg, "factory reset")
+	h.sendDeviceCommandAndRespond(w, r, number, hwID, msg, "factory reset")
 }
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
+	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	if ln == nil {
 		return
 	}
 	if !parseForm(w, r) {
@@ -852,11 +977,15 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
 	msg := &signaling.Message{
 		Type:        signaling.TypeRestart,
 		RestartMode: mode,
 	}
-	h.sendPhoneCommandAndRespond(w, r, number, msg, "restart command", "mode", mode)
+	h.sendDeviceCommandAndRespond(w, r, number, hwID, msg, "restart command", "mode", mode)
 }
 
 // devModePasswordMin and devModePasswordMax bound the SSH login password set
@@ -893,7 +1022,8 @@ func validateDevModePassword(pw string) error {
 // signaling channel.
 func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if ln, _ := h.requireLineOwnershipAdmin(w, r, number); ln == nil {
+	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	if ln == nil {
 		return
 	}
 	if !parseForm(w, r) {
@@ -913,7 +1043,12 @@ func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
 		}
 		msg.DevModePassword = pw
 	}
-	h.sendPhoneCommandAndRespond(w, r, number, msg, "dev mode command", "enabled", enabled)
+
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
+		return
+	}
+	h.sendDeviceCommandAndRespond(w, r, number, hwID, msg, "dev mode command", "enabled", enabled)
 }
 
 // handlePhoneDevModeStatus reports the device's current developer-mode state so
@@ -922,12 +1057,20 @@ func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
 // HTML on page reload, never in JSON (see DeviceInfoSnapshot.RemoteAddr).
 func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
+		return
+	}
+	if !parseForm(w, r) {
+		return
+	}
+	hwID, ok := h.requireLineDevice(w, r, ln)
+	if !ok {
 		return
 	}
 	enabled := false
 	for _, info := range h.hub.AllDeviceInfo(number) {
-		if info.DevMode {
+		if (hwID == "" || info.HardwareID == hwID) && info.DevMode {
 			enabled = true
 			break
 		}
@@ -940,18 +1083,63 @@ func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// sendPhoneCommandAndRespond pushes msg to the device, logs the outcome
-// (warn on hub send failure, info on success), and writes the standard
-// phone-command response. opName names the operation for the log
-// messages; extraInfo is forwarded to both the warn and info logs as
-// command-specific context (restart mode, update targets, etc.).
-func (h *Handler) sendPhoneCommandAndRespond(w http.ResponseWriter, r *http.Request, number string, msg *signaling.Message, opName string, extraInfo ...any) {
+// requireLineDevice resolves the hardware_id param to a device on this line.
+// When hardware_id is empty it defaults to the line's first device (the common
+// single-device case). Returns ("", true) when no device rows exist and no
+// hardware_id was requested: callers treat this as "send to line level" so
+// existing connections without DB rows continue to work. Returns ("", false)
+// after writing a 400 when a specific hardware_id was requested but not found.
+// Caller must already hold line ownership and have called parseForm.
+func (h *Handler) requireLineDevice(w http.ResponseWriter, r *http.Request, ln *line.Line) (hardwareID string, ok bool) {
+	want := strings.TrimSpace(r.FormValue("hardware_id"))
+	if h.deviceStore == nil {
+		if want != "" {
+			jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
+			return "", false
+		}
+		return "", true
+	}
+	devices, err := h.deviceStore.ListByLine(r.Context(), ln.ID)
+	if err != nil {
+		jsonError(r.Context(), w, "no devices on line", http.StatusBadRequest)
+		return "", false
+	}
+	if len(devices) == 0 {
+		if want != "" {
+			jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
+			return "", false
+		}
+		return "", true
+	}
+	if want == "" {
+		return devices[0].HardwareID, true
+	}
+	for _, d := range devices {
+		if d.HardwareID == want {
+			return want, true
+		}
+	}
+	jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
+	return "", false
+}
+
+// sendDeviceCommandAndRespond pushes msg to a specific device by hardware id,
+// logs the outcome, and writes the standard phone-command response. When
+// hardwareID is empty (no device rows; legacy connection) it falls back to
+// line-level SendTo so single-device lines without DB rows still work.
+func (h *Handler) sendDeviceCommandAndRespond(w http.ResponseWriter, r *http.Request, number, hardwareID string, msg *signaling.Message, opName string, extraInfo ...any) {
 	var sendErr string
-	if err := h.hub.SendTo(number, msg); err != nil {
-		slog.WarnContext(r.Context(), opName+" failed", append([]any{"number", number, "err", err}, extraInfo...)...)
+	var err error
+	if hardwareID != "" {
+		err = h.hub.SendToHardware(hardwareID, msg)
+	} else {
+		err = h.hub.SendTo(number, msg)
+	}
+	if err != nil {
+		slog.WarnContext(r.Context(), opName+" failed", append([]any{"number", number, "hardware_id", hardwareID, "err", err}, extraInfo...)...)
 		sendErr = err.Error()
 	} else {
-		slog.InfoContext(r.Context(), opName+" sent", append([]any{"number", number}, extraInfo...)...)
+		slog.InfoContext(r.Context(), opName+" sent", append([]any{"number", number, "hardware_id", hardwareID}, extraInfo...)...)
 	}
 	h.respondPhoneCommandResult(w, r, number, sendErr)
 }

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -50,6 +50,29 @@ func updateNotes(idx *updates.ReleaseIndex, infos []signaling.DeviceInfoSnapshot
 	return pi, fw
 }
 
+// buildDeviceViews joins each paired device row to its live hub snapshot by
+// hardware id and returns the views plus the hardware id to select by default
+// (first online device, else the first device, else "").
+func (h *Handler) buildDeviceViews(devices []device.Device, infos []signaling.DeviceInfoSnapshot) (views []deviceView, selected string) {
+	byHW := make(map[string]*signaling.DeviceInfoSnapshot, len(infos))
+	for i := range infos {
+		byHW[infos[i].HardwareID] = &infos[i]
+	}
+	for _, d := range devices {
+		v := deviceView{Device: d, DeviceInfo: byHW[d.HardwareID]}
+		v.Online = h.hub.IsHardwareOnline(d.HardwareID)
+		v.LastSeenAt = d.LastSeenAt
+		views = append(views, v)
+		if selected == "" && v.Online {
+			selected = d.HardwareID
+		}
+	}
+	if selected == "" && len(devices) > 0 {
+		selected = devices[0].HardwareID
+	}
+	return views, selected
+}
+
 func validateLineName(raw string) (string, error) {
 	name := strings.TrimSpace(raw)
 	if name == "" {
@@ -270,11 +293,21 @@ func (h *Handler) handlePhonesPairPost(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/?"+v.Encode(), http.StatusSeeOther)
 }
 
+// deviceView is one handset's per-device operator data for the detail page.
+type deviceView struct {
+	Device     device.Device
+	DeviceInfo *signaling.DeviceInfoSnapshot // nil if the device has not reported
+	Online     bool
+	LastSeenAt *time.Time
+}
+
 type lineDetailData struct {
 	chromeData
 	Line                  line.Line
 	Online                bool
 	Devices               []device.Device
+	DeviceViews           []deviceView
+	SelectedHardwareID    string
 	DeviceInfo            *signaling.DeviceInfoSnapshot
 	LastSeenAt            *time.Time
 	LatestPiVersion       string
@@ -339,12 +372,26 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	allInfos := h.hub.AllDeviceInfo(number)
+	views, selected := h.buildDeviceViews(devices, allInfos)
 	var devInfo *signaling.DeviceInfoSnapshot
-	if len(allInfos) > 0 {
+	selOnline := online
+	for i := range views {
+		if views[i].Device.HardwareID == selected {
+			devInfo = views[i].DeviceInfo
+			selOnline = views[i].Online
+		}
+	}
+	// Fall back to the first hub snapshot when no paired device rows exist yet
+	// (device registered but not yet in the DB, or legacy connection without HW id).
+	if devInfo == nil && len(allInfos) > 0 {
 		devInfo = &allInfos[0]
 	}
 
-	piUpdateNotes, firmwareUpdateNotes := updateNotes(idx, allInfos, latestPi, latestFw)
+	var oneSnapshot []signaling.DeviceInfoSnapshot
+	if devInfo != nil {
+		oneSnapshot = []signaling.DeviceInfoSnapshot{*devInfo}
+	}
+	piUpdateNotes, firmwareUpdateNotes := updateNotes(idx, oneSnapshot, latestPi, latestFw)
 
 	var otherLines []line.Line
 	allLines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
@@ -359,8 +406,10 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	renderWith(r.Context(), w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
 		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
 		Line:                  *ln,
-		Online:                online,
+		Online:                selOnline,
 		Devices:               devices,
+		DeviceViews:           views,
+		SelectedHardwareID:    selected,
 		DeviceInfo:            devInfo,
 		LastSeenAt:            lastSeenAt,
 		LatestPiVersion:       latestPi,

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -452,13 +452,16 @@ func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *househol
 
 	online := h.hub.IsHardwareOnline(hardwareID)
 
+	// Last-seen is sourced from this device's own row, not the line-level hub
+	// aggregate: on a multi-device line the line aggregate would show the most
+	// recently active sibling's time, which is wrong for the selected device.
+	// The throttled last-seen writer keeps the row fresh while the device is
+	// connected.
 	var lastSeenAt *time.Time
-	if online {
-		lastSeenAt = h.hub.LastSeenAt(ln.Number)
-	} else if h.deviceStore != nil {
+	if h.deviceStore != nil {
 		devices, _ := h.deviceStore.ListByLine(r.Context(), ln.ID)
 		for _, d := range devices {
-			if d.HardwareID == hardwareID && d.LastSeenAt != nil {
+			if d.HardwareID == hardwareID {
 				lastSeenAt = d.LastSeenAt
 				break
 			}
@@ -513,7 +516,8 @@ func (h *Handler) handlePhoneOperator(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	if h.requireLineOwnership(w, r, number) == nil {
+	ln := h.requireLineOwnership(w, r, number)
+	if ln == nil {
 		return
 	}
 	if !parseForm(w, r) {
@@ -524,7 +528,14 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	hwID := strings.TrimSpace(r.FormValue("hardware_id"))
 	var online bool
 	if hwID != "" && !isHTMX(r) {
-		online = h.hub.IsHardwareOnline(hwID)
+		// Validate the id belongs to this line before probing it, so this
+		// endpoint can't be used as an online oracle for other households'
+		// hardware. requireLineDevice returns the id unchanged when valid.
+		validHW, ok := h.requireLineDevice(w, r, ln)
+		if !ok {
+			return
+		}
+		online = h.hub.IsHardwareOnline(validHW)
 	} else {
 		online = h.hub.IsOnline(number)
 	}
@@ -1068,6 +1079,8 @@ func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
+	// hwID is "" only in requireLineDevice's no-device-rows fallback; there it
+	// means "no specific device to match", so fall back to a line-level scan.
 	enabled := false
 	for _, info := range h.hub.AllDeviceInfo(number) {
 		if (hwID == "" || info.HardwareID == hwID) && info.DevMode {

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -327,7 +327,6 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 	if ln == nil {
 		return
 	}
-	online := h.hub.IsOnline(number)
 
 	var devices []device.Device
 	if h.deviceStore != nil {
@@ -338,99 +337,34 @@ func (h *Handler) handlePhoneDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// For online devices, use the real-time in-memory timestamp from the Hub.
-	// For offline devices, fall back to the last disconnect time from the DB.
-	var lastSeenAt *time.Time
-	if online {
-		lastSeenAt = h.hub.LastSeenAt(number)
-	} else {
-		for _, d := range devices {
-			if d.LastSeenAt != nil && (lastSeenAt == nil || d.LastSeenAt.After(*lastSeenAt)) {
-				lastSeenAt = d.LastSeenAt
-			}
-		}
-	}
-
-	var latestPi, latestFw string
-	var piReleases, fwReleases []updates.Release
-	var idx *updates.ReleaseIndex
-	if h.releases != nil {
-		idx = h.releases.ReleaseIndex()
-	}
-	if idx != nil {
-		latestPi = idx.Pi.Latest
-		latestFw = idx.Firmware.Latest
-		piReleases = idx.SortedReleases(updates.ComponentPi)
-		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
-	}
-
-	loc := hh.Location()
-
-	if lastSeenAt != nil {
-		t := lastSeenAt.In(loc)
-		lastSeenAt = &t
-	}
-
 	allInfos := h.hub.AllDeviceInfo(number)
 	views, selected := h.buildDeviceViews(devices, allInfos)
-	var devInfo *signaling.DeviceInfoSnapshot
-	selOnline := online
-	for i := range views {
-		if views[i].Device.HardwareID == selected {
-			devInfo = views[i].DeviceInfo
-			selOnline = views[i].Online
-		}
-	}
-	// Fall back to the first hub snapshot when no paired device rows exist yet
-	// (device registered but not yet in the DB, or legacy connection without HW id).
-	if devInfo == nil && len(allInfos) > 0 {
-		devInfo = &allInfos[0]
-	}
 
-	var oneSnapshot []signaling.DeviceInfoSnapshot
-	if devInfo != nil {
-		oneSnapshot = []signaling.DeviceInfoSnapshot{*devInfo}
-	}
-	piUpdateNotes, firmwareUpdateNotes := updateNotes(idx, oneSnapshot, latestPi, latestFw)
+	// The operator panel renders the selected device through the same builder
+	// the toggle-swap endpoint uses, so the initial page and a later swap show
+	// identical fields.
+	data := h.buildOperatorData(r, ln, hh, selected, devices, allInfos)
+	data.chromeData = h.newChromeDataWithHouseholds(r, "phones")
+	data.Devices = devices
+	data.DeviceViews = views
+	data.NumberError = r.URL.Query().Get("number_error")
 
-	var otherLines []line.Line
 	allLines, err := h.lineStore.ListByHousehold(r.Context(), hh.ID)
 	if err == nil {
 		for _, ol := range allLines {
 			if ol.ID != ln.ID {
-				otherLines = append(otherLines, ol)
+				data.OtherLines = append(data.OtherLines, ol)
 			}
 		}
 	}
 
-	renderWith(r.Context(), w, h.tmplPhoneDetail, layoutFor(r), lineDetailData{
-		chromeData:            h.newChromeDataWithHouseholds(r, "phones"),
-		Line:                  *ln,
-		Online:                selOnline,
-		Devices:               devices,
-		DeviceViews:           views,
-		SelectedHardwareID:    selected,
-		DeviceInfo:            devInfo,
-		LastSeenAt:            lastSeenAt,
-		LatestPiVersion:       latestPi,
-		LatestFirmwareVersion: latestFw,
-		PiReleases:            piReleases,
-		FWReleases:            fwReleases,
-		PiUpdateNotes:         piUpdateNotes,
-		FirmwareUpdateNotes:   firmwareUpdateNotes,
-		OtherLines:            otherLines,
-		NumberError:           r.URL.Query().Get("number_error"),
-		IsAdmin:               h.isHouseholdAdmin(r, hh.ID),
-	})
+	renderWith(r.Context(), w, h.tmplPhoneDetail, layoutFor(r), data)
 }
 
-// buildOperatorData assembles the per-device operator view for hardwareID.
-// It is shared between handlePhoneDetail (full page) and handlePhoneOperator
-// (partial swap) so a toggle swap produces identical fields to a full reload.
-func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *household.Household, hardwareID string) lineDetailData {
-	var latestPi, latestFw string
-	var piReleases, fwReleases []updates.Release
-	var idx *updates.ReleaseIndex
+// releaseData reads the cached release index and the per-component latest
+// versions and sorted release lists. Returns zero values when no index is
+// loaded.
+func (h *Handler) releaseData() (idx *updates.ReleaseIndex, latestPi, latestFw string, piReleases, fwReleases []updates.Release) {
 	if h.releases != nil {
 		idx = h.releases.ReleaseIndex()
 	}
@@ -440,8 +374,19 @@ func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *househol
 		piReleases = idx.SortedReleases(updates.ComponentPi)
 		fwReleases = idx.SortedReleases(updates.ComponentFirmware)
 	}
+	return idx, latestPi, latestFw, piReleases, fwReleases
+}
 
-	allInfos := h.hub.AllDeviceInfo(ln.Number)
+// buildOperatorData assembles the per-device operator view for hardwareID from
+// already-fetched device rows and hub snapshots. It is shared between
+// handlePhoneDetail (full page) and handlePhoneOperator (partial swap) so a
+// toggle swap produces identical fields to a full reload. An empty hardwareID
+// means no device rows exist yet (legacy/unpaired connection): fall back to the
+// first hub snapshot and the line-level online state so those connections still
+// render.
+func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *household.Household, hardwareID string, devices []device.Device, allInfos []signaling.DeviceInfoSnapshot) lineDetailData {
+	idx, latestPi, latestFw, piReleases, fwReleases := h.releaseData()
+
 	var devInfo *signaling.DeviceInfoSnapshot
 	for i := range allInfos {
 		if allInfos[i].HardwareID == hardwareID {
@@ -449,8 +394,11 @@ func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *househol
 			break
 		}
 	}
-
 	online := h.hub.IsHardwareOnline(hardwareID)
+	if hardwareID == "" && len(allInfos) > 0 {
+		devInfo = &allInfos[0]
+		online = h.hub.IsOnline(ln.Number)
+	}
 
 	// Last-seen is sourced from this device's own row, not the line-level hub
 	// aggregate: on a multi-device line the line aggregate would show the most
@@ -458,19 +406,14 @@ func (h *Handler) buildOperatorData(r *http.Request, ln *line.Line, hh *househol
 	// The throttled last-seen writer keeps the row fresh while the device is
 	// connected.
 	var lastSeenAt *time.Time
-	if h.deviceStore != nil {
-		devices, _ := h.deviceStore.ListByLine(r.Context(), ln.ID)
-		for _, d := range devices {
-			if d.HardwareID == hardwareID {
-				lastSeenAt = d.LastSeenAt
-				break
-			}
+	for _, d := range devices {
+		if d.HardwareID == hardwareID {
+			lastSeenAt = d.LastSeenAt
+			break
 		}
 	}
-
-	loc := hh.Location()
 	if lastSeenAt != nil {
-		t := lastSeenAt.In(loc)
+		t := lastSeenAt.In(hh.Location())
 		lastSeenAt = &t
 	}
 
@@ -505,11 +448,12 @@ func (h *Handler) handlePhoneOperator(w http.ResponseWriter, r *http.Request) {
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, devices, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
-	data := h.buildOperatorData(r, ln, hh, hwID)
+	allInfos := h.hub.AllDeviceInfo(number)
+	data := h.buildOperatorData(r, ln, hh, hwID, devices, allInfos)
 	data.chromeData = h.newChromeDataWithHouseholds(r, "phones")
 	renderWith(r.Context(), w, h.tmplPhoneDetail, partialFor(r, "operator-panel", "am-operator-panel"), data)
 }
@@ -523,15 +467,15 @@ func (h *Handler) handlePhoneOnline(w http.ResponseWriter, r *http.Request) {
 	if !parseForm(w, r) {
 		return
 	}
-	// Per-device online check when hardware_id is provided; line-level otherwise.
-	// The HTMX header-badge path stays line-level so the badge reflects any device on the line.
-	hwID := strings.TrimSpace(r.FormValue("hardware_id"))
+	// Per-device online check when a hardware_id is provided; line-level
+	// otherwise. The header-badge poll sends no hardware_id, so it stays
+	// line-level and reflects any device on the line.
 	var online bool
-	if hwID != "" && !isHTMX(r) {
+	if strings.TrimSpace(r.FormValue("hardware_id")) != "" {
 		// Validate the id belongs to this line before probing it, so this
 		// endpoint can't be used as an online oracle for other households'
 		// hardware. requireLineDevice returns the id unchanged when valid.
-		validHW, ok := h.requireLineDevice(w, r, ln)
+		validHW, _, ok := h.requireLineDevice(w, r, ln)
 		if !ok {
 			return
 		}
@@ -890,7 +834,7 @@ func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -916,7 +860,7 @@ func (h *Handler) handlePhoneUpdateStatus(w http.ResponseWriter, r *http.Request
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -941,7 +885,7 @@ func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -960,7 +904,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -988,7 +932,7 @@ func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -1055,7 +999,7 @@ func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
 		msg.DevModePassword = pw
 	}
 
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -1075,7 +1019,7 @@ func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Reques
 	if !parseForm(w, r) {
 		return
 	}
-	hwID, ok := h.requireLineDevice(w, r, ln)
+	hwID, _, ok := h.requireLineDevice(w, r, ln)
 	if !ok {
 		return
 	}
@@ -1096,44 +1040,46 @@ func (h *Handler) handlePhoneDevModeStatus(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// requireLineDevice resolves the hardware_id param to a device on this line.
-// When hardware_id is empty it defaults to the line's first device (the common
-// single-device case). Returns ("", true) when no device rows exist and no
-// hardware_id was requested: callers treat this as "send to line level" so
-// existing connections without DB rows continue to work. Returns ("", false)
-// after writing a 400 when a specific hardware_id was requested but not found.
-// Caller must already hold line ownership and have called parseForm.
-func (h *Handler) requireLineDevice(w http.ResponseWriter, r *http.Request, ln *line.Line) (hardwareID string, ok bool) {
+// requireLineDevice resolves the hardware_id param to a device on this line and
+// returns the line's device rows so callers can reuse them without a second
+// query. When hardware_id is empty it defaults to the line's first device (the
+// common single-device case). Returns ("", _, true) when no device rows exist
+// and no hardware_id was requested: callers treat this as "send to line level"
+// so existing connections without DB rows continue to work. Returns
+// ("", _, false) after writing a 400 when a specific hardware_id was requested
+// but not found. Caller must already hold line ownership and have called
+// parseForm.
+func (h *Handler) requireLineDevice(w http.ResponseWriter, r *http.Request, ln *line.Line) (hardwareID string, devices []device.Device, ok bool) {
 	want := strings.TrimSpace(r.FormValue("hardware_id"))
 	if h.deviceStore == nil {
 		if want != "" {
 			jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
-			return "", false
+			return "", nil, false
 		}
-		return "", true
+		return "", nil, true
 	}
 	devices, err := h.deviceStore.ListByLine(r.Context(), ln.ID)
 	if err != nil {
 		jsonError(r.Context(), w, "no devices on line", http.StatusBadRequest)
-		return "", false
+		return "", nil, false
 	}
 	if len(devices) == 0 {
 		if want != "" {
 			jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
-			return "", false
+			return "", devices, false
 		}
-		return "", true
+		return "", devices, true
 	}
 	if want == "" {
-		return devices[0].HardwareID, true
+		return devices[0].HardwareID, devices, true
 	}
 	for _, d := range devices {
 		if d.HardwareID == want {
-			return want, true
+			return want, devices, true
 		}
 	}
 	jsonError(r.Context(), w, "unknown device for line", http.StatusBadRequest)
-	return "", false
+	return "", devices, false
 }
 
 // sendDeviceCommandAndRespond pushes msg to a specific device by hardware id,

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1932,3 +1932,149 @@ func TestChangePhoneNumberDuplicate(t *testing.T) {
 		t.Error("original line should still exist")
 	}
 }
+
+func TestPhoneDetail_BuildsPerDeviceViews(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140010", "Kitchen", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id IN ('hw-a','hw-b')")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	// Seed two devices: hw-a paired + online with a version, hw-b paired only.
+	var devAID, devBID int64
+	if err := database.DB.QueryRow(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-a', 'dev-a', 'Kitchen A', NOW())
+		RETURNING id
+	`, ln.ID).Scan(&devAID); err != nil {
+		t.Fatalf("seed device A: %v", err)
+	}
+	if err := database.DB.QueryRow(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-b', 'dev-b', 'Kitchen B', NOW())
+		RETURNING id
+	`, ln.ID).Scan(&devBID); err != nil {
+		t.Fatalf("seed device B: %v", err)
+	}
+	_ = devAID
+	_ = devBID
+
+	// Register hw-a as online with version info.
+	connA := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-a"}
+	if err := h.hub.Register("3140010", connA); err != nil {
+		t.Fatalf("register conn A: %v", err)
+	}
+	h.hub.UpdateDeviceInfoByHardware("hw-a", signaling.DeviceInfoParams{
+		FirmwareVersion: "1.2.0",
+		PiVersion:       "2.0.0",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/phones/3140010", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Kitchen A") {
+		t.Errorf("page missing device A name 'Kitchen A'")
+	}
+	if !strings.Contains(body, "Kitchen B") {
+		t.Errorf("page missing device B name 'Kitchen B'")
+	}
+	if !strings.Contains(body, "2.0.0") {
+		t.Errorf("page missing selected device's Pi version '2.0.0'")
+	}
+}
+
+func TestPhoneRestart_TargetsHardware(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140011", "Porch", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id = 'hw-porch'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-porch', 'dev-porch', 'Porch Phone', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device: %v", err)
+	}
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-porch"}
+	if err := h.hub.Register("3140011", conn); err != nil {
+		t.Fatalf("register conn: %v", err)
+	}
+
+	form := url.Values{"mode": {"service"}, "hardware_id": {"hw-porch"}}
+	req := httptest.NewRequest("POST", "/phones/3140011/restart", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case data := <-conn.Send:
+		msg, _ := signaling.ParseMessage(data)
+		if msg.Type != signaling.TypeRestart {
+			t.Fatalf("expected restart message, got %s", msg.Type)
+		}
+	default:
+		t.Fatal("device did not receive restart message")
+	}
+}
+
+func TestPhoneRestart_RejectsForeignHardware(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140012", "Garage", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id = 'hw-garage'")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-garage', 'dev-garage', 'Garage Phone', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device: %v", err)
+	}
+
+	form := url.Values{"mode": {"service"}, "hardware_id": {"hw-other-household"}}
+	req := httptest.NewRequest("POST", "/phones/3140012/restart", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for foreign hardware_id, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2119,3 +2119,86 @@ func TestPhoneRestart_RejectsForeignHardware(t *testing.T) {
 		t.Fatalf("expected 400 for foreign hardware_id, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestPhoneOperator_SwapsPanel(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140020", "Study", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id IN ('hw-study-a','hw-study-b')")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-study-a', 'dev-study-a', 'Study A', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device A: %v", err)
+	}
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-study-b', 'dev-study-b', 'Study B', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device B: %v", err)
+	}
+
+	connA := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-study-a"}
+	if err := h.hub.Register("3140020", connA); err != nil {
+		t.Fatalf("register conn A: %v", err)
+	}
+	h.hub.UpdateDeviceInfoByHardware("hw-study-a", signaling.DeviceInfoParams{
+		PiVersion:       "3.1.0",
+		FirmwareVersion: "1.5.0",
+	})
+
+	connB := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-study-b"}
+	if err := h.hub.Register("3140020", connB); err != nil {
+		t.Fatalf("register conn B: %v", err)
+	}
+	h.hub.UpdateDeviceInfoByHardware("hw-study-b", signaling.DeviceInfoParams{
+		PiVersion:       "2.9.0",
+		FirmwareVersion: "1.4.0",
+	})
+
+	// Request the operator partial for device A.
+	req := httptest.NewRequest(http.MethodGet, "/phones/3140020/operator?hardware_id=hw-study-a", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `data-hardware-id="hw-study-a"`) {
+		t.Errorf("response missing data-hardware-id for hw-study-a")
+	}
+	if !strings.Contains(body, "3.1.0") {
+		t.Errorf("response missing device A Pi version 3.1.0")
+	}
+	if strings.Contains(body, "2.9.0") {
+		t.Errorf("response should not contain device B Pi version 2.9.0")
+	}
+
+	// Request the operator partial for device B.
+	req = httptest.NewRequest(http.MethodGet, "/phones/3140020/operator?hardware_id=hw-study-b", nil)
+	req.AddCookie(cookie)
+	w = httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for B, got %d: %s", w.Code, w.Body.String())
+	}
+	body = w.Body.String()
+	if !strings.Contains(body, `data-hardware-id="hw-study-b"`) {
+		t.Errorf("response missing data-hardware-id for hw-study-b")
+	}
+	if !strings.Contains(body, "2.9.0") {
+		t.Errorf("response missing device B Pi version 2.9.0")
+	}
+}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -1996,6 +1996,47 @@ func TestPhoneDetail_BuildsPerDeviceViews(t *testing.T) {
 	}
 }
 
+func TestBuildDeviceViews_Selection(t *testing.T) {
+	h, _, _ := setupHandler(t)
+
+	devices := []device.Device{
+		{ID: 1, Name: "A", HardwareID: "hw-1"},
+		{ID: 2, Name: "B", HardwareID: "hw-2"},
+	}
+
+	// No device online: the first device is selected.
+	views, selected := h.buildDeviceViews(devices, nil)
+	if len(views) != 2 {
+		t.Fatalf("want 2 views, got %d", len(views))
+	}
+	if selected != "hw-1" {
+		t.Errorf("no devices online: want first device hw-1 selected, got %q", selected)
+	}
+
+	// hw-2 online: the online device is selected even though it is not first.
+	conn := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-2"}
+	if err := h.hub.Register("3140099", conn); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	views, selected = h.buildDeviceViews(devices, nil)
+	if selected != "hw-2" {
+		t.Errorf("hw-2 online: want hw-2 selected, got %q", selected)
+	}
+	for _, v := range views {
+		if v.Device.HardwareID == "hw-2" && !v.Online {
+			t.Error("hw-2 view should be marked online")
+		}
+		if v.Device.HardwareID == "hw-1" && v.Online {
+			t.Error("hw-1 view should be offline")
+		}
+	}
+
+	// Empty device list: no selection.
+	if _, sel := h.buildDeviceViews(nil, nil); sel != "" {
+		t.Errorf("empty devices: want empty selection, got %q", sel)
+	}
+}
+
 func TestPhoneRestart_TargetsHardware(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2202,3 +2202,68 @@ func TestPhoneOperator_SwapsPanel(t *testing.T) {
 		t.Errorf("response missing device B Pi version 2.9.0")
 	}
 }
+
+func TestPhoneOperator_AMTheme(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
+
+	user, err := authStore.GetUserByEmail(context.Background(), "test@example.com")
+	if err != nil {
+		t.Fatalf("get test user: %v", err)
+	}
+	if err := authStore.SetTheme(context.Background(), user.ID, auth.ThemeAnsweringMachine); err != nil {
+		t.Fatalf("set AM theme: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = authStore.SetTheme(context.Background(), user.ID, auth.ThemeIntercom)
+	})
+
+	lineStore := line.NewStore(database)
+	ln, err := lineStore.Add(context.Background(), "3140021", "Attic", hh.ID)
+	if err != nil {
+		t.Fatalf("add line: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id IN ('hw-attic-a','hw-attic-b')")
+		_, _ = database.DB.Exec("DELETE FROM lines WHERE id = $1", ln.ID)
+	})
+
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-attic-a', 'dev-attic-a', 'Attic A', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device A: %v", err)
+	}
+	if _, err := database.DB.Exec(`
+		INSERT INTO devices (line_id, hardware_id, device_id, name, paired_at)
+		VALUES ($1, 'hw-attic-b', 'dev-attic-b', 'Attic B', NOW())
+	`, ln.ID); err != nil {
+		t.Fatalf("seed device B: %v", err)
+	}
+
+	conn := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-attic-a"}
+	if err := h.hub.Register("3140021", conn); err != nil {
+		t.Fatalf("register conn A: %v", err)
+	}
+	h.hub.UpdateDeviceInfoByHardware("hw-attic-a", signaling.DeviceInfoParams{
+		PiVersion:       "4.0.0",
+		FirmwareVersion: "1.8.0",
+	})
+
+	// The AM operator partial is served when the user's theme is answering-machine.
+	req := httptest.NewRequest(http.MethodGet, "/phones/3140021/operator?hardware_id=hw-attic-a", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	h.Router().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `data-hardware-id="hw-attic-a"`) {
+		t.Errorf("AM operator response missing data-hardware-id for hw-attic-a")
+	}
+	if !strings.Contains(body, "4.0.0") {
+		t.Errorf("AM operator response missing device A Pi version 4.0.0")
+	}
+}

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -2241,13 +2241,21 @@ func TestPhoneOperator_AMTheme(t *testing.T) {
 		t.Fatalf("seed device B: %v", err)
 	}
 
-	conn := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-attic-a"}
-	if err := h.hub.Register("3140021", conn); err != nil {
+	connA := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-attic-a"}
+	if err := h.hub.Register("3140021", connA); err != nil {
 		t.Fatalf("register conn A: %v", err)
 	}
 	h.hub.UpdateDeviceInfoByHardware("hw-attic-a", signaling.DeviceInfoParams{
 		PiVersion:       "4.0.0",
 		FirmwareVersion: "1.8.0",
+	})
+	connB := &signaling.Conn{Send: make(chan []byte, 10), HardwareID: "hw-attic-b"}
+	if err := h.hub.Register("3140021", connB); err != nil {
+		t.Fatalf("register conn B: %v", err)
+	}
+	h.hub.UpdateDeviceInfoByHardware("hw-attic-b", signaling.DeviceInfoParams{
+		PiVersion:       "2.9.0",
+		FirmwareVersion: "1.5.0",
 	})
 
 	// The AM operator partial is served when the user's theme is answering-machine.
@@ -2265,5 +2273,8 @@ func TestPhoneOperator_AMTheme(t *testing.T) {
 	}
 	if !strings.Contains(body, "4.0.0") {
 		t.Errorf("AM operator response missing device A Pi version 4.0.0")
+	}
+	if strings.Contains(body, "2.9.0") {
+		t.Errorf("AM operator response for device A leaked device B Pi version 2.9.0")
 	}
 }

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1113,7 +1113,7 @@
     {{if gt (len .DeviceViews) 1}}
     <section class="am-plate am-handset__plate am-handset__plate--wide">
       <span class="am-plate__label">Handset</span>
-      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px;">
+      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px; align-self: flex-start;">
         {{range .DeviceViews}}
         <label class="seg-radio__opt">
           <input type="radio" name="device_toggle" value="{{.Device.HardwareID}}"

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1110,137 +1110,23 @@
       {{template "am-voicemail-section" .}}
     </section>
 
-    {{template "am-software-update-section" .}}
-
-    {{if .Online}}
+    {{if gt (len .DeviceViews) 1}}
     <section class="am-plate am-handset__plate am-handset__plate--wide">
-      <span class="am-plate__label">Device controls</span>
-      <div id="am-ctrl-buttons" class="am-handset__actions-row" style="gap: 8px; flex-wrap: wrap;">
-        <button type="button" id="am-ring-test-btn" onclick="amDoRingTest()" class="am-key">
-          <span class="am-key__symbol">&#x266A;</span>
-          <span class="am-key__label">Ring test</span>
-        </button>
-        <button type="button" onclick="amShowRestartConfirm('service')" class="am-key">
-          <span class="am-key__symbol">&#x21BB;</span>
-          <span class="am-key__label">Restart service</span>
-        </button>
-        <button type="button" onclick="amShowRestartConfirm('reboot')" class="am-key">
-          <span class="am-key__symbol">&#x23FB;</span>
-          <span class="am-key__label">Reboot device</span>
-        </button>
-      </div>
-      <div id="am-ring-test-status" class="hidden" style="margin-top: 10px;">
-        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
-          <span id="am-ring-test-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
-          <span id="am-ring-test-text" class="am-led">Ringing...</span>
-        </div>
-      </div>
-      <div id="am-restart-confirm" class="hidden" style="margin-top: 10px;">
-        <p id="am-restart-confirm-text" class="am-hint" style="margin: 0 0 10px;"></p>
-        <div class="am-handset__actions-row" style="gap: 8px;">
-          <button type="button" id="am-restart-confirm-btn" onclick="amDoRestart()" class="am-key am-key--accent">
-            <span class="am-key__symbol">&#x2713;</span>
-            <span class="am-key__label">Confirm</span>
-          </button>
-          <button type="button" onclick="amCancelRestartConfirm()" class="am-key">
-            <span class="am-key__symbol">&#x2715;</span>
-            <span class="am-key__label">Cancel</span>
-          </button>
-        </div>
-      </div>
-      <div id="am-restart-progress" class="hidden" style="margin-top: 10px;">
-        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
-          <span id="am-restart-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
-          <span id="am-restart-text" class="am-led">Sending command...</span>
-        </div>
-      </div>
-      <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
-        <div id="am-recovery-default">
-          <button type="button" onclick="amShowRecoveryConfirm()" class="am-key am-key--red">
-            <span class="am-key__symbol">&#x26A0;</span>
-            <span class="am-key__label">Recovery mode</span>
-          </button>
-          <p class="am-hint" style="margin: 6px 0 0;">Reboots the device into recovery mode. Connect to the device's recovery Wi-Fi network to try again or perform a factory reset.</p>
-        </div>
-        <div id="am-recovery-confirm" class="hidden">
-          <p class="am-hint" style="margin: 0 0 10px;">The device will reboot into recovery mode. You'll need to connect to its recovery Wi-Fi network to choose an action. Continue?</p>
-          <div class="am-handset__actions-row" style="gap: 8px;">
-            <button type="button" onclick="amDoRecovery()" class="am-key am-key--red">
-              <span class="am-key__symbol">&#x2713;</span>
-              <span class="am-key__label">Confirm</span>
-            </button>
-            <button type="button" onclick="amCancelRecovery()" class="am-key">
-              <span class="am-key__symbol">&#x2715;</span>
-              <span class="am-key__label">Cancel</span>
-            </button>
-          </div>
-        </div>
-        <div id="am-recovery-progress" class="hidden" style="margin-top: 10px;">
-          <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
-            <span id="am-recovery-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
-            <span id="am-recovery-text" class="am-led">Sending reset command...</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    {{if .IsAdmin}}
-    <section class="am-plate am-handset__plate am-handset__plate--wide">
-      <span class="am-plate__label">Developer mode</span>
-      {{if and .DeviceInfo .DeviceInfo.DevMode}}
-      <div id="am-devmode-on-default">
-        <button type="button" onclick="amShowDevModeDisable()" class="am-key am-key--red">
-          <span class="am-key__symbol">&#x26D4;</span>
-          <span class="am-key__label">Disable dev mode</span>
-        </button>
-        <p class="am-hint" style="margin: 6px 0 0;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code>{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
-      </div>
-      <div id="am-devmode-disable-confirm" class="hidden" style="margin-top: 10px;">
-        <p class="am-hint" style="margin: 0 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
-        <div class="am-handset__actions-row" style="gap: 8px;">
-          <button type="button" onclick="amDoDevModeDisable()" class="am-key am-key--red">
-            <span class="am-key__symbol">&#x2713;</span>
-            <span class="am-key__label">Confirm</span>
-          </button>
-          <button type="button" onclick="amCancelDevModeDisable()" class="am-key">
-            <span class="am-key__symbol">&#x2715;</span>
-            <span class="am-key__label">Cancel</span>
-          </button>
-        </div>
-      </div>
-      {{else}}
-      <div id="am-devmode-off-default">
-        <button type="button" onclick="amShowDevModeEnable()" class="am-key">
-          <span class="am-key__symbol">&#x1F527;</span>
-          <span class="am-key__label">Enable dev mode</span>
-        </button>
-        <p class="am-hint" style="margin: 6px 0 0;">Enables SSH (user <code>dev</code>) and the on-device admin panel. You'll set an SSH password.</p>
-      </div>
-      <div id="am-devmode-enable-form" class="hidden" style="margin-top: 10px;">
-        <label for="am-devmode-password" class="am-hint" style="display: block; margin: 0 0 4px;">SSH password (8 to 72 characters)</label>
-        <input type="password" id="am-devmode-password" autocomplete="new-password" maxlength="72" aria-describedby="am-devmode-pw-error" oninput="amClearDevModePwError()" class="field__input" style="max-width: 280px;" placeholder="At least 8 characters">
-        <span id="am-devmode-pw-error" class="hidden am-hint" style="display: block; margin: 4px 0 0; color: var(--rust);">Password must be 8 to 72 characters.</span>
-        <div class="am-handset__actions-row" style="gap: 8px; margin-top: 10px;">
-          <button type="button" onclick="amDoDevModeEnable()" class="am-key am-key--accent">
-            <span class="am-key__symbol">&#x2713;</span>
-            <span class="am-key__label">Enable</span>
-          </button>
-          <button type="button" onclick="amCancelDevModeEnable()" class="am-key">
-            <span class="am-key__symbol">&#x2715;</span>
-            <span class="am-key__label">Cancel</span>
-          </button>
-        </div>
-      </div>
-      {{end}}
-      <div id="am-devmode-progress" class="hidden" style="margin-top: 10px;">
-        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
-          <span id="am-devmode-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
-          <span id="am-devmode-text" class="am-led">Sending command...</span>
-        </div>
+      <span class="am-plate__label">Handset</span>
+      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px;">
+        {{range .DeviceViews}}
+        <label class="seg-radio__opt">
+          <input type="radio" name="device_toggle" value="{{.Device.HardwareID}}"
+                 {{if eq .Device.HardwareID $.SelectedHardwareID}}checked{{end}}
+                 hx-get="/phones/{{$.Line.Number}}/operator?hardware_id={{.Device.HardwareID}}"
+                 hx-target="#operator-panel" hx-swap="outerHTML">
+          <span class="seg-radio__label">{{if .Device.Name}}{{.Device.Name}}{{else}}Unnamed{{end}}</span>
+        </label>
+        {{end}}
       </div>
     </section>
     {{end}}
-    {{end}}
+    {{template "am-operator-panel" .}}
 
     <section class="am-plate am-handset__plate am-handset__plate--wide am-handset__plate--danger am-handset__actions">
       <span class="am-plate__label">Actions</span>
@@ -1352,11 +1238,17 @@
     var phoneNumber = {{.Line.Number}};
     var pollers = {pi: null, fw: null};
 
+    function selectedHardwareID() {
+      var p = document.getElementById('operator-panel');
+      return p ? (p.getAttribute('data-hardware-id') || '') : '';
+    }
+
     window.amTriggerComponentUpdate = function(prefix, paramName) {
       var btn = document.getElementById(prefix + '-install-btn');
       var radio = document.querySelector('input[name="' + paramName + '"]:checked');
       var body = new URLSearchParams();
       if (radio) body.append(paramName, radio.value);
+      body.append('hardware_id', selectedHardwareID());
       amStartUpdate(prefix, btn, body);
     };
 
@@ -1389,7 +1281,7 @@
       pollers[prefix] = setInterval(function() {
         attempts++;
         if (attempts > 120) { clearInterval(pollers[prefix]); amShowResult(prefix, 'failed', 'Timed out, please retry'); return; }
-        fetch('/phones/' + phoneNumber + '/update-status')
+        fetch('/phones/' + phoneNumber + '/update-status?hardware_id=' + encodeURIComponent(selectedHardwareID()))
         .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
         .then(function(data) {
           if (!data.status) return;
@@ -1433,9 +1325,12 @@
       lamp.classList.add('am-lamp--on-amber');
       text.classList.remove('am-led--green', 'am-led--red');
       text.textContent = 'Ringing...';
+      var rtBody = new URLSearchParams();
+      rtBody.append('hardware_id', selectedHardwareID());
       fetch('/phones/' + phoneNumber + '/ring-test', {
         method: 'POST',
-        headers: {'Accept': 'application/json'}
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: rtBody.toString()
       })
       .then(function(r) { return r.json(); })
       .then(function(data) {
@@ -1497,6 +1392,7 @@
       text.classList.remove('am-led--green', 'am-led--red');
       text.textContent = mode === 'reboot' ? 'Sending reboot command...' : 'Sending restart command...';
       var body = new URLSearchParams({mode: mode});
+      body.append('hardware_id', selectedHardwareID());
       fetch('/phones/' + phoneNumber + '/restart', {
         method: 'POST',
         headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
@@ -1520,7 +1416,7 @@
         amRestartPollTimer = setInterval(function() {
           attempts++;
           if (attempts > maxAttempts) { clearInterval(amRestartPollTimer); amShowRestartResult('failed', 'Timed out waiting for device to come back online'); return; }
-          fetch('/phones/' + phoneNumber + '/online')
+          fetch('/phones/' + phoneNumber + '/online?hardware_id=' + encodeURIComponent(selectedHardwareID()))
           .then(function(r) { return r.json(); })
           .then(function(data) {
             if (!data.online) { sawOffline = true; document.getElementById('am-restart-text').textContent = 'Waiting for device to reconnect...'; }
@@ -1556,7 +1452,13 @@
       var lamp = document.getElementById('am-recovery-lamp');
       var text = document.getElementById('am-recovery-text');
       progress.classList.remove('hidden');
-      fetch('/phones/' + phoneNumber + '/factory-reset', { method: 'POST', headers: {'Accept': 'application/json'} })
+      var frBody = new URLSearchParams();
+      frBody.append('hardware_id', selectedHardwareID());
+      fetch('/phones/' + phoneNumber + '/factory-reset', {
+        method: 'POST',
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: frBody.toString()
+      })
       .then(function(r) { return r.json(); })
       .then(function(data) {
         lamp.classList.remove('am-lamp--on-amber');
@@ -1632,6 +1534,7 @@
       amSendDevMode(new URLSearchParams({enabled: 'false'}), false);
     };
     function amSendDevMode(body, target) {
+      body.append('hardware_id', selectedHardwareID());
       fetch('/phones/' + phoneNumber + '/dev-mode', {
         method: 'POST',
         headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
@@ -1651,7 +1554,7 @@
       amDevModePollTimer = setInterval(function() {
         attempts++;
         if (attempts > 15) { clearInterval(amDevModePollTimer); amDevModeError('Timed out waiting for the device to apply the change.'); return; }
-        fetch('/phones/' + phoneNumber + '/dev-mode-status')
+        fetch('/phones/' + phoneNumber + '/dev-mode-status?hardware_id=' + encodeURIComponent(selectedHardwareID()))
         .then(function(r) { return r.json(); })
         .then(function(d) {
           if (d.enabled === target) {
@@ -2155,4 +2058,140 @@
 </div>
 {{end}}
 
-{{define "am-operator-panel"}}{{end}}
+{{define "am-operator-panel"}}
+<div id="operator-panel" data-hardware-id="{{.SelectedHardwareID}}">
+
+  {{template "am-software-update-section" .}}
+
+  {{if .Online}}
+  <section class="am-plate am-handset__plate am-handset__plate--wide">
+    <span class="am-plate__label">Device controls</span>
+    <div id="am-ctrl-buttons" class="am-handset__actions-row" style="gap: 8px; flex-wrap: wrap;">
+      <button type="button" id="am-ring-test-btn" onclick="amDoRingTest()" class="am-key">
+        <span class="am-key__symbol">&#x266A;</span>
+        <span class="am-key__label">Ring test</span>
+      </button>
+      <button type="button" onclick="amShowRestartConfirm('service')" class="am-key">
+        <span class="am-key__symbol">&#x21BB;</span>
+        <span class="am-key__label">Restart service</span>
+      </button>
+      <button type="button" onclick="amShowRestartConfirm('reboot')" class="am-key">
+        <span class="am-key__symbol">&#x23FB;</span>
+        <span class="am-key__label">Reboot device</span>
+      </button>
+    </div>
+    <div id="am-ring-test-status" class="hidden" style="margin-top: 10px;">
+      <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+        <span id="am-ring-test-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+        <span id="am-ring-test-text" class="am-led">Ringing...</span>
+      </div>
+    </div>
+    <div id="am-restart-confirm" class="hidden" style="margin-top: 10px;">
+      <p id="am-restart-confirm-text" class="am-hint" style="margin: 0 0 10px;"></p>
+      <div class="am-handset__actions-row" style="gap: 8px;">
+        <button type="button" id="am-restart-confirm-btn" onclick="amDoRestart()" class="am-key am-key--accent">
+          <span class="am-key__symbol">&#x2713;</span>
+          <span class="am-key__label">Confirm</span>
+        </button>
+        <button type="button" onclick="amCancelRestartConfirm()" class="am-key">
+          <span class="am-key__symbol">&#x2715;</span>
+          <span class="am-key__label">Cancel</span>
+        </button>
+      </div>
+    </div>
+    <div id="am-restart-progress" class="hidden" style="margin-top: 10px;">
+      <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+        <span id="am-restart-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+        <span id="am-restart-text" class="am-led">Sending command...</span>
+      </div>
+    </div>
+    <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+      <div id="am-recovery-default">
+        <button type="button" onclick="amShowRecoveryConfirm()" class="am-key am-key--red">
+          <span class="am-key__symbol">&#x26A0;</span>
+          <span class="am-key__label">Recovery mode</span>
+        </button>
+        <p class="am-hint" style="margin: 6px 0 0;">Reboots the device into recovery mode. Connect to the device's recovery Wi-Fi network to try again or perform a factory reset.</p>
+      </div>
+      <div id="am-recovery-confirm" class="hidden">
+        <p class="am-hint" style="margin: 0 0 10px;">The device will reboot into recovery mode. You'll need to connect to its recovery Wi-Fi network to choose an action. Continue?</p>
+        <div class="am-handset__actions-row" style="gap: 8px;">
+          <button type="button" onclick="amDoRecovery()" class="am-key am-key--red">
+            <span class="am-key__symbol">&#x2713;</span>
+            <span class="am-key__label">Confirm</span>
+          </button>
+          <button type="button" onclick="amCancelRecovery()" class="am-key">
+            <span class="am-key__symbol">&#x2715;</span>
+            <span class="am-key__label">Cancel</span>
+          </button>
+        </div>
+      </div>
+      <div id="am-recovery-progress" class="hidden" style="margin-top: 10px;">
+        <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+          <span id="am-recovery-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+          <span id="am-recovery-text" class="am-led">Sending reset command...</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {{if .IsAdmin}}
+  <section class="am-plate am-handset__plate am-handset__plate--wide">
+    <span class="am-plate__label">Developer mode</span>
+    {{if and .DeviceInfo .DeviceInfo.DevMode}}
+    <div id="am-devmode-on-default">
+      <button type="button" onclick="amShowDevModeDisable()" class="am-key am-key--red">
+        <span class="am-key__symbol">&#x26D4;</span>
+        <span class="am-key__label">Disable dev mode</span>
+      </button>
+      <p class="am-hint" style="margin: 6px 0 0;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code>{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
+    </div>
+    <div id="am-devmode-disable-confirm" class="hidden" style="margin-top: 10px;">
+      <p class="am-hint" style="margin: 0 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
+      <div class="am-handset__actions-row" style="gap: 8px;">
+        <button type="button" onclick="amDoDevModeDisable()" class="am-key am-key--red">
+          <span class="am-key__symbol">&#x2713;</span>
+          <span class="am-key__label">Confirm</span>
+        </button>
+        <button type="button" onclick="amCancelDevModeDisable()" class="am-key">
+          <span class="am-key__symbol">&#x2715;</span>
+          <span class="am-key__label">Cancel</span>
+        </button>
+      </div>
+    </div>
+    {{else}}
+    <div id="am-devmode-off-default">
+      <button type="button" onclick="amShowDevModeEnable()" class="am-key">
+        <span class="am-key__symbol">&#x1F527;</span>
+        <span class="am-key__label">Enable dev mode</span>
+      </button>
+      <p class="am-hint" style="margin: 6px 0 0;">Enables SSH (user <code>dev</code>) and the on-device admin panel. You'll set an SSH password.</p>
+    </div>
+    <div id="am-devmode-enable-form" class="hidden" style="margin-top: 10px;">
+      <label for="am-devmode-password" class="am-hint" style="display: block; margin: 0 0 4px;">SSH password (8 to 72 characters)</label>
+      <input type="password" id="am-devmode-password" autocomplete="new-password" maxlength="72" aria-describedby="am-devmode-pw-error" oninput="amClearDevModePwError()" class="field__input" style="max-width: 280px;" placeholder="At least 8 characters">
+      <span id="am-devmode-pw-error" class="hidden am-hint" style="display: block; margin: 4px 0 0; color: var(--rust);">Password must be 8 to 72 characters.</span>
+      <div class="am-handset__actions-row" style="gap: 8px; margin-top: 10px;">
+        <button type="button" onclick="amDoDevModeEnable()" class="am-key am-key--accent">
+          <span class="am-key__symbol">&#x2713;</span>
+          <span class="am-key__label">Enable</span>
+        </button>
+        <button type="button" onclick="amCancelDevModeEnable()" class="am-key">
+          <span class="am-key__symbol">&#x2715;</span>
+          <span class="am-key__label">Cancel</span>
+        </button>
+      </div>
+    </div>
+    {{end}}
+    <div id="am-devmode-progress" class="hidden" style="margin-top: 10px;">
+      <div class="am-well" style="display: flex; align-items: center; gap: 10px; padding: 6px 10px;">
+        <span id="am-devmode-lamp" class="am-lamp am-lamp--on-amber" aria-hidden="true"></span>
+        <span id="am-devmode-text" class="am-led">Sending command...</span>
+      </div>
+    </div>
+  </section>
+  {{end}}
+  {{end}}
+
+</div>
+{{end}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -2117,3 +2117,6 @@
   {{end}}
 </section>
 {{end}}
+
+{{define "operator-panel"}}{{end}}
+{{define "am-operator-panel"}}{{end}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1113,7 +1113,7 @@
     {{if gt (len .DeviceViews) 1}}
     <section class="am-plate am-handset__plate am-handset__plate--wide">
       <span class="am-plate__label">Handset</span>
-      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px; align-self: flex-start;">
+      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px; align-self: flex-start; width: fit-content;">
         {{range .DeviceViews}}
         <label class="seg-radio__opt">
           <input type="radio" name="device_toggle" value="{{.Device.HardwareID}}"

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -1111,7 +1111,7 @@
     </section>
 
     {{if gt (len .DeviceViews) 1}}
-    <section class="am-plate am-handset__plate am-handset__plate--wide">
+    <section class="am-plate am-handset__plate am-handset__plate--wide" style="width: fit-content; justify-self: start;">
       <span class="am-plate__label">Handset</span>
       <div class="seg-radio" id="device-toggle" role="tablist" style="margin-top: 8px; align-self: flex-start; width: fit-content;">
         {{range .DeviceViews}}

--- a/server/internal/web/templates/phone-detail.html
+++ b/server/internal/web/templates/phone-detail.html
@@ -128,292 +128,22 @@
 
     </div>
 
-    <!-- Right: operator service panel (collapsed by default) -->
+    <!-- Right: operator service panel -->
     <div class="stack-md">
-
-      <!-- Hardware & firmware: visible by default, but quieter styling -->
-      <section class="panel">
-        <header class="panel__head">
-          <h2 class="panel__title">Hardware &amp; firmware</h2>
-        </header>
-        <div class="panel__body">
-          <div id="auto-update-section" style="margin-bottom: 12px;">
-            {{template "auto-update-section" .}}
-          </div>
-          {{if .DeviceInfo}}
-          <div class="stack-md" style="margin-bottom: 12px;">
-            <div>
-              <div class="field__label" style="margin-bottom: 4px;">Pi software</div>
-              <div class="hstack hstack--wrap" style="gap: 8px;">
-                <span class="num" style="font-size: 13.5px; color: var(--ink);">
-                  {{if .DeviceInfo.PiVersion}}{{.DeviceInfo.PiVersion}}{{else}}<span class="muted italic">unknown</span>{{end}}
-                </span>
-                {{if .DeviceInfo.PiCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.PiCommit}}</span>{{end}}
-                {{if and .LatestPiVersion (ne .DeviceInfo.PiVersion .LatestPiVersion)}}
-                  {{if .PiUpdateNotes}}
-                  <details class="update-details" style="display: inline-block;">
-                    <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</summary>
-                    <div class="update-notes">
-                      {{range .PiUpdateNotes}}
-                        <article class="update-note">
-                          <span class="update-note__version">pi {{.Version}}</span>
-                          {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
-                        </article>
-                      {{end}}
-                    </div>
-                  </details>
-                  {{else}}
-                  <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</span>
-                  {{end}}
-                {{else if .LatestPiVersion}}
-                  <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
-                {{end}}
-              </div>
-            </div>
-            <div>
-              <div class="field__label" style="margin-bottom: 4px;">Firmware</div>
-              <div class="hstack hstack--wrap" style="gap: 8px;">
-                <span class="num" style="font-size: 13.5px; color: var(--ink);">
-                  {{if .DeviceInfo.FirmwareVersion}}{{.DeviceInfo.FirmwareVersion}}{{else}}<span class="muted italic">unknown</span>{{end}}
-                </span>
-                {{if .DeviceInfo.FirmwareCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.FirmwareCommit}}</span>{{end}}
-                {{if and .LatestFirmwareVersion (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion)}}
-                  {{if .FirmwareUpdateNotes}}
-                  <details class="update-details" style="display: inline-block;">
-                    <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</summary>
-                    <div class="update-notes">
-                      {{range .FirmwareUpdateNotes}}
-                        <article class="update-note">
-                          <span class="update-note__version">fw {{.Version}}</span>
-                          {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
-                        </article>
-                      {{end}}
-                    </div>
-                  </details>
-                  {{else}}
-                  <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</span>
-                  {{end}}
-                {{else if .LatestFirmwareVersion}}
-                  <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
-                {{end}}
-              </div>
-            </div>
-            {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
-            <div>
-              <div class="field__label" style="margin-bottom: 4px;">LAN IP</div>
-              <div class="hstack hstack--wrap" style="gap: 8px;">
-                <span class="num" style="font-size: 13.5px; color: var(--ink);">{{.DeviceInfo.RemoteAddr}}</span>
-              </div>
-            </div>
-            {{if .DeviceInfo.DevMode}}
-            <div>
-              <div class="field__label" style="margin-bottom: 4px;">Dev mode</div>
-              <a href="http://{{.DeviceInfo.RemoteAddr}}:8080" target="_blank" rel="noopener" class="chip chip--live" style="text-decoration: none;">
-                <span class="chip__dot"></span>Admin panel &#x2197;
-              </a>
-            </div>
-            {{end}}
-            {{end}}
-            {{if $.LastSeenAt}}
-            <div>
-              <div class="field__label" style="margin-bottom: 4px;">Last check-in</div>
-              <div style="font-size: 13px; color: var(--ink);">{{$.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}</div>
-            </div>
-            {{end}}
-          </div>
-
-          {{if .Online}}
-          <!-- Pi Software update -->
-          <details class="disclosure" style="margin-bottom: 10px;">
-            <summary>Update Pi software</summary>
-            <div class="panel__body">
-              {{if .PiReleases}}
-              <div class="stack-sm" style="max-height: 200px; overflow-y: auto;">
-                {{range .PiReleases}}
-                <label class="radio-card">
-                  <input type="radio" name="target_pi_version" value="{{.Version}}"
-                         {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}checked{{end}}{{end}}>
-                  <div class="radio-card__title">
-                    <span class="radio-card__indicator"></span>
-                    <span class="num" style="font-size: 14px;">{{.Version}}</span>
-                    {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}
-                    <span class="chip chip--live"><span class="chip__dot"></span>latest</span>
-                    {{end}}{{end}}
-                    {{if $.DeviceInfo.PiVersion}}{{if eq .Version $.DeviceInfo.PiVersion}}
-                    <span class="chip chip--on"><span class="chip__dot"></span>installed</span>
-                    {{end}}{{end}}
-                    {{if .Date}}<span class="radio-card__meta">{{.Date}}</span>{{end}}
-                  </div>
-                </label>
-                {{end}}
-              </div>
-              <button type="button" id="pi-install-btn" onclick="triggerComponentUpdate('pi', 'target_pi_version')" class="btn btn--primary" style="width: 100%; margin-top: 10px;">Install Pi software</button>
-              <div id="pi-update-progress" class="hidden" style="margin-top: 10px;">
-                <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-                  <div id="pi-progress-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-                  <span id="pi-progress-text" style="font-size: 13px; color: var(--ink);">Sending update command...</span>
-                </div>
-              </div>
-              {{else}}
-              <p class="muted" style="font-size: 13px; margin: 0;">No Pi releases available.</p>
-              {{end}}
-            </div>
-          </details>
-
-          <!-- Firmware update -->
-          <details class="disclosure">
-            <summary>Update firmware</summary>
-            <div class="panel__body">
-              {{if .FWReleases}}
-              <div class="stack-sm" style="max-height: 200px; overflow-y: auto;">
-                {{range .FWReleases}}
-                <label class="radio-card">
-                  <input type="radio" name="target_fw_version" value="{{.Version}}"
-                         {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}checked{{end}}{{end}}>
-                  <div class="radio-card__title">
-                    <span class="radio-card__indicator"></span>
-                    <span class="num" style="font-size: 14px;">{{.Version}}</span>
-                    {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}
-                    <span class="chip chip--live"><span class="chip__dot"></span>latest</span>
-                    {{end}}{{end}}
-                    {{if $.DeviceInfo.FirmwareVersion}}{{if eq .Version $.DeviceInfo.FirmwareVersion}}
-                    <span class="chip chip--on"><span class="chip__dot"></span>installed</span>
-                    {{end}}{{end}}
-                    {{if .Date}}<span class="radio-card__meta">{{.Date}}</span>{{end}}
-                  </div>
-                </label>
-                {{end}}
-              </div>
-              <button type="button" id="fw-install-btn" onclick="triggerComponentUpdate('fw', 'target_fw_version')" class="btn btn--primary" style="width: 100%; margin-top: 10px;">Install firmware</button>
-              <div id="fw-update-progress" class="hidden" style="margin-top: 10px;">
-                <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-                  <div id="fw-progress-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-                  <span id="fw-progress-text" style="font-size: 13px; color: var(--ink);">Sending update command...</span>
-                </div>
-              </div>
-              {{else}}
-              <p class="muted" style="font-size: 13px; margin: 0;">No firmware releases available.</p>
-              {{end}}
-            </div>
-          </details>
-          {{end}}
-
-          {{else}}
-            {{if .Online}}
-            <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report: device is online but hasn't reported version info yet.</p>
-            <form method="POST" action="/phones/{{.Line.Number}}/update">
-              <button type="submit" class="btn btn--primary">Check for updates</button>
-            </form>
-            {{else}}
-            <p class="muted" style="font-size: 13px; margin: 0;">Device is offline.</p>
-            {{if $.LastSeenAt}}
-            <p class="muted" style="font-size: 12.5px; margin: 6px 0 0;">Last seen {{$.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}.</p>
-            {{end}}
-            {{end}}
-          {{end}}
-        </div>
-      </section>
-
-      {{if .Online}}
-      <!-- Device controls: Restart / Reboot / Recovery -->
-      <section class="panel">
-        <header class="panel__head">
-          <h2 class="panel__title">Device controls</h2>
-        </header>
-        <div class="panel__body">
-
-          <div id="restart-buttons" class="hstack hstack--wrap" style="gap: 8px;">
-            <button type="button" id="ring-test-btn" onclick="doRingTest()" class="btn">Ring test</button>
-            <button type="button" onclick="showRestartConfirm('service')" class="btn">Restart service</button>
-            <button type="button" onclick="showRestartConfirm('reboot')" class="btn">Reboot device</button>
-          </div>
-
-          <div id="ring-test-status" class="hidden" style="margin-bottom: 10px;">
-            <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-              <div id="ring-test-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-              <span id="ring-test-text" style="font-size: 13px; color: var(--ink);">Ringing...</span>
-            </div>
-          </div>
-
-          <div id="restart-confirm" class="hidden">
-            <p id="restart-confirm-text" style="font-size: 13.5px; color: var(--ink); margin: 0 0 10px;"></p>
-            <div class="hstack" style="gap: 8px;">
-              <button type="button" id="restart-confirm-btn" onclick="doRestart()" class="btn btn--primary">Confirm</button>
-              <button type="button" onclick="cancelRestartConfirm()" class="btn">Cancel</button>
-            </div>
-          </div>
-
-          <div id="restart-progress" class="hidden">
-            <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-              <div id="restart-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-              <span id="restart-status" style="font-size: 13px; color: var(--ink);">Sending command...</span>
-            </div>
-          </div>
-
-          <!-- Recovery mode -->
-          <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
-            <div id="factory-reset-default">
-              <button type="button" onclick="showFactoryResetConfirm()" class="btn btn--danger">Recovery mode</button>
-              <p class="muted" style="font-size: 12px; margin: 6px 0 0;">Reboots the device into recovery mode. Connect to the device's recovery Wi-Fi network to try again or perform a factory reset.</p>
-            </div>
-            <div id="factory-reset-confirm" class="hidden">
-              <p style="font-size: 13.5px; color: var(--ink); margin: 0 0 10px;">The device will reboot into recovery mode. You'll need to connect to its recovery Wi-Fi network to choose an action. Continue?</p>
-              <div class="hstack" style="gap: 8px;">
-                <button type="button" onclick="doFactoryReset()" class="btn btn--danger">Confirm</button>
-                <button type="button" onclick="cancelFactoryReset()" class="btn">Cancel</button>
-              </div>
-            </div>
-            <div id="factory-reset-progress" class="hidden">
-              <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-                <div id="factory-reset-spinner" style="width: 14px; height: 14px; border: 2px solid var(--rust); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-                <span id="factory-reset-text" style="font-size: 13px; color: var(--ink);">Sending reset command...</span>
-              </div>
-            </div>
-          </div>
-
-          {{if .IsAdmin}}
-          <!-- Developer mode -->
-          <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
-            {{if and .DeviceInfo .DeviceInfo.DevMode}}
-            <div id="devmode-on-default">
-              <button type="button" onclick="showDevModeDisableConfirm()" class="btn btn--danger">Disable developer mode</button>
-              <p class="muted" style="font-size: 12px; margin: 6px 0 0;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code class="num">{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
-            </div>
-            <div id="devmode-disable-confirm" class="hidden">
-              <p style="font-size: 13.5px; color: var(--ink); margin: 8px 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
-              <div class="hstack" style="gap: 8px;">
-                <button type="button" onclick="doDevModeDisable()" class="btn btn--danger">Confirm</button>
-                <button type="button" onclick="cancelDevModeDisable()" class="btn">Cancel</button>
-              </div>
-            </div>
-            {{else}}
-            <div id="devmode-off-default">
-              <button type="button" onclick="showDevModeEnableForm()" class="btn">Enable developer mode</button>
-              <p class="muted" style="font-size: 12px; margin: 6px 0 0;">Enables SSH (user <code>dev</code>) and the on-device admin panel. You'll set an SSH password.</p>
-            </div>
-            <div id="devmode-enable-form" class="hidden">
-              <label for="devmode-password" class="field__label" style="display: block; margin: 8px 0 4px;">SSH password</label>
-              <input type="password" id="devmode-password" class="field__input" autocomplete="new-password" maxlength="72" aria-describedby="devmode-pw-hint devmode-pw-error" oninput="clearDevModePwError()" style="max-width: 280px;" placeholder="At least 8 characters">
-              <span id="devmode-pw-hint" class="muted" style="display: block; font-size: 11px; margin-top: 4px;">8 to 72 characters. Used to log in as <code>dev</code> over SSH.</span>
-              <span id="devmode-pw-error" class="hidden" style="display: block; font-size: 11px; margin-top: 4px; color: var(--rust);">Password must be 8 to 72 characters.</span>
-              <div class="hstack" style="gap: 8px; margin-top: 10px;">
-                <button type="button" onclick="doDevModeEnable()" class="btn btn--primary">Enable</button>
-                <button type="button" onclick="cancelDevModeEnable()" class="btn">Cancel</button>
-              </div>
-            </div>
-            {{end}}
-            <div id="devmode-progress" class="hidden" style="margin-top: 10px;">
-              <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
-                <div id="devmode-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
-                <span id="devmode-text" style="font-size: 13px; color: var(--ink);">Sending command...</span>
-              </div>
-            </div>
-          </div>
-          {{end}}
-
-        </div>
-      </section>
+      {{if gt (len .DeviceViews) 1}}
+      <div class="seg-radio" id="device-toggle" role="tablist" style="margin-bottom: 8px;">
+        {{range .DeviceViews}}
+        <label class="seg-radio__opt">
+          <input type="radio" name="device_toggle" value="{{.Device.HardwareID}}"
+                 {{if eq .Device.HardwareID $.SelectedHardwareID}}checked{{end}}
+                 hx-get="/phones/{{$.Line.Number}}/operator?hardware_id={{.Device.HardwareID}}"
+                 hx-target="#operator-panel" hx-swap="outerHTML">
+          <span class="seg-radio__label">{{if .Device.Name}}{{.Device.Name}}{{else}}Unnamed{{end}}</span>
+        </label>
+        {{end}}
+      </div>
       {{end}}
+      {{template "operator-panel" .}}
     </div>
   </div>
 
@@ -514,6 +244,11 @@
   var devModePollTimer = null;
   var restartMode = null;
 
+  function selectedHardwareID() {
+    var p = document.getElementById('operator-panel');
+    return p ? (p.getAttribute('data-hardware-id') || '') : '';
+  }
+
   function doRingTest() {
     var btn = document.getElementById('ring-test-btn');
     var status = document.getElementById('ring-test-status');
@@ -524,9 +259,12 @@
     spinner.classList.remove('hidden');
     text.textContent = 'Ringing...';
     text.style.color = 'var(--ink)';
+    var body = new URLSearchParams();
+    body.append('hardware_id', selectedHardwareID());
     fetch('/phones/' + phoneNumber + '/ring-test', {
       method: 'POST',
-      headers: {'Accept': 'application/json'}
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+      body: body.toString()
     })
     .then(function(r) { return r.json(); })
     .then(function(data) {
@@ -554,6 +292,7 @@
     var radio = document.querySelector('input[name="' + paramName + '"]:checked');
     var body = new URLSearchParams();
     if (radio) body.append(paramName, radio.value);
+    body.append('hardware_id', selectedHardwareID());
     startUpdate(prefix, btn, body);
   }
 
@@ -585,7 +324,7 @@
     window[timerVar] = setInterval(function() {
       attempts++;
       if (attempts > 120) { clearInterval(window[timerVar]); showResult(prefix, 'failed', 'Timed out; please retry'); return; }
-      fetch('/phones/' + phoneNumber + '/update-status')
+      fetch('/phones/' + phoneNumber + '/update-status?hardware_id=' + encodeURIComponent(selectedHardwareID()))
       .then(function(r) { return r.json(); })
       .then(function(data) {
         if (!data.status) return;
@@ -645,6 +384,7 @@
     status.style.color = 'var(--ink)';
     document.getElementById('restart-spinner').classList.remove('hidden');
     var body = new URLSearchParams({mode: mode});
+    body.append('hardware_id', selectedHardwareID());
     fetch('/phones/' + phoneNumber + '/restart', {
       method: 'POST',
       headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
@@ -667,7 +407,7 @@
       restartPollTimer = setInterval(function() {
         attempts++;
         if (attempts > maxAttempts) { clearInterval(restartPollTimer); showRestartResult('failed', 'Timed out waiting for device to come back online'); return; }
-        fetch('/phones/' + phoneNumber + '/online')
+        fetch('/phones/' + phoneNumber + '/online?hardware_id=' + encodeURIComponent(selectedHardwareID()))
         .then(function(r) { return r.json(); })
         .then(function(data) {
           if (!data.online) { sawOffline = true; document.getElementById('restart-status').textContent = 'Waiting for device to reconnect...'; }
@@ -694,7 +434,13 @@
   function doFactoryReset() {
     document.getElementById('factory-reset-confirm').classList.add('hidden');
     document.getElementById('factory-reset-progress').classList.remove('hidden');
-    fetch('/phones/' + phoneNumber + '/factory-reset', { method: 'POST', headers: {'Accept': 'application/json'} })
+    var frBody = new URLSearchParams();
+    frBody.append('hardware_id', selectedHardwareID());
+    fetch('/phones/' + phoneNumber + '/factory-reset', {
+      method: 'POST',
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+      body: frBody.toString()
+    })
     .then(function(r) { return r.json(); })
     .then(function(data) {
       var spinner = document.getElementById('factory-reset-spinner');
@@ -763,6 +509,7 @@
     sendDevMode(new URLSearchParams({enabled: 'false'}), false);
   }
   function sendDevMode(body, target) {
+    body.append('hardware_id', selectedHardwareID());
     fetch('/phones/' + phoneNumber + '/dev-mode', {
       method: 'POST',
       headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
@@ -782,7 +529,7 @@
     devModePollTimer = setInterval(function() {
       attempts++;
       if (attempts > 15) { clearInterval(devModePollTimer); devModeError('Timed out waiting for the device to apply the change.'); return; }
-      fetch('/phones/' + phoneNumber + '/dev-mode-status')
+      fetch('/phones/' + phoneNumber + '/dev-mode-status?hardware_id=' + encodeURIComponent(selectedHardwareID()))
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.enabled === target) {
@@ -2118,5 +1865,294 @@
 </section>
 {{end}}
 
-{{define "operator-panel"}}{{end}}
+{{define "operator-panel"}}
+<div id="operator-panel" data-hardware-id="{{.SelectedHardwareID}}">
+
+  <!-- Hardware and firmware -->
+  <section class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">Hardware &amp; firmware</h2>
+    </header>
+    <div class="panel__body">
+      <div id="auto-update-section" style="margin-bottom: 12px;">
+        {{template "auto-update-section" .}}
+      </div>
+      {{if .DeviceInfo}}
+      <div class="stack-md" style="margin-bottom: 12px;">
+        <div>
+          <div class="field__label" style="margin-bottom: 4px;">Pi software</div>
+          <div class="hstack hstack--wrap" style="gap: 8px;">
+            <span class="num" style="font-size: 13.5px; color: var(--ink);">
+              {{if .DeviceInfo.PiVersion}}{{.DeviceInfo.PiVersion}}{{else}}<span class="muted italic">unknown</span>{{end}}
+            </span>
+            {{if .DeviceInfo.PiCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.PiCommit}}</span>{{end}}
+            {{if and .LatestPiVersion (ne .DeviceInfo.PiVersion .LatestPiVersion)}}
+              {{if .PiUpdateNotes}}
+              <details class="update-details" style="display: inline-block;">
+                <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</summary>
+                <div class="update-notes">
+                  {{range .PiUpdateNotes}}
+                    <article class="update-note">
+                      <span class="update-note__version">pi {{.Version}}</span>
+                      {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+                    </article>
+                  {{end}}
+                </div>
+              </details>
+              {{else}}
+              <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestPiVersion}} available</span>
+              {{end}}
+            {{else if .LatestPiVersion}}
+              <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
+            {{end}}
+          </div>
+        </div>
+        <div>
+          <div class="field__label" style="margin-bottom: 4px;">Firmware</div>
+          <div class="hstack hstack--wrap" style="gap: 8px;">
+            <span class="num" style="font-size: 13.5px; color: var(--ink);">
+              {{if .DeviceInfo.FirmwareVersion}}{{.DeviceInfo.FirmwareVersion}}{{else}}<span class="muted italic">unknown</span>{{end}}
+            </span>
+            {{if .DeviceInfo.FirmwareCommit}}<span class="num muted" style="font-size: 12px;">{{.DeviceInfo.FirmwareCommit}}</span>{{end}}
+            {{if and .LatestFirmwareVersion (ne .DeviceInfo.FirmwareVersion .LatestFirmwareVersion)}}
+              {{if .FirmwareUpdateNotes}}
+              <details class="update-details" style="display: inline-block;">
+                <summary class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</summary>
+                <div class="update-notes">
+                  {{range .FirmwareUpdateNotes}}
+                    <article class="update-note">
+                      <span class="update-note__version">fw {{.Version}}</span>
+                      {{if .Notes}}{{renderNotes .Notes}}{{else}}<p class="update-note__empty">Notes not available yet.</p>{{end}}
+                    </article>
+                  {{end}}
+                </div>
+              </details>
+              {{else}}
+              <span class="chip chip--warn"><span class="chip__dot"></span>{{.LatestFirmwareVersion}} available</span>
+              {{end}}
+            {{else if .LatestFirmwareVersion}}
+              <span class="chip chip--on"><span class="chip__dot"></span>up to date</span>
+            {{end}}
+          </div>
+        </div>
+        {{if and .Online .DeviceInfo .DeviceInfo.RemoteAddr}}
+        <div>
+          <div class="field__label" style="margin-bottom: 4px;">LAN IP</div>
+          <div class="hstack hstack--wrap" style="gap: 8px;">
+            <span class="num" style="font-size: 13.5px; color: var(--ink);">{{.DeviceInfo.RemoteAddr}}</span>
+          </div>
+        </div>
+        {{if .DeviceInfo.DevMode}}
+        <div>
+          <div class="field__label" style="margin-bottom: 4px;">Dev mode</div>
+          <a href="http://{{.DeviceInfo.RemoteAddr}}:8080" target="_blank" rel="noopener" class="chip chip--live" style="text-decoration: none;">
+            <span class="chip__dot"></span>Admin panel &#x2197;
+          </a>
+        </div>
+        {{end}}
+        {{end}}
+        {{if .LastSeenAt}}
+        <div>
+          <div class="field__label" style="margin-bottom: 4px;">Last check-in</div>
+          <div style="font-size: 13px; color: var(--ink);">{{.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}</div>
+        </div>
+        {{end}}
+      </div>
+
+      {{if .Online}}
+      <!-- Pi software update -->
+      <details class="disclosure" style="margin-bottom: 10px;">
+        <summary>Update Pi software</summary>
+        <div class="panel__body">
+          {{if .PiReleases}}
+          <div class="stack-sm" style="max-height: 200px; overflow-y: auto;">
+            {{range .PiReleases}}
+            <label class="radio-card">
+              <input type="radio" name="target_pi_version" value="{{.Version}}"
+                     {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}checked{{end}}{{end}}>
+              <div class="radio-card__title">
+                <span class="radio-card__indicator"></span>
+                <span class="num" style="font-size: 14px;">{{.Version}}</span>
+                {{if $.LatestPiVersion}}{{if eq .Version $.LatestPiVersion}}
+                <span class="chip chip--live"><span class="chip__dot"></span>latest</span>
+                {{end}}{{end}}
+                {{if $.DeviceInfo.PiVersion}}{{if eq .Version $.DeviceInfo.PiVersion}}
+                <span class="chip chip--on"><span class="chip__dot"></span>installed</span>
+                {{end}}{{end}}
+                {{if .Date}}<span class="radio-card__meta">{{.Date}}</span>{{end}}
+              </div>
+            </label>
+            {{end}}
+          </div>
+          <button type="button" id="pi-install-btn" onclick="triggerComponentUpdate('pi', 'target_pi_version')" class="btn btn--primary" style="width: 100%; margin-top: 10px;">Install Pi software</button>
+          <div id="pi-update-progress" class="hidden" style="margin-top: 10px;">
+            <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+              <div id="pi-progress-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+              <span id="pi-progress-text" style="font-size: 13px; color: var(--ink);">Sending update command...</span>
+            </div>
+          </div>
+          {{else}}
+          <p class="muted" style="font-size: 13px; margin: 0;">No Pi releases available.</p>
+          {{end}}
+        </div>
+      </details>
+
+      <!-- Firmware update -->
+      <details class="disclosure">
+        <summary>Update firmware</summary>
+        <div class="panel__body">
+          {{if .FWReleases}}
+          <div class="stack-sm" style="max-height: 200px; overflow-y: auto;">
+            {{range .FWReleases}}
+            <label class="radio-card">
+              <input type="radio" name="target_fw_version" value="{{.Version}}"
+                     {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}checked{{end}}{{end}}>
+              <div class="radio-card__title">
+                <span class="radio-card__indicator"></span>
+                <span class="num" style="font-size: 14px;">{{.Version}}</span>
+                {{if $.LatestFirmwareVersion}}{{if eq .Version $.LatestFirmwareVersion}}
+                <span class="chip chip--live"><span class="chip__dot"></span>latest</span>
+                {{end}}{{end}}
+                {{if $.DeviceInfo.FirmwareVersion}}{{if eq .Version $.DeviceInfo.FirmwareVersion}}
+                <span class="chip chip--on"><span class="chip__dot"></span>installed</span>
+                {{end}}{{end}}
+                {{if .Date}}<span class="radio-card__meta">{{.Date}}</span>{{end}}
+              </div>
+            </label>
+            {{end}}
+          </div>
+          <button type="button" id="fw-install-btn" onclick="triggerComponentUpdate('fw', 'target_fw_version')" class="btn btn--primary" style="width: 100%; margin-top: 10px;">Install firmware</button>
+          <div id="fw-update-progress" class="hidden" style="margin-top: 10px;">
+            <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+              <div id="fw-progress-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+              <span id="fw-progress-text" style="font-size: 13px; color: var(--ink);">Sending update command...</span>
+            </div>
+          </div>
+          {{else}}
+          <p class="muted" style="font-size: 13px; margin: 0;">No firmware releases available.</p>
+          {{end}}
+        </div>
+      </details>
+      {{end}}
+
+      {{else}}
+        {{if .Online}}
+        <p class="muted" style="font-size: 13px; margin: 0 0 10px;">Waiting for version report: device is online but hasn't reported version info yet.</p>
+        <form method="POST" action="/phones/{{.Line.Number}}/update">
+          <button type="submit" class="btn btn--primary">Check for updates</button>
+        </form>
+        {{else}}
+        <p class="muted" style="font-size: 13px; margin: 0;">Device is offline.</p>
+        {{if .LastSeenAt}}
+        <p class="muted" style="font-size: 12.5px; margin: 6px 0 0;">Last seen {{.LastSeenAt.Format "Jan 2, 2006 3:04 PM"}}.</p>
+        {{end}}
+        {{end}}
+      {{end}}
+    </div>
+  </section>
+
+  {{if .Online}}
+  <!-- Device controls: Restart / Reboot / Recovery -->
+  <section class="panel">
+    <header class="panel__head">
+      <h2 class="panel__title">Device controls</h2>
+    </header>
+    <div class="panel__body">
+
+      <div id="restart-buttons" class="hstack hstack--wrap" style="gap: 8px;">
+        <button type="button" id="ring-test-btn" onclick="doRingTest()" class="btn">Ring test</button>
+        <button type="button" onclick="showRestartConfirm('service')" class="btn">Restart service</button>
+        <button type="button" onclick="showRestartConfirm('reboot')" class="btn">Reboot device</button>
+      </div>
+
+      <div id="ring-test-status" class="hidden" style="margin-bottom: 10px;">
+        <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+          <div id="ring-test-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+          <span id="ring-test-text" style="font-size: 13px; color: var(--ink);">Ringing...</span>
+        </div>
+      </div>
+
+      <div id="restart-confirm" class="hidden">
+        <p id="restart-confirm-text" style="font-size: 13.5px; color: var(--ink); margin: 0 0 10px;"></p>
+        <div class="hstack" style="gap: 8px;">
+          <button type="button" id="restart-confirm-btn" onclick="doRestart()" class="btn btn--primary">Confirm</button>
+          <button type="button" onclick="cancelRestartConfirm()" class="btn">Cancel</button>
+        </div>
+      </div>
+
+      <div id="restart-progress" class="hidden">
+        <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+          <div id="restart-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+          <span id="restart-status" style="font-size: 13px; color: var(--ink);">Sending command...</span>
+        </div>
+      </div>
+
+      <!-- Recovery mode -->
+      <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+        <div id="factory-reset-default">
+          <button type="button" onclick="showFactoryResetConfirm()" class="btn btn--danger">Recovery mode</button>
+          <p class="muted" style="font-size: 12px; margin: 6px 0 0;">Reboots the device into recovery mode. Connect to the device's recovery Wi-Fi network to try again or perform a factory reset.</p>
+        </div>
+        <div id="factory-reset-confirm" class="hidden">
+          <p style="font-size: 13.5px; color: var(--ink); margin: 0 0 10px;">The device will reboot into recovery mode. You'll need to connect to its recovery Wi-Fi network to choose an action. Continue?</p>
+          <div class="hstack" style="gap: 8px;">
+            <button type="button" onclick="doFactoryReset()" class="btn btn--danger">Confirm</button>
+            <button type="button" onclick="cancelFactoryReset()" class="btn">Cancel</button>
+          </div>
+        </div>
+        <div id="factory-reset-progress" class="hidden">
+          <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+            <div id="factory-reset-spinner" style="width: 14px; height: 14px; border: 2px solid var(--rust); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+            <span id="factory-reset-text" style="font-size: 13px; color: var(--ink);">Sending reset command...</span>
+          </div>
+        </div>
+      </div>
+
+      {{if .IsAdmin}}
+      <!-- Developer mode -->
+      <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--rule-soft);">
+        {{if and .DeviceInfo .DeviceInfo.DevMode}}
+        <div id="devmode-on-default">
+          <button type="button" onclick="showDevModeDisableConfirm()" class="btn btn--danger">Disable developer mode</button>
+          <p class="muted" style="font-size: 12px; margin: 6px 0 0;">SSH is enabled. Log in as <code>dev</code>{{if .DeviceInfo.RemoteAddr}} at <code class="num">{{.DeviceInfo.RemoteAddr}}</code>{{end}} with the password you set.</p>
+        </div>
+        <div id="devmode-disable-confirm" class="hidden">
+          <p style="font-size: 13.5px; color: var(--ink); margin: 8px 0 10px;">Turning developer mode off stops SSH and ends any active SSH session. Continue?</p>
+          <div class="hstack" style="gap: 8px;">
+            <button type="button" onclick="doDevModeDisable()" class="btn btn--danger">Confirm</button>
+            <button type="button" onclick="cancelDevModeDisable()" class="btn">Cancel</button>
+          </div>
+        </div>
+        {{else}}
+        <div id="devmode-off-default">
+          <button type="button" onclick="showDevModeEnableForm()" class="btn">Enable developer mode</button>
+          <p class="muted" style="font-size: 12px; margin: 6px 0 0;">Enables SSH (user <code>dev</code>) and the on-device admin panel. You'll set an SSH password.</p>
+        </div>
+        <div id="devmode-enable-form" class="hidden">
+          <label for="devmode-password" class="field__label" style="display: block; margin: 8px 0 4px;">SSH password</label>
+          <input type="password" id="devmode-password" class="field__input" autocomplete="new-password" maxlength="72" aria-describedby="devmode-pw-hint devmode-pw-error" oninput="clearDevModePwError()" style="max-width: 280px;" placeholder="At least 8 characters">
+          <span id="devmode-pw-hint" class="muted" style="display: block; font-size: 11px; margin-top: 4px;">8 to 72 characters. Used to log in as <code>dev</code> over SSH.</span>
+          <span id="devmode-pw-error" class="hidden" style="display: block; font-size: 11px; margin-top: 4px; color: var(--rust);">Password must be 8 to 72 characters.</span>
+          <div class="hstack" style="gap: 8px; margin-top: 10px;">
+            <button type="button" onclick="doDevModeEnable()" class="btn btn--primary">Enable</button>
+            <button type="button" onclick="cancelDevModeEnable()" class="btn">Cancel</button>
+          </div>
+        </div>
+        {{end}}
+        <div id="devmode-progress" class="hidden" style="margin-top: 10px;">
+          <div class="hstack" style="gap: 10px; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 6px; background: var(--paper-2);">
+            <div id="devmode-spinner" style="width: 14px; height: 14px; border: 2px solid var(--brass); border-top-color: transparent; border-radius: 50%; animation: spin 0.8s linear infinite;"></div>
+            <span id="devmode-text" style="font-size: 13px; color: var(--ink);">Sending command...</span>
+          </div>
+        </div>
+      </div>
+      {{end}}
+
+    </div>
+  </section>
+  {{end}}
+
+</div>
+{{end}}
+
 {{define "am-operator-panel"}}{{end}}


### PR DESCRIPTION
## Why

When two devices are joined to one line, the line detail page only ever showed **one** of them. The operator panel (versions, status, LAN IP, dev/admin link, restart/recovery/dev-mode controls) rendered an arbitrary device (`allInfos[0]`), so a secondary handset like `Justin Office` on `245-6390` was unreachable: no way to see its software version, its dev link, or to restart just that handset. Worse, the operator actions fanned out over `SendTo(number)`, so "Reboot device" silently rebooted **every** handset on the line.

## What

A segmented device toggle on the operator column lets you switch between the handsets joined to a line and view plus control each one individually.

- **Left column stays shared** (line settings: voice style, ringer, quiet hours, voicemail). These are line-level and apply to every handset.
- **Right column is per-device.** A toggle (one segment per handset, shown only when a line has 2+ devices) htmx-swaps an operator-panel partial scoped to the selected device.
- **Commands target the selected handset.** Restart, reboot, recovery, developer mode, Pi/firmware update, and ring test now route to that device's `HardwareID` via the hub's `SendToHardware`, with the `hardware_id` validated to belong to the line. This also fixes the prior behavior where those actions hit every joined handset.
- **Per-device status.** Update progress and online state are keyed by hardware ID, and last-seen is sourced from the selected device's own row (not the line-level aggregate), so a swap matches a full reload.
- Single-device lines are unchanged: no toggle, same behavior.
- All three themes get the toggle.

## Screenshots

Each pair is the same line with two handsets reporting distinct versions: selecting **Kitchen** (Pi 1.21.0 / fw 0.9.0 / 192.168.2.142) vs **Hallway** (Pi 1.20.0 / fw 0.8.1 / 192.168.2.150) swaps the operator panel to that handset while the shared line settings stay put.

### Intercom (default)

| Kitchen selected | Hallway selected |
|---|---|
| ![intercom kitchen](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-intercom-kitchen.png) | ![intercom hallway](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-intercom-hallway.png) |

### Dialup

| Kitchen selected | Hallway selected |
|---|---|
| ![dialup kitchen](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-dialup-kitchen.png) | ![dialup hallway](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-dialup-hallway.png) |

### Answering machine

| Kitchen selected | Hallway selected |
|---|---|
| ![am kitchen](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-am-kitchen-v3.png) | ![am hallway](https://raw.githubusercontent.com/justinlindh/digits/pr-assets/pr-779-am-hallway-v3.png) |

## Testing

- Unit suite green; integration suite green (`-race -p 1`, CI-style).
- New coverage: `buildDeviceViews` selection logic, per-device command routing and foreign-`hardware_id` rejection, operator-panel swap returns the requested device's data without leaking a sibling's (both themes), per-hardware update status.
- Verified end to end against a local stack with two live handsets reporting distinct versions (the screenshots above).
