### PR TITLE
refactor(server): tidy store constructors, error handling, and dead code

### DIFF
--- a/server/cmd/devseed/main.go
+++ b/server/cmd/devseed/main.go
@@ -152,7 +152,7 @@ func main() {
 		auth:  auth.NewStore(database.DB),
 		house: household.NewStore(database.DB),
 		link:  household.NewLinkStore(database.DB),
-		line:  line.NewStore(database),
+		line:  line.NewStore(database.DB),
 		db:    database.DB,
 	}
 

--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -104,8 +104,8 @@ func run(ctx context.Context) error {
 	defer func() { _ = database.Close() }()
 
 	// Core stores
-	lineStore := line.NewStore(database)
-	deviceStore := device.NewStore(database)
+	lineStore := line.NewStore(database.DB)
+	deviceStore := device.NewStore(database.DB)
 	hub := signaling.NewHub()
 
 	// Redis pub/sub for multi-replica signaling. When REDIS_URL is set,

--- a/server/internal/auth/store.go
+++ b/server/internal/auth/store.go
@@ -363,8 +363,10 @@ func (s *Store) ValidateMagicLink(ctx context.Context, token string) (string, st
 // CountUsers returns the total number of user accounts.
 func (s *Store) CountUsers(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count)
-	return count, err
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count users: %w", err)
+	}
+	return count, nil
 }
 
 // CleanupExpired removes expired sessions and used/expired magic links.

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
@@ -43,9 +42,9 @@ type Store struct {
 	db *sql.DB
 }
 
-// NewStore creates a new device Store backed by the given database.
-func NewStore(database *db.Database) *Store {
-	return &Store{db: database.DB}
+// NewStore creates a new device Store backed by an existing *sql.DB.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
 }
 
 // deviceColumns is the SELECT list for queries that scan into a Device via

