### PR TITLE
refactor(server): route all cross-pod publishes through one Hub helper

### DIFF
--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -144,11 +144,7 @@ func (h *Hub) PublishReconnect(number, hardwareID string) {
 	if bridge == nil {
 		return
 	}
-	bridge.Publish(context.Background(), &Envelope{
-		TargetType: "reconnect",
-		Target:     number,
-		Message:    &Message{HardwareID: hardwareID},
-	})
+	h.publish(bridge, "reconnect", number, &Message{HardwareID: hardwareID})
 }
 
 // SetDeviceState attaches a DeviceState to the hub, enabling cluster-wide
@@ -509,6 +505,19 @@ func (h *Hub) ConnectionCount(number string) int {
 // buffer does not drain within the deadline.
 var ErrSendTimeout = errors.New("send timed out: buffer full")
 
+// publish sends msg to the target across pods via Redis. bridge must be
+// non-nil. It centralizes Envelope construction so every cross-pod send path
+// (the always-publish line/broadcast paths and the publishFallback no-local-
+// conn path) frames messages identically; callers decide whether and when to
+// publish.
+func (h *Hub) publish(bridge redisPubSub, targetType, target string, msg *Message) {
+	bridge.Publish(context.Background(), &Envelope{
+		TargetType: targetType,
+		Target:     target,
+		Message:    msg,
+	})
+}
+
 // publishFallback routes msg to the target across pods via Redis when no
 // local connection was found, returning nil once published. In
 // single-instance mode (no Redis bridge) there is nowhere else to deliver, so
@@ -516,11 +525,7 @@ var ErrSendTimeout = errors.New("send timed out: buffer full")
 // together form the wrapped error ("<label> <target>: not connected").
 func (h *Hub) publishFallback(bridge redisPubSub, targetType, target, label string, msg *Message) error {
 	if bridge != nil {
-		bridge.Publish(context.Background(), &Envelope{
-			TargetType: targetType,
-			Target:     target,
-			Message:    msg,
-		})
+		h.publish(bridge, targetType, target, msg)
 		return nil
 	}
 	return fmt.Errorf("%s %s: %w", label, target, ErrNotConnected)
@@ -563,10 +568,10 @@ func (h *Hub) SendTo(number string, msg *Message) error {
 	h.mu.RUnlock()
 
 	// Always publish for cross-pod delivery, even when a local device received
-	// the message: a line's devices can live on other pods. publishFallback
-	// publishes and returns nil when Redis is configured.
+	// the message: a line's devices can live on other pods.
 	if bridge != nil {
-		return h.publishFallback(bridge, "number", number, "phone", msg)
+		h.publish(bridge, "number", number, msg)
+		return nil
 	}
 	if len(conns) == 0 {
 		return fmt.Errorf("phone %s: %w", number, ErrNotConnected)
@@ -605,11 +610,7 @@ func (h *Hub) SendToWithTimeout(number string, msg *Message, timeout time.Durati
 	bridge := h.redis
 	h.mu.RUnlock()
 	if bridge != nil {
-		bridge.Publish(context.Background(), &Envelope{
-			TargetType: "number",
-			Target:     number,
-			Message:    msg,
-		})
+		h.publish(bridge, "number", number, msg)
 	}
 
 	deadline := time.Now().Add(timeout)
@@ -697,10 +698,7 @@ func (h *Hub) Broadcast(msg *Message) {
 	h.mu.RUnlock()
 
 	if bridge != nil {
-		bridge.Publish(context.Background(), &Envelope{
-			TargetType: "broadcast",
-			Message:    msg,
-		})
+		h.publish(bridge, "broadcast", "", msg)
 	}
 }
 


### PR DESCRIPTION
## What

Centralizes Redis cross-pod publishing in `internal/signaling/hub.go` behind a single `publish(bridge, targetType, target, msg)` helper, and routes all five publish sites through it: `publishFallback`, `SendTo`, `SendToWithTimeout`, `Broadcast`, and `PublishReconnect`.

## Why (cross-PR coherence)

This is a holistic, across-PR finding rather than a single-PR nit. Two PRs that merged nine minutes apart left the Hub send paths in a half-consolidated state:

- **#784** ("tidy dead code, dedupe Hub fallback") extracted `publishFallback` specifically so `SendTo`, `SendToWithTimeout`, and `SendToHardware` "stay in lockstep," collapsing three identical publish-to-Redis blocks into one helper.
- **#785** ("fan out line messages to devices on every pod"), merged ~9 minutes later, changed `SendTo` and `SendToWithTimeout` to publish unconditionally. In doing so it:
  - re-inlined the `&Envelope{TargetType: "number", ...}` publish in `SendToWithTimeout`, reintroducing the exact duplication #784 had just removed, and
  - made `SendTo` call `publishFallback` on every Redis-configured send, which contradicts that helper's documented contract ("routes msg to the target across pods via Redis when no local connection was found").

The result was two divergent publish idioms and a helper whose doc no longer matched its primary caller.

## The fix

- New `publish` owns `Envelope` construction; `publishFallback` delegates to it for its fallback branch.
- `SendTo` and `SendToWithTimeout` call `publish` directly (always-publish semantics from #785 preserved).
- `SendTo` no longer routes through `publishFallback`, so `publishFallback` returns to its accurate fallback-only role: `SendToHardware` is now its only caller, and its "no local connection" doc is correct again.
- `Broadcast` and `PublishReconnect` also route through `publish`, so every cross-pod envelope is framed in one place.

No behavior change: same framing, same return values, same always-publish vs. fallback semantics. Net -2 lines, one file.

## Validation

- `go build ./...`, `go test ./...` (full unit tier) pass in `server`.
- `go vet ./internal/signaling/` clean; `gofmt` clean. (The pinned `golangci-lint` v2.5.0 binary in this environment refuses the Go 1.26 toolchain; CI runs the v2.11 build the merged PRs used.)

Motivated by merged PRs #784 and #785.