### PR TITLE
refactor(server): drop healthLifecycle interface over *HealthStore

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -59,16 +59,6 @@ type ActiveCall struct {
 	StartedAt time.Time
 }
 
-// healthLifecycle is the subset of *HealthStore that Tracker drives for
-// per-session lifecycle. Init/Evict handle 2-party calls; InitConference/
-// EvictConference handle 3-way conferences.
-type healthLifecycle interface {
-	Init(callID int64)
-	Evict(callID int64)
-	InitConference(confID uuid.UUID)
-	EvictConference(confID uuid.UUID)
-}
-
 // dashNotifier is the subset of *dashboard/events.Broadcaster the Tracker
 // uses to wake dashboard SSE subscribers when active-call count changes.
 // Optional; nil disables notifications.
@@ -90,7 +80,7 @@ type Tracker struct {
 	mu          sync.Mutex
 	active      map[string]*ActiveCall // "caller→callee" → call
 	conferences *ConferenceTracker
-	health      healthLifecycle
+	health      *HealthStore
 	dashEvents  dashNotifier
 	callEndObs  callEndObserver
 	state       *CallState
@@ -114,7 +104,7 @@ func (t *Tracker) Conferences() *ConferenceTracker {
 
 // SetHealthStore registers an optional health store for per-call lifecycle
 // management. Safe to call once at startup; subsequent calls overwrite.
-func (t *Tracker) SetHealthStore(h healthLifecycle) {
+func (t *Tracker) SetHealthStore(h *HealthStore) {
 	t.mu.Lock()
 	t.health = h
 	t.mu.Unlock()


### PR DESCRIPTION
## What

Removes the `healthLifecycle` interface in `internal/calls/tracker.go` and uses `*HealthStore` directly for the `Tracker.health` field and the `SetHealthStore` parameter.

## Why

`healthLifecycle` declared the subset of `*HealthStore` that `Tracker` drives, but it earned nothing:

- **Same package.** `HealthStore` lives in `internal/calls` alongside `Tracker`, so the interface breaks no import cycle (unlike its sibling `dashNotifier`, which abstracts `*events.Broadcaster` from another package and *is* mocked in tests, and `callEndObserver`, which breaks the signaling import cycle. Both of those stay).
- **One implementation, never mocked.** Every `SetHealthStore` caller, in production (`cmd/signald/main.go`) and in tests (`conference_integration_test.go`, `web/testhelpers_integration_test.go`), passes a concrete `*HealthStore`. No test substitutes a fake.

So the only thing the interface added was an extra hop when reading what `t.health` is. Pointing the field and setter at `*HealthStore` removes that indirection.

## Safety

The call sites read `h := t.health` under the lock and nil-check before use; a nil `*HealthStore` behaves identically to a nil interface there, so behavior is unchanged. Build, `go test ./...`, `go vet`, and golangci-lint all pass.