### PR TITLE
fix(server): consistent JSON error on stats endpoint and calls cleanups

### DIFF
--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -205,8 +205,8 @@ func (ct *ConferenceTracker) DropMember(ctx context.Context, confID uuid.UUID, p
 	m.LeftReason = reason
 	delete(ct.memberIndex, phone)
 
-	for p := range conf.Members {
-		if conf.Members[p].LeftAt == nil {
+	for p, m := range conf.Members {
+		if m.LeftAt == nil {
 			remaining = append(remaining, p)
 		}
 	}

--- a/server/internal/calls/state_redis.go
+++ b/server/internal/calls/state_redis.go
@@ -33,6 +33,9 @@ func NewCallState(client redis.UniversalClient) *CallState {
 	return &CallState{client: client}
 }
 
+// OnCallInitiated records caller and callee as participants in callID, each
+// pointing at the other with a safety-net TTL. Redis errors are logged and
+// swallowed; the call still proceeds in memory on the originating pod.
 func (s *CallState) OnCallInitiated(ctx context.Context, callID int64, caller, callee string) {
 	now := time.Now()
 
@@ -59,6 +62,8 @@ func (s *CallState) OnCallInitiated(ctx context.Context, callID int64, caller, c
 	}
 }
 
+// OnCallEnded removes the membership link between caller and callee and prunes
+// either hash key if it is left empty. Redis errors are logged and swallowed.
 func (s *CallState) OnCallEnded(ctx context.Context, caller, callee string) {
 	pipe := s.client.Pipeline()
 	pipe.HDel(ctx, callKeyPrefix+caller, callee)
@@ -73,6 +78,10 @@ func (s *CallState) OnCallEnded(ctx context.Context, caller, callee string) {
 	s.deleteIfEmpty(ctx, callKeyPrefix+callee)
 }
 
+// ClearByNumber removes number from every call it participates in, including
+// the back-references held by its peers, and prunes any keys left empty. Used
+// to reset a phone's call state on disconnect. Redis errors are logged and
+// swallowed.
 func (s *CallState) ClearByNumber(ctx context.Context, number string) {
 	key := callKeyPrefix + number
 	entries, err := s.client.HGetAll(ctx, key).Result()
@@ -100,6 +109,8 @@ func (s *CallState) ClearByNumber(ctx context.Context, number string) {
 	}
 }
 
+// Busy reports whether number is currently in any call. On a Redis error it
+// logs and returns false, so an outage fails open rather than blocking calls.
 func (s *CallState) Busy(ctx context.Context, number string) bool {
 	n, err := s.client.Exists(ctx, callKeyPrefix+number).Result()
 	if err != nil {
@@ -109,6 +120,9 @@ func (s *CallState) Busy(ctx context.Context, number string) bool {
 	return n > 0
 }
 
+// PeerOf returns one peer number sharing a call with number, or "" if there is
+// none. With multiple peers (conference) the choice is arbitrary; use AllPeersOf
+// when every peer matters. Redis errors are logged and return "".
 func (s *CallState) PeerOf(ctx context.Context, number string) string {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
@@ -121,6 +135,8 @@ func (s *CallState) PeerOf(ctx context.Context, number string) string {
 	return ""
 }
 
+// AllPeersOf returns every number sharing a call with number. Redis errors are
+// logged and return nil.
 func (s *CallState) AllPeersOf(ctx context.Context, number string) []string {
 	keys, err := s.client.HKeys(ctx, callKeyPrefix+number).Result()
 	if err != nil {
@@ -130,6 +146,8 @@ func (s *CallState) AllPeersOf(ctx context.Context, number string) []string {
 	return keys
 }
 
+// InCall reports whether a and b are participants in the same call. On a Redis
+// error it logs and returns false.
 func (s *CallState) InCall(ctx context.Context, a, b string) bool {
 	exists, err := s.client.HExists(ctx, callKeyPrefix+a, b).Result()
 	if err != nil {
@@ -139,6 +157,9 @@ func (s *CallState) InCall(ctx context.Context, a, b string) bool {
 	return exists
 }
 
+// CallIDFor returns the ID of a call number is participating in and whether one
+// was found. With multiple peers any one call ID may be returned. Redis errors
+// are logged and return (0, false).
 func (s *CallState) CallIDFor(ctx context.Context, number string) (int64, bool) {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
@@ -155,6 +176,8 @@ func (s *CallState) CallIDFor(ctx context.Context, number string) (int64, bool) 
 	return 0, false
 }
 
+// CallIDForPair returns the ID of the call shared by a and b, checking the link
+// in both directions, or 0 if they are not in a call together or on any error.
 func (s *CallState) CallIDForPair(ctx context.Context, a, b string) int64 {
 	raw, err := s.client.HGet(ctx, callKeyPrefix+a, b).Result()
 	if err == nil {
@@ -175,6 +198,9 @@ func (s *CallState) CallIDForPair(ctx context.Context, a, b string) int64 {
 	return 0
 }
 
+// CanAddAsHost reports whether number may host a conference: it must be in
+// exactly one call and be the caller of it. Redis errors are logged and return
+// false.
 func (s *CallState) CanAddAsHost(ctx context.Context, number string) bool {
 	entries, err := s.client.HGetAll(ctx, callKeyPrefix+number).Result()
 	if err != nil {
@@ -194,6 +220,9 @@ func (s *CallState) CanAddAsHost(ctx context.Context, number string) bool {
 	return false
 }
 
+// Active scans all call keys and returns one ActiveCall per distinct call ID,
+// de-duplicating the two-sided membership entries. Keys that error mid-scan are
+// skipped; a scan error is logged and the partial result is returned.
 func (s *CallState) Active(ctx context.Context) []ActiveCall {
 	seen := make(map[int64]bool)
 	var calls []ActiveCall

--- a/server/internal/web/handler_api.go
+++ b/server/internal/web/handler_api.go
@@ -12,7 +12,7 @@ import (
 func (h *Handler) handleInternalStats(w http.ResponseWriter, r *http.Request) {
 	if h.cfg.AdminSecret == "" ||
 		subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Admin-Secret")), []byte(h.cfg.AdminSecret)) != 1 {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		jsonError(r.Context(), w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
 


### PR DESCRIPTION
## What

A small code-quality pass over the `server` module. Three focused changes:

1. `handleInternalStats` now returns its `unauthorized` response through `jsonError`. It already used `jsonError` for every other failure and returns JSON on success, so this was the one path that emitted a plain-text body.
2. `ConferenceTracker.DropMember` binds the member value in the `range` clause instead of ranging by key and re-indexing the map, matching how the rest of the `calls` package iterates member maps.
3. Documented the eleven exported methods on `CallState`. The type and its constructor were documented but the methods were not; each now records the non-obvious behavior that Redis errors are logged and swallowed in favor of a safe default (`Busy` fails open, lookups return zero values).

No behavior changes beyond the stats endpoint's error response now being structured JSON rather than plain text.

## Why

The `server` module is already in strong shape: `go build`, `go vet`, `golangci-lint` (v2, standard preset), `deadcode -test`, and `go mod tidy` all run clean, there are no stale static assets or templates, and no `TODO`/`FIXME` markers. The remaining nits were a single error-response inconsistency on a JSON endpoint, one non-idiomatic map iteration, and a coherent doc-comment gap on a cross-pod state type whose failure semantics are easy to misread. These were the genuine, high-confidence findings; broader `http.Error` usage is a deliberate per-endpoint choice (htmx/HTML handlers return text, JSON handlers return JSON) and was left alone.

## Test plan

- `go build ./...`: clean
- `go vet ./...`: clean
- `golangci-lint run ./...`: 0 issues
- `go test ./...` (unit tier): all packages pass
- The stats endpoint change keeps the same status codes; no test asserts the plain-text error bodies that changed.

## Code-quality grade

**Before: 93 / 100.  After: 94 / 100.**

The module was already near the top of the range; this pass closes the small gaps rather than restructuring anything.

| Dimension | Assessment |
| --- | --- |
| Tooling (build, vet, lint, deadcode, mod tidy) | All clean before and after. |
| Project layout | Idiomatic `cmd/` + `internal/` split with well-scoped packages; no misplaced or single-file dead packages. |
| Stale / unreferenced | None. Static assets, templates, and dependencies are all referenced; the embedded dev test client at `/test` is intentional and was left in place. |
| Idiomatic Go | Strong. One double map-lookup in a loop was the only clear outlier across ~19.5k non-test lines; now fixed. |
| Test coverage | Tiered unit + integration (build-tagged) + Playwright e2e. Low default coverage in some packages reflects DB glue exercised by integration tests, not real gaps. |
| Documentation | High and consistent, with the `CallState` method set the one notable exported-symbol gap; now documented. |

The 1-point lift reflects the closed error-response inconsistency, the idiom fix, and the documented failure semantics. The remaining distance to 100 is subjective polish (a few long setup functions like `Router`/`NewHandler`, and a dev test client shipped in the production binary) that is reasonable as-is and not worth churn.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ynTrHf8yreugqEUeLpuSn)_