### PR TITLE
fix(server): stop counting unreachable dials as signaling errors

### DIFF
--- a/server/docs/metrics.md
+++ b/server/docs/metrics.md
@@ -50,13 +50,15 @@ All metric names are prefixed with `digits_signald_`.
 ### Signaling errors (signald only)
 
 - `digits_signald_signaling_errors_total{category}` (counter): signaling
-  errors observed by the relay. `category` is a closed set defined in code
+  errors observed by the relay. The set counts genuine server-side faults
+  only: normal user behavior, such as dialing a phone that is offline or
+  unregistered (and the SDP/ICE/DTMF that trails such a dial), is not an
+  error and is not counted. `category` is a closed set defined in code
   (see `internal/metrics/metrics.go`):
-  - `peer_unreachable`: a CALL was sent to a phone not connected.
   - `auth_failed`: the call authorizer denied the call.
   - `call_setup_failed`: the tracker failed to record a call initiation.
-  - `invalid_message`: the relay received a malformed or out-of-context
-    message (e.g. `ICE_RESTART` with no active call).
+  - `invalid_message`: the relay received a malformed message (e.g. one with
+    no destination).
   - `relay_delivery`: a forward to a peer's WebSocket failed.
   - `turn_alloc_failed`, `ice_timeout`: reserved for future use.
   - Any value not in the closed set collapses to `other`. The relay

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -186,7 +186,6 @@ func (r *Registry) RegisterCallsGauge(read func() float64) {
 var validErrorCategories = map[string]struct{}{
 	"turn_alloc_failed": {},
 	"ice_timeout":       {},
-	"peer_unreachable":  {},
 	"call_setup_failed": {},
 	"auth_failed":       {},
 	"invalid_message":   {},

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -556,7 +556,7 @@ func (r *Relay) handleSignalingForward(ctx context.Context, from string, msg *Me
 		// SDP/ICE for a call that isn't active: the peer was never reachable
 		// (dialed an offline or unregistered number) or the call already ended
 		// and candidates are still trickling in. Both are normal, not errors.
-		slog.DebugContext(ctx, msg.Type+" without active call", "from", from, "to", msg.To)
+		slog.DebugContext(ctx, "signaling without active call", "type", msg.Type, "from", from, "to", msg.To)
 		return
 	}
 	var callID int64

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -380,7 +380,24 @@ func (r *Relay) inCallOrConference(ctx context.Context, from, to string) bool {
 	return false
 }
 
+// rejectNoDest reports a relay message that names no destination and returns
+// true if the caller should stop. An empty To is a malformed message
+// (invalid_message): a genuine fault, distinct from a valid destination with
+// no active call. It is checked before the active-call guard so it is counted
+// rather than collapsing into that guard's benign drop.
+func (r *Relay) rejectNoDest(ctx context.Context, from string, msg *Message) bool {
+	if msg.To != "" {
+		return false
+	}
+	slog.WarnContext(ctx, "no destination for message", "type", msg.Type, "from", from)
+	r.observeError("invalid_message")
+	return true
+}
+
 func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
+	if r.rejectNoDest(ctx, from, msg) {
+		return
+	}
 	if !r.inCallOrConference(ctx, from, msg.To) {
 		// Stray control/media for a call that isn't active (raced past teardown,
 		// or trailing a dial to an unreachable number) is normal, not an error.
@@ -399,16 +416,14 @@ func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
 const iceRestartDeliveryTimeout = 2 * time.Second
 
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
+	if r.rejectNoDest(ctx, from, msg) {
+		return
+	}
 	if !r.inCallOrConference(ctx, from, msg.To) {
 		// Recovery raced past call teardown: tell the client there's no call to
 		// restart, but don't count it as a signaling fault.
 		slog.DebugContext(ctx, "ice_restart without active call", "from", from, "to", msg.To)
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
-		return
-	}
-	if msg.To == "" {
-		slog.WarnContext(ctx, "no destination for ice_restart", "from", from)
-		r.observeError("invalid_message")
 		return
 	}
 	// Bounded retry so the offer is not silently dropped when the peer's send
@@ -421,6 +436,9 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 }
 
 func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
+	if r.rejectNoDest(ctx, from, msg) {
+		return
+	}
 	if !r.inCallOrConference(ctx, from, msg.To) {
 		// Answer landing after the caller already hung up is a benign race, not
 		// an error.
@@ -530,6 +548,9 @@ func (r *Relay) endActiveCallsAsHangup(ctx context.Context, number string) {
 // empty and omitted from the encoded message, so the wire format per type
 // is unchanged.
 func (r *Relay) handleSignalingForward(ctx context.Context, from string, msg *Message) {
+	if r.rejectNoDest(ctx, from, msg) {
+		return
+	}
 	if msg.Extension && r.routeExtensionSignaling(ctx, from, msg) {
 		return
 	}
@@ -1007,12 +1028,9 @@ func (r *Relay) HandleRemoteReconnect(number, hardwareID string) {
 	r.cancelGraceLocal(number, hardwareID)
 }
 
+// forward sends msg to msg.To. Callers must reject an empty destination first
+// (see rejectNoDest); forward assumes a non-empty To.
 func (r *Relay) forward(ctx context.Context, msg *Message) {
-	if msg.To == "" {
-		slog.WarnContext(ctx, "no destination for message", "type", msg.Type, "from", msg.From)
-		r.observeError("invalid_message")
-		return
-	}
 	if err := r.Hub.SendTo(msg.To, msg); err != nil {
 		slog.ErrorContext(ctx, "forward failed", "to", msg.To, "err", err)
 		r.observeError("relay_delivery")

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -312,7 +312,9 @@ func (r *Relay) handleCall(ctx context.Context, from string, msg *Message) {
 			_ = r.Hub.SendTo(from, &Message{Type: TypeBusy, From: msg.To})
 			return
 		}
-		r.observeError("peer_unreachable")
+		// Dialing a phone that is offline or unregistered is normal user
+		// behavior, not a signaling fault: just tell the caller it didn't
+		// connect. It must not count toward signaling_errors_total.
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "phone not connected"})
 		return
 	}
@@ -380,8 +382,9 @@ func (r *Relay) inCallOrConference(ctx context.Context, from, to string) bool {
 
 func (r *Relay) handleDTMF(ctx context.Context, from string, msg *Message) {
 	if !r.inCallOrConference(ctx, from, msg.To) {
-		slog.WarnContext(ctx, "dtmf without active call", "from", from, "to", msg.To)
-		r.observeError("invalid_message")
+		// Stray control/media for a call that isn't active (raced past teardown,
+		// or trailing a dial to an unreachable number) is normal, not an error.
+		slog.DebugContext(ctx, "dtmf without active call", "from", from, "to", msg.To)
 		return
 	}
 	r.forward(ctx, msg)
@@ -397,8 +400,9 @@ const iceRestartDeliveryTimeout = 2 * time.Second
 
 func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message) {
 	if !r.inCallOrConference(ctx, from, msg.To) {
-		slog.WarnContext(ctx, "ice_restart without active call", "from", from, "to", msg.To)
-		r.observeError("invalid_message")
+		// Recovery raced past call teardown: tell the client there's no call to
+		// restart, but don't count it as a signaling fault.
+		slog.DebugContext(ctx, "ice_restart without active call", "from", from, "to", msg.To)
 		_ = r.Hub.SendTo(from, &Message{Type: TypeError, Error: "no active call"})
 		return
 	}
@@ -418,8 +422,9 @@ func (r *Relay) handleICERestart(ctx context.Context, from string, msg *Message)
 
 func (r *Relay) handleAnswer(ctx context.Context, from string, msg *Message) {
 	if !r.inCallOrConference(ctx, from, msg.To) {
-		slog.WarnContext(ctx, "answer without active call", "from", from, "to", msg.To)
-		r.observeError("invalid_message")
+		// Answer landing after the caller already hung up is a benign race, not
+		// an error.
+		slog.DebugContext(ctx, "answer without active call", "from", from, "to", msg.To)
 		return
 	}
 
@@ -548,8 +553,10 @@ func (r *Relay) handleSignalingForward(ctx context.Context, from string, msg *Me
 		}
 	}
 	if !r.inCallOrConference(ctx, from, msg.To) {
-		slog.WarnContext(ctx, msg.Type+" without active call", "from", from, "to", msg.To)
-		r.observeError("invalid_message")
+		// SDP/ICE for a call that isn't active: the peer was never reachable
+		// (dialed an offline or unregistered number) or the call already ended
+		// and candidates are still trickling in. Both are normal, not errors.
+		slog.DebugContext(ctx, msg.Type+" without active call", "from", from, "to", msg.To)
 		return
 	}
 	var callID int64

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1162,7 +1162,7 @@ func (f *fakeErrorObserver) ObserveSignalingError(category string) {
 	f.seen = append(f.seen, category)
 }
 
-func TestRelayObservesPeerUnreachableOnOfflineCall(t *testing.T) {
+func TestRelayDoesNotErrorOnOfflineCall(t *testing.T) {
 	hub := NewHub()
 	obs := &fakeErrorObserver{}
 	relay := NewRelay(hub, nil, nil, nil)
@@ -1172,8 +1172,22 @@ func TestRelayObservesPeerUnreachableOnOfflineCall(t *testing.T) {
 	_ = hub.Register("3140001", conn1)
 	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeCall, To: "3140099"})
 
-	if len(obs.seen) != 1 || obs.seen[0] != "peer_unreachable" {
-		t.Fatalf("expected peer_unreachable, got %v", obs.seen)
+	// Dialing an offline or unregistered number is normal user behavior. The
+	// caller is told it didn't connect, but nothing is counted as an error.
+	select {
+	case data := <-conn1.Send:
+		msg, err := ParseMessage(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if msg.Type != TypeError || msg.Error != "phone not connected" {
+			t.Fatalf("expected 'phone not connected' error, got %s/%q", msg.Type, msg.Error)
+		}
+	default:
+		t.Fatal("caller did not receive a not-connected reply")
+	}
+	if len(obs.seen) != 0 {
+		t.Fatalf("dialing an unreachable number must not be recorded as an error, got %v", obs.seen)
 	}
 }
 
@@ -1196,18 +1210,29 @@ func TestRelayObservesAuthFailedWhenAuthorizerDenies(t *testing.T) {
 	}
 }
 
-func TestRelayObservesInvalidMessageOnICERestartWithoutCall(t *testing.T) {
-	hub := NewHub()
-	obs := &fakeErrorObserver{}
-	relay := NewRelay(hub, newMockTracker(), nil, nil)
-	relay.Errors = obs
+func TestRelayDoesNotErrorOnSignalingWithoutCall(t *testing.T) {
+	// Stray control/media for a call that isn't active (raced past teardown or
+	// trailing a dial to an unreachable number) is normal and must not be
+	// recorded as a signaling error.
+	for _, msg := range []*Message{
+		{Type: TypeICERestart, To: "3140002"},
+		{Type: TypeDTMF, To: "3140002", Digit: "5"},
+		{Type: TypeAnswer, To: "3140002"},
+		{Type: TypeSDP, To: "3140002", SDP: "v=0\r\n"},
+		{Type: TypeICE, To: "3140002", Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"},
+	} {
+		hub := NewHub()
+		obs := &fakeErrorObserver{}
+		relay := NewRelay(hub, newMockTracker(), nil, nil)
+		relay.Errors = obs
 
-	conn1 := &Conn{Send: make(chan []byte, 10)}
-	_ = hub.Register("3140001", conn1)
-	relay.HandleMessage(context.Background(), "3140001", &Message{Type: TypeICERestart, To: "3140002"})
+		conn1 := &Conn{Send: make(chan []byte, 10)}
+		_ = hub.Register("3140001", conn1)
+		relay.HandleMessage(context.Background(), "3140001", msg)
 
-	if len(obs.seen) != 1 || obs.seen[0] != "invalid_message" {
-		t.Fatalf("expected invalid_message, got %v", obs.seen)
+		if len(obs.seen) != 0 {
+			t.Fatalf("%s without active call must not be an error, got %v", msg.Type, obs.seen)
+		}
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1213,13 +1213,61 @@ func TestRelayObservesAuthFailedWhenAuthorizerDenies(t *testing.T) {
 func TestRelayDoesNotErrorOnSignalingWithoutCall(t *testing.T) {
 	// Stray control/media for a call that isn't active (raced past teardown or
 	// trailing a dial to an unreachable number) is normal and must not be
-	// recorded as a signaling error.
+	// recorded as a signaling error. Where a client-facing reply is part of the
+	// contract (ice_restart), it must still be delivered.
+	for _, tc := range []struct {
+		msg          *Message
+		wantReplyErr string // "" means no reply expected
+	}{
+		{&Message{Type: TypeICERestart, To: "3140002"}, "no active call"},
+		{&Message{Type: TypeDTMF, To: "3140002", Digit: "5"}, ""},
+		{&Message{Type: TypeAnswer, To: "3140002"}, ""},
+		{&Message{Type: TypeSDP, To: "3140002", SDP: "v=0\r\n"}, ""},
+		{&Message{Type: TypeICE, To: "3140002", Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"}, ""},
+	} {
+		hub := NewHub()
+		obs := &fakeErrorObserver{}
+		relay := NewRelay(hub, newMockTracker(), nil, nil)
+		relay.Errors = obs
+
+		conn1 := &Conn{Send: make(chan []byte, 10)}
+		_ = hub.Register("3140001", conn1)
+		relay.HandleMessage(context.Background(), "3140001", tc.msg)
+
+		if len(obs.seen) != 0 {
+			t.Fatalf("%s without active call must not be an error, got %v", tc.msg.Type, obs.seen)
+		}
+
+		select {
+		case data := <-conn1.Send:
+			reply, err := ParseMessage(data)
+			if err != nil {
+				t.Fatalf("%s: parse reply: %v", tc.msg.Type, err)
+			}
+			if tc.wantReplyErr == "" {
+				t.Fatalf("%s without active call should send no reply, got %+v", tc.msg.Type, reply)
+			}
+			if reply.Type != TypeError || reply.Error != tc.wantReplyErr {
+				t.Fatalf("%s: expected error reply %q, got %s/%q", tc.msg.Type, tc.wantReplyErr, reply.Type, reply.Error)
+			}
+		default:
+			if tc.wantReplyErr != "" {
+				t.Fatalf("%s without active call should reply %q, got nothing", tc.msg.Type, tc.wantReplyErr)
+			}
+		}
+	}
+}
+
+func TestRelayObservesInvalidMessageOnEmptyDestination(t *testing.T) {
+	// A relay message with no destination is malformed, a genuine fault. It is
+	// counted as invalid_message and dropped before the active-call guard, so it
+	// is not shadowed into that guard's benign drop.
 	for _, msg := range []*Message{
-		{Type: TypeICERestart, To: "3140002"},
-		{Type: TypeDTMF, To: "3140002", Digit: "5"},
-		{Type: TypeAnswer, To: "3140002"},
-		{Type: TypeSDP, To: "3140002", SDP: "v=0\r\n"},
-		{Type: TypeICE, To: "3140002", Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"},
+		{Type: TypeICERestart},
+		{Type: TypeDTMF, Digit: "5"},
+		{Type: TypeAnswer},
+		{Type: TypeSDP, SDP: "v=0\r\n"},
+		{Type: TypeICE, Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"},
 	} {
 		hub := NewHub()
 		obs := &fakeErrorObserver{}
@@ -1230,8 +1278,8 @@ func TestRelayDoesNotErrorOnSignalingWithoutCall(t *testing.T) {
 		_ = hub.Register("3140001", conn1)
 		relay.HandleMessage(context.Background(), "3140001", msg)
 
-		if len(obs.seen) != 0 {
-			t.Fatalf("%s without active call must not be an error, got %v", msg.Type, obs.seen)
+		if len(obs.seen) != 1 || obs.seen[0] != "invalid_message" {
+			t.Fatalf("%s with empty destination: expected invalid_message, got %v", msg.Type, obs.seen)
 		}
 	}
 }


### PR DESCRIPTION
## What

The `DigitsSignalingErrors` critical alert paged. Root cause: a registered phone dialed a run of numbers that don't exist, then trickled SDP/ICE for those never-established calls. The relay recorded each as a signaling error (`peer_unreachable` for the call, `invalid_message` for the trailing SDP/ICE), and the alert fires on any nonzero error rate, so one phone dialing dead numbers paged on-call critical with nothing actually wrong.

Dialing an offline or unregistered peer is normal user behavior, not a server fault. This stops counting it as one.

## Changes

- `handleCall`: dialing an offline/unregistered number no longer emits `peer_unreachable`. The caller still gets the `phone not connected` reply.
- `handleDTMF`, `handleICERestart`, `handleAnswer`, `handleSignalingForward`: the "without active call" branches no longer emit `invalid_message`. These are benign races (candidates trickling past teardown) or the tail of an unreachable dial. The `ice_restart` path still sends its `no active call` reply.
- These stray-message logs drop from `Warn` to `Debug` since they're expected, not anomalies. (One phone produced ~80 `Warn` lines in 10 minutes.)
- `peer_unreachable` is now unemitted, so it's removed from the metric category allowlist.
- `docs/metrics.md` updated to describe the category set as genuine faults only.

`signaling_errors_total` keeps counting real faults: `auth_failed`, `call_setup_failed`, `relay_delivery`, malformed messages (empty destination), and the reserved TURN/ICE categories.

## Out of scope

The `DigitsSignalingErrors` alert rule itself (the `rate(...) > 0` threshold) lives in the deployment's alerting config, not this repo. This PR fixes what feeds the metric; the threshold can be revisited separately if a single genuine fault paging critical is still too sensitive.

## Test

- Replaced the two tests that asserted the old behavior (`TestRelayObservesPeerUnreachableOnOfflineCall`, `TestRelayObservesInvalidMessageOnICERestartWithoutCall`) with tests asserting no error is recorded while the caller-facing replies are preserved, covering call/dtmf/ice_restart/answer/sdp/ice.
- Full server unit suite passes; `go vet` and `golangci-lint run ./...` clean.