### PR TITLE
refactor(server): tidy dead code, dedupe Hub fallback, and close test gaps

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -250,7 +250,7 @@ See `.env.example` for a starter config file.
 | `/api/active-calls`     | Active calls list                        |
 | `/internal/stats`       | Internal stats (requires `ADMIN_SECRET`) |
 
-The UI uses htmx for partial updates and Tailwind CSS for styling. Three themes ship: `intercom` (default), `dialup`, and `answering-machine`; the per-user choice lives on `users.theme`.
+The UI uses htmx for partial updates and hand-written custom CSS for styling (`digits.css` plus per-theme overrides in `internal/web/static/`). Three themes ship: `intercom` (default), `dialup`, and `answering-machine`; the per-user choice lives on `users.theme`.
 
 ## WebSocket Protocol
 

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -256,7 +256,6 @@ func run(ctx context.Context) error {
 		Emailer:        emailSender,
 		Metrics:        mreg,
 	}, web.HandlerConfig{
-		Addr:              cfg.Addr,
 		BaseURL:           cfg.BaseURL,
 		AdminSecret:       cfg.AdminSecret,
 		DevMode:           cfg.DevMode,

--- a/server/internal/auth/google_unit_test.go
+++ b/server/internal/auth/google_unit_test.go
@@ -11,6 +11,11 @@ import (
 // with a nil store rather than requiring Postgres. Keeping them out of the
 // integration tier means the CSRF protection is verified on every push, not
 // only in the integration job.
+//
+// The nil store is safe only because the state check precedes any store access
+// in HandleCallback (and HandleLogin never touches the store). Preserve that
+// ordering: a store call inserted before the state check would turn these into
+// nil-pointer panics instead of clean assertions.
 
 func TestGoogleAuth_HandleLogin_SetsStateCookie(t *testing.T) {
 	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", nil)

--- a/server/internal/auth/google_unit_test.go
+++ b/server/internal/auth/google_unit_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package auth
 
 import (
@@ -8,9 +6,14 @@ import (
 	"testing"
 )
 
+// These tests exercise the OAuth state/CSRF guards and the login redirect.
+// None of these code paths touch the Store, so they run in the fast unit tier
+// with a nil store rather than requiring Postgres. Keeping them out of the
+// integration tier means the CSRF protection is verified on every push, not
+// only in the integration job.
+
 func TestGoogleAuth_HandleLogin_SetsStateCookie(t *testing.T) {
-	s := testDB(t)
-	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/auth/google/login", nil)
 	w := httptest.NewRecorder()
@@ -46,8 +49,7 @@ func TestGoogleAuth_HandleLogin_SetsStateCookie(t *testing.T) {
 }
 
 func TestGoogleAuth_HandleCallback_MissingStateCookie(t *testing.T) {
-	s := testDB(t)
-	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state=abc&code=xyz", nil)
 	w := httptest.NewRecorder()
@@ -59,8 +61,7 @@ func TestGoogleAuth_HandleCallback_MissingStateCookie(t *testing.T) {
 }
 
 func TestGoogleAuth_HandleCallback_StateMismatch(t *testing.T) {
-	s := testDB(t)
-	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", s)
+	g := NewGoogleAuth("test-client-id", "test-secret", "http://localhost/callback", "", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/auth/google/callback?state=abc&code=xyz", nil)
 	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "different-state"})

--- a/server/internal/calls/rename_integration_test.go
+++ b/server/internal/calls/rename_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package calls_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/justinlindh/digits/server/internal/calls"
+)
+
+// TestRenameNumber_Integration verifies that RenameNumber rewrites a phone
+// number across every table its transaction touches: calls.caller,
+// calls.callee, conferences.host_phone, conference_members.phone, and
+// conference_kicks.kicked_phone. A missed table or a wrong column would
+// silently strand call history under the old number, so each one is asserted
+// explicitly.
+func TestRenameNumber_Integration(t *testing.T) {
+	d := openTestDB(t)
+	tr := calls.New(d)
+	ctx := context.Background()
+
+	const (
+		oldNum = "+15557770001"
+		newNum = "+15557770099"
+		peer   = "+15557770002"
+	)
+
+	// calls.caller = old (outbound leg) and calls.callee = old (inbound leg).
+	var outboundID, inboundID int64
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		oldNum, peer,
+	).Scan(&outboundID); err != nil {
+		t.Fatalf("seed outbound call: %v", err)
+	}
+	if err := d.DB.QueryRow(
+		`INSERT INTO calls (caller, callee, status) VALUES ($1, $2, 'initiated') RETURNING id`,
+		peer, oldNum,
+	).Scan(&inboundID); err != nil {
+		t.Fatalf("seed inbound call: %v", err)
+	}
+
+	// conferences.host_phone = old.
+	confID := uuid.New()
+	if _, err := d.DB.Exec(
+		`INSERT INTO conferences (id, host_phone, originating_call_id, state) VALUES ($1, $2, $3, 'active')`,
+		confID, oldNum, outboundID,
+	); err != nil {
+		t.Fatalf("seed conference: %v", err)
+	}
+
+	// conference_members.phone = old.
+	if _, err := d.DB.Exec(
+		`INSERT INTO conference_members (conference_id, phone, role) VALUES ($1, $2, 'host')`,
+		confID, oldNum,
+	); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+
+	// conference_kicks.kicked_phone = old (needs a user for the FK).
+	var userID string
+	if err := d.DB.QueryRow(
+		`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id`,
+		"rename-"+confID.String()+"@example.com", "Rename Test",
+	).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() { _, _ = d.DB.Exec("DELETE FROM users WHERE id = $1", userID) })
+	if _, err := d.DB.Exec(
+		`INSERT INTO conference_kicks (conference_id, kicked_phone, kicked_by_user_id) VALUES ($1, $2, $3)`,
+		confID, oldNum, userID,
+	); err != nil {
+		t.Fatalf("seed kick: %v", err)
+	}
+
+	if err := tr.RenameNumber(ctx, oldNum, newNum); err != nil {
+		t.Fatalf("RenameNumber: %v", err)
+	}
+
+	// Assert against the specific rows this test seeded (by id / conference id)
+	// rather than table-wide counts: the integration suite shares one database,
+	// so a global count would be perturbed by other tests' rows.
+	assertPhone := func(query string, args []any, want, what string) {
+		t.Helper()
+		var got string
+		if err := d.DB.QueryRow(query, args...).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", what, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %q, want %q", what, got, want)
+		}
+	}
+	assertScopedCount := func(query string, args []any, want int, what string) {
+		t.Helper()
+		var got int
+		if err := d.DB.QueryRow(query, args...).Scan(&got); err != nil {
+			t.Fatalf("count %s: %v", what, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %d rows, want %d", what, got, want)
+		}
+	}
+
+	assertPhone(`SELECT caller FROM calls WHERE id = $1`, []any{outboundID}, newNum, "calls.caller renamed")
+	assertPhone(`SELECT callee FROM calls WHERE id = $1`, []any{inboundID}, newNum, "calls.callee renamed")
+	assertPhone(`SELECT host_phone FROM conferences WHERE id = $1`, []any{confID}, newNum, "conferences.host_phone renamed")
+	assertScopedCount(`SELECT COUNT(*) FROM conference_members WHERE conference_id = $1 AND phone = $2`, []any{confID, newNum}, 1, "conference_members.phone renamed")
+	assertScopedCount(`SELECT COUNT(*) FROM conference_members WHERE conference_id = $1 AND phone = $2`, []any{confID, oldNum}, 0, "conference_members still holding old phone")
+	assertScopedCount(`SELECT COUNT(*) FROM conference_kicks WHERE conference_id = $1 AND kicked_phone = $2`, []any{confID, newNum}, 1, "conference_kicks.kicked_phone renamed")
+	assertScopedCount(`SELECT COUNT(*) FROM conference_kicks WHERE conference_id = $1 AND kicked_phone = $2`, []any{confID, oldNum}, 0, "conference_kicks still holding old phone")
+}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -512,8 +512,8 @@ var ErrSendTimeout = errors.New("send timed out: buffer full")
 // publishFallback routes msg to the target across pods via Redis when no
 // local connection was found, returning nil once published. In
 // single-instance mode (no Redis bridge) there is nowhere else to deliver, so
-// it returns ErrNotConnected. label and target form both the envelope target
-// and the wrapped error ("<label> <target>: not connected").
+// it returns ErrNotConnected. target is the envelope target; label and target
+// together form the wrapped error ("<label> <target>: not connected").
 func (h *Hub) publishFallback(bridge redisPubSub, targetType, target, label string, msg *Message) error {
 	if bridge != nil {
 		bridge.Publish(context.Background(), &Envelope{

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -509,6 +509,23 @@ func (h *Hub) ConnectionCount(number string) int {
 // buffer does not drain within the deadline.
 var ErrSendTimeout = errors.New("send timed out: buffer full")
 
+// publishFallback routes msg to the target across pods via Redis when no
+// local connection was found, returning nil once published. In
+// single-instance mode (no Redis bridge) there is nowhere else to deliver, so
+// it returns ErrNotConnected. label and target form both the envelope target
+// and the wrapped error ("<label> <target>: not connected").
+func (h *Hub) publishFallback(bridge redisPubSub, targetType, target, label string, msg *Message) error {
+	if bridge != nil {
+		bridge.Publish(context.Background(), &Envelope{
+			TargetType: targetType,
+			Target:     target,
+			Message:    msg,
+		})
+		return nil
+	}
+	return fmt.Errorf("%s %s: %w", label, target, ErrNotConnected)
+}
+
 // SendTo marshals msg and sends it to every device on the given line number.
 // This is the POTS extension model: a ring reaches all phones on the line.
 // Returns ErrNotConnected only when no devices are connected locally AND
@@ -524,15 +541,7 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 	bridge := h.redis
 	if len(conns) == 0 {
 		h.mu.RUnlock()
-		if bridge != nil {
-			bridge.Publish(context.Background(), &Envelope{
-				TargetType: "number",
-				Target:     number,
-				Message:    msg,
-			})
-			return nil
-		}
-		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
+		return h.publishFallback(bridge, "number", number, "phone", msg)
 	}
 	dropHook := h.dropHook
 	for _, conn := range conns {
@@ -585,15 +594,7 @@ func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Durati
 			h.mu.RUnlock()
 			// No local conn: fall back to cross-pod delivery via Redis,
 			// best-effort, exactly as SendTo does.
-			if bridge != nil {
-				bridge.Publish(context.Background(), &Envelope{
-					TargetType: "number",
-					Target:     number,
-					Message:    msg,
-				})
-				return nil
-			}
-			return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
+			return h.publishFallback(bridge, "number", number, "phone", msg)
 		}
 		pending := false
 		for _, conn := range conns {
@@ -638,16 +639,7 @@ func (h *Hub) SendToHardware(hardwareID string, msg *Message) error {
 		return err
 	}
 
-	if bridge != nil {
-		bridge.Publish(context.Background(), &Envelope{
-			TargetType: "hardware",
-			Target:     hardwareID,
-			Message:    msg,
-		})
-		return nil
-	}
-
-	return fmt.Errorf("hardware %s: %w", hardwareID, ErrNotConnected)
+	return h.publishFallback(bridge, "hardware", hardwareID, "hardware", msg)
 }
 
 // Broadcast marshals msg and sends it to every connected device without

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -689,6 +689,72 @@ func TestRelayICERestartRejectedWithoutCall(t *testing.T) {
 	}
 }
 
+func TestRelayDTMFForwardedDuringCall(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
+
+	// Establish an active call first.
+	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140002"})
+	<-conn2.Send // drain ring
+
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:  TypeDTMF,
+		To:    "3140002",
+		Digit: "5",
+	})
+
+	select {
+	case data := <-conn2.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeDTMF {
+			t.Fatalf("expected dtmf, got %s", msg.Type)
+		}
+		if msg.From != "3140001" {
+			t.Fatalf("expected from 3140001, got %s", msg.From)
+		}
+		if msg.Digit != "5" {
+			t.Fatalf("expected digit 5, got %q", msg.Digit)
+		}
+	default:
+		t.Fatal("phone 2 did not receive dtmf")
+	}
+}
+
+func TestRelayDTMFDroppedWithoutCall(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	relay := NewRelay(hub, tracker, nil, nil)
+
+	conn1 := &Conn{Send: make(chan []byte, 10)}
+	conn2 := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", conn1)
+	_ = hub.Register("3140002", conn2)
+
+	// No active call: DTMF must not be relayed.
+	relay.HandleMessage(context.Background(), "3140001", &Message{
+		Type:  TypeDTMF,
+		To:    "3140002",
+		Digit: "5",
+	})
+
+	select {
+	case data := <-conn2.Send:
+		msg, _ := ParseMessage(data)
+		t.Fatalf("target should not receive dtmf without an active call, got: %+v", msg)
+	default:
+		// correct: dropped
+	}
+}
+
 func TestRelayOnDisconnectClearsActiveCalls(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -60,7 +60,7 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 		AuthStore:    authStore,
 		AuthHandlers: authHandlers,
 		GoogleAuth:   googleAuth,
-	}, HandlerConfig{Addr: ":0"})
+	}, HandlerConfig{})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -49,7 +49,7 @@ func setupCallsTestServer(t *testing.T) callsTestEnv {
 	t.Cleanup(func() { _ = database.Close() })
 
 	deps, authStore := testDeps(t, database)
-	h, err := NewHandler(deps, HandlerConfig{Addr: ":0"})
+	h, err := NewHandler(deps, HandlerConfig{})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -302,7 +302,6 @@ func toSegments(val, perSegment, badThreshold, warnThreshold float32) segDesc {
 // HandlerConfig carries Handler behavior knobs that are not collaborator
 // dependencies (those live in Deps).
 type HandlerConfig struct {
-	Addr string
 	// BaseURL is the public origin for the app (e.g. https://app.digits.family).
 	// Used for WebSocket origin checks and outgoing magic-link URLs.
 	BaseURL string

--- a/server/internal/web/ratelimit_test.go
+++ b/server/internal/web/ratelimit_test.go
@@ -25,7 +25,7 @@ func setupRateLimitTestServer(t *testing.T) *httptest.Server {
 	t.Cleanup(func() { _ = database.Close() })
 
 	deps, _ := testDeps(t, database)
-	h, err := NewHandler(deps, HandlerConfig{Addr: ":0"})
+	h, err := NewHandler(deps, HandlerConfig{})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -60,7 +60,7 @@ func setupHandler(t *testing.T) (*Handler, *db.Database, *auth.Store) {
 	t.Cleanup(func() { _ = database.Close() })
 
 	deps, authStore := testDeps(t, database)
-	h, err := NewHandler(deps, HandlerConfig{Addr: ":8443"})
+	h, err := NewHandler(deps, HandlerConfig{})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}
@@ -92,7 +92,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Database, *line.Store,
 
 	deps, authStore := testDeps(t, database)
 	deps.PairingStore = nil
-	h, err := NewHandler(deps, HandlerConfig{Addr: ":0"})
+	h, err := NewHandler(deps, HandlerConfig{})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
 	}


### PR DESCRIPTION
## What

A cleanliness and test-coverage pass over `server/`. No user-visible or device-visible behavior changes. The PR:

- **Docs.** Corrects a stale `README.md` line claiming the UI uses "Tailwind CSS". The UI uses hand-written custom CSS (`digits.css` plus per-theme overrides); Tailwind appears nowhere else in the repo.
- **Dead code.** Removes `web.HandlerConfig.Addr`, which was set by the caller but never read inside the `web` package (the HTTP server binds `config.Addr` directly).
- **Duplication.** Extracts a single `publishFallback` helper in `internal/signaling/hub.go`. `SendTo`, `SendToWithTimeout`, and `SendToHardware` each repeated the same publish-to-Redis-or-return-`ErrNotConnected` block verbatim; they now route through one helper so the three send paths stay in lockstep.
- **Test coverage.** Closes three genuine gaps:
  - Moves the Google OAuth state/CSRF tests out of the integration tier into the fast unit tier. Those guards never touch the `Store`, yet the tests required Postgres, so the CSRF protection was skipped entirely in the unit job and only ran in the integration job. They now run on every push.
  - Covers `handleDTMF`, previously the only relay message handler at 0%, with forwarded-during-call and dropped-without-call cases.
  - Covers `calls.RenameNumber`, a five-table transactional rename with no prior coverage where a dropped table would silently strand call history under the old number.

## Why

The `server/` module was already in strong shape: `go build`, `go vet`, `golangci-lint`, and the full test suite all pass clean, dependencies are tidy (`go mod tidy` is a no-op), the package layout is sound, and `deadcode -test ./...` finds nothing. The remaining issues were finer-grained: one stale doc line, one dead field, one triplicated block, and a handful of risky paths that were untested or whose tests were miscategorized. This PR addresses those.

### Deliberately skipped (with reasons)

- **`profiling.Config.MutexProfileFraction` / `BlockProfileRate`.** Wired into real logic but never set by any env var or caller. Left as-is: they are documented, intentional rate knobs gated at the cmd boundary, and removing well-commented working code is more destructive than the dead-config smell it would clear.
- **Broad unexport sweep.** Several exported identifiers are used only within their own package. They live under `internal/` (no external importers by definition), and several form a deliberate, cohesive package surface. A mass rename would be high-churn and low-value, so it is out of scope here.
- **Duplicated `envOr` helper** (`cmd/devseed`, `internal/tracing`). Three identical lines. Forcing a shared dependency between a cmd binary and an observability package to save them is worse than the duplication. YAGNI.

## Test plan

- `go build ./...`, `go vet ./...`: clean.
- `golangci-lint run ./...` (v2.5.0 rebuilt against Go 1.26): 0 issues.
- `go test ./...` (unit tier): all pass.
- `go test -tags=integration -p 1 ./...` against a local Postgres 16 and Redis 7: all pass (auth, calls, household, line, pairing, device, signaling, web).
- New `RenameNumber` test verified non-vacuous via mutation: dropping any one of the five UPDATE statements makes it fail with a scoped assertion.
- Refactor verified to preserve behavior: the signaling Redis cross-pod integration tests pass with the extracted helper.

## Grade

Scoring `server/` on code cleanliness, idiomatic Go, stale/unreferenced code, project layout, and test coverage.

**Before: 88 / 100.** Excellent baseline (green build/vet/lint/tests, clean deps, sound layout, no tooling-detectable dead code), held back only by a stale doc line, a dead config field, a triplicated send-fallback block, CSRF tests that never ran in the unit tier, and a few untested high-risk paths (`RenameNumber`, `handleDTMF`).

**After: 93 / 100.** Stale doc and dead field gone, the send-fallback duplication collapsed to one helper, CSRF protection now verified on every push, and the two highest-risk untested code paths covered. Remaining headroom is the intentionally-skipped items above plus broader unit coverage on DB-backed handlers, which is largely a structural trade-off the integration tier already addresses.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TcBwU8QrYz9ZndHy4DunNH)_