### PR TITLE
test(server): cover untested pure helpers and align an error string

### DIFF
--- a/server/internal/email/email_test.go
+++ b/server/internal/email/email_test.go
@@ -23,3 +23,30 @@ func TestLogSenderSendReturnsNil(t *testing.T) {
 		t.Errorf("LogSender.Send: %v", err)
 	}
 }
+
+func TestSMTPSenderRejectsHeaderInjection(t *testing.T) {
+	// The CRLF guard runs before any network or address parsing, so these
+	// cases exercise the injection check without contacting an SMTP server.
+	tests := []struct {
+		name    string
+		to      string
+		subject string
+		from    string
+	}{
+		{name: "newline in to", to: "victim@example.com\r\nBcc: evil@example.com", subject: "s", from: "noreply@example.com"},
+		{name: "bare LF in subject", to: "victim@example.com", subject: "hello\ninjected", from: "noreply@example.com"},
+		{name: "CR in from", to: "victim@example.com", subject: "s", from: "noreply@example.com\rX: y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSMTPSender("smtp.example.com", "587", "user", "pass", tt.from)
+			err := s.Send(tt.to, tt.subject, "body")
+			if err == nil {
+				t.Fatal("Send accepted header with embedded CR/LF; want rejection")
+			}
+			if err.Error() != "invalid email header value" {
+				t.Errorf("err = %q, want %q", err.Error(), "invalid email header value")
+			}
+		})
+	}
+}

--- a/server/internal/signaling/candidate_test.go
+++ b/server/internal/signaling/candidate_test.go
@@ -113,3 +113,49 @@ func TestParseCandidateOddTrailingTokens(t *testing.T) {
 		t.Errorf("raddr/rport mismatch with trailing odd token: %q/%q", got.RelatedAddress, got.RelatedPort)
 	}
 }
+
+func TestSummarizeSDP(t *testing.T) {
+	tests := []struct {
+		name           string
+		sdp            string
+		wantMLines     int
+		wantCandidates int
+	}{
+		{name: "empty", sdp: "", wantMLines: 0, wantCandidates: 0},
+		{
+			name:       "single audio m-line, LF",
+			sdp:        "v=0\no=- 0 0 IN IP4 0.0.0.0\nm=audio 9 UDP/TLS/RTP/SAVPF 111\n",
+			wantMLines: 1,
+		},
+		{
+			name:       "CRLF line endings",
+			sdp:        "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+			wantMLines: 1,
+		},
+		{
+			name:           "bundled candidates",
+			sdp:            "m=audio 9 UDP/TLS/RTP/SAVPF 111\na=candidate:1 1 udp 2 192.0.2.1 5000 typ host\na=candidate:2 1 udp 1 198.51.100.1 5000 typ srflx\n",
+			wantMLines:     1,
+			wantCandidates: 2,
+		},
+		{
+			name:       "multiple m-lines",
+			sdp:        "m=audio 9 UDP/TLS/RTP/SAVPF 111\nm=video 9 UDP/TLS/RTP/SAVPF 96\n",
+			wantMLines: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SummarizeSDP(tt.sdp)
+			if got.MLines != tt.wantMLines {
+				t.Errorf("MLines = %d, want %d", got.MLines, tt.wantMLines)
+			}
+			if got.Candidates != tt.wantCandidates {
+				t.Errorf("Candidates = %d, want %d", got.Candidates, tt.wantCandidates)
+			}
+			if got.Bytes != len(tt.sdp) {
+				t.Errorf("Bytes = %d, want %d", got.Bytes, len(tt.sdp))
+			}
+		})
+	}
+}

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -720,7 +720,7 @@ func sendToConn(conn *Conn, msg *Message, label, id string) error {
 	case conn.Send <- data:
 		return nil
 	default:
-		return fmt.Errorf("send buffer full for %s %s", label, id)
+		return fmt.Errorf("%s %s: send buffer full", label, id)
 	}
 }
 

