### PR TITLE
refactor(server): tidy stale comments, doc coverage, and em-dash compliance

### DIFF
--- a/server/e2e/README.md
+++ b/server/e2e/README.md
@@ -20,7 +20,7 @@ The tests use Playwright's [storageState](https://playwright.dev/docs/auth) to s
 an authenticated session between test files. The `auth.setup.ts` project runs first
 and writes `.auth/user.json` (gitignored).
 
-### Option A — Session cookie (fastest)
+### Option A: Session cookie (fastest)
 
 If you have a valid `digits_session` cookie from a running dev server:
 
@@ -28,7 +28,7 @@ If you have a valid `digits_session` cookie from a running dev server:
 E2E_SESSION_COOKIE=<cookie-value> make e2e
 ```
 
-### Option B — Magic link token
+### Option B: Magic link token
 
 1. Start the server with `DEV_MODE=true` (it logs magic link URLs to stdout).
 2. POST a magic link request:
@@ -42,7 +42,7 @@ E2E_SESSION_COOKIE=<cookie-value> make e2e
    E2E_MAGIC_TOKEN=<token> make e2e
    ```
 
-### Option C — No auth (public pages only)
+### Option C: No auth (public pages only)
 
 Run without any auth env vars. Tests that require an authenticated session
 will skip themselves gracefully. Public-page tests (login page, healthz) still run.

--- a/server/internal/auth/store_test.go
+++ b/server/internal/auth/store_test.go
@@ -19,7 +19,7 @@ func testDB(t *testing.T) *Store {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping DB tests")
+		t.Skip("TEST_DATABASE_URL not set, skipping DB tests")
 	}
 	// Use db.Open to ensure migrations run (creates tables)
 	database, err := db.Open(dsn)

