### PR TITLE
fix(server): reconcile stale device numbers on register instead of rejecting

### DIFF
--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -121,12 +121,18 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if boundNumber != msg.Number {
-				slog.WarnContext(r.Context(), "ws register number mismatch",
+				// The device registered with a stale number: its line was
+				// moved, joined to another line, or renumbered, and the device
+				// still has the old number in its local config. The bound
+				// number is authoritative (the device can only ever land on
+				// the line it is actually paired to), so register it on its
+				// real line instead of rejecting. Rejecting would strand the
+				// device offline in a reconnect loop, unable to receive calls.
+				slog.InfoContext(r.Context(), "ws register reconciled to bound line",
 					"hardware_id", msg.HardwareID,
 					"claimed", msg.Number,
 					"bound", boundNumber)
-				wsReject(ws, "number does not match paired line")
-				return
+				msg.Number = boundNumber
 			}
 		}
 	}

--- a/server/internal/web/handler_ws_test.go
+++ b/server/internal/web/handler_ws_test.go
@@ -152,3 +152,39 @@ func TestWSRegister_PairedDevice_CorrectToken(t *testing.T) {
 		t.Fatalf("expected timeout error, got: %v", err)
 	}
 }
+
+// A paired device whose stored number no longer matches its bound line (after
+// a move, join, or renumber) must not be rejected: rejecting strands it
+// offline in a reconnect loop. The bound number is authoritative, so the
+// server reconciles and registers the device under its real line.
+func TestWSRegister_PairedDevice_NumberMismatch_UsesBoundNumber(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      "1001", // stale / wrong number the device still thinks it has
+		HardwareID:  hwID,
+		DeviceToken: token,
+	})
+
+	// No error message: the connection is accepted, not rejected.
+	_ = ws.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, _, err := ws.ReadMessage(); err == nil {
+		t.Fatal("expected no error message (connection accepted), but got one")
+	} else if !strings.Contains(err.Error(), "i/o timeout") {
+		t.Fatalf("expected timeout (accepted), got: %v", err)
+	}
+
+	// The device is online under its BOUND number, never under the stale one.
+	if !h.hub.IsOnline(number) {
+		t.Errorf("device should be online under its bound number %q", number)
+	}
+	if h.hub.IsOnline("1001") {
+		t.Error("device must not be registered under the stale claimed number 1001")
+	}
+}


### PR DESCRIPTION
## Incident

A critical `DigitsSignalingErrors` alert fired in prod (`invalid_message` + `peer_unreachable`). Root cause traced from the signald logs:

```
"ws register number mismatch" hardware_id=df994964 claimed=2451234 bound=2456390
```

A paired device ("Justin Office") registers with the phone number stored in its local config. When its line was joined to another line, the device's stored number (`2451234`) stopped matching its DB-bound line (`2456390`). The WS register handler (rejection added in #488) rejected the connection, so the device retried forever (~3/sec across pods), never coming online: it can't receive calls, shows offline, and the reject loop drives the signaling-error metric that tripped the alert.

This is latent and predates this change; any signald restart (e.g. a deploy) forces every device to reconnect and exposes devices whose stored number drifted from their bound line (move / join / renumber). The same mechanism explains numbers that "place calls but can't be dialed": the device is online under a stale number, so inbound routing to its real number finds no presence.

## Fix

The bound line number is already authoritative: a device can only ever land on the line it is actually paired to. So on a mismatch, register the device under its **bound** number instead of rejecting. The device comes online on its real line immediately, with no device-side change, and any stranded device self-heals on its next reconnect.

This is strictly safer than the old reject: the claimed number is ignored entirely, so a device can never register as a line it is not paired to (the property #488 was protecting).

## Test plan

- [x] New `TestWSRegister_PairedDevice_NumberMismatch_UsesBoundNumber`: a paired device registering with a stale number is accepted and registered under its bound number, never the stale one.
- [x] Existing WS register tests (missing hw id, missing/wrong/correct token) still pass.
- [x] build + vet + golangci-lint clean.