### PR TITLE
refactor(digitsd): drop dead WiFi-AP systemd code path

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1054,11 +1054,10 @@ func setupRegistrations() ([]subsystem.Registration, *subsystem.WebModule, *subs
 		ToneDir:         *toneDir,
 		GPCLK0Retrigger: gpclk0.Retrigger,
 	})
-	// AP is managed by digits-dnsmasq-ap.service (systemd), not our module.
-	wifiAP := subsystem.NewWiFiAPModule(subsystem.WiFiAPConfig{
-		SSID:       "Digits-Setup",
-		UseSystemd: true,
-	})
+	// AP is managed by digits-dnsmasq-ap.service (systemd), not our module,
+	// so this registration is Disabled below: it exists only so the module
+	// shows up as "wifi-ap: disabled" on the setup-mode status page.
+	wifiAP := subsystem.NewWiFiAPModule(subsystem.WiFiAPConfig{SSID: "Digits-Setup"})
 
 	regs := []subsystem.Registration{
 		{Module: gpclk0, Required: true},

--- a/pi/digitsd/internal/subsystem/wifiap.go
+++ b/pi/digitsd/internal/subsystem/wifiap.go
@@ -12,7 +12,6 @@ import (
 
 type WiFiAPConfig struct {
 	SSID          string
-	UseSystemd    bool
 	HostapdPath   string
 	DnsmasqPath   string
 	InterfaceWait time.Duration
@@ -48,14 +47,8 @@ func (w *WiFiAPModule) Init(ctx context.Context) error {
 	}
 	unblockWifi()
 
-	var initErr error
-	if w.cfg.UseSystemd {
-		initErr = w.initSystemd()
-	} else {
-		initErr = w.initDirect()
-	}
-	if initErr != nil {
-		return initErr
+	if err := w.initDirect(); err != nil {
+		return err
 	}
 	w.ready = true
 	return nil
@@ -103,25 +96,9 @@ func (w *WiFiAPModule) initDirect() error {
 	return nil
 }
 
-func (w *WiFiAPModule) initSystemd() error {
-	for _, svc := range []string{"hostapd", "dnsmasq"} {
-		if err := exec.Command("systemctl", "start", svc).Run(); err != nil {
-			return fmt.Errorf("start %s: %w", svc, err)
-		}
-	}
-	slog.Info("subsystem wifi-ap: AP started via systemd", "ssid", w.cfg.SSID)
-	return nil
-}
-
 func (w *WiFiAPModule) Teardown() error {
-	if w.cfg.UseSystemd {
-		for _, svc := range []string{"hostapd", "dnsmasq"} {
-			_ = exec.Command("systemctl", "stop", svc).Run()
-		}
-	} else {
-		_ = exec.Command("killall", "hostapd").Run()
-		_ = exec.Command("killall", "dnsmasq").Run()
-	}
+	_ = exec.Command("killall", "hostapd").Run()
+	_ = exec.Command("killall", "dnsmasq").Run()
 	return nil
 }
 


### PR DESCRIPTION
## What

Removes the unreachable systemd branch from `WiFiAPModule`: the `UseSystemd` config field, the `initSystemd` method, and the `UseSystemd` conditionals in `Init` and `Teardown`. `Init` now always takes `initDirect` and `Teardown` always kills hostapd/dnsmasq directly.

## Why

There are exactly two `WiFiAPModule` registrations:

- Recovery mode (`main.go:1013`) is enabled but leaves `UseSystemd` false, so it already took `initDirect`.
- Setup mode constructed the module with `UseSystemd: true` but registered it `Disabled: true`. The manager excludes disabled modules from its topo layers, so `Init` (and therefore `initSystemd`) and `Teardown` never run for it.

So no code path ever set `UseSystemd` true on a module the manager actually initializes. The field, the method, and the branches were dead. The setup-mode registration stays `Disabled` (with a clarified comment) so the module still reports `wifi-ap: disabled` on the setup status page; only the inert systemd config is dropped.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all pass in `pi/digitsd/`.
- No `wifiap` tests reference the removed field or method; behavior of the one live (recovery) path is unchanged since it already used `initDirect`.