### PR TITLE
refactor(digitsd): centralize voicemail playback session construction

### DIFF
--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -1091,6 +1091,26 @@ func (d *daemonCallbacks) closeMixerSourceLocked() {
 	d.voicemailMixerCh = nil
 }
 
+// newPlaybackSessionLocked builds a playback session for an already-open
+// player and installs it as the current session. It is the counterpart to
+// teardownPlaybackLocked: every session is created with its own cancelable
+// context and stored in d.voicemailPlayback here, so that invariant lives in
+// one place rather than being re-spelled at each open site. Caller must hold
+// voicemailMu and have already torn down any prior session.
+func (d *daemonCallbacks) newPlaybackSessionLocked(id int64, number int, saved bool, player *voicemail.Player) *voicemailPlaybackSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	sess := &voicemailPlaybackSession{
+		ctx:    ctx,
+		cancel: cancel,
+		id:     id,
+		number: number,
+		saved:  saved,
+		player: player,
+	}
+	d.voicemailPlayback = sess
+	return sess
+}
+
 // teardownPlaybackLocked cancels the current playback goroutine, closes its
 // player, and clears the session pointer. Caller must hold voicemailMu.
 // Returns the prior session (or nil if there was none) so the caller can
@@ -1133,17 +1153,8 @@ func (d *daemonCallbacks) openNextUnheardLocked(store *voicemail.Store, afterID 
 			slog.Warn("voicemail: open player failed, skipping", "id", m.ID, "error", err)
 			continue
 		}
-		ctx, cancel := context.WithCancel(context.Background())
 		d.voicemailMessageSeq++
-		sess := &voicemailPlaybackSession{
-			ctx:    ctx,
-			cancel: cancel,
-			id:     m.ID,
-			number: d.voicemailMessageSeq,
-			player: player,
-		}
-		d.voicemailPlayback = sess
-		return sess, nil
+		return d.newPlaybackSessionLocked(m.ID, d.voicemailMessageSeq, false, player), nil
 	}
 	return nil, nil
 }
@@ -1183,16 +1194,7 @@ func (d *daemonCallbacks) openNextSavedLocked(store *voicemail.Store) *voicemail
 			slog.Warn("voicemail: open saved player failed, skipping", "id", id, "error", err)
 			continue
 		}
-		ctx, cancel := context.WithCancel(context.Background())
-		sess := &voicemailPlaybackSession{
-			ctx:    ctx,
-			cancel: cancel,
-			id:     id,
-			saved:  true,
-			player: player,
-		}
-		d.voicemailPlayback = sess
-		return sess
+		return d.newPlaybackSessionLocked(id, 0, true, player)
 	}
 }
 
@@ -1207,17 +1209,7 @@ func (d *daemonCallbacks) reopenLocked(store *voicemail.Store, id int64, number 
 	if err != nil {
 		return nil, fmt.Errorf("reopen message %d: %w", id, err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	sess := &voicemailPlaybackSession{
-		ctx:    ctx,
-		cancel: cancel,
-		id:     id,
-		number: number,
-		saved:  saved,
-		player: player,
-	}
-	d.voicemailPlayback = sess
-	return sess, nil
+	return d.newPlaybackSessionLocked(id, number, saved, player), nil
 }
 
 // transitionToSavedPhase announces the saved-message count and begins playing


### PR DESCRIPTION
## What

Adds `newPlaybackSessionLocked` as the constructor counterpart to the existing `teardownPlaybackLocked`, and routes the three voicemail-playback open paths (`openNextUnheardLocked`, `openNextSavedLocked`, `reopenLocked`) through it. No behavior change.

## Why

The three open sites each re-spelled the same three steps: create a cancelable context, build a `voicemailPlaybackSession`, and store it in `d.voicemailPlayback`. That last step is an invariant every open path must honor (the session pointer is how teardown, staleness checks, and the mixer find the active playback), but nothing enforced it, so a future fourth open site could silently forget to install the session.

The teardown side was already centralized in `teardownPlaybackLocked`; the open side was not. This adds the symmetric constructor so session creation and installation live in one place. Each call site collapses to a one-liner that supplies `id`, `number`, and the `saved` flag, and the differences between the three paths (unheard bumps `voicemailMessageSeq`, saved passes `0`/`true`, reopen carries the prior position) stay visible at the call sites where they belong.

Net change is `-8` lines, but the point is the centralized invariant and the constructor/destructor symmetry, not the line count.

## Test plan

- `go build ./...`, `go test ./...`, and `golangci-lint run ./...` all pass from `pi/digitsd/`.
- The refactored paths are exercised by the existing `openNextUnheardLocked` tests in `cmd/digitsd/main_test.go`.