### PR TITLE
fix(server): self-heal device line-number drift instead of reconciling forever

### DIFF
--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -383,12 +383,18 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 			break
 		}
 		slog.Info("signal: line renumber", "old", d.cfg.PhoneNumber, "new", msg.Number)
+		// Persist to disk before committing the change in memory. If Save fails
+		// we revert so in-memory state never diverges from disk: the daemon
+		// stays on its old number (the server reconciles again next connect)
+		// rather than running half-applied until the next reload.
+		oldNumber := d.cfg.PhoneNumber
 		d.cfg.PhoneNumber = msg.Number
-		d.number = msg.Number
 		if err := d.cfg.Save(); err != nil {
+			d.cfg.PhoneNumber = oldNumber
 			slog.Warn("signal: line renumber -- failed to save config", "error", err)
 			break
 		}
+		d.number = msg.Number
 		slog.Info("signal: restarting to re-register on corrected line", "number", msg.Number, "config", d.cfg.Path())
 		go func() {
 			time.Sleep(1 * time.Second)

--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -372,6 +372,29 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 			}()
 		}
 
+	case sigclient.TypeLineRenumber:
+		// The server reconciled our register to a different bound line: our
+		// stored number is stale (line moved, joined, or renumbered). Persist
+		// the authoritative number and restart to re-register under it. Without
+		// this the server would reconcile on every reconnect forever and we'd
+		// never learn our real line. No-op when the number is empty or already
+		// matches so a redundant/echoed message can't trigger a restart loop.
+		if msg.Number == "" || d.cfg == nil || msg.Number == d.cfg.PhoneNumber {
+			break
+		}
+		slog.Info("signal: line renumber", "old", d.cfg.PhoneNumber, "new", msg.Number)
+		d.cfg.PhoneNumber = msg.Number
+		d.number = msg.Number
+		if err := d.cfg.Save(); err != nil {
+			slog.Warn("signal: line renumber -- failed to save config", "error", err)
+			break
+		}
+		slog.Info("signal: restarting to re-register on corrected line", "number", msg.Number, "config", d.cfg.Path())
+		go func() {
+			time.Sleep(1 * time.Second)
+			d.reexecProcess() // systemd restarts; we re-register with the saved number
+		}()
+
 	case sigclient.TypeRestart:
 		mode := msg.RestartMode
 		slog.Info("received restart command", "mode", mode)

--- a/pi/digitsd/cmd/digitsd/dispatch_test.go
+++ b/pi/digitsd/cmd/digitsd/dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/justinlindh/digits/pi/digitsd/internal/audio"
 	"github.com/justinlindh/digits/pi/digitsd/internal/config"
