### PR TITLE
refactor(server): bundle link-health name-resolution maps into a type

### DIFF
--- a/server/internal/web/handler_calls.go
+++ b/server/internal/web/handler_calls.go
@@ -105,8 +105,8 @@ func (h *Handler) handleCallLiveDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	linkedIndex := h.linkedIndexForCall(r.Context(), ownedLines)
-	callerEp, calleeEp, err := h.buildCallEndpoints(r.Context(), call, linkedIndex, ownedLines)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForCall(r.Context(), ownedLines)}
+	callerEp, calleeEp, err := h.buildCallEndpoints(r.Context(), call, nr)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "call-live: build endpoints failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/justinlindh/digits/server/internal/auth"
 	"github.com/justinlindh/digits/server/internal/calls"
-	"github.com/justinlindh/digits/server/internal/line"
 )
 
 // ConferenceLinkHealthEdge is the per-directed-edge section of
@@ -57,9 +56,9 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForHousehold(r.Context(), primaryHH)}
 
-	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, nr)
 
 	if err := writeJSON(w, resp); err != nil {
 		slog.ErrorContext(r.Context(), "conference_link_health encode failed", "conf_id", confID, "err", err)
@@ -69,12 +68,12 @@ func (h *Handler) handleConferenceLinkHealth(w http.ResponseWriter, r *http.Requ
 // buildConferenceLinkHealthResp builds the response in-memory (or via DB
 // readback for an ended conference). Always emits all N*(N-1) edges,
 // even if an edge has no samples yet.
-func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string) ConferenceLinkHealthResp {
+func (h *Handler) buildConferenceLinkHealthResp(ctx context.Context, conf *calls.ConferenceSummary, nr nameResolver) ConferenceLinkHealthResp {
 	members := make([]ConferenceMemberInfo, 0, len(conf.Members))
 	for _, m := range conf.Members {
 		members = append(members, ConferenceMemberInfo{
 			Number:      m,
-			DisplayName: resolveMemberDisplayName(m, ownedLines, linkedIndex),
+			DisplayName: nr.display(m),
 			IsHost:      m == conf.Host,
 		})
 	}
@@ -144,7 +143,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 		return
 	}
 
-	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForHousehold(r.Context(), primaryHH)}
 
 	// Subscribe FIRST so samples arriving between the initial snapshot and
 	// the select loop are buffered rather than silently dropped.
@@ -162,7 +161,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	}
 
 	// Initial snapshot.
-	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+	snapshot := h.buildConferenceLinkHealthResp(r.Context(), conf, nr)
 	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "SSE conference stream: initial render failed", "conf_id", confID, "err", err)
@@ -174,7 +173,7 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	flusher.Flush()
 
 	streamSSE(r.Context(), w, flusher, sub, renderEndedConferenceFragment(""), func(ev calls.Event) error {
-		if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, ownedLines, linkedIndex, ev); err != nil {
+		if err := h.writeConferenceEvent(r.Context(), w, flusher, conf, nr, ev); err != nil {
 			slog.DebugContext(r.Context(), "SSE conference stream: write failed", "conf_id", confID, "err", err)
 			return err
 		}
@@ -182,12 +181,12 @@ func (h *Handler) handleConferenceLinkHealthStream(w http.ResponseWriter, r *htt
 	})
 }
 
