### PR TITLE
chore(digitsd): stop search tools from hiding cmd/digitsd source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ tools/build/
 artifacts/*
 
 # Compiled binaries
-pi/digitsd/digitsd
 server/bin/
 
 # rnnoise test binaries (keep lib/ and rnnoise.h)

--- a/pi/digitsd/.gitignore
+++ b/pi/digitsd/.gitignore
@@ -1,4 +1,10 @@
 bin/
 digitsd-arm64
+# Host build output. Leading slash anchors this to the module root so it
+# matches only ./digitsd, not the cmd/digitsd/ source package. (A bare
+# `digitsd` here, or `pi/digitsd/digitsd` in the repo-root .gitignore, makes
+# ripgrep/fd/editor search silently prune cmd/digitsd/ when searching from
+# this directory, even though git itself does not ignore it.)
+/digitsd
 internal/assets/embed/*
 !internal/assets/embed/.gitkeep


### PR DESCRIPTION
## Motivation

The repo-root `.gitignore` ignored the host build binary with the pattern `pi/digitsd/digitsd`. Git matches that as an exact anchored path and ignores only the file. But the `ignore` crate behind **ripgrep, fd, and editor search** (VS Code and others) treats the trailing `digitsd` component as also matching the `cmd/digitsd/` **directory** whenever the traversal root is `pi/digitsd`.

The practical effect: running a search from inside the module directory (the normal `cd pi/digitsd` workflow, where `go build`, `make`, and editors operate) silently pruned the **entire main daemon package** from results: `dispatch.go`, `main.go`, `recovery.go`, `setup.go`, `voicemail.go`, and the rest. Git never ignored those files; only the search tooling did.

Reproduction (before this change):

```
$ cd pi/digitsd && rg -l 'newDevModeManager' </dev/null | wc -l
0          # the daemon's own constructor is invisible
$ git check-ignore pi/digitsd/cmd/digitsd
           # (empty) git does NOT ignore it
```

## The change

Move the binary ignore out of the repo-root `.gitignore` and into `pi/digitsd/.gitignore` as the **anchored** `/digitsd`. A leading-slash, single-segment pattern anchored to the module root matches only `./digitsd` (the build output) and cannot collide with `cmd/digitsd/`.

After:

```
$ cd pi/digitsd && rg -l 'newDevModeManager' </dev/null | wc -l
3          # source package is searchable again
$ git check-ignore pi/digitsd/digitsd
pi/digitsd/digitsd     # build binary still ignored
```

## Why this scope

No root-level variant of the pattern avoids the mis-anchor: leading slash, trailing slash, and the original form all still prune `cmd/digitsd/` because the trailing path component is `digitsd`, the same name as the directory. The only robust fix is a single-segment anchored pattern in the module's own `.gitignore`. A short comment is added there so the anchor is not "simplified" back to a bare `digitsd` (which would reintroduce the bug). Git's ignore behavior for the binary is byte-for-byte unchanged; only the two `.gitignore` files are touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyfi27DxgGbkVBiVLdkoHP)_