@@ -364,5 +365,91 @@ func TestDispatchRouting_DTMFGatedByState(t *testing.T) {
 	d.handleSignal(&sigclient.Message{Type: sigclient.TypeDTMF, From: "3140001", Digit: "5"})
 	if _, ok := fc.lastSignal(); ok {
 		t.Errorf("DTMF while idle should not reach the controller")
+	}
+}
+
+// TestDispatchRouting_LineRenumberPersistsAndRestarts is the self-heal path: a
+// line_renumber message with a number that differs from the stored one must
+// write the new number to config (so the next register stops claiming the
+// stale one) and request a restart to re-register.
+func TestDispatchRouting_LineRenumberPersistsAndRestarts(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.json")
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.PhoneNumber = "2451234" // stale number the device still claims
+
+	fc := &fakeController{}
+	d := newDispatchDaemon(t, fc)
+	d.cfg = cfg
+	d.number = "2451234"
+
+	restarted := make(chan struct{})
+	d.reexec = func() { close(restarted) }
+
+	d.handleSignal(&sigclient.Message{Type: sigclient.TypeLineRenumber, Number: "2456390"})
+
+	// In-memory state updated synchronously.
+	if d.number != "2456390" {
+		t.Errorf("d.number = %q, want %q", d.number, "2456390")
+	}
+	if d.cfg.PhoneNumber != "2456390" {
+		t.Errorf("cfg.PhoneNumber = %q, want %q", d.cfg.PhoneNumber, "2456390")
+	}
+
+	// The corrected number was persisted to disk: reload from the same path
+	// and confirm it survives a restart.
+	reloaded, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if reloaded.PhoneNumber != "2456390" {
+		t.Errorf("persisted PhoneNumber = %q, want %q", reloaded.PhoneNumber, "2456390")
+	}
+
+	// The restart fires from a 1s-delayed goroutine; wait for it.
+	select {
+	case <-restarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a restart to re-register, none requested")
+	}
+}
+
+// TestDispatchRouting_LineRenumberNoopWhenUnchanged confirms a redundant
+// line_renumber (same number we already have, or empty) neither rewrites
+// config nor restarts: that guard is what prevents a restart loop if the
+// server echoes the message after the device has already self-healed.
+func TestDispatchRouting_LineRenumberNoopWhenUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		incoming string
+		current  string
+	}{
+		{"same number", "2456390", "2456390"},
+		{"empty number", "", "2456390"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := filepath.Join(t.TempDir(), "config.json")
+			cfg, err := config.Load(cfgPath)
+			if err != nil {
+				t.Fatalf("config.Load: %v", err)
+			}
+			cfg.PhoneNumber = tc.current
+
+			fc := &fakeController{}
+			d := newDispatchDaemon(t, fc)
+			d.cfg = cfg
+			d.number = tc.current
+			d.reexec = func() { t.Error("no-op renumber must not request a restart") }
+
+			d.handleSignal(&sigclient.Message{Type: sigclient.TypeLineRenumber, Number: tc.incoming})
+
+			if d.cfg.PhoneNumber != tc.current {
+				t.Errorf("cfg.PhoneNumber = %q, want unchanged %q", d.cfg.PhoneNumber, tc.current)
+			}
+			// Give any errant restart goroutine a moment to fire.
+			time.Sleep(50 * time.Millisecond)
+		})
 	}
 }

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -253,6 +253,23 @@ type daemonCallbacks struct {
 	// to seed server-side state.
 	publishVMMu   sync.Mutex
 	publishVMLast int64
+
+	// reexec restarts the process so it re-registers from a freshly saved
+	// config (used by the line-renumber self-heal path). Nil in production,
+	// where reexecProcess does the os.Exit; tests inject a recorder to assert
+	// the restart was requested without killing the test binary.
+	reexec func()
+}
+
+// reexecProcess exits so systemd restarts digitsd, which re-registers using
+// the current on-disk config. Indirected through d.reexec so tests can
+// substitute a no-op recorder.
+func (d *daemonCallbacks) reexecProcess() {
+	if d.reexec != nil {
+		d.reexec()
+		return
+	}
+	os.Exit(0)
 }
 
 // getFirmwareVersion returns the current firmware version and commit under mu.

--- a/pi/digitsd/internal/signal/protocol.go
+++ b/pi/digitsd/internal/signal/protocol.go
@@ -68,6 +68,12 @@ const (
 	// new release is available. Carries LatestPiVersion and LatestFWVersion.
 	TypeReleaseAvailable = "release_available"
 
+	// TypeLineRenumber is sent by the server when a register reconcile detects
+	// this device claimed a stale line number. Carries the authoritative line
+	// number in the Number field. The device persists it to config and
+	// re-registers so it stops claiming the stale number. Server -> Phone only.
+	TypeLineRenumber = "line_renumber"
+
 	// TypeLinkHealth is sent by the phone to the server with a per-call
 	// quality telemetry snapshot. Phone → Server only.
 	TypeLinkHealth = "link_health"

--- a/server/internal/signaling/protocol.go
+++ b/server/internal/signaling/protocol.go
@@ -38,6 +38,8 @@ const (
 
 	TypeReleaseAvailable = "release_available" // Server → All: new release detected
 
+	TypeLineRenumber = "line_renumber" // Server → Phone: persist corrected line number after a register reconcile
+
 	TypeVoicemailState = "voicemail_state" // Phone → Server: per-handset unheard voicemail count snapshot
 )
 

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -149,6 +149,17 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 		Send:       make(chan []byte, wsSendBuf),
 		LastSeen:   time.Now(),
 	}
