### PR TITLE
refactor(server): extract parseCallID helper for call-id path parsing

### DIFF
--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/justinlindh/digits/server/internal/calls"
 )
@@ -97,10 +96,8 @@ type callLiveDetailData struct {
 // NOT 404'd here; they render in terminal state with the last-known samples
 // from DB fallback, making the URL useful as a postmortem surface.
 func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
-	idStr := r.PathValue("id")
-	callID, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil || callID <= 0 {
-		http.NotFound(w, r)
+	callID, ok := parseCallID(w, r)
+	if !ok {
 		return
 	}
 	call, ownedLines, _, ok := h.requireCallEndpointOwnership(w, r, callID)

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,6 +116,19 @@ func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[s
 		}
 	}
 	return lines, households[0], true
+}
+
+// parseCallID reads the "id" path value and parses it as a positive call ID.
+// On a malformed or non-positive value it writes 404 (the same response the
+// ownership check gives a nonexistent call) and returns (0, false), so call
+// handlers can guard with a single `if !ok { return }`.
+func parseCallID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	callID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil || callID <= 0 {
+		http.NotFound(w, r)
+		return 0, false
+	}
+	return callID, true
 }
 
 // requireCallEndpointOwnership verifies the authenticated user owns either

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -73,10 +72,8 @@ func samplesToWindow(samples []calls.Sample) ([]LinkHealthSample, *LinkHealthSam
 }
 
 func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
-	idStr := r.PathValue("id")
-	callID, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil || callID <= 0 {
-		http.NotFound(w, r)
+	callID, ok := parseCallID(w, r)
+	if !ok {
 		return
 	}
 	call, ownedLines, primaryHH, ok := h.requireCallEndpointOwnership(w, r, callID)
@@ -156,10 +153,8 @@ const sseHeartbeatInterval = 15 * time.Second
 // Auth: same as the JSON endpoint (direct-endpoint-ownership). Ended calls
 // return 404 before any stream bytes are written.
 func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Request) {
-	idStr := r.PathValue("id")
-	callID, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil || callID <= 0 {
-		http.NotFound(w, r)
+	callID, ok := parseCallID(w, r)
+	if !ok {
 		return
 	}
 	call, ownedLines, _, ok := h.requireCallEndpointOwnership(w, r, callID)
@@ -392,10 +387,8 @@ func renderEndedConferenceFragment(endedBy string) string {
 // Idempotent: calling against an already-ended call returns 200 without
 // overwriting the audit column.
 func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
-	idStr := r.PathValue("id")
-	callID, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil || callID <= 0 {
-		http.NotFound(w, r)
+	callID, ok := parseCallID(w, r)
+	if !ok {
 		return
 	}
 	call, _, _, ok := h.requireCallEndpointOwnership(w, r, callID)


### PR DESCRIPTION
## What

Four call / link-health handlers (`handleCallLiveDetail`, `handleCallLinkHealth`, `handleCallLinkHealthStream`, `handleCallDisconnect`) each opened with the exact same six-line block:

```go
idStr := r.PathValue("id")
callID, err := strconv.ParseInt(idStr, 10, 64)
if err != nil || callID <= 0 {
    http.NotFound(w, r)
    return
}
```

This extracts a `parseCallID(w, r) (int64, bool)` helper placed next to `requireCallEndpointOwnership` in `handler_helpers.go`, so each site becomes:

```go
callID, ok := parseCallID(w, r)
if !ok {
    return
}
```

## Why this shape

The helper mirrors the existing `parseClampedInt(w, r, name, lo, hi) (int, bool)` convention in this package: write the error response, return an `ok` bool the caller guards on. The 404 (rather than 400) is preserved intentionally so a malformed id is indistinguishable from a nonexistent one, matching the ownership check. `strconv` was these two files' only use, so the import drops out of both.

## Validation

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` (v2.11) all pass in `server`.