### PR TITLE
refactor(digitsd): drop subsystem.IsReady free-function wrapper

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1178,7 +1178,7 @@ func main() {
 		// serial subsystem has brought the Pico up (flashing it if needed), so
 		// the phase byte the firmware wrote when * was held is readable here.
 		// Setup mode is pre-pairing, so pass an empty device token.
-		if subsystem.IsReady(serial) {
+		if serial.IsReady() {
 			if sp := serial.Port(); sp != nil {
 				if phase, err := queryPicoPhase(sp); err != nil {
 					slog.Error("setup: phase query failed, proceeding without panic-button check", "error", err)

--- a/pi/digitsd/cmd/digitsd/recovery.go
+++ b/pi/digitsd/cmd/digitsd/recovery.go
@@ -172,11 +172,11 @@ func runRecoveryMode(web *subsystem.WebModule, serial *subsystem.SerialModule, a
 
 	var sp *phone.SerialPort
 	var mixer *audio.Mixer
-	if serial != nil && subsystem.IsReady(serial) {
+	if serial != nil && serial.IsReady() {
 		sp = serial.Port()
 		sp.StateSet("RECOVERY")
 	}
-	if audioMod != nil && subsystem.IsReady(audioMod) {
+	if audioMod != nil && audioMod.IsReady() {
 		mixer = audioMod.Mixer()
 	}
 

--- a/pi/digitsd/cmd/digitsd/setup.go
+++ b/pi/digitsd/cmd/digitsd/setup.go
@@ -37,7 +37,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		slog.Warn("setup: failed to clear boot counter", "error", err)
 	}
 
-	if serial != nil && subsystem.IsReady(serial) {
+	if serial != nil && serial.IsReady() {
 		serial.Port().StateSet("SETUP")
 	}
 
@@ -111,7 +111,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "verifying"}) //nolint:errcheck
 
-		if serial != nil && subsystem.IsReady(serial) {
+		if serial != nil && serial.IsReady() {
 			serial.Port().LED("LOCK")
 			serial.Port().LED("CONNECTING")
 		}
@@ -124,14 +124,14 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 					state.verifying = false
 					state.lastAttempt = &wifi.VerifyResult{Error: fmt.Sprintf("internal error: %v", r)}
 					state.mu.Unlock()
-					if serial != nil && subsystem.IsReady(serial) {
+					if serial != nil && serial.IsReady() {
 						serial.Port().LED("UNLOCK")
 					}
 				}
 			}()
 
 			slog.Info("setup: verifying WiFi credentials", "ssid", req.SSID)
-			if audio != nil && subsystem.IsReady(audio) {
+			if audio != nil && audio.IsReady() {
 				audio.Mixer().PlayOnce("wifi_connecting")
 				waitForOnceComplete(audio.Mixer(), 5*time.Second)
 			}
@@ -154,20 +154,20 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 
 			if result.Connected && result.Error == "" {
 				slog.Info("setup: WiFi configured, rebooting")
-				if serial != nil && subsystem.IsReady(serial) {
+				if serial != nil && serial.IsReady() {
 					serial.Port().LED("UNLOCK")
 					serial.Port().LED("ON")
 				}
-				if audio != nil && subsystem.IsReady(audio) {
+				if audio != nil && audio.IsReady() {
 					audio.Mixer().PlayOnce("wifi_connected")
 					waitForOnceComplete(audio.Mixer(), 10*time.Second)
 				}
 				doReboot()
 			} else {
-				if serial != nil && subsystem.IsReady(serial) {
+				if serial != nil && serial.IsReady() {
 					serial.Port().LED("UNLOCK")
 				}
-				if audio != nil && subsystem.IsReady(audio) {
+				if audio != nil && audio.IsReady() {
 					audio.Mixer().PlayOnce("wifi_failed")
 				}
 			}
@@ -178,7 +178,7 @@ func runSetupMode(web *subsystem.WebModule, serial *subsystem.SerialModule, audi
 
 	// Voice prompt loop: when the user picks up the handset, play setup
 	// instructions on a timer, similar to recovery's voice menu.
-	if serial != nil && subsystem.IsReady(serial) && audio != nil && subsystem.IsReady(audio) {
+	if serial != nil && serial.IsReady() && audio != nil && audio.IsReady() {
 		go setupVoiceLoop(serial, audio)
 	}
 

--- a/pi/digitsd/internal/subsystem/module.go
+++ b/pi/digitsd/internal/subsystem/module.go
@@ -41,10 +41,6 @@ type Module interface {
 	Shutdown(ctx context.Context) error
 }
 
-// IsReady is a convenience wrapper so callers that hold a Module can write
-// `subsystem.IsReady(m)` to match the natural "is X ready?" reading order.
-func IsReady(m Module) bool { return m.IsReady() }
-
 // Registration declares a module and how the Manager should treat it.
 // The zero value is the common case: enabled, not required, no deps. Set
 // Disabled to register a module that the Manager should skip but still report


### PR DESCRIPTION
## What

`internal/subsystem` exported a package-level free function:

```go
// IsReady is a convenience wrapper so callers that hold a Module can write
// `subsystem.IsReady(m)` to match the natural "is X ready?" reading order.
func IsReady(m Module) bool { return m.IsReady() }
```

It is deleted, and the thirteen call sites now call the method directly, e.g.
`subsystem.IsReady(serial)` becomes `serial.IsReady()`.

## Why

The free function did nothing the interface method `Module.IsReady()` did not already do: it took a `Module` and returned `m.IsReady()`. Worse, it shadowed that method with an identically named package symbol, so the codebase had two spellings for the same question. A direct `serial.IsReady()` reads at least as naturally as `subsystem.IsReady(serial)` and is shorter, so the wrapper was pure indirection.

Every call site already holds a concrete `*subsystem.SerialModule` or `*subsystem.AudioModule` (both implement `IsReady`), so the conversion is mechanical and the `!= nil` guards in front of the calls are unchanged.

Pure internal restructuring with no user- or device-visible change, hence `refactor`.

## Test plan

- `make embed && go build ./...` clean.
- `go test ./...` passes.
- `golangci-lint run ./...` reports 0 issues.