--- a/server/internal/autodeploy/config.go
+++ b/server/internal/autodeploy/config.go
@@ -84,12 +84,12 @@ func LoadConfig(path string) (Config, error) {
 	// box with public GHCR images (no token needed) doesn't have to invent
 	// an empty placeholder file just to satisfy config loading.
 	for _, r := range []struct {
-		name, pathKey string
-		dst           *string
+		pathKey string
+		dst     *string
 	}{
-		{"GHCR_TOKEN", "GHCR_TOKEN_FILE", &c.GHCRToken},
-		{"SMTP_PASS", "SMTP_PASS_FILE", &c.SMTPPass},
-		{"GITHUB_TOKEN", "GITHUB_TOKEN_FILE", &c.GitHubToken},
+		{"GHCR_TOKEN_FILE", &c.GHCRToken},
+		{"SMTP_PASS_FILE", &c.SMTPPass},
+		{"GITHUB_TOKEN_FILE", &c.GitHubToken},
 	} {
 		p := raw[r.pathKey]
 		if p == "" {

--- a/server/internal/autodeploy/config_test.go
+++ b/server/internal/autodeploy/config_test.go
@@ -114,7 +114,7 @@ func TestLoadConfigOptionalTokenFileUnreadable(t *testing.T) {
 		t.Skip("skipping: root bypasses file permissions")
 	}
 	// A file that exists but cannot be read (permission denied, etc) is a
-	// real config problem, not an "optional unset" — must still error.
+	// real config problem, not an "optional unset": must still error.
 	dir := t.TempDir()
 	tokenPath := filepath.Join(dir, "tok")
 	if err := os.WriteFile(tokenPath, []byte("ghp_x"), 0o000); err != nil {

--- a/server/internal/calls/history_integration_test.go
+++ b/server/internal/calls/history_integration_test.go
@@ -202,7 +202,7 @@ func TestRecentHistoryForPhones_MixedTimeline(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	// T3: another 2-party call (reuse same numbers — OK since earlier calls are ended)
+	// T3: another 2-party call (reuse same numbers, OK since earlier calls are ended)
 	_, err = tr.OnCallInitiated(context.Background(), "7773001", "7773002")
 	if err != nil {
 		t.Fatalf("OnCallInitiated T3: %v", err)
@@ -211,7 +211,7 @@ func TestRecentHistoryForPhones_MixedTimeline(t *testing.T) {
 		t.Fatalf("OnCallEnded T3: %v", err)
 	}
 
-	// Suppress "declared and not used" — id1 is referenced only for clarity.
+	// Suppress "declared and not used": id1 is referenced only for clarity.
 	_ = id1
 
 	entries, err := tr.RecentHistoryForPhones(context.Background(), []string{"7773001", "7773002", "7773003"}, nil, 10)

--- a/server/internal/calls/linkhealth.go
+++ b/server/internal/calls/linkhealth.go
@@ -469,7 +469,7 @@ func (sr *sessionRings) broadcastLocked(ev Event) {
 	}
 }
 
-// flushInterval is how often the background flusher runs. See spec §2.
+// flushInterval is how often the background flusher runs.
 const flushInterval = 10 * time.Second
 
 // FlushOnce walks every tracked call and writes one row per (endpoint) for

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -72,6 +72,8 @@ func scanInvite(row dbutil.RowScanner) (*HouseholdInvite, error) {
 	return inv, nil
 }
 
+// CreateInvite issues a pending invite for email to join householdID and
+// returns it with a freshly generated token and expiry.
 func (s *InviteStore) CreateInvite(ctx context.Context, householdID, email, invitedByUserID string) (*HouseholdInvite, error) {
 	token, err := generateInviteToken()
 	if err != nil {
@@ -104,6 +106,8 @@ func (s *InviteStore) GetByID(ctx context.Context, id string) (*HouseholdInvite,
 	return inv, nil
 }
 
+// GetByToken looks up an invite by its token, returning ErrInviteNotFound
+// when no row matches.
 func (s *InviteStore) GetByToken(ctx context.Context, token string) (*HouseholdInvite, error) {
 	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
 		SELECT `+inviteColumns+` FROM household_invites WHERE token = $1
@@ -117,6 +121,8 @@ func (s *InviteStore) GetByToken(ctx context.Context, token string) (*HouseholdI
 	return inv, nil
 }
 
+// AcceptInvite marks a pending, unexpired invite as accepted and returns it.
+// It returns ErrInviteExpiredOrUsed when no matching pending invite exists.
 func (s *InviteStore) AcceptInvite(ctx context.Context, token string) (*HouseholdInvite, error) {
 	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
 		UPDATE household_invites
@@ -134,6 +140,8 @@ func (s *InviteStore) AcceptInvite(ctx context.Context, token string) (*Househol
 	return inv, nil
 }
 
+// CancelInvite marks a pending invite as cancelled. It returns
+// ErrInviteNotPending when the invite is missing or no longer pending.
 func (s *InviteStore) CancelInvite(ctx context.Context, inviteID string) error {
 	var id string
 	err := s.db.QueryRowContext(ctx, `
@@ -150,6 +158,8 @@ func (s *InviteStore) CancelInvite(ctx context.Context, inviteID string) error {
 	return nil
 }
 
+// GetPendingForHousehold returns the household's pending, unexpired invites,
+// newest first.
 func (s *InviteStore) GetPendingForHousehold(ctx context.Context, householdID string) ([]*HouseholdInvite, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT `+inviteColumns+`
@@ -172,6 +182,8 @@ func (s *InviteStore) GetPendingForHousehold(ctx context.Context, householdID st
 	return invites, rows.Err()
 }
 
+// IsPendingForHouseholdEmail reports whether a pending, unexpired invite
+// already exists for email in householdID.
 func (s *InviteStore) IsPendingForHouseholdEmail(ctx context.Context, householdID, email string) (bool, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
 	var count int

--- a/server/internal/household/link_test.go
+++ b/server/internal/household/link_test.go
@@ -264,7 +264,7 @@ func TestCreateInvite_NoDuplicateLinks(t *testing.T) {
 		t.Fatalf("AcceptInvite: %v", err)
 	}
 
-	// Now hA tries to create another invite — hB then tries to accept from a different direction
+	// Now hA tries to create another invite, hB then tries to accept from a different direction
 	// The real duplicate prevention is in AcceptInvite via AreLinked check.
 	// Create a new invite from hB (now it can create a pending one since no pending exists for hB)
 	invite2, err := store.CreateInvite(context.Background(), hB, userB)

--- a/server/internal/household/store_test.go
+++ b/server/internal/household/store_test.go
@@ -17,7 +17,7 @@ func testStore(t *testing.T) (*Store, *db.Database) {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping DB tests")
+		t.Skip("TEST_DATABASE_URL not set, skipping DB tests")
 	}
 	database, err := db.Open(dsn)
 	if err != nil {

--- a/server/internal/line/authorizer.go
+++ b/server/internal/line/authorizer.go
@@ -18,6 +18,9 @@ func NewAuthorizer(database *db.Database) *Authorizer {
 	return &Authorizer{db: database.DB}
 }
 
+// CanCall reports whether fromNumber is permitted to call toNumber, which is
+// true when both lines share a household or their households have an active
+// link.
 func (a *Authorizer) CanCall(ctx context.Context, fromNumber, toNumber string) (bool, error) {
 	var allowed bool
 	err := a.db.QueryRowContext(ctx, `

--- a/server/internal/line/authorizer_test.go
+++ b/server/internal/line/authorizer_test.go
@@ -16,7 +16,7 @@ func testAuthorizer(t *testing.T) (*Authorizer, *db.Database) {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping DB tests")
+		t.Skip("TEST_DATABASE_URL not set, skipping DB tests")
 	}
 	database, err := db.Open(dsn)
 	if err != nil {

--- a/server/internal/line/store_test.go
+++ b/server/internal/line/store_test.go
@@ -17,7 +17,7 @@ func testStore(t *testing.T) (*Store, *db.Database) {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping DB tests")
+		t.Skip("TEST_DATABASE_URL not set, skipping DB tests")
 	}
 	database, err := db.Open(dsn)
 	if err != nil {

--- a/server/internal/pairing/pairing_test.go
+++ b/server/internal/pairing/pairing_test.go
@@ -21,7 +21,7 @@ func setupStore(t *testing.T) *Store {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("TEST_DATABASE_URL not set — skipping DB tests")
+		t.Skip("TEST_DATABASE_URL not set, skipping DB tests")
 	}
 	database, err := db.Open(dsn)
 	if err != nil {

--- a/server/internal/signaling/conference_integration_test.go
+++ b/server/internal/signaling/conference_integration_test.go
@@ -362,7 +362,7 @@ func TestDisconnectNonHostConferenceParticipant_Integration(t *testing.T) {
 	if countType(cMsgs, signaling.TypeConferenceEnd) != 1 {
 		t.Fatalf("C: expected 1 ConferenceEnd, got %d (msgs: %v)", countType(cMsgs, signaling.TypeConferenceEnd), cMsgs)
 	}
-	// Disconnect path ends the conference for all — no ConferenceLeave expected.
+	// Disconnect path ends the conference for all: no ConferenceLeave expected.
 	if countType(aMsgs, signaling.TypeConferenceLeave) != 0 {
 		t.Errorf("A: expected 0 ConferenceLeave on disconnect (endConference path), got %d", countType(aMsgs, signaling.TypeConferenceLeave))
 	}

--- a/server/internal/updates/github_test.go
+++ b/server/internal/updates/github_test.go
@@ -175,7 +175,7 @@ func TestGitHubReleases_APIError(t *testing.T) {
 }
 
 func TestClassifyAssets_SHA256NotPickedAsBinary(t *testing.T) {
-	// GitHub doesn't guarantee asset order — .sha256 might come last and
+	// GitHub doesn't guarantee asset order: .sha256 might come last and
 	// its name also contains "aarch64", so it must be explicitly skipped.
 	assets := []ghAsset{
 		{Name: "digitsd-1.0.0-aarch64.sha256", BrowserDownloadURL: "https://example.com/digitsd.sha256"},

--- a/server/internal/web/e2e_auth_test.go
+++ b/server/internal/web/e2e_auth_test.go
@@ -24,7 +24,7 @@ import (
 func setupAuthTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	// Open a sql.DB lazily — no Ping, so no real connection is required.
+	// Open a sql.DB lazily: no Ping, so no real connection is required.
 	// Tests that don't trigger DB operations (no-cookie redirect, login page render)
 	// work fine without a live database.
 	rawDB, err := sql.Open("postgres", "postgres://test:test@localhost/testdb?sslmode=disable")
@@ -50,7 +50,7 @@ func setupAuthTestServer(t *testing.T) *httptest.Server {
 	authHandlers := auth.NewHandlers(authStore, googleAuth, emailSender, "http://localhost", "", loginTmpl, false)
 
 	hub := signaling.NewHub()
-	tracker := calls.New(nil) // nil DB — no DB calls expected in these tests
+	tracker := calls.New(nil) // nil DB: no DB calls expected in these tests
 	relay := signaling.NewRelay(hub, tracker, nil, nil)
 
 	h, err := NewHandler(Deps{

--- a/server/internal/web/e2e_calls_test.go
+++ b/server/internal/web/e2e_calls_test.go
@@ -327,7 +327,7 @@ func TestCallsPageRenders3WayConference(t *testing.T) {
 	// pre-merge calls should be excluded.
 	// Note: the mobile layout uses "→" for 2-party calls; conference rows do not.
 	if strings.Contains(body, "→") {
-		t.Errorf("expected no 2-party arrow (→) in body — merged legs should be hidden\nbody snippet: %s", truncate(body, 800))
+		t.Errorf("expected no 2-party arrow (→) in body: merged legs should be hidden\nbody snippet: %s", truncate(body, 800))
 	}
 
 	t.Logf("✓ /calls page renders 3-way conference with chip--conf and all participant numbers")

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -698,8 +698,8 @@ func (h *Handler) handlePhoneQuietHoursPost(w http.ResponseWriter, r *http.Reque
 
 // handlePhoneVoicemailPost accepts a form submission with the full voicemail
 // configuration for the line. Every field is validated server-side before
-// any DB write: out-of-range ints and malformed retrieval codes
-// return 400 with a friendly message so the form can surface it. On success
+// any DB write: an out-of-range ring timeout returns 400 with a friendly
+// message so the form can surface it. On success
 // the new settings are persisted and pushed to the device (if connected),
 // then either the voicemail-section partial is swapped (htmx) or the user
 // is redirected back to the phone detail page (regular form post).
@@ -733,7 +733,7 @@ func (h *Handler) handlePhoneVoicemailPost(w http.ResponseWriter, r *http.Reques
 // are preserved through Normalize, which backfills defaults when the row
 // was created before voicemail existed. Path is intentionally separate
 // from the full-form POST so a checkbox-only round-trip does not have to
-// resubmit the timing/code fields.
+// resubmit the ring-timeout field.
 func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
 	ln := h.requireLineOwnership(w, r, number)
@@ -748,8 +748,7 @@ func (h *Handler) handlePhoneVoicemailTogglePost(w http.ResponseWriter, r *http.
 // parseClampedInt reads form field `name`, parses it as an integer, and
 // requires it to fall in [lo, hi]. On any failure it writes a 400 with a
 // friendly message naming the field and the allowed range, then returns
-// (0, false). Helper for handlePhoneVoicemailPost so the three numeric
-// validations don't repeat the same boilerplate.
+// (0, false). Helper for handlePhoneVoicemailPost's ring-timeout validation.
 func parseClampedInt(w http.ResponseWriter, r *http.Request, name string, lo, hi int) (int, bool) {
 	raw := strings.TrimSpace(r.FormValue(name))
 	v, err := strconv.Atoi(raw)

--- a/server/internal/web/handler_test.go
+++ b/server/internal/web/handler_test.go
@@ -595,7 +595,7 @@ func TestPhoneVoiceStyleEmptyReturns400(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty voice_style, got %d: %s", w.Code, w.Body.String())
 	}
-	// Must not have written anything — default is copper on insert.
+	// Must not have written anything: default is copper on insert.
 	if got := read(); got != "copper" {
 		t.Fatalf("expected voice_style untouched (copper), got %q", got)
 	}
@@ -910,7 +910,7 @@ func TestPhoneVoiceStyleNoOpSkipsPush(t *testing.T) {
 	conn := &signaling.Conn{Send: make(chan []byte, 10)}
 	_ = h.hub.Register("3140001", conn)
 
-	// Line defaults to copper on insert — saving copper again must be a no-op.
+	// Line defaults to copper on insert: saving copper again must be a no-op.
 	if w := postVoiceStyle(t, h, cookie, "copper", false); w.Code != http.StatusSeeOther {
 		t.Fatalf("save failed: %d %s", w.Code, w.Body.String())
 	}

--- a/server/internal/web/linkhealth_integration_test.go
+++ b/server/internal/web/linkhealth_integration_test.go
@@ -94,7 +94,7 @@ func newLHEnv(t *testing.T) lhSetup {
 	env := setupCallsTestServer(t)
 	db := env.database.DB
 
-	// Register cleanup IMMEDIATELY — before any partial setup can fail.
+	// Register cleanup IMMEDIATELY, before any partial setup can fail.
 	// All DELETEs are idempotent against missing rows.
 	t.Cleanup(func() {
 		_, _ = db.Exec("DELETE FROM call_link_health WHERE call_id IN (SELECT id FROM calls WHERE caller IN ($1,$2,$3) OR callee IN ($1,$2,$3))", numA, numB, numC)
@@ -312,7 +312,7 @@ func TestLinkHealth_LinkedHouseholdStillGets404(t *testing.T) {
 		t.Fatalf("AcceptInvite: %v", err)
 	}
 
-	// Call is between B and C — A is NOT an endpoint owner.
+	// Call is between B and C: A is NOT an endpoint owner.
 	callID, err := s.env.tracker.OnCallInitiated(context.Background(), s.numB, s.numC)
 	if err != nil {
 		t.Fatalf("OnCallInitiated: %v", err)
@@ -364,7 +364,7 @@ func TestLinkHealth_UnauthenticatedRedirectsOr401(t *testing.T) {
 		t.Fatalf("OnCallInitiated: %v", err)
 	}
 
-	// Unauthenticated client — no jar, no redirect-following.
+	// Unauthenticated client: no jar, no redirect-following.
 	client := &http.Client{
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/server/internal/web/ratelimit_test.go
+++ b/server/internal/web/ratelimit_test.go
@@ -38,13 +38,13 @@ func TestMagicLinkRateLimited(t *testing.T) {
 	srv := setupRateLimitTestServer(t)
 
 	client := &http.Client{
-		// Don't follow redirects — we care about the immediate response code
+		// Don't follow redirects: we care about the immediate response code
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
 
-	// Send 5 requests — all should succeed (2xx or 3xx redirect, not 429)
+	// Send 5 requests: all should succeed (2xx or 3xx redirect, not 429)
 	for i := 1; i <= 5; i++ {
 		resp, err := client.Post(srv.URL+"/auth/magic", "application/x-www-form-urlencoded",
 			strings.NewReader("email=test@example.com"))

--- a/server/internal/web/spec_compliance_test.go
+++ b/server/internal/web/spec_compliance_test.go
@@ -152,7 +152,7 @@ func TestSpecFamilies(t *testing.T) {
 	}
 	seedLinkedFamily(t, h, database, authStore, hh.ID, user.ID, "Grandma Lindh", "2180042", "Grandma")
 
-	// Default view — no postcard yet.
+	// Default view: no postcard yet.
 	req := httptest.NewRequest(http.MethodGet, "/links", nil)
 	req.AddCookie(cookie)
 	w := httptest.NewRecorder()
@@ -194,7 +194,7 @@ func TestSpecFamilies(t *testing.T) {
 		t.Errorf("Families page still shows old 'Generate invite code' CTA")
 	}
 
-	// Postcard view — pass ?created= so the postcard is gated in.
+	// Postcard view: pass ?created= so the postcard is gated in.
 	req2 := httptest.NewRequest(http.MethodGet, "/links?created=DEMO-123", nil)
 	req2.AddCookie(cookie)
 	w2 := httptest.NewRecorder()

--- a/server/internal/web/static/connecting.css
+++ b/server/internal/web/static/connecting.css
@@ -1,5 +1,5 @@
 /* =========================================================================
-   /connecting — dial-up dialing intro. Lives inside a CRT screen (or not,
+   /connecting: dial-up dialing intro. Lives inside a CRT screen (or not,
    depending on body.crt-page). Consumes tokens from dialup.css.
    ========================================================================= */
 

--- a/server/internal/web/static/dialup.css
+++ b/server/internal/web/static/dialup.css
@@ -1,5 +1,5 @@
 /* =========================================================================
-   Digits — dial-up online service 1997 theme
+   Digits: dial-up online service 1997 theme
    Companion to digits.css (direction C). Imitates the dial-up client client:
    title bar, menu bar, toolbar, Keyword bar, CHANNELS sidebar, status bar,
    chunky 3D bevels, Tahoma/MS Sans Serif, dial-up blue + yellow palette.
@@ -1502,7 +1502,7 @@ details.disclosure > *:not(summary) { border-top: 1px dotted var(--dialup-chrome
 }
 .neighborhood__line:last-child { border-bottom: 0; }
 
-/* The template emits .lines__dot before the line name — already styled
+/* The template emits .lines__dot before the line name, already styled
    elsewhere. Just ensure it reads as a clear lead-in here. */
 .neighborhood__line .lines__dot { flex-shrink: 0; }
 
@@ -2134,7 +2134,7 @@ body.crt-all .crt__brand::after {
 }
 
 /* Narrow viewports: shrink the bezel rings so the inner content has room.
-   Drop the 4:3 aspect-ratio on /connecting — at ~360px wide the forced 4:3
+   Drop the 4:3 aspect-ratio on /connecting: at ~360px wide the forced 4:3
    leaves only ~248px of height, which clips the Connect + Skip controls
    out of view with the screen's overflow: hidden. Let content size it. */
 @media (max-width: 640px) {
@@ -2547,7 +2547,7 @@ body.dialup .phone-silent__text {
 .changelog__empty { color: gray; font-style: italic; font-size: 12px; }
 
 /* =========================================================================
-   Call-live observation deck — dialup theme (MODEM CONNECTED)
+   Call-live observation deck: dialup theme (MODEM CONNECTED)
    ========================================================================= */
 
 .deck {
@@ -2703,7 +2703,7 @@ body.dialup .phone-silent__text {
   font-size: 11px;
 }
 
-/* MODEM CONNECTED status lamp — dialup-only ornament, black terminal panel
+/* MODEM CONNECTED status lamp: dialup-only ornament, black terminal panel
    at the top of the deck. The CONNECTED text is static via ::before so no
    template change is needed. */
 .deck::before {

--- a/server/internal/web/static/digits.css
+++ b/server/internal/web/static/digits.css
@@ -1,5 +1,5 @@
 /* =========================================================================
-   Digits — design system stylesheet
+   Digits: design system stylesheet
    Direction C (home intercom / soft domestic hardware) reinterpreted for an
    app surface. Warm paper, walnut, brass spice. App-grade density, not
    marketing-page generosity.
@@ -643,7 +643,7 @@ hr { border: 0; border-top: 1px solid var(--rule); margin: 0; }
 }
 .dnd-toggle__label { font-size: 13px; color: var(--ink-muted); white-space: nowrap; }
 
-/* --------- Chip / state badge (used sparingly — prefer dot) --------- */
+/* --------- Chip / state badge (used sparingly, prefer dot) --------- */
 
 .chip {
   display: inline-flex;
@@ -1924,7 +1924,7 @@ details.disclosure > *:not(summary) { border-top: 1px solid var(--rule-soft); }
 }
 
 /* =========================================================================
-   Call-live observation deck — intercom theme
+   Call-live observation deck: intercom theme
    ========================================================================= */
 
 .deck { display: flex; flex-direction: column; gap: 18px; }

--- a/server/internal/web/static/test-client.html
+++ b/server/internal/web/static/test-client.html
@@ -166,7 +166,7 @@
             case 'ring':
                 pendingCaller = msg.from;
                 setStatus('📞 Incoming call from ' + msg.from, 'ringing');
-                log('RING from ' + msg.from + ' — click Answer to pick up');
+                log('RING from ' + msg.from + ': click Answer to pick up');
                 startRinging();
                 break;
 
@@ -182,7 +182,7 @@
                         pc._pendingOffer = true;
                     }
                 } else if (!pc && msg.sdp) {
-                    // Incoming offer before we created PC — store it
+                    // Incoming offer before we created PC: store it
                     pendingOffer = msg.sdp;
                     pendingCaller = msg.from;
                 }
@@ -288,17 +288,17 @@
                 log('Microphone acquired');
                 document.getElementById('audioStatus').textContent = '🎤 Mic active';
             } else {
-                // No getUserMedia (insecure context) — add receive-only transceiver
+                // No getUserMedia (insecure context): add receive-only transceiver
                 pc.addTransceiver('audio', { direction: 'recvonly' });
                 log('⚠️ No mic access (HTTPS required). Receive-only mode.');
                 log('TIP: chrome://flags/#unsafely-treat-insecure-origin-as-secure → add this URL → relaunch');
-                document.getElementById('audioStatus').textContent = '🔇 No mic (HTTP) — receive only';
+                document.getElementById('audioStatus').textContent = '🔇 No mic (HTTP): receive only';
             }
         } catch (e) {
             // getUserMedia exists but was denied or failed
             pc.addTransceiver('audio', { direction: 'recvonly' });
-            log('Mic error: ' + e + ' — falling back to receive-only');
-            document.getElementById('audioStatus').textContent = '🔇 Mic denied — receive only';
+            log('Mic error: ' + e + ', falling back to receive-only');
+            document.getElementById('audioStatus').textContent = '🔇 Mic denied: receive only';
         }
     }
 


### PR DESCRIPTION
## What

A cleanliness pass over the `server` module. It removes one dead struct field, corrects three stale comments, fills gaps in exported-method doc coverage, and strips em dashes from comments, test messages, CSS, and the dev test client so the code matches the project's no-em-dash rule. No behavior changes.

Concretely:

- **Dead code.** Dropped the unused `name` field from the autodeploy secret-file loop struct in `internal/autodeploy/config.go`. The loop body only reads `pathKey` and `dst`, unlike the sibling `durations` and `required` structs that genuinely use `name`.
- **Stale comments.** Fixed three voicemail comments in `internal/web/handler_phones.go` that still referenced removed retrieval-code and multi-field validation (there is now a single `ring_timeout_seconds` check), and dropped a dangling `See spec §2.` reference in `internal/calls/linkhealth.go` that pointed at a spec document that does not exist in the repo.
- **Doc coverage.** Added doc comments to the six undocumented `InviteStore` methods in `internal/household/invite.go` and to `Authorizer.CanCall` in `internal/line/authorizer.go`, matching the documented-exported-method style already used across those packages (`GetByID` and the other stores were already documented).
- **Em-dash compliance.** Replaced em dashes with colons or commas in test comments and skip/error messages, CSS header and section comments, the `/test` dev client copy, and the `e2e` README. `CLAUDE.md` forbids em dashes anywhere; these were the only remaining occurrences in the module.

## Why

The `server` module is already in very good shape, so this is a targeted polish rather than a rewrite. The findings came from a review pass looking at cleanliness, idiomatic Go, stale or unreferenced code, project layout, and doc consistency. `staticcheck`, dead-code analysis, `gofmt`, and `go mod tidy` were all already clean; these were the residual rough edges worth smoothing.

### Server code review grade: 90 then 96 (out of 100)

**Before: 90.** The module is genuinely well maintained: `staticcheck` clean, dead-code analysis clean (only test-helper false positives), `gofmt` clean, `go mod tidy` clean, `go build` and `go vet` pass, no TODO/FIXME/HACK markers, a clear package layout, and a well-documented `main.go` wiring path. Points came off for the project's own no-em-dash rule being violated across roughly two dozen files, one dead struct field, a few stale or misleading comments, and inconsistent doc-comment coverage on exported methods (some documented, their siblings not).

**After: 96.** Every issue above is fixed. The remaining gap to 100 is inherently subjective and covers items deliberately left alone with a concrete reason:

- `DeviceState` and `Tracker` leave their obvious CRUD and Redis-mirror methods uncommented as a consistent, package-wide choice. Documenting only some would make it less consistent, not more, so this was skipped as YAGNI.
- The tiny `envOr` helper is duplicated in `cmd/devseed` and `internal/tracing`; `tracing.go` documents that it keeps a local copy to avoid importing `config`. Consolidating would add an awkward dependency for a three-line helper.
- The `/test` dev client is served without auth in production. That is a behavior and routing question, out of scope for a cleanliness-only pass.
- A few packages show low unit coverage because their real coverage lives in integration-tagged tests that the default `go test ./...` run does not count.

## Test plan

- `go build ./...` and `go vet ./...` pass from `server/`.
- `go test ./...` (unit tier) passes for every package.
- Changes are limited to comments, doc strings, test message text, CSS comments, and one unused struct field, so runtime behavior is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BjH1wuTh7kLNV1CyRvEarq)_