--- a/server/internal/web/segments_test.go
+++ b/server/internal/web/segments_test.go
@@ -1,0 +1,36 @@
+package web
+
+import "testing"
+
+func TestToSegments(t *testing.T) {
+	tests := []struct {
+		name          string
+		val           float32
+		perSegment    float32
+		badThreshold  float32
+		warnThreshold float32
+		wantLit       int
+		wantSeverity  string
+	}{
+		{name: "zero is dark", val: 0, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: 0, wantSeverity: ""},
+		{name: "tiny positive lights one segment", val: 0.3, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: 1, wantSeverity: ""},
+		{name: "warn threshold boundary", val: pctWarnThreshold, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: 1, wantSeverity: "warn"},
+		{name: "bad threshold boundary", val: pctBadThreshold, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: 1, wantSeverity: "bad"},
+		{name: "mid range pct", val: 50, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: 5, wantSeverity: "bad"},
+		{name: "over range clamps to segmentCount", val: 200, perSegment: pctPerSegment, badThreshold: pctBadThreshold, warnThreshold: pctWarnThreshold, wantLit: segmentCount, wantSeverity: "bad"},
+		{name: "ms good", val: 6, perSegment: msPerSegment, badThreshold: msBadThreshold, warnThreshold: msWarnThreshold, wantLit: 1, wantSeverity: ""},
+		{name: "ms warn boundary", val: msWarnThreshold, perSegment: msPerSegment, badThreshold: msBadThreshold, warnThreshold: msWarnThreshold, wantLit: 3, wantSeverity: "warn"},
+		{name: "ms bad boundary", val: msBadThreshold, perSegment: msPerSegment, badThreshold: msBadThreshold, warnThreshold: msWarnThreshold, wantLit: 6, wantSeverity: "bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toSegments(tt.val, tt.perSegment, tt.badThreshold, tt.warnThreshold)
+			if got.Lit != tt.wantLit {
+				t.Errorf("Lit = %d, want %d", got.Lit, tt.wantLit)
+			}
+			if got.Severity != tt.wantSeverity {
+				t.Errorf("Severity = %q, want %q", got.Severity, tt.wantSeverity)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What and why

A cleanliness audit of `server/`: grading the package on idiomatic Go, dead/stale code, project layout, and test coverage. The package is already in very good shape, so this PR is a small, surgical pass: it fills three genuine unit-test gaps on pure helpers and corrects one internal error string that contradicted its own doc comment. No behavior visible to a user or device changes.

## Audit result

**Grade: 90 → 93** (before → after)

The codebase was already excellent going in; this raises the floor on coverage and consistency rather than fixing anything broken.

### What was already clean (verified, no changes)

- `go build`, `go vet`, `staticcheck` (incl. unused), `errcheck`, and `ineffassign` all pass. The only `errcheck` hits are intentional `//nolint:errcheck` on `syscall.Flock` unlock defers.
- `deadcode -test ./...` reports zero unreachable functions. No `TODO`/`FIXME`/`XXX`/`HACK` comments anywhere.
- Project layout is idiomatic: `cmd/` binaries are thin wrappers over `internal/`, ~25 cohesive packages, no grab-bag `util` package, no circular deps.
- Static assets and templates under `internal/web/` are all referenced; docs match the code.

### Findings addressed

1. **Untested pure helpers (test gap).** Three functions with real branching logic had no unit coverage. All are now table-driven tested in the fast unit tier:
   - `signaling.SummarizeSDP`: counts `m=` and `a=candidate:` lines plus byte length, across both LF and CRLF bodies.
   - `web.toSegments`: health-bar segment clamping and warn/bad threshold selection, for both the percent and millisecond scales.
   - `email.SMTPSender.Send` CRLF header-injection guard: the check returns before any network call, so it is unit-testable. Pinned as a regression test for the injection boundary (newline in `to`, bare LF in `subject`, CR in `from`).

2. **Error string inconsistent with its contract (consistency).** `sendToConn` documents its error shape as `<label> <id>: <reason>`, and the nil-conn path already emits `"%s %s: %w"`. The buffer-full path used a divergent `"send buffer full for %s %s"`. Normalized to match. No caller depends on the old text (callers only `errors.Is` against `ErrNotConnected`).

### Findings deliberately skipped (with reasons)

- **Capitalized error strings** flagged by a reviewer (e.g. `"DATABASE_URL must be set"`): not a defect. These begin with an all-caps identifier, which `staticcheck` ST1005 explicitly allows, and lowercasing the env-var name would be wrong.
- **`errors.New` vs `fmt.Errorf` "inconsistency"** in `autodeploy/config.go`: correct as-is. `errors.New` is used for static strings and `fmt.Errorf` only where a `%s` is formatted, which is the idiomatic split.
- **`context.Background()` in grace-timer logging** (`signaling/relay.go`): these fire from detached `time.AfterFunc` callbacks after the originating request has ended; using a fresh context is appropriate and threading a cancelled request context through would be a regression.
- **Shared 15s HTTP-client timeout** in `updates/github.go` and `autodeploy/github.go`: YAGNI. Two unrelated packages each owning their own timeout constant is fine decoupling, not duplication worth coupling them over.

## Testing

- `go test ./...` passes.
- `go vet ./...` and `staticcheck` clean on the changed packages.
- New subtests confirmed to exercise the target functions (`go test -run ... -v`).