### PR TITLE
refactor(digitsd): reuse one link_health send builder for 2-party and mesh

### DIFF
--- a/pi/digitsd/cmd/digitsd/linkhealth.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth.go
@@ -37,15 +37,17 @@ func (d *daemonCallbacks) meshReporterOnConnected(pm *owebrtc.PeerManager, peerP
 		}
 		rctx, cancel := context.WithCancel(context.Background())
 		d.meshReporterCancels[peerPhone] = cancel
-		reporter := owebrtc.NewReporter(pm, buildMeshLinkHealthSend(d.sig, peerPhone), d.linkHealthInterval)
+		reporter := owebrtc.NewReporter(pm, buildLinkHealthSend(d.sig, peerPhone), d.linkHealthInterval)
 		go reporter.Run(rctx)
 	}
 }
 
-// buildMeshLinkHealthSend returns an owebrtc.Reporter send callback that
-// emits a link_health signaling message stamped with the given remote
-// peer phone. Every other field is copied through from the sample.
-func buildMeshLinkHealthSend(sig sigSender, peer string) func(owebrtc.Sample) error {
+// buildLinkHealthSend returns an owebrtc.Reporter send callback that emits a
+// link_health signaling message from a sample. peer names the remote endpoint
+// for a mesh (conference) edge; pass "" for a 2-party call, where the server
+// reads the empty Peer as the single-peer case. Every other field is copied
+// through from the sample.
+func buildLinkHealthSend(sig sigSender, peer string) func(owebrtc.Sample) error {
 	return func(s owebrtc.Sample) error {
 		payload := &sigclient.LinkHealthPayload{
 			TS:       s.TS.UnixMilli(),

--- a/pi/digitsd/cmd/digitsd/linkhealth_test.go
+++ b/pi/digitsd/cmd/digitsd/linkhealth_test.go
@@ -15,9 +15,9 @@ func (r *recordingSig) Send(m *sigclient.Message) error {
 	return nil
 }
 
-func TestBuildMeshLinkHealthSend_StampsPeer(t *testing.T) {
+func TestBuildLinkHealthSend_StampsPeer(t *testing.T) {
 	rs := &recordingSig{}
-	send := buildMeshLinkHealthSend(rs, "+15555550123")
+	send := buildLinkHealthSend(rs, "+15555550123")
 
 	loss := float32(1.25)
 	s := owebrtc.Sample{
@@ -45,5 +45,25 @@ func TestBuildMeshLinkHealthSend_StampsPeer(t *testing.T) {
 	}
 	if rs.last.LinkHealth.LossPct == nil || *rs.last.LinkHealth.LossPct != 1.25 {
 		t.Fatalf("LossPct not preserved")
+	}
+}
+
+// The 2-party call path passes peer="" so the message carries no remote-peer
+// stamp; the rest of the payload maps through identically to the mesh case.
+func TestBuildLinkHealthSend_EmptyPeerForTwoParty(t *testing.T) {
+	rs := &recordingSig{}
+	send := buildLinkHealthSend(rs, "")
+
+	if err := send(owebrtc.Sample{TS: time.UnixMilli(1714000000000), ConnType: "host"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if rs.last == nil || rs.last.LinkHealth == nil {
+		t.Fatal("no link_health message sent")
+	}
+	if rs.last.LinkHealth.Peer != "" {
+		t.Fatalf("Peer: got %q want empty", rs.last.LinkHealth.Peer)
+	}
+	if rs.last.LinkHealth.ConnType != "host" {
+		t.Fatalf("ConnType not preserved: got %q", rs.last.LinkHealth.ConnType)
 	}
 }

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -829,19 +829,9 @@ func (d *daemonCallbacks) handleConnectionStateChange(pm *owebrtc.PeerManager, s
 			sig := d.sig
 			interval := d.linkHealthInterval
 			d.mu.Unlock()
-			send := func(s owebrtc.Sample) error {
-				payload := &sigclient.LinkHealthPayload{
-					TS:       s.TS.UnixMilli(),
-					LossPct:  s.LossPct,
-					JitterMs: s.JitterMs,
-					RttMs:    s.RttMs,
-					ConnType: s.ConnType,
-					BytesIn:  s.BytesIn,
-					BytesOut: s.BytesOut,
-				}
-				return sig.Send(&sigclient.Message{Type: sigclient.TypeLinkHealth, LinkHealth: payload})
-			}
-			reporter := owebrtc.NewReporter(pm, send, interval)
+			// 2-party call: no remote-peer stamp (empty Peer). Same payload
+			// mapping as the mesh reporter.
+			reporter := owebrtc.NewReporter(pm, buildLinkHealthSend(sig, ""), interval)
 			go reporter.Run(rctx)
 		} else {
 			d.mu.Unlock()


### PR DESCRIPTION
## What

Deletes the inline `link_health` payload closure in `handleConnectionStateChange` (the 2-party reporter) and reuses `buildMeshLinkHealthSend`, renamed to `buildLinkHealthSend`, for both the 2-party and mesh paths.

## Why

The 2-party reporter built its `sigclient.LinkHealthPayload` with a hand-written closure that mapped all seven `owebrtc.Sample` fields, an exact duplicate of `buildMeshLinkHealthSend` except for the `Peer` stamp. An empty `Peer` is already the 2-party wire form, so `buildLinkHealthSend(sig, "")` produces exactly that message. Keeping two copies meant the field-for-field mapping had to be updated in lockstep whenever `Sample` or `LinkHealthPayload` gained a field; one of the two would eventually be missed.

Reusing the single builder removes that hazard and makes the reporter wiring identical on both paths. The builder is renamed because it is no longer mesh-specific, and its doc now spells out the empty-peer 2-party case.

## Test plan

In `pi/digitsd/`:

- `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` all pass.
- The existing peer-stamping test is retained (renamed), and a new `TestBuildLinkHealthSend_EmptyPeerForTwoParty` covers the now-shared empty-peer path.