### PR TITLE
docs: document ICE relay metrics added in #781

### DIFF
--- a/server/docs/metrics.md
+++ b/server/docs/metrics.md
@@ -66,6 +66,32 @@ All metric names are prefixed with `digits_signald_`.
 No peer identity, phone number, call ID, conference ID, or content is
 included in any signaling-error label.
 
+### Signaling media (signald only)
+
+The relay sees both ends' media negotiation as it forwards SDP and ICE
+between peers, so it counts two things. Both use closed label sets defined
+in code (`internal/metrics/metrics.go`), identical in spirit to
+`signaling_errors_total`: any value outside the set collapses to `other`,
+and the relay parses candidates from untrusted device input, so it can
+never widen the label space or smuggle an identifier into a label.
+
+- `digits_signald_ice_candidates_relayed_total{cand_type, transport}`
+  (counter): ICE candidates relayed between peers. `cand_type` is the
+  closed set `host`, `srflx`, `prflx`, `relay`; `transport` is `udp` or
+  `tcp`. Anything else (including an unparseable candidate) collapses to
+  `other`, so a malformed-candidate spike is visible on a dashboard. A
+  rising `relay` share signals direct and reflexive paths are failing and
+  media is falling back to TURN. The candidate address and port are never
+  labels.
+- `digits_signald_ice_servers_issued_total{turn}` (counter): ICE-server
+  responses handed to devices, partitioned only by whether TURN was
+  included. `turn="false"` means the pod issued STUN only, which usually
+  indicates a TURN misconfiguration. No device identity, TURN username, or
+  credential is recorded.
+
+No peer identity, phone number, call ID, candidate address, or TURN
+credential is included in any signaling-media label.
+
 ### Build info
 
 - `digits_<svc>_build_info{version, commit}` (gauge, always 1): allows a


### PR DESCRIPTION
## What

Adds a "Signaling media" subsection to `server/docs/metrics.md` documenting the two Prometheus counters that #781 introduced in signald:

- `digits_signald_ice_candidates_relayed_total{cand_type, transport}`
- `digits_signald_ice_servers_issued_total{turn}`

The entry spells out each closed label set (`host`/`srflx`/`prflx`/`relay`, `udp`/`tcp`, `true`/`false`, everything else collapsing to `other`) and states that candidate address, port, and TURN credentials are never labels.

## Why (cross-PR coherence)

This is a holistic, across-PR finding rather than a single-PR nit. `docs/metrics.md` is the canonical enumeration of every metric signald exposes, and it opens by instructing reviewers to treat "any new label as a privacy decision, not a routine refactor." #781 shipped two new privacy-relevant counters with closed label sets but did not update that doc, leaving the metrics catalog out of sync with the code. Notably the same day's #778 edited this very file to clarify a docs path, so the file was in active maintenance; the metrics it lists simply drifted from what signald now emits.

No behavior change: documentation only. The wording mirrors the existing `signaling_errors_total` section so the closed-set privacy contract reads consistently.

Motivated by merged PR #781 (and #778, which touched the same doc the same day).