### PR TITLE
refactor(server): centralize component-to-index lookup in updates

### DIFF
--- a/server/internal/updates/github.go
+++ b/server/internal/updates/github.go
@@ -205,15 +205,8 @@ func (g *GitHubReleases) fetch(ctx context.Context) (*ReleaseIndex, error) {
 			AudioURL: findAudioAsset(rel.Assets),
 		}
 
-		var ci *ComponentIndex
-		switch component {
-		case ComponentPi:
-			ci = &idx.Pi
-		case ComponentFirmware:
-			ci = &idx.Firmware
-		case ComponentServer:
-			ci = &idx.Server
-		default:
+		ci := idx.Component(component)
+		if ci == nil {
 			continue
 		}
 
@@ -321,20 +314,13 @@ func (g *GitHubReleases) ServeAudio() http.HandlerFunc {
 			return
 		}
 
-		var m map[string]*Release
-		switch component {
-		case ComponentPi:
-			m = idx.Pi.Releases
-		case ComponentFirmware:
-			m = idx.Firmware.Releases
-		case ComponentServer:
-			m = idx.Server.Releases
-		default:
+		ci := idx.Component(component)
+		if ci == nil {
 			http.NotFound(w, r)
 			return
 		}
 
-		rel, ok := m[version]
+		rel, ok := ci.Releases[version]
 		if !ok || rel.AudioURL == "" {
 			http.NotFound(w, r)
 			return

--- a/server/internal/updates/store.go
+++ b/server/internal/updates/store.go
@@ -40,20 +40,31 @@ type ComponentIndex struct {
 	Releases map[string]*Release `json:"releases"`
 }
 
-// SortedReleases returns releases for the given component sorted newest-first.
-// Returns nil for unknown components.
-func (idx *ReleaseIndex) SortedReleases(component string) []Release {
-	var m map[string]*Release
+// Component returns the ComponentIndex for the given component selector, or
+// nil for an unrecognized one. It is the single place that maps a component
+// string to its field on the index; lookups and the release fetch all route
+// through it so a new component is wired up in exactly one switch.
+func (idx *ReleaseIndex) Component(component string) *ComponentIndex {
 	switch component {
 	case ComponentPi:
-		m = idx.Pi.Releases
+		return &idx.Pi
 	case ComponentFirmware:
-		m = idx.Firmware.Releases
+		return &idx.Firmware
 	case ComponentServer:
-		m = idx.Server.Releases
+		return &idx.Server
 	default:
 		return nil
 	}
+}
+
+// SortedReleases returns releases for the given component sorted newest-first.
+// Returns nil for unknown components.
+func (idx *ReleaseIndex) SortedReleases(component string) []Release {
+	ci := idx.Component(component)
+	if ci == nil {
+		return nil
+	}
+	m := ci.Releases
 	releases := make([]Release, 0, len(m))
 	for _, r := range m {
 		releases = append(releases, *r)


### PR DESCRIPTION
## What

The mapping from a component selector (`pi` / `firmware` / `server`) to its field on `ReleaseIndex` was open-coded as the same three-case `switch` in three places:

- `store.go` `SortedReleases`
- `github.go` `fetch` (the release-build loop)
- `github.go` `ServeAudio` (the audio-proxy handler)

This change introduces one `ReleaseIndex.Component(component string) *ComponentIndex` method that returns the matching component index (or `nil` for an unknown selector), and routes all three call sites through it. Each site collapses to a lookup plus a nil check.

## Why this scope

The three switches were identical in intent and drifted only in shape (one took the address of the field, two read `.Releases` off it). Keeping the component set in one switch removes a real maintenance hazard: adding or renaming a component previously meant editing all three in lockstep, with no compiler help if one was missed. The new method is the single source of truth for that mapping.

Behavior is unchanged: unknown selectors still produce the same `nil` / `continue` / `404` outcomes they did before.

## Test plan

- `go build ./...`: clean
- `go vet ./...`: clean
- `go test ./...`: all packages pass (including `internal/updates` `TestSortedReleases`, `TestSortedReleases_UnknownComponent`, `TestRangeReleases`)
- `golangci-lint run ./...`: 0 issues