-func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
+func (h *Handler) writeConferenceEvent(ctx context.Context, w io.Writer, flusher http.Flusher, conf *calls.ConferenceSummary, nr nameResolver, ev calls.Event) error {
 	if handled, err := writeTerminalEvent(w, flusher, ev, renderEndedConferenceFragment); handled {
 		return err
 	}
 	// SampleKind
-	snapshot := h.buildConferenceLinkHealthResp(ctx, conf, ownedLines, linkedIndex)
+	snapshot := h.buildConferenceLinkHealthResp(ctx, conf, nr)
 	fragment, err := h.renderConferenceLinkHealthPanel(snapshot)
 	if err != nil {
 		return err
@@ -228,8 +227,8 @@ func (h *Handler) handleConferenceLiveDetail(w http.ResponseWriter, r *http.Requ
 	}
 	user := auth.UserFromContext(r.Context())
 
-	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
-	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, ownedLines, linkedIndex)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForHousehold(r.Context(), primaryHH)}
+	resp := h.buildConferenceLinkHealthResp(r.Context(), conf, nr)
 
 	_, isHostHH := ownedLines[conf.Host]
 	data := conferenceLiveDetailData{

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -240,14 +240,23 @@ func (h *Handler) requireConferenceHostOwnership(w http.ResponseWriter, r *http.
 	return conf, ownedLines, primaryHH, true
 }
 
-// resolveMemberDisplayName picks the best label for a member phone.
-// Priority: owned-line name (only if non-empty), linked-index peer name,
-// bare number fallback.
-func resolveMemberDisplayName(number string, ownedLines map[string]*line.Line, linkedIndex map[string]string) string {
-	if ln, ok := ownedLines[number]; ok && ln != nil && ln.Name != "" {
+// nameResolver labels a phone number for display. It bundles the two maps
+// (the user's owned lines and the linked-families index) that the link-health
+// handlers always compute together and thread down to their build/render
+// helpers purely to name endpoints. Construct one at the top of a handler and
+// pass it down instead of the two maps.
+type nameResolver struct {
+	ownedLines  map[string]*line.Line
+	linkedIndex map[string]string
+}
+
+// display picks the best label for a member phone. Priority: owned-line name
+// (only if non-empty), linked-index peer name, bare number fallback.
+func (nr nameResolver) display(number string) string {
+	if ln, ok := nr.ownedLines[number]; ok && ln != nil && ln.Name != "" {
 		return ln.Name
 	}
-	if name := resolvePeerName(number, linkedIndex); name != "" {
+	if name := resolvePeerName(number, nr.linkedIndex); name != "" {
 		return name
 	}
 	return number

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -85,9 +85,9 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 	// Linked-household names are shown for peers that the user already sees in
 	// their call log; the underlying auth check does not grant read access to
 	// calls the user was not part of.
-	linkedIndex := h.linkedIndexForHousehold(r.Context(), primaryHH)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForHousehold(r.Context(), primaryHH)}
 
-	caller, callee, err := h.buildCallEndpoints(r.Context(), call, linkedIndex, ownedLines)
+	caller, callee, err := h.buildCallEndpoints(r.Context(), call, nr)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "link_health: build endpoints failed", "call_id", callID, "err", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -104,24 +104,22 @@ func (h *Handler) handleCallLinkHealth(w http.ResponseWriter, r *http.Request) {
 // values for a 2-party call in one go. The same caller/callee pair is needed
 // by the JSON endpoint, the live-detail page, and the SSE sample frame; this
 // helper keeps the duplicated nil-error short-circuit out of all three.
-func (h *Handler) buildCallEndpoints(ctx context.Context, call calls.Call, linkedIndex map[string]string, ownedLines map[string]*line.Line) (LinkHealthEndpointResp, LinkHealthEndpointResp, error) {
-	caller, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Caller, linkedIndex, ownedLines)
+func (h *Handler) buildCallEndpoints(ctx context.Context, call calls.Call, nr nameResolver) (LinkHealthEndpointResp, LinkHealthEndpointResp, error) {
+	caller, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Caller, nr)
 	if err != nil {
 		return LinkHealthEndpointResp{}, LinkHealthEndpointResp{}, fmt.Errorf("caller: %w", err)
 	}
-	callee, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Callee, linkedIndex, ownedLines)
+	callee, err := h.buildLinkHealthEndpoint(ctx, call.ID, call.Callee, nr)
 	if err != nil {
 		return LinkHealthEndpointResp{}, LinkHealthEndpointResp{}, fmt.Errorf("callee: %w", err)
 	}
 	return caller, callee, nil
 }
 
-func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, linkedIndex map[string]string, ownedLines map[string]*line.Line) (LinkHealthEndpointResp, error) {
+func (h *Handler) buildLinkHealthEndpoint(ctx context.Context, callID int64, number string, nr nameResolver) (LinkHealthEndpointResp, error) {
 	out := LinkHealthEndpointResp{Number: number, Window: []LinkHealthSample{}}
 
-	// Display name resolution: owned line first (non-empty name only), then
-	// linked-index for peer names, then bare number as fallback.
-	out.DisplayName = resolveMemberDisplayName(number, ownedLines, linkedIndex)
+	out.DisplayName = nr.display(number)
 
 	if windowMem := h.healthStore.Window(callID, number); len(windowMem) > 0 {
 		out.Window, out.Latest = samplesToWindow(windowMem)
@@ -175,9 +173,9 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 	// change mid-call (household membership changes don't retroactively
 	// apply to a live call), and buildLinkedFamilies + buildLinkedLineIndex
 	// together issue DB queries we don't want on the per-sample hot path.
-	linkedIndex := h.linkedIndexForCall(r.Context(), ownedLines)
+	nr := nameResolver{ownedLines: ownedLines, linkedIndex: h.linkedIndexForCall(r.Context(), ownedLines)}
 
-	if err := h.writeSampleEvent(r.Context(), w, flusher, call, ownedLines, linkedIndex); err != nil {
+	if err := h.writeSampleEvent(r.Context(), w, flusher, call, nr); err != nil {
 		slog.DebugContext(r.Context(), "SSE stream: initial snapshot write failed", "call_id", callID, "err", err)
 		return
 	}
@@ -197,7 +195,7 @@ func (h *Handler) handleCallLinkHealthStream(w http.ResponseWriter, r *http.Requ
 	}
 
 	streamSSE(r.Context(), w, flusher, sub, renderEndedFragment(""), func(ev calls.Event) error {
-		if err := h.writeEvent(r.Context(), w, flusher, call, ownedLines, linkedIndex, ev); err != nil {
+		if err := h.writeEvent(r.Context(), w, flusher, call, nr, ev); err != nil {
 			slog.DebugContext(r.Context(), "SSE stream: write failed; client gone", "call_id", callID, "err", err)
 			return err
 		}
@@ -293,8 +291,8 @@ func writeSSE(w io.Writer, event, data string) error {
 // writeSampleEvent renders the call-live panel for both endpoints and emits
 // it as a "sample" SSE frame. Used for the initial stream snapshot and for
 // every subsequent SampleKind event; the two are the same frame.
-func (h *Handler) writeSampleEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, ownedLines map[string]*line.Line, linkedIndex map[string]string) error {
-	callerEp, calleeEp, err := h.buildCallEndpoints(ctx, call, linkedIndex, ownedLines)
+func (h *Handler) writeSampleEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, nr nameResolver) error {
+	callerEp, calleeEp, err := h.buildCallEndpoints(ctx, call, nr)
 	if err != nil {
 		return err
 	}
@@ -331,12 +329,12 @@ func writeTerminalEvent(w io.Writer, flusher http.Flusher, ev calls.Event, rende
 	return true, nil
 }
 
-func (h *Handler) writeEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, ownedLines map[string]*line.Line, linkedIndex map[string]string, ev calls.Event) error {
+func (h *Handler) writeEvent(ctx context.Context, w io.Writer, flusher http.Flusher, call calls.Call, nr nameResolver, ev calls.Event) error {
 	if handled, err := writeTerminalEvent(w, flusher, ev, renderEndedFragment); handled {
 		return err
 	}
 	// SampleKind
-	return h.writeSampleEvent(ctx, w, flusher, call, ownedLines, linkedIndex)
+	return h.writeSampleEvent(ctx, w, flusher, call, nr)
 }
 
 // linkedIndexForCall builds the linked-families index for display-name


### PR DESCRIPTION
## What

Replaces the `(ownedLines map[string]*line.Line, linkedIndex map[string]string)` parameter pair, threaded through the link-health build/render helpers, with a small `nameResolver` value that carries both maps and exposes a `display(number)` method. The free `resolveMemberDisplayName` function is folded into that method.

## Why

The two maps were a data clump: always computed together at the top of a handler and always passed together down through six helpers (`buildCallEndpoints`, `buildLinkHealthEndpoint`, `writeSampleEvent`, `writeEvent`, `buildConferenceLinkHealthResp`, `writeConferenceEvent`) across three files, purely so `resolveMemberDisplayName` could pick a label. Bundling them:

- puts the "how do we label a phone number" rule in one type instead of a free function that has to re-take both maps,
- drops a parameter from each of those six signatures,
- makes the call sites read `nr.display(m)` instead of `resolveMemberDisplayName(m, ownedLines, linkedIndex)`.

The standalone `ownedLines` membership checks (`isHostHH`, host-ownership gating) are untouched: they run at the handler top level, before the resolver is built, off the same local `ownedLines` the ownership check already returns. The `line` import is dropped from the conference handler now that its signatures no longer name the map type.

## Test plan

In `server/`:

- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` all clean.
- `go test ./...` (unit) passes.
- `go test -tags=integration ./...` compiles and passes (DB-backed cases skip without a DSN).
- `golangci-lint run ./...`: 0 issues.