### PR TITLE
refactor(server): share SSE plumbing across the two link-health streams

### DIFF
--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -183,24 +183,17 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 }
 
 func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
-	switch ev.Kind {
-	case calls.SampleKind:
-		snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
-		fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
-		if err != nil {
-			return err
-		}
-		if err := writeSSE(w, sseEventSample, fragment); err != nil {
-			return err
-		}
-	case calls.EndedKind:
-		if err := writeSSE(w, sseEventEnded, renderEndedConferenceFragment("")); err != nil {
-			return err
-		}
-	case calls.DisconnectKind:
-		if err := writeSSE(w, sseEventDisconnect, renderEndedConferenceFragment(ev.EndedBy)); err != nil {
-			return err
-		}
+	if handled, err := writeTerminalEvent(w, flusher, ev, renderEndedConferenceFragment); handled {
+		return err
+	}
+	// SampleKind
+	snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
+	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
+	if err != nil {
+		return err
+	}
+	if err := writeSSE(w, sseEventSample, fragment); err != nil {
+		return err
 	}
 	flusher.Flush()
 	return nil

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -173,30 +173,13 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	}
 	flusher.Flush()
 
-	heartbeat := time.NewTicker(sseHeartbeatInterval)
-	defer heartbeat.Stop()
-
-	for {
-		select {
-		case <-r.Context().Done():
-			return
-		case ev, okEv := <-sub.C:
-			if !okEv {
-				_ = writeSSE(w, sseEventEnded, renderEndedConferenceFragment(""))
-				flusher.Flush()
-				return
-			}
-			if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, ownedLines, linkedIndex, ev); err != nil {
-				slog.DebugContext(r.Context(), "SSE conference stream: write failed", "conf_id", confID, "err", err)
-				return
-			}
-		case <-heartbeat.C:
-			if err := writeSSE(w, sseEventHeartbeat, "{}"); err != nil {
-				return
-			}
-			flusher.Flush()
+	streamSSE(r.Context(), w, flusher, sub, renderEndedConferenceFragment(""), func(ev calls.Event) error {
+		if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, ownedLines, linkedIndex, ev); err != nil {
+			slog.DebugContext(r.Context(), "SSE conference stream: write failed", "conf_id", confID, "err", err)
+			return err
 		}
-	}
+		return nil
+	})
 }
 
 func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -201,22 +201,39 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	streamSSE(r.Context(), w, flusher, sub, renderEndedFragment(""), func(ev calls.Event) error {
+		if err := h.writeEvent(r.Context(), w, flusher, call, ownedLines, linkedIndex, ev); err != nil {
+			slog.DebugContext(r.Context(), "SSE stream: write failed; client gone", "call_id", callID, "err", err)
+			return err
+		}
+		return nil
+	})
+}
+
+// streamSSE runs the heartbeat/event select loop shared by the link-health
+// SSE streams (2-party calls and conferences). It forwards each subscription
+// event to onEvent, writes endedFragment when the subscription channel closes
+// (the cross-pod Evict path), and emits a heartbeat on every tick. It returns
+// when the client disconnects, the subscription closes, or onEvent reports a
+// write failure. Callers do their own pre-loop setup (initial snapshot,
+// subscribe ordering) because that part legitimately differs between the two
+// streams.
+func streamSSE(ctx context.Context, w io.Writer, flusher http.Flusher, sub *calls.Subscription, endedFragment string, onEvent func(ev calls.Event) error) {
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
 
 	for {
 		select {
-		case <-r.Context().Done():
+		case <-ctx.Done():
 			return
 		case ev, ok := <-sub.C:
 			if !ok {
 				// Channel closed by Evict. Send one final ended event and return.
-				_ = writeSSE(w, sseEventEnded, renderEndedFragment(""))
+				_ = writeSSE(w, sseEventEnded, endedFragment)
 				flusher.Flush()
 				return
 			}
-			if err := h.writeEvent(r.Context(), w, flusher, call, ownedLines, linkedIndex, ev); err != nil {
-				slog.DebugContext(r.Context(), "SSE stream: write failed; client gone", "call_id", callID, "err", err)
+			if err := onEvent(ev); err != nil {
 				return
 			}
 		case <-heartbeat.C:

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -315,16 +315,18 @@ func (h *Handler) writeSampleEvent(ctx context.Context, w io.Writer, flusher htt
 }
 
 // writeTerminalEvent writes an SSE frame for an EndedKind or DisconnectKind
-// event using renderEndedFragment. Returns true if the event was a terminal
+// event, rendering the ended/disconnect body via renderEnded so the 2-party
+// and conference streams can share the same terminal-event handling while
+// keeping their own deck wording. Returns true if the event was a terminal
 // kind and was handled, false for SampleKind (which the caller handles).
-func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event) (bool, error) {
+func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event, renderEnded func(endedBy string) string) (bool, error) {
 	switch ev.Kind {
 	case calls.EndedKind:
-		if err := writeSSE(w, sseEventEnded, renderEndedFragment("")); err != nil {
+		if err := writeSSE(w, sseEventEnded, renderEnded("")); err != nil {
 			return true, err
 		}
 	case calls.DisconnectKind:
-		if err := writeSSE(w, sseEventDisconnect, renderEndedFragment(ev.EndedBy)); err != nil {
+		if err := writeSSE(w, sseEventDisconnect, renderEnded(ev.EndedBy)); err != nil {
 			return true, err
 		}
 	default:
@@ -335,7 +337,7 @@ func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event) (bool
 }
 
 func (h *Handler) writeEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
-	if handled, err := writeTerminalEvent(w, flusher, ev); handled {
+	if handled, err := writeTerminalEvent(w, flusher, ev, renderEndedFragment); handled {
 		return err
 	}
 	// SampleKind


### PR DESCRIPTION
## What

The 2-party call and conference link-health SSE handlers (`handleCallLinkHealthStream`, `handleConferenceLinkHealthStream`) were near-duplicates of each other in their stream plumbing. This shares the two pieces that were genuinely identical:

1. **The heartbeat/event select loop.** Both carried a byte-for-byte identical loop: `ctx.Done()` teardown, an ended fragment on subscription-channel close (the cross-pod `Evict` path), per-event forwarding, and a periodic heartbeat. Extracted into a single `streamSSE` helper parameterized by the ended-fragment string and a per-event callback. Both subscriptions are already `*calls.Subscription`, so the loop body is shared as-is.

2. **The terminal-event frame.** `writeConferenceEvent` inlined the same `EndedKind`/`DisconnectKind` switch the 2-party path had already factored into `writeTerminalEvent`, differing only in the deck wording. `writeTerminalEvent` now takes the ended-fragment renderer as a parameter, so both streams reuse it and each path handles only its own `SampleKind` frame.

## Why this scope

Each handler keeps its own pre-loop setup. The initial-snapshot timing and the subscribe-before/after-snapshot ordering differ between the two streams on purpose (the conference path subscribes first to avoid dropping samples, documented in place), and the `SampleKind` render paths legitimately differ (two endpoints vs. an N*(N-1) edge matrix). So the shared helpers cover only the lifecycle loop and terminal-event writing, not the snapshot/render logic, which would trade clear duplication for a cleverer abstraction that hides those intentional differences.

No behavior change: heartbeat interval, event handling, deck wording, and the per-handler debug logging on write failure are all preserved.

## Validation

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all pass.
