### PR TITLE
fix(server): fan out line messages to devices on every pod

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -515,7 +515,11 @@ var ErrSendTimeout = errors.New("send timed out: buffer full")
 // phones on the line. A line's devices can be spread across pods, so SendTo
 // always both delivers to local connections AND, when Redis is configured,
 // publishes for cross-pod delivery. The Redis subscriber filters out our own
-// pod's envelope, so local devices are never double-sent.
+// pod's envelope, so local devices are never double-sent. Publishing is
+// unconditional rather than gated on per-line presence: a presence read per
+// send would add a TOCTOU window (a device can connect on another pod between
+// the check and the send) to shave a single missed map lookup off an already
+// cheap call-signaling path, so the gate is deliberately omitted.
 // Returns ErrNotConnected only when no devices are connected locally AND
 // Redis is not configured.
 func (h *Hub) SendTo(number string, msg *Message) error {

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -509,10 +509,15 @@ func (h *Hub) ConnectionCount(number string) int {
 // buffer does not drain within the deadline.
 var ErrSendTimeout = errors.New("send timed out: buffer full")
 
-// SendTo marshals msg and sends it to every device on the given line number.
-// This is the POTS extension model: a ring reaches all phones on the line.
+// SendTo marshals msg and sends it to every device on the given line number,
+// wherever each device's WebSocket happens to be terminated. This is the POTS
+// extension model: a ring (and every other line-targeted message) reaches all
+// phones on the line. A line's devices can be spread across pods, so SendTo
+// always both delivers to local connections AND, when Redis is configured,
+// publishes for cross-pod delivery. The Redis subscriber filters out our own
+// pod's envelope, so local devices are never double-sent.
 // Returns ErrNotConnected only when no devices are connected locally AND
-// Redis cannot deliver.
+// Redis is not configured.
 func (h *Hub) SendTo(number string, msg *Message) error {
 	data, err := msg.Marshal()
 	if err != nil {
@@ -522,18 +527,6 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 	h.mu.RLock()
 	conns := h.conns[number]
 	bridge := h.redis
-	if len(conns) == 0 {
-		h.mu.RUnlock()
-		if bridge != nil {
-			bridge.Publish(context.Background(), &Envelope{
-				TargetType: "number",
-				Target:     number,
-				Message:    msg,
-			})
-			return nil
-		}
-		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
-	}
 	dropHook := h.dropHook
 	for _, conn := range conns {
 		select {
@@ -547,6 +540,19 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 		}
 	}
 	h.mu.RUnlock()
+
+	if bridge != nil {
+		bridge.Publish(context.Background(), &Envelope{
+			TargetType: "number",
+			Target:     number,
+			Message:    msg,
+		})
+		return nil
+	}
+
+	if len(conns) == 0 {
+		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
+	}
 	return nil
 }
 
@@ -554,7 +560,7 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 // re-offer a message to a device whose send buffer was full.
 const sendRetryInterval = 20 * time.Millisecond
 
-// SendToWithTimeout delivers msg to every local device on number, retrying
+// SendToWithTimeout delivers msg to every device on number, retrying local
 // buffer-full devices until the buffer drains or the timeout elapses. Each
 // send is attempted under the read lock inside a non-blocking select, so a
 // concurrent Unregister (which closes conn.Send under the write lock) can
@@ -563,15 +569,29 @@ const sendRetryInterval = 20 * time.Millisecond
 // prevents re-sending to a device that already accepted the message while a
 // sibling's buffer was still full.
 //
-// When no local device is connected the message is published to Redis for
-// cross-pod delivery, mirroring SendTo, so reliable callers (ICE-restart)
-// reach peers on other pods. Returns ErrSendTimeout if any device's buffer
-// stays full for the whole timeout, ErrNotConnected if there is neither a
-// local conn nor a Redis bridge.
+// A line's devices can be spread across pods, so when Redis is configured the
+// message is always published once up front for cross-pod delivery (best
+// effort, mirroring SendTo) so reliable callers (ICE-restart) reach peers on
+// other pods even when a sibling device is connected locally. The Redis
+// subscriber filters out our own pod's envelope, so local devices are not
+// double-sent. Returns ErrSendTimeout if any local device's buffer stays full
+// for the whole timeout, ErrNotConnected if there is neither a local conn nor
+// a Redis bridge.
 func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Duration) error {
 	data, err := msg.Marshal()
 	if err != nil {
 		return err
+	}
+
+	h.mu.RLock()
+	bridge := h.redis
+	h.mu.RUnlock()
+	if bridge != nil {
+		bridge.Publish(context.Background(), &Envelope{
+			TargetType: "number",
+			Target:     number,
+			Message:    msg,
+		})
 	}
 
 	deadline := time.Now().Add(timeout)
@@ -579,18 +599,12 @@ func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Durati
 	for {
 		h.mu.RLock()
 		conns := h.conns[number]
-		bridge := h.redis
 		dropHook := h.dropHook
 		if len(conns) == 0 {
 			h.mu.RUnlock()
-			// No local conn: fall back to cross-pod delivery via Redis,
-			// best-effort, exactly as SendTo does.
+			// No local conn: Redis (published above, if configured) is the only
+			// delivery path. Without it there is nowhere to send.
 			if bridge != nil {
-				bridge.Publish(context.Background(), &Envelope{
-					TargetType: "number",
-					Target:     number,
-					Message:    msg,
-				})
 				return nil
 			}
 			return fmt.Errorf("phone %s: %w", number, ErrNotConnected)

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -436,6 +436,38 @@ func TestSendToWithTimeoutFallsBackToRedis(t *testing.T) {
 	}
 }
 
+// TestSendToWithTimeoutPublishesToRedisWithLocalConn guards the cross-pod
+// regression: when a sibling device for the line is connected locally,
+// SendToWithTimeout must still publish so the in-call peer on another pod
+// receives the ICE-restart. It both delivers locally and publishes.
+func TestSendToWithTimeoutPublishesToRedisWithLocalConn(t *testing.T) {
+	hub := NewHub()
+	fake := newFakeRedis()
+	hub.SetRedis(fake)
+
+	conn := &Conn{Send: make(chan []byte, 10), HardwareID: "hw-local"}
+	_ = hub.Register("3140002", conn)
+
+	err := hub.SendToWithTimeout("3140002", &Message{Type: TypeICERestart, From: "3140001", To: "3140002"}, time.Second)
+	if err != nil {
+		t.Fatalf("SendToWithTimeout returned error, want nil: %v", err)
+	}
+
+	select {
+	case <-conn.Send:
+	default:
+		t.Error("local connection should have received the message")
+	}
+
+	envs := fake.publishedEnvelopes()
+	if len(envs) != 1 {
+		t.Fatalf("published %d envelopes, want 1 for cross-pod delivery", len(envs))
+	}
+	if envs[0].TargetType != "number" || envs[0].Target != "3140002" {
+		t.Fatalf("unexpected envelope: %+v", envs[0])
+	}
+}
+
 // TestSendToWithTimeoutNoPanicOnConcurrentUnregister verifies the panic-safety
 // fix: closing a conn's Send channel (via Unregister) while a
 // SendToWithTimeout is retrying against a full buffer must not send on a

--- a/server/internal/signaling/redis_test.go
+++ b/server/internal/signaling/redis_test.go
@@ -112,7 +112,12 @@ func TestSendToPublishesToRedisWhenNotLocal(t *testing.T) {
 	}
 }
 
-func TestSendToLocalFastPathSkipsRedis(t *testing.T) {
+// TestSendToAlsoPublishesToRedisWithLocalConn guards against the cross-pod
+// fan-out regression where SendTo delivered only to local connections and
+// skipped Redis whenever any device for the line was connected locally. A
+// line's devices can be spread across pods, so SendTo must both deliver
+// locally AND publish so peers on other pods ring too.
+func TestSendToAlsoPublishesToRedisWithLocalConn(t *testing.T) {
 	hub := NewHub()
 	fake := newFakeRedis()
 	hub.redis = fake
@@ -125,14 +130,21 @@ func TestSendToLocalFastPathSkipsRedis(t *testing.T) {
 		t.Fatalf("SendTo local should succeed: %v", err)
 	}
 
-	if len(fake.publishedEnvelopes()) != 0 {
-		t.Errorf("expected 0 published envelopes (local fast path), got %d", len(fake.publishedEnvelopes()))
-	}
-
 	select {
 	case <-conn.Send:
 	default:
 		t.Error("local connection should have received the message")
+	}
+
+	envs := fake.publishedEnvelopes()
+	if len(envs) != 1 {
+		t.Fatalf("expected 1 published envelope for cross-pod delivery, got %d", len(envs))
+	}
+	if envs[0].TargetType != "number" {
+		t.Errorf("TargetType = %q, want %q", envs[0].TargetType, "number")
+	}
+	if envs[0].Target != "3140001" {
+		t.Errorf("Target = %q, want %q", envs[0].Target, "3140001")
 	}
 }
 


### PR DESCRIPTION
## What

Line-targeted Hub sends now reach every device on the line regardless of which signald pod terminates each device's WebSocket.

## Root cause

`Hub.SendTo` (the fan-out path behind ring, offer/answer, hangup, busy, conference, call-return, quiet-hours) delivered only to connections on the pod that handled the message, and skipped the Redis cross-pod publish whenever at least one device for the line was connected locally:

```go
conns := h.conns[number]      // local conns on THIS pod only
if len(conns) == 0 {
    bridge.Publish(...)       // cross-pod ONLY when zero local conns
    return nil
}
for _, conn := range conns { conn.Send <- data }  // local only, no publish
return nil
```

signald runs 3 replicas, so a line's devices are spread across pods. An incoming call to a multi-device line rang only the device(s) that happened to share a pod with the caller's relay; siblings on other pods were silently dropped. This was observed in prod: a line with three phones rang only one (then two on retry, depending on pod placement). `ring_test` always worked because it uses `SendToHardware`, which falls back to Redis when the device is not local.

## Fix

`SendTo` now mirrors `Broadcast`: it always delivers to local connections AND publishes to Redis. The Redis subscriber already filters out the origin pod's own envelope (by `PodID`), so local devices are not double-sent, and remote pods fan out to their local connections via `deliverFromRedis`.

`SendToWithTimeout` (reliable ICE-restart delivery) had the identical gap: a sibling device connected locally suppressed the cross-pod publish, so an in-call peer on another pod could miss an ICE restart. It now publishes once up front and still retries local buffer-full delivery against the deadline.

## Tests

- Rewrote `TestSendToLocalFastPathSkipsRedis` (which asserted the buggy behavior) as `TestSendToAlsoPublishesToRedisWithLocalConn`: a local conn receives the message AND a cross-pod envelope is published.
- Added `TestSendToWithTimeoutPublishesToRedisWithLocalConn`.
- Full server unit suite passes; `golangci-lint` v2.11 clean on the package.