+	// Self-heal a stale-number register: tell the device its real line number
+	// so digitsd persists it and registers correctly next time. Enqueued before
+	// Register so the conn is not yet visible to hub fan-out: nothing else can
+	// contend for the freshly created buffer, so this send never blocks. The
+	// write pump below drains it once it starts.
+	if reconciledNumber != "" {
+		conn.Send <- mustMarshal(&signaling.Message{
+			Type:   signaling.TypeLineRenumber,
+			Number: reconciledNumber,
+		})
+	}
 	if err := h.hub.Register(msg.Number, conn); err != nil {
 		wsReject(ws, "server shutting down")
 		return
@@ -156,15 +167,6 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	if isPaired {
 		h.relay.OnRegistered(r.Context(), msg.Number)
 		h.relay.OnReconnect(r.Context(), msg.Number, msg.HardwareID)
-	}
-	// Self-heal a stale-number register: tell the device its real line number
-	// so digitsd persists it and registers correctly next time. Enqueued on the
-	// buffered Send channel; the write pump below drains it once it starts.
-	if reconciledNumber != "" {
-		conn.Send <- mustMarshal(&signaling.Message{
-			Type:   signaling.TypeLineRenumber,
-			Number: reconciledNumber,
-		})
 	}
 	number := msg.Number
 	ctx := r.Context()

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -77,6 +77,11 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	// bound line number is authoritative: a device cannot register as a
 	// line it is not paired to.
 	isPaired := false
+	// reconciledNumber is set to the bound line number when a paired device
+	// registered with a stale number. After the connection is wired up we push
+	// it back so the device persists the correction and stops re-claiming the
+	// stale number on every reconnect.
+	reconciledNumber := ""
 	if h.pairingStore != nil {
 		paired, tokenValid, err := h.deviceStore.AuthStatus(r.Context(), msg.HardwareID, msg.DeviceToken)
 		if err != nil {
@@ -133,6 +138,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 					"claimed", msg.Number,
 					"bound", boundNumber)
 				msg.Number = boundNumber
+				reconciledNumber = boundNumber
 			}
 		}
 	}
@@ -150,6 +156,15 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 	if isPaired {
 		h.relay.OnRegistered(r.Context(), msg.Number)
 		h.relay.OnReconnect(r.Context(), msg.Number, msg.HardwareID)
+	}
+	// Self-heal a stale-number register: tell the device its real line number
+	// so digitsd persists it and registers correctly next time. Enqueued on the
+	// buffered Send channel; the write pump below drains it once it starts.
+	if reconciledNumber != "" {
+		conn.Send <- mustMarshal(&signaling.Message{
+			Type:   signaling.TypeLineRenumber,
+			Number: reconciledNumber,
+		})
 	}
 	number := msg.Number
 	ctx := r.Context()