--- a/server/internal/device/store_test.go
+++ b/server/internal/device/store_test.go
@@ -24,7 +24,7 @@ func testStore(t *testing.T) (*Store, *db.Database) {
 	if err != nil {
 		t.Fatalf("db.Open: %v", err)
 	}
-	s := NewStore(database)
+	s := NewStore(database.DB)
 	t.Cleanup(func() {
 		_, _ = database.DB.Exec("DELETE FROM devices")
 		_, _ = database.DB.Exec("DELETE FROM lines")

--- a/server/internal/household/link.go
+++ b/server/internal/household/link.go
@@ -20,6 +20,18 @@ const LinkStatusPending = "pending"
 const inviteCodeAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 const inviteCodeLength = 8
 
+// Link operation failures, named to match invite.go's sentinel pattern so the
+// package is internally consistent and the strings live in one place. The
+// handler surfaces the message text to the user via the /links?error= query
+// param, so the wording is UI copy and must stay user-readable.
+var (
+	ErrInviteCodeUsed   = errors.New("invite code not found or already used")
+	ErrSelfLink         = errors.New("cannot link a household to itself")
+	ErrAlreadyLinked    = errors.New("households are already linked")
+	ErrLinkNotRevocable = errors.New("link not found or already revoked")
+	ErrLinkNotFound     = errors.New("link not found")
+)
+
 // linkColumns is the SELECT/RETURNING list for queries that scan into a
 // HouseholdLink. Field order must stay aligned with the destination order in
 // scanLink below.
@@ -117,7 +129,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 			FOR UPDATE
 		`, code))
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.New("invite code not found or already used")
+			return ErrInviteCodeUsed
 		}
 		if err != nil {
 			return fmt.Errorf("lookup invite: %w", err)
@@ -125,7 +137,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 
 		// Prevent self-linking
 		if link.HouseholdAID == acceptingHouseholdID {
-			return errors.New("cannot link a household to itself")
+			return ErrSelfLink
 		}
 
 		// Check not already linked
@@ -134,7 +146,7 @@ func (s *LinkStore) AcceptInvite(ctx context.Context, code, acceptingUserID, acc
 			return err
 		}
 		if already {
-			return errors.New("households are already linked")
+			return ErrAlreadyLinked
 		}
 
 		// Normalize: a_id < b_id
@@ -213,7 +225,7 @@ func (s *LinkStore) RevokeLink(ctx context.Context, linkID, revokedByUserID stri
 		RETURNING id
 	`, time.Now(), revokedByUserID, linkID).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return errors.New("link not found or already revoked")
+		return ErrLinkNotRevocable
 	}
 	if err != nil {
 		return fmt.Errorf("revoke link: %w", err)
@@ -228,7 +240,7 @@ func (s *LinkStore) GetByID(ctx context.Context, id string) (*HouseholdLink, err
 		FROM household_links WHERE id = $1
 	`, id))
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, errors.New("link not found")
+		return nil, ErrLinkNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get link by id: %w", err)
@@ -265,8 +277,10 @@ func scanLinks(rows *sql.Rows) ([]HouseholdLink, error) {
 // CountActiveLinks returns the total number of active household links.
 func (s *LinkStore) CountActiveLinks(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM household_links WHERE status = 'active'`).Scan(&count)
-	return count, err
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM household_links WHERE status = 'active'`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count active links: %w", err)
+	}
+	return count, nil
 }
 
 // NumberConflict represents a phone number that exists in both households.

--- a/server/internal/household/onboarding.go
+++ b/server/internal/household/onboarding.go
@@ -1,6 +1,9 @@
 package household
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
 // NeedsOnboarding returns true if the given user has no household memberships.
 func (s *Store) NeedsOnboarding(ctx context.Context, userID string) bool {
@@ -10,7 +13,10 @@ func (s *Store) NeedsOnboarding(ctx context.Context, userID string) bool {
 		userID,
 	).Scan(&count)
 	if err != nil {
-		// On error, assume they don't need onboarding to avoid redirect loops
+		// On error, assume they don't need onboarding to avoid redirect loops.
+		// Log so a persistent lookup failure is visible rather than silently
+		// stranding the user on a household-less dashboard.
+		slog.ErrorContext(ctx, "NeedsOnboarding: count memberships failed", "user_id", userID, "err", err)
 		return false
 	}
 	return count == 0

--- a/server/internal/household/store.go
+++ b/server/internal/household/store.go
@@ -201,8 +201,10 @@ func (s *Store) IsMemberByEmail(ctx context.Context, householdID, email string) 
 // CountHouseholds returns the total number of households.
 func (s *Store) CountHouseholds(ctx context.Context) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM households`).Scan(&count)
-	return count, err
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM households`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count households: %w", err)
+	}
+	return count, nil
 }
 
 // UpdateName changes the name of a household.
@@ -253,11 +255,13 @@ func (s *Store) RemoveMember(ctx context.Context, userID, householdID string) er
 // MemberCount returns the number of members in a household.
 func (s *Store) MemberCount(ctx context.Context, householdID string) (int, error) {
 	var count int
-	err := s.db.QueryRowContext(ctx,
+	if err := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM household_members WHERE household_id = $1`,
 		householdID,
-	).Scan(&count)
-	return count, err
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("member count: %w", err)
+	}
+	return count, nil
 }
 
 // SetCallHistoryEnabled toggles call history for a household.

