### PR TITLE
refactor(digitsd): collapse devmode flag accessors to IsSet/Set

### DIFF
--- a/pi/digitsd/cmd/digitsd/devmode.go
+++ b/pi/digitsd/cmd/digitsd/devmode.go
@@ -211,9 +211,9 @@ func devModeStatusHandler(cfg *devModeConfig) http.HandlerFunc {
 			"online":             status.Online,
 			"phone_number":       status.PhoneNumber,
 			"config_auto_update": status.ConfigAutoUpdate,
-			"dev_mode":           devmode.Enabled(cfg.FlagPath),
-			"skip_fw_reflash":    devmode.SkipFWReflash(cfg.SkipFWReflashPath),
-			"skip_auto_update":   devmode.SkipAutoUpdate(cfg.SkipAutoUpdatePath),
+			"dev_mode":           devmode.IsSet(cfg.FlagPath),
+			"skip_fw_reflash":    devmode.IsSet(cfg.SkipFWReflashPath),
+			"skip_auto_update":   devmode.IsSet(cfg.SkipAutoUpdatePath),
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp) //nolint:errcheck
@@ -238,15 +238,11 @@ func devModeToggleHandler(cfg *devModeConfig) http.HandlerFunc {
 		var err error
 		switch req.Name {
 		case "devmode":
-			if req.Enabled {
-				err = devmode.Enable(cfg.FlagPath)
-			} else {
-				err = devmode.Disable(cfg.FlagPath)
-			}
+			err = devmode.Set(cfg.FlagPath, req.Enabled)
 		case "fw_reflash":
-			err = devmode.SetSkipFWReflash(cfg.SkipFWReflashPath, req.Enabled)
+			err = devmode.Set(cfg.SkipFWReflashPath, req.Enabled)
 		case "auto_update":
-			err = devmode.SetSkipAutoUpdate(cfg.SkipAutoUpdatePath, req.Enabled)
+			err = devmode.Set(cfg.SkipAutoUpdatePath, req.Enabled)
 		default:
 			http.Error(w, "unknown toggle: "+req.Name, http.StatusBadRequest)
 			return

--- a/pi/digitsd/cmd/digitsd/devmode_test.go
+++ b/pi/digitsd/cmd/digitsd/devmode_test.go
@@ -125,7 +125,7 @@ func TestDevModeStatusHandler(t *testing.T) {
 			}
 		},
 	}
-	_ = devmode.Enable(cfg.FlagPath)
+	_ = devmode.Set(cfg.FlagPath, true)
 
 	h := devModeStatusHandler(cfg)
 	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
@@ -191,7 +191,7 @@ func TestDevModeToggleHandler_DevMode(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("enable: status code = %d, want 200", w.Code)
 	}