--- a/server/internal/web/handler_ws_test.go
+++ b/server/internal/web/handler_ws_test.go
@@ -156,7 +156,9 @@ func TestWSRegister_PairedDevice_CorrectToken(t *testing.T) {
 // A paired device whose stored number no longer matches its bound line (after
 // a move, join, or renumber) must not be rejected: rejecting strands it
 // offline in a reconnect loop. The bound number is authoritative, so the
-// server reconciles and registers the device under its real line.
+// server reconciles and registers the device under its real line. It then
+// self-heals the drift by pushing the corrected number back so the device
+// persists it and stops re-claiming the stale one on the next register.
 func TestWSRegister_PairedDevice_NumberMismatch_UsesBoundNumber(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	srv := httptest.NewServer(h.Router())
@@ -172,12 +174,22 @@ func TestWSRegister_PairedDevice_NumberMismatch_UsesBoundNumber(t *testing.T) {
 		DeviceToken: token,
 	})
 
-	// No error message: the connection is accepted, not rejected.
+	// The connection is accepted (not rejected with an error), and the server
+	// immediately pushes the corrected line number so the device self-heals.
+	msg := recvMsg(t, ws)
+	if msg.Type != signaling.TypeLineRenumber {
+		t.Fatalf("expected %q message, got %q (error=%q)", signaling.TypeLineRenumber, msg.Type, msg.Error)
+	}
+	if msg.Number != number {
+		t.Errorf("renumber carried %q, want bound number %q", msg.Number, number)
+	}
+
+	// Nothing else follows: the renumber is sent exactly once, not on a loop.
 	_ = ws.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
 	if _, _, err := ws.ReadMessage(); err == nil {
-		t.Fatal("expected no error message (connection accepted), but got one")
+		t.Fatal("expected no further message after the single renumber, but got one")
 	} else if !strings.Contains(err.Error(), "i/o timeout") {
-		t.Fatalf("expected timeout (accepted), got: %v", err)
+		t.Fatalf("expected timeout after renumber, got: %v", err)
 	}
 
 	// The device is online under its BOUND number, never under the stale one.
@@ -186,5 +198,31 @@ func TestWSRegister_PairedDevice_NumberMismatch_UsesBoundNumber(t *testing.T) {
 	}
 	if h.hub.IsOnline("1001") {
 		t.Error("device must not be registered under the stale claimed number 1001")
+	}
+}
+
+// A paired device that registers with the correct number must NOT receive a
+// renumber message: the self-heal push fires only on an actual reconcile, so
+// the common case stays silent.
+func TestWSRegister_PairedDevice_CorrectNumber_NoRenumber(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      number, // correct number: no drift to heal
+		HardwareID:  hwID,
+		DeviceToken: token,
+	})
+
+	_ = ws.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, _, err := ws.ReadMessage(); err == nil {
+		t.Fatal("expected no message for a correctly-numbered register, but got one")
+	} else if !strings.Contains(err.Error(), "i/o timeout") {
+		t.Fatalf("expected timeout (no renumber), got: %v", err)
 	}
 }


### PR DESCRIPTION
## Root cause

Devices store their line number locally and claim it on every WebSocket register. When a line is renumbered, moved, or rejoined, the device keeps claiming its OLD number. `handler_ws.go` already "reconciles" this on the fly: it looks up the device's `BoundLineNumber`, and when the claimed `Number` differs it logs `ws register reconciled to bound line` and registers the device under the bound number instead.

The problem is the reconcile is a perpetual band-aid. The device never learns its correct number, so it re-claims the stale one on the next register, and the server re-reconciles, forever. Real example in prod: device `df994964-ab73-4581-aa01-c16376f32a59` ("Justin Office") claims `2451234` but is bound to `2456390`, reconciling on every register.

## Fix

Make the drift self-heal. When the server reconciles, it pushes the corrected number back to the device so `digitsd` persists it and stops claiming the stale one.

- New `line_renumber` message type (Server -> Phone), carrying the bound number in `Number`. Added to both protocol definitions.
- `server/internal/web/handler_ws.go`: after the reconciled connection is registered, enqueue a single `line_renumber` with the bound number on the connection's buffered send channel. It fires only on an actual reconcile; a correctly-numbered register stays silent.
- `pi/digitsd`: a `line_renumber` handler writes the authoritative number to config (`PhoneNumber`, persisted to `/data/digits/config.json` via the existing atomic Save), then restarts so the daemon re-registers under it. The handler is a no-op when the incoming number is empty or already matches the stored one, so a redundant or echoed message can never cause a restart loop. The restart exit is indirected through `reexecProcess` so the path is unit-testable.

I considered reusing the existing `paired` message (it already persists `Number`), but its `digitsd` handler is gated on a non-empty `DeviceToken` and unconditionally fires `StateSet("PAIRED")` plus a dial tone. Replaying the pairing UX (audible dial tone on an idle, on-hook, already-paired phone) during a routine reconnect is wrong, so a narrow dedicated message keeps `paired` semantics clean.

I did not touch `hub.go` `SendTo`: the message is delivered directly on the connection's own send channel in `handleWS`.

## Tested

- `pi/digitsd`: new unit tests in `dispatch_test.go` prove a `line_renumber` with a different number persists to config (reloaded from disk) and requests a restart, and that a same/empty number is a no-op (no config write, no restart). Full `pi/digitsd` unit suite passes; `golangci-lint` clean.
- `server`: updated the existing reconcile integration test to assert the device receives exactly one `line_renumber` carrying the bound number, and added a test that a correctly-numbered register receives no renumber. WS and signaling integration tests pass against Postgres; full unit suite passes; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)