--- a/server/internal/line/authorizer_test.go
+++ b/server/internal/line/authorizer_test.go
@@ -71,7 +71,7 @@ func TestCanCall_SameHousehold(t *testing.T) {
 	auth, database := testAuthorizer(t)
 	householdID := createTestHousehold(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "1000001", "Alice", householdID); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestCanCall_LinkedHouseholds(t *testing.T) {
 	houseB := createTestHousehold(t, database)
 	userID := createAuthTestUser(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "2000001", "Alice", houseA); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestCanCall_UnlinkedHouseholds(t *testing.T) {
 	houseA := createTestHousehold(t, database)
 	houseB := createTestHousehold(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "3000001", "Alice", houseA); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestCanCall_UnknownCaller(t *testing.T) {
 	auth, database := testAuthorizer(t)
 	householdID := createTestHousehold(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "4000001", "Alice", householdID); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestCanCall_UnknownCallee(t *testing.T) {
 	auth, database := testAuthorizer(t)
 	householdID := createTestHousehold(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "4100001", "Alice", householdID); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestCanCall_RevokedLink(t *testing.T) {
 	houseB := createTestHousehold(t, database)
 	userID := createAuthTestUser(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "5000001", "Alice", houseA); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestCanCall_PendingLink(t *testing.T) {
 	houseB := createTestHousehold(t, database)
 	userID := createAuthTestUser(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "6000001", "Alice", houseA); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestCanCall_SameNumber(t *testing.T) {
 	auth, database := testAuthorizer(t)
 	householdID := createTestHousehold(t, database)
 
-	store := NewStore(database)
+	store := NewStore(database.DB)
 	if _, err := store.Add(context.Background(), "7000001", "Alice", householdID); err != nil {
 		t.Fatalf("Add Alice: %v", err)
 	}

--- a/server/internal/line/store.go
+++ b/server/internal/line/store.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/justinlindh/digits/server/internal/db"
 	"github.com/justinlindh/digits/server/internal/dbutil"
 )
 
@@ -106,9 +105,9 @@ type Store struct {
 	db *sql.DB
 }
 
-// NewStore wraps a *db.Database.
-func NewStore(database *db.Database) *Store {
-	return &Store{db: database.DB}
+// NewStore wraps an existing *sql.DB.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
 }
 
 // Add inserts a new line for the given household and returns it. The initial
@@ -386,19 +385,4 @@ func (s *Store) AllSilentByHousehold(ctx context.Context, householdID string) (b
 		return false, fmt.Errorf("all silent by household: %w", err)
 	}
 	return total > 0 && total == silentCount, nil
-}
-
-// GetHouseholdIDByNumber returns the household UUID for the given phone number.
-func (s *Store) GetHouseholdIDByNumber(ctx context.Context, number string) (string, error) {
-	var householdID string
-	err := s.db.QueryRowContext(ctx,
-		`SELECT household_id FROM lines WHERE number = $1`, number,
-	).Scan(&householdID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", ErrNotFound
-	}
-	if err != nil {
-		return "", fmt.Errorf("get household id by number: %w", err)
-	}
-	return householdID, nil
 }

--- a/server/internal/line/store_test.go
+++ b/server/internal/line/store_test.go
@@ -23,7 +23,7 @@ func testStore(t *testing.T) (*Store, *db.Database) {
 	if err != nil {
 		t.Fatalf("db.Open: %v", err)
 	}
-	s := NewStore(database)
+	s := NewStore(database.DB)
 	t.Cleanup(func() {
 		_, _ = database.DB.Exec("DELETE FROM lines")
 		_, _ = database.DB.Exec("DELETE FROM household_members")
@@ -347,29 +347,6 @@ func TestStoreSettingsDefaultAndUpdate(t *testing.T) {
 	}
 	if got.Settings.VoiceStyle != VoiceStyleCopper {
 		t.Errorf("empty json should fall through to default, got %q", got.Settings.VoiceStyle)
-	}
-}
-
-func TestGetHouseholdIDByNumber(t *testing.T) {
-	s, database := testStore(t)
-	householdID := createTestHousehold(t, database)
-
-	if _, err := s.Add(context.Background(), "5550001", "HHTest", householdID); err != nil {
-		t.Fatalf("Add: %v", err)
-	}
-
-	got, err := s.GetHouseholdIDByNumber(context.Background(), "5550001")
-	if err != nil {
-		t.Fatalf("GetHouseholdIDByNumber: %v", err)
-	}
-	if got != householdID {
-		t.Errorf("HouseholdID = %q, want %q", got, householdID)
-	}
-
-	// Non-existent number should return error
-	_, err = s.GetHouseholdIDByNumber(context.Background(), "0000000")
-	if err == nil {
-		t.Error("expected error for non-existent number, got nil")
 	}
 }
 

--- a/server/internal/turn/credentials_test.go
+++ b/server/internal/turn/credentials_test.go
@@ -1,6 +1,8 @@
 package turn
 
 import (
+	"crypto/hmac"
+	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -37,5 +39,42 @@ func TestGenerateCredentials(t *testing.T) {
 	}
 	if _, err := base64.StdEncoding.DecodeString(creds.Credential); err != nil {
 		t.Errorf("credential is not valid base64: %v", err)
+	}
+}
+
+// TestGenerateCredential_HMACMatches pins the credential to the exact
+// HMAC-SHA1 of the username. The base64-validity check above would still pass
+// if Generate hashed the wrong field (or used the wrong key); this recomputes
+// the digest independently so a regression in the scheme is caught here rather
+// than only by coturn rejecting calls in production.
+func TestGenerateCredential_HMACMatches(t *testing.T) {
+	const secret = "supersecret"
+	gen := NewCredentialGenerator(secret, 24*time.Hour)
+	creds := gen.Generate("user@digits")
+
+	mac := hmac.New(sha1.New, []byte(secret))
+	mac.Write([]byte(creds.Username))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	if creds.Credential != want {
+		t.Errorf("credential = %q, want HMAC-SHA1 of username = %q", creds.Credential, want)
+	}
+}
+
+// TestGenerateCredential_KnownAnswer is a fixed test vector: a known secret and
+// a known username produce a known credential. It guards the wire format
+// (HMAC-SHA1 + standard base64) against an accidental algorithm or encoding
+// swap that the self-consistency check above would not detect.
+func TestGenerateCredential_KnownAnswer(t *testing.T) {
+	// Independently computed: base64(HMAC-SHA1("secret123", "1700000000:alice")).
+	const (
+		secret   = "secret123"
+		username = "1700000000:alice"
+		want     = "pItSt+AgllVYw7AC0p93hqNrtPQ="
+	)
+	gen := NewCredentialGenerator(secret, time.Hour)
+	got := gen.computeHMAC(username)
+	if got != want {
+		t.Errorf("computeHMAC(%q) = %q, want %q", username, got, want)
 	}
 }

--- a/server/internal/web/handler_links.go
+++ b/server/internal/web/handler_links.go
@@ -24,12 +24,11 @@ type linksData struct {
 }
 
 type linkRow struct {
-	ID             string
-	OtherHousehold string
-	InviteCode     string
-	Status         string
-	CreatedAt      time.Time
-	AcceptedAt     *time.Time
+	ID         string
+	InviteCode string
+	Status     string
+	CreatedAt  time.Time
+	AcceptedAt *time.Time
 }
 
 func (h *Handler) handleLinksGet(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/web/handler_settings_test.go
+++ b/server/internal/web/handler_settings_test.go
@@ -132,7 +132,7 @@ func TestHandleAccountDeletePost(t *testing.T) {
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 
 	// Add a line so we can verify it's cleaned up.
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "555-0099", "Delete Test", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -108,7 +108,7 @@ func TestLinksPage_InviteFriendButton(t *testing.T) {
 func TestDeletePhone(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	_, err := lineStore.Add(context.Background(), "3140001", "Test Phone", hh.ID)
 	if err != nil {
 		t.Fatalf("add test line: %v", err)
@@ -136,7 +136,7 @@ func TestDeletePhone(t *testing.T) {
 func TestConvertLineToExtension(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 
 	srcLn, err := lineStore.Add(context.Background(), "3140001", "Kitchen", hh.ID)
 	if err != nil {
@@ -177,7 +177,7 @@ func TestConvertLineToExtension(t *testing.T) {
 		t.Error("source line should have been deleted")
 	}
 
-	devStore := device.NewStore(database)
+	devStore := device.NewStore(database.DB)
 	devices, err := devStore.ListByLine(context.Background(), tgtLn.ID)
 	if err != nil {
 		t.Fatalf("list target devices: %v", err)
@@ -190,7 +190,7 @@ func TestConvertLineToExtension(t *testing.T) {
 func TestConvertLineToSelfRejected(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 
 	ln, err := lineStore.Add(context.Background(), "3140001", "Kitchen", hh.ID)
 	if err != nil {
@@ -552,7 +552,7 @@ func setupVoiceStyleLine(t *testing.T, h *Handler, database *db.Database, authSt
 	if err != nil {
 		t.Fatalf("create household: %v", err)
 	}
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	if _, err := lineStore.Add(context.Background(), "3140001", "Test Phone", hh.ID); err != nil {
 		t.Fatalf("add line: %v", err)
 	}
@@ -1734,7 +1734,7 @@ func TestPhoneDetail_OmitsLANIPWhenOffline(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 	// Add a line WITHOUT registering a Conn: phone is offline.
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140044", "Garage", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)
@@ -1859,7 +1859,7 @@ func TestDashboard_DoesNotRenderLANIP(t *testing.T) {
 func TestChangePhoneNumber(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 
 	_, err := lineStore.Add(context.Background(), "3140001", "Kitchen", hh.ID)
 	if err != nil {
@@ -1899,7 +1899,7 @@ func TestChangePhoneNumber(t *testing.T) {
 func TestChangePhoneNumberDuplicate(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 
 	_, err := lineStore.Add(context.Background(), "3140001", "Kitchen", hh.ID)
 	if err != nil {
@@ -1937,7 +1937,7 @@ func TestPhoneDetail_BuildsPerDeviceViews(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140010", "Kitchen", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)
@@ -2041,7 +2041,7 @@ func TestPhoneRestart_TargetsHardware(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140011", "Porch", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)
@@ -2090,7 +2090,7 @@ func TestPhoneRestart_RejectsForeignHardware(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140012", "Garage", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)
@@ -2124,7 +2124,7 @@ func TestPhoneOperator_SwapsPanel(t *testing.T) {
 	h, database, authStore := setupHandler(t)
 	cookie, hh := setupAuthedHousehold(t, h, database, authStore)
 
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140020", "Study", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)
@@ -2218,7 +2218,7 @@ func TestPhoneOperator_AMTheme(t *testing.T) {
 		_ = authStore.SetTheme(context.Background(), user.ID, auth.ThemeIntercom)
 	})
 
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), "3140021", "Attic", hh.ID)
 	if err != nil {
 		t.Fatalf("add line: %v", err)

--- a/server/internal/web/handler_ws_test.go
+++ b/server/internal/web/handler_ws_test.go
@@ -226,3 +226,97 @@ func TestWSRegister_PairedDevice_CorrectNumber_NoRenumber(t *testing.T) {
 		t.Fatalf("expected timeout (no renumber), got: %v", err)
 	}
 }
+
+// An unknown device (no paired row) that registers must be issued a pairing
+// code and parked under its unpaired hardware-ID key, never under the line
+// number it claimed. This is the first-contact handshake every new device goes
+// through; parking it under the unpaired prefix lets it receive the eventual
+// TypePaired via SendToHardware without displacing a real line's connection.
+func TestWSRegister_UnpairedDevice_GetsPairingCode(t *testing.T) {
+	h, database, _ := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID := fmt.Sprintf("test-hw-unpaired-%d", time.Now().UnixNano())
+	number := fmt.Sprintf("88%05d", time.Now().UnixNano()%100000)
+	t.Cleanup(func() {
+		_, _ = database.DB.Exec("DELETE FROM devices WHERE hardware_id = $1", hwID)
+	})
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:       signaling.TypeRegister,
+		Number:     number,
+		HardwareID: hwID,
+	})
+
+	msg := recvMsg(t, ws)
+	if msg.Type != signaling.TypePairingCode {
+		t.Fatalf("expected %q, got %q (error=%q)", signaling.TypePairingCode, msg.Type, msg.Error)
+	}
+	if msg.PairingCode == "" {
+		t.Error("pairing code message carried an empty code")
+	}
+	if msg.PairingCodeTTL != int(pairing.CodeTTL.Seconds()) {
+		t.Errorf("PairingCodeTTL = %d, want %d", msg.PairingCodeTTL, int(pairing.CodeTTL.Seconds()))
+	}
+
+	// The device is parked under the unpaired prefix, not the claimed number.
+	waitForRegister(t, h.hub, signaling.UnpairedPrefix+hwID)
+	if h.hub.IsOnline(number) {
+		t.Errorf("unpaired device must not be online under claimed number %q", number)
+	}
+}
+
+// A paired device clears its own server-side pairing by sending a repair
+// message (the *#0* service code) before reboot. After repair the stored token
+// and paired_at are gone, so the device's next token-less register is treated
+// as a fresh pair-up instead of being rejected for a missing token.
+func TestWSRegister_RepairUnpairsDevice(t *testing.T) {
+	h, database, authStore := setupHandler(t)
+	srv := httptest.NewServer(h.Router())
+	defer srv.Close()
+
+	hwID, number, token := setupPairedDevice(t, database, h.pairingStore, h.householdStore, authStore)
+
+	// Precondition: the device is paired and its token validates.
+	paired, valid, err := h.deviceStore.AuthStatus(context.Background(), hwID, token)
+	if err != nil {
+		t.Fatalf("auth status before repair: %v", err)
+	}
+	if !paired || !valid {
+		t.Fatalf("device should be paired with a valid token before repair (paired=%v valid=%v)", paired, valid)
+	}
+
+	ws := dialWS(t, srv)
+	sendMsg(t, ws, signaling.Message{
+		Type:        signaling.TypeRegister,
+		Number:      number,
+		HardwareID:  hwID,
+		DeviceToken: token,
+	})
+	// Register runs in the read goroutine; wait for it so the read pump is live
+	// to receive the repair message that follows.
+	waitForRegister(t, h.hub, number)
+
+	sendMsg(t, ws, signaling.Message{
+		Type:       signaling.TypeRepair,
+		HardwareID: hwID,
+	})
+
+	// Unpair runs in the read pump; poll until the device row reflects it.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		stillPaired, _, err := h.deviceStore.AuthStatus(context.Background(), hwID, token)
+		if err != nil {
+			t.Fatalf("auth status after repair: %v", err)
+		}
+		if !stillPaired {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("device still paired 2s after repair message")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/server/internal/web/testhelpers_integration_test.go
+++ b/server/internal/web/testhelpers_integration_test.go
@@ -126,8 +126,8 @@ func waitForRegister(t *testing.T, hub *signaling.Hub, number string) {
 // can swap the field for their own instance.
 func testDeps(t *testing.T, database *db.Database) (Deps, *auth.Store) {
 	t.Helper()
-	lineStore := line.NewStore(database)
-	deviceStore := device.NewStore(database)
+	lineStore := line.NewStore(database.DB)
+	deviceStore := device.NewStore(database.DB)
 	hub := signaling.NewHub()
 	tracker := calls.New(database)
 	healthStore := calls.NewHealthStore(database, calls.WithFlushDisabled())
@@ -226,7 +226,7 @@ func setupAuthedHousehold(t *testing.T, h *Handler, database *db.Database, authS
 // so callers can assert push payloads via conn.Send.
 func setupLineWithConn(t *testing.T, h *Handler, database *db.Database, hh *household.Household, number, name string) (*line.Line, *signaling.Conn) {
 	t.Helper()
-	lineStore := line.NewStore(database)
+	lineStore := line.NewStore(database.DB)
 	ln, err := lineStore.Add(context.Background(), number, name, hh.ID)
 	if err != nil {
 		t.Fatalf("add line %s: %v", number, err)


### PR DESCRIPTION
## What

A focused cleanliness pass over the `server` module: remove dead code, standardize store constructors, tighten error handling, and close two test gaps. No user- or device-visible behavior changes, so this is a `refactor`.

Changes:

- **Standardize store constructors.** `line.NewStore` and `device.NewStore` now take `*sql.DB` instead of `*db.Database`, matching `auth`, `household`, and `pairing`. Both stores already held a `*sql.DB` internally and only used `database.DB`, so this drops a needless `internal/db` import and removes the asymmetry at the call sites (`device.NewStore(database)` sitting next to `household.NewStore(database.DB)`).
- **Remove dead code.** Deleted `line.Store.GetHouseholdIDByNumber` (no production callers, only its own test) and the never-set, never-read `linkRow.OtherHousehold` field.
- **Promote link errors to sentinels.** `household/link.go` returned inline `errors.New(...)` while its sibling `invite.go` defines proper sentinels. Promoted them (`ErrInviteCodeUsed`, `ErrSelfLink`, `ErrAlreadyLinked`, `ErrLinkNotRevocable`, `ErrLinkNotFound`). The exact message text is preserved because the links handler surfaces `err.Error()` through the `/links?error=` query param, so the strings are UI copy.
- **Wrap bare Scan errors.** `CountUsers`, `CountHouseholds`, `MemberCount`, and `CountActiveLinks` returned the raw `Scan` error while every sibling wraps with `%w`. Made them consistent.
- **Surface a swallowed error.** `NeedsOnboarding` silently returned `false` on a DB error; it now logs via `slog.ErrorContext` while keeping the redirect-loop-safe fallback.
- **Close two test gaps.** Added a TURN credential test that recomputes the HMAC over the username plus a fixed known-answer vector (the prior test only checked the credential was non-empty base64, so a wrong-but-well-formed credential would have passed). Added WS integration tests for the unpaired-device register path (pairing-code issuance and unpaired-prefix parking) and the repair-unpairs flow, neither of which had coverage at any tier.

## Why

The `server` module was audited for cleanliness, idiomatic Go, dead/stale code, layout, and test coverage. It is already in very good shape (zero `TODO`/`FIXME`, tidy `go.mod`, `deadcode`/`staticcheck` clean, strong integration coverage, consistent handler and store patterns). The items above are the genuine findings: small consistency drift from the store layer evolving piecemeal, plus two untested critical paths (the device pairing handshake and the security-sensitive TURN credential scheme).

Findings deliberately skipped (YAGNI or out of scope for a cleanliness pass):

- The `signaling.CallTracker` interface returns concrete `*calls` types. No second tracker implementation exists, so generalizing now would be speculative.
- `auth.Store` carries a small amount of HTTP surface (`RequireAuth`, `CookieDomain`). Package cohesion is fine and splitting it is not worth the churn in isolation.
- The `/test` redirect alias and the two tiny duplicate `envOr` helpers are intentional or too small to consolidate across unrelated packages.

## Test plan

- `go build ./...`, `go vet ./...`, and `go vet -tags=integration ./...`: clean.
- `gofmt -l`: clean.
- Unit suite (`go test ./...`): pass.
- Full integration suite against a local Postgres (`go test -tags=integration -count=1 -p 1 ./...`): all packages pass, including the two new WS tests and the new TURN tests.

## Code quality grade

Scope: the `server` module only.

**Before: 90 / 100. After: 94 / 100.**

The starting point was already high. The audit looked at cleanliness, idiomatic Go, dead/stale code, project layout, and test coverage:

- **Layout and idiom (strong):** thin `cmd/` mains with logic in `internal/`, a testable `run()` entrypoint, clean dependency injection, consumer-side interfaces with adapters to avoid import cycles, security-conscious handlers (constant-time auth queries, information-hiding 404s, hashed device tokens), and consistent `handler_*.go` / store / SQL conventions.
- **Dead/stale code (was near-zero):** `deadcode`/`staticcheck` clean, `go.mod` tidy, all templates and static assets referenced, no stale comments. The only removable items were the two addressed here.
- **Test coverage (strong, now stronger):** three documented tiers with the unit/integration split respected; the gaps closed here were the unpaired-device WS handshake, the repair flow, and an HMAC value assertion for TURN.

The remaining 6 points reflect the YAGNI-skipped interface-altitude and package-cohesion nits listed above, which are judgment calls rather than defects.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXHp3QTYLh1jsZciGLPdKz)_