-	if !devmode.Enabled(cfg.FlagPath) {
+	if !devmode.IsSet(cfg.FlagPath) {
 		t.Error("dev-mode flag not created")
 	}
 
@@ -205,7 +205,7 @@ func TestDevModeToggleHandler_DevMode(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("disable: status code = %d, want 200", w.Code)
 	}
-	if devmode.Enabled(cfg.FlagPath) {
+	if devmode.IsSet(cfg.FlagPath) {
 		t.Error("dev-mode flag not removed")
 	}
 }
@@ -228,7 +228,7 @@ func TestDevModeToggleHandler_FWReflash(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status code = %d, want 200", w.Code)
 	}
-	if !devmode.SkipFWReflash(cfg.SkipFWReflashPath) {
+	if !devmode.IsSet(cfg.SkipFWReflashPath) {
 		t.Error("skip-fw-reflash flag not created")
 	}
 }
@@ -251,7 +251,7 @@ func TestDevModeToggleHandler_AutoUpdate(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status code = %d, want 200", w.Code)
 	}
-	if !devmode.SkipAutoUpdate(cfg.SkipAutoUpdatePath) {
+	if !devmode.IsSet(cfg.SkipAutoUpdatePath) {
 		t.Error("skip-auto-update flag not created")
 	}
 }

--- a/pi/digitsd/cmd/digitsd/dispatch.go
+++ b/pi/digitsd/cmd/digitsd/dispatch.go
@@ -500,7 +500,7 @@ func (d *daemonCallbacks) handleSignal(msg *sigclient.Message) {
 		}
 
 		au := msg.LineSettings.AutoUpdate
-		if devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+		if devmode.IsSet(devmode.DefaultSkipAutoUpdatePath) {
 			slog.Info("line_settings: ignoring server auto_update push (dev-mode skip flag)", "server_wants", au)
 		} else if au != d.autoUpdateEnabled.Load() {
 			d.autoUpdateEnabled.Store(au)

--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -292,7 +292,7 @@ func (d *daemonCallbacks) setFirmwareVersion(version, commit string) {
 // is not present. Every place that decides to trigger an update gates on this
 // so the two-part policy stays in one spot.
 func (d *daemonCallbacks) autoUpdateAllowed() bool {
-	return d.autoUpdateEnabled.Load() && !devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath)
+	return d.autoUpdateEnabled.Load() && !devmode.IsSet(devmode.DefaultSkipAutoUpdatePath)
 }
 
 // sendSignal sends a signaling message and logs failures.
@@ -1422,7 +1422,7 @@ func main() {
 	if postOk && fwVersion != "" {
 		bundled := readBundledFirmwareVersion()
 		needsReflash := firmwareNeedsReflash(fwVersion, bundled)
-		skipReflash := devmode.SkipFWReflash(devmode.DefaultSkipFWReflashPath)
+		skipReflash := devmode.IsSet(devmode.DefaultSkipFWReflashPath)
 		if needsReflash && skipReflash {
 			slog.Info("firmware reflash: skip flag present, keeping current Pico firmware",
 				"pico", fwVersion, "bundled", bundled)
@@ -1919,7 +1919,7 @@ func main() {
 	if cb.autoUpdateAllowed() {
 		slog.Info("auto-update: enabled, checking for updates on startup")
 		go cb.triggerAutoUpdate()
-	} else if devmode.SkipAutoUpdate(devmode.DefaultSkipAutoUpdatePath) {
+	} else if devmode.IsSet(devmode.DefaultSkipAutoUpdatePath) {
 		slog.Info("auto-update: suppressed by dev-mode skip flag")
 	}
 
@@ -2042,7 +2042,7 @@ func main() {
 	}
 	cb.devMode = newDevModeManager(devCfg)
 	defer cb.devMode.Close()
-	if devmode.Enabled(devmode.DefaultFlagPath) {
+	if devmode.IsSet(devmode.DefaultFlagPath) {
 		slog.Info("devmode: flag present, starting dev-mode web UI")
 		if err := cb.devMode.EnsureListener(); err != nil {
 			slog.Warn("devmode: failed to start web UI", "error", err)
@@ -2488,7 +2488,7 @@ func requestICEServers(sig *sigclient.Client) {
 
 func sendDeviceInfo(sig *sigclient.Client, fwVersion, fwCommit string) {
 	localAddr := primaryLocalAddr()
-	devModeOn := devmode.Enabled(devmode.DefaultFlagPath)
+	devModeOn := devmode.IsSet(devmode.DefaultFlagPath)
 	if err := sig.Send(&sigclient.Message{
 		Type:            sigclient.TypeDeviceInfo,
 		PiVersion:       version.Version,

--- a/pi/digitsd/internal/devmode/devmode.go
+++ b/pi/digitsd/internal/devmode/devmode.go
@@ -9,24 +9,25 @@ import (
 	"path/filepath"
 )
 
-// Default paths on the device data partition.
+// Default paths on the device data partition. The path identifies the flag;
+// IsSet and Set work on any of them.
 const (
 	DefaultFlagPath           = "/data/digits/dev-mode"
 	DefaultSkipFWReflashPath  = "/data/digits/skip-fw-reflash"
 	DefaultSkipAutoUpdatePath = "/data/digits/skip-auto-update"
 )
 
-// flagSet reports whether a flag file exists at path.
-func flagSet(path string) bool {
+// IsSet reports whether the flag file at path exists.
+func IsSet(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
 
-// setFlag creates or removes a flag file. When set is true the file is
-// created (parent dirs included); when false the file is removed. Removing
-// a file that does not exist is not an error.
-func setFlag(path string, set bool) error {
-	if set {
+// Set creates or removes the flag file at path. When on is true the file is
+// created (parent dirs included); when false it is removed. Removing a file
+// that does not exist is not an error.
+func Set(path string, on bool) error {
+	if on {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
@@ -38,15 +39,3 @@ func setFlag(path string, set bool) error {
 	}
 	return err
 }
-
-// Public API -- each flag gets its own named accessor so call sites are
-// grep-friendly. The underlying check is identical (presence of a flat file
-// at the given path).
-
-func Enabled(path string) bool                       { return flagSet(path) }
-func Enable(path string) error                       { return setFlag(path, true) }
-func Disable(path string) error                      { return setFlag(path, false) }
-func SkipFWReflash(path string) bool                 { return flagSet(path) }
-func SetSkipFWReflash(path string, skip bool) error  { return setFlag(path, skip) }
-func SkipAutoUpdate(path string) bool                { return flagSet(path) }
-func SetSkipAutoUpdate(path string, skip bool) error { return setFlag(path, skip) }

--- a/pi/digitsd/internal/devmode/devmode_test.go
+++ b/pi/digitsd/internal/devmode/devmode_test.go
@@ -6,90 +6,70 @@ import (
 	"testing"
 )
 
-func TestEnabled_MissingFile(t *testing.T) {
+func TestIsSet_MissingFile(t *testing.T) {
 	dir := t.TempDir()
-	if Enabled(filepath.Join(dir, "dev-mode")) {
-		t.Error("Enabled returned true for missing file")
+	if IsSet(filepath.Join(dir, "dev-mode")) {
+		t.Error("IsSet returned true for missing file")
 	}
 }
 
-func TestEnable_CreatesFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "dev-mode")
-	if err := Enable(path); err != nil {
-		t.Fatal(err)
-	}
-	if !Enabled(path) {
-		t.Error("Enabled returned false after Enable")
-	}
-}
-
-func TestDisable_RemovesFile(t *testing.T) {
+func TestSet_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dev-mode")
-	if err := Enable(path); err != nil {
+	if err := Set(path, true); err != nil {
 		t.Fatal(err)
 	}
-	if err := Disable(path); err != nil {
-		t.Fatal(err)
-	}
-	if Enabled(path) {
-		t.Error("Enabled returned true after Disable")
+	if !IsSet(path) {
+		t.Error("IsSet returned false after Set(true)")
 	}
 }
 
-func TestDisable_NoErrorWhenMissing(t *testing.T) {
+func TestSet_RemovesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "dev-mode")
-	if err := Disable(path); err != nil {
-		t.Errorf("Disable on missing file returned error: %v", err)
+	if err := Set(path, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := Set(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if IsSet(path) {
+		t.Error("IsSet returned true after Set(false)")
 	}
 }
 
-func TestSkipFWReflash(t *testing.T) {
+func TestSet_NoErrorWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dev-mode")
+	if err := Set(path, false); err != nil {
+		t.Errorf("Set(false) on missing file returned error: %v", err)
+	}
+}
+
+func TestSet_Roundtrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "skip-fw-reflash")
-	if SkipFWReflash(path) {
-		t.Error("SkipFWReflash returned true for missing file")
+	if IsSet(path) {
+		t.Error("IsSet returned true for missing file")
 	}
-	if err := SetSkipFWReflash(path, true); err != nil {
+	if err := Set(path, true); err != nil {
 		t.Fatal(err)
 	}
-	if !SkipFWReflash(path) {
-		t.Error("SkipFWReflash returned false after SetSkipFWReflash(true)")
+	if !IsSet(path) {
+		t.Error("IsSet returned false after Set(true)")
 	}
-	if err := SetSkipFWReflash(path, false); err != nil {
+	if err := Set(path, false); err != nil {
 		t.Fatal(err)
 	}
-	if SkipFWReflash(path) {
-		t.Error("SkipFWReflash returned true after SetSkipFWReflash(false)")
+	if IsSet(path) {
+		t.Error("IsSet returned true after Set(false)")
 	}
 }
 
-func TestSkipAutoUpdate(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "skip-auto-update")
-	if SkipAutoUpdate(path) {
-		t.Error("SkipAutoUpdate returned true for missing file")
-	}
-	if err := SetSkipAutoUpdate(path, true); err != nil {
-		t.Fatal(err)
-	}
-	if !SkipAutoUpdate(path) {
-		t.Error("SkipAutoUpdate returned false after set true")
-	}
-	if err := SetSkipAutoUpdate(path, false); err != nil {
-		t.Fatal(err)
-	}
-	if SkipAutoUpdate(path) {
-		t.Error("SkipAutoUpdate returned true after set false")
-	}
-}
-
-func TestEnable_CreatesDirIfNeeded(t *testing.T) {
+func TestSet_CreatesDirIfNeeded(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "dev-mode")
-	if err := Enable(path); err != nil {
+	if err := Set(path, true); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); err != nil {


### PR DESCRIPTION
## What

The `devmode` package exposed seven public functions:

```go
func Enabled(path string) bool
func Enable(path string) error
func Disable(path string) error
func SkipFWReflash(path string) bool
func SetSkipFWReflash(path string, skip bool) error
func SkipAutoUpdate(path string) bool
func SetSkipAutoUpdate(path string, skip bool) error
```

Each one took the flag's path as an argument and forwarded to the private `flagSet`/`setFlag` helpers. This PR collapses them to two honest predicates and updates every call site:

```go
func IsSet(path string) bool
func Set(path string, on bool) error
```

## Why

The "each flag gets its own named accessor so call sites are grep-friendly" comment was misleading. The flag's identity is carried entirely by the `path` argument (and the `Default*Path` constants already name it), not by the function name. As a result:

- The three getters (`Enabled`, `SkipFWReflash`, `SkipAutoUpdate`) were byte-identical: each was `return flagSet(path)`.
- Two of the setters (`SetSkipFWReflash`, `SetSkipAutoUpdate`) were byte-identical too.
- The named accessors gave a false impression of type safety: nothing stopped `SkipFWReflash(cfg.FlagPath)` from compiling and checking the wrong flag.

At the call sites the function name just duplicated the path constant, e.g. `devmode.SkipFWReflash(devmode.DefaultSkipFWReflashPath)`. After the change that reads `devmode.IsSet(devmode.DefaultSkipFWReflashPath)`, with the flag named once. The toggle handler's enable/disable branch folds into a single `devmode.Set(path, req.Enabled)`.

This is a pure internal restructuring with no user- or device-visible change (the on-disk flag files and their semantics are untouched), hence `refactor`.

## Test plan

- `make embed && go build ./...` clean.
- `go test -race ./...` passes; the package's own tests were rewritten against the new API with the same coverage (missing-file, set/unset round-trip, remove-when-absent is not an error, parent-dir creation).
- `golangci-lint run ./...` reports 0 issues.