### PR TITLE
fix(server): stop a same-hardware reconnect from dropping a live call

### DIFF
--- a/server/internal/signaling/grace_test.go
+++ b/server/internal/signaling/grace_test.go
@@ -124,6 +124,66 @@ func TestOnDisconnectHoldsInCall2Party(t *testing.T) {
 	}
 }
 
+// A device that reconnects with the same hardware_id while its previous
+// connection is still registered must not have its live call torn down. The
+// new conn replaces the old in place and runs OnReconnect (which finds no
+// timer yet); then the old conn's read loop unwinds. OnConnClosed must notice
+// the old conn was superseded and skip teardown, so no orphaned grace timer is
+// left to expire and hang up the reconnected call.
+func TestOnConnClosedSkipsTeardownForSupersededReconnect(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = time.Hour // a wrongly-started timer would not fire during the test
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	oldConn := &Conn{HardwareID: "hw-1", Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", oldConn)
+	newConn := &Conn{HardwareID: "hw-1", Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", newConn) // replaces oldConn in place
+
+	// New conn's register path: cancels any pending timer (there is none yet).
+	relay.OnReconnect(context.Background(), "3140001", "hw-1")
+
+	// Old conn's read loop finally unwinds and reports the disconnect.
+	relay.OnConnClosed(context.Background(), oldConn)
+
+	if relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("an orphaned grace timer was started for a reconnected device")
+	}
+	if len(tracker.ended) != 0 {
+		t.Fatalf("OnCallEnded called %v; the reconnected call must be left intact", tracker.ended)
+	}
+}
+
+// A genuine last-device disconnect (conn still current, not superseded) must
+// still hold the call open with a grace timer. Guards against the reconnect
+// fix over-suppressing normal teardown.
+func TestOnConnClosedHoldsCallForGenuineDisconnect(t *testing.T) {
+	hub := NewHub()
+	tracker := newMockTracker()
+	tracker.peers = map[string]string{"3140001": "3140002"}
+	relay := NewRelay(hub, tracker, nil, nil)
+	relay.GraceWindow = time.Hour
+
+	peer := &Conn{Send: make(chan []byte, 10)}
+	_ = hub.Register("3140002", peer)
+
+	// OnConnClosed runs before Unregister, so the departing conn is still the
+	// hub's current conn for its line: teardown proceeds into the grace path.
+	conn := &Conn{HardwareID: "hw-1", Send: make(chan []byte, 10)}
+	_ = hub.Register("3140001", conn)
+
+	relay.OnConnClosed(context.Background(), conn)
+
+	if !relay.cancelGraceLocal("3140001", "hw-1") {
+		t.Fatal("expected a grace timer for a genuine in-call disconnect")
+	}
+}
+
 func TestOnDisconnectIdlePhoneClearsImmediately(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()

--- a/server/internal/signaling/hub.go
+++ b/server/internal/signaling/hub.go
@@ -501,6 +501,26 @@ func (h *Hub) ConnectionCount(number string) int {
 	return len(h.conns[number])
 }
 
+// ConnIsCurrent reports whether conn is still the hub's registered connection
+// on its line, compared by identity. When a device reconnects with the same
+// hardware_id, Register replaces the previous conn in place, so the displaced
+// conn is no longer current even before its read loop runs Unregister.
+// Disconnect handling uses this to avoid tearing down a line that a newer
+// connection already owns.
+func (h *Hub) ConnIsCurrent(conn *Conn) bool {
+	if conn == nil {
+		return false
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, c := range h.conns[conn.Number] {
+		if c == conn {
+			return true
+		}
+	}
+	return false
+}
+
 // ErrSendTimeout is returned by SendToWithTimeout when the target's send
 // buffer does not drain within the deadline.
 var ErrSendTimeout = errors.New("send timed out: buffer full")

--- a/server/internal/signaling/hub_test.go
+++ b/server/internal/signaling/hub_test.go
@@ -34,6 +34,42 @@ func TestUnregisterRemovesMatchingConnection(t *testing.T) {
 	}
 }
 
+func TestConnIsCurrent(t *testing.T) {
+	hub := NewHub()
+	number := "3140001"
+
+	if hub.ConnIsCurrent(nil) {
+		t.Fatal("nil conn must not be current")
+	}
+
+	conn := &Conn{HardwareID: "hw-1", Send: make(chan []byte, 1)}
+	if hub.ConnIsCurrent(conn) {
+		t.Fatal("unregistered conn must not be current")
+	}
+
+	_ = hub.Register(number, conn)
+	if !hub.ConnIsCurrent(conn) {
+		t.Fatal("registered conn should be current")
+	}
+
+	// A reconnect from the same hardware_id replaces the old conn in place.
+	// The displaced conn is no longer current; the replacement is.
+	replacement := &Conn{HardwareID: "hw-1", Send: make(chan []byte, 1)}
+	_ = hub.Register(number, replacement)
+	if hub.ConnIsCurrent(conn) {
+		t.Fatal("conn displaced by a same-hardware reconnect must not be current")
+	}
+	if !hub.ConnIsCurrent(replacement) {
+		t.Fatal("replacement conn should be current")
+	}
+
+	// After the replacement unregisters, it is no longer current either.
+	hub.Unregister(number, replacement)
+	if hub.ConnIsCurrent(replacement) {
+		t.Fatal("unregistered replacement must not be current")
+	}
+}
+
 func TestIsOnlineReturnsFalseForUnpaired(t *testing.T) {
 	hub := NewHub()
 	conn := &Conn{Send: make(chan []byte, 10)}

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -759,6 +759,24 @@ func (r *Relay) OnRegistered(ctx context.Context, number string) {
 // the call when the last device on that line disconnects. OnDisconnect
 // runs before Unregister (LIFO defer order in handler_ws.go), so the
 // departing conn is still counted; >1 means siblings remain.
+// OnConnClosed is the disconnect entry point for a websocket read loop. It
+// runs OnDisconnect only when conn is still the hub's current connection for
+// its line. A device that reconnects with the same hardware_id replaces its
+// previous conn in place, and the new conn's OnReconnect runs before the old
+// conn's read loop unwinds. Without this guard the old loop would call
+// OnDisconnect, see the (new) sibling as the sole remaining connection, and
+// start a grace timer that nothing cancels, tearing the reconnected call down
+// when the window expires.
+func (r *Relay) OnConnClosed(ctx context.Context, conn *Conn) {
+	if conn == nil {
+		return
+	}
+	if !r.Hub.ConnIsCurrent(conn) {
+		return
+	}
+	r.OnDisconnect(ctx, conn.Number, conn.HardwareID)
+}
+
 func (r *Relay) OnDisconnect(ctx context.Context, number string, hardwareID string) {
 	// Clear any extension state for this specific device, regardless of
 	// whether other devices remain on the line.

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -754,11 +754,6 @@ func (r *Relay) OnRegistered(ctx context.Context, number string) {
 	}
 }
 
-// OnDisconnect cleans up any active calls or conference membership for a
-// phone that disconnected. With multiple devices per line, only tear down
-// the call when the last device on that line disconnects. OnDisconnect
-// runs before Unregister (LIFO defer order in handler_ws.go), so the
-// departing conn is still counted; >1 means siblings remain.
 // OnConnClosed is the disconnect entry point for a websocket read loop. It
 // runs OnDisconnect only when conn is still the hub's current connection for
 // its line. A device that reconnects with the same hardware_id replaces its
@@ -777,6 +772,11 @@ func (r *Relay) OnConnClosed(ctx context.Context, conn *Conn) {
 	r.OnDisconnect(ctx, conn.Number, conn.HardwareID)
 }
 
+// OnDisconnect cleans up any active calls or conference membership for a
+// phone that disconnected. With multiple devices per line, only tear down
+// the call when the last device on that line disconnects. OnDisconnect
+// runs before Unregister (LIFO defer order in handler_ws.go), so the
+// departing conn is still counted; >1 means siblings remain.
 func (r *Relay) OnDisconnect(ctx context.Context, number string, hardwareID string) {
 	// Clear any extension state for this specific device, regardless of
 	// whether other devices remain on the line.

--- a/server/internal/web/handler_ws.go
+++ b/server/internal/web/handler_ws.go
@@ -214,7 +214,7 @@ func (h *Handler) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	// Read pump (blocks until disconnect)
 	defer h.hub.Unregister(number, conn)
-	defer h.relay.OnDisconnect(ctx, number, conn.HardwareID)
+	defer h.relay.OnConnClosed(ctx, conn)
 	defer func() {
 		if msg.HardwareID != "" && h.deviceStore != nil {
 			if err := h.deviceStore.TouchLastSeen(ctx, msg.HardwareID); err != nil {


### PR DESCRIPTION
## What

Fixes a race where a device reconnecting with the same `hardware_id` during an active 2-party call has that call torn down ~20 seconds later.

## Why

When a device reconnects while its previous websocket is still registered, `Hub.Register` replaces the old conn in place and the new conn runs `OnReconnect` before the old conn's read loop unwinds. The reconnect's `cancelGraceLocal` finds no timer yet (nothing to cancel). Then the old loop's `OnDisconnect` runs, sees the new sibling as the sole remaining connection (`ConnectionCount == 1`, so the `> 1` guard does not fire), finds a peer, and calls `startGraceTimer`. Nothing ever cancels that timer, so when `GraceWindow` (20s) expires it runs `endActiveCallsAsHangup` and drops the reconnected, still-active call.

This is common on mobile and flaky Wi-Fi, where a new socket lands before the server notices the stale one via the 45s pong deadline. The user sees a call drop about 20 seconds after a brief blip.

The fix routes disconnect through a new `Relay.OnConnClosed`, which skips teardown when the departing conn is no longer the hub's current connection for its line (identity check via the new `Hub.ConnIsCurrent`). A conn displaced by a same-hardware reconnect is not current, so its stale disconnect no longer starts an orphaned timer. `OnDisconnect` is unchanged and still holds the call open for genuine last-device drops.

## Test plan

- `go test ./internal/signaling/...` passes, including the existing grace-window suite.
- New `TestConnIsCurrent` covers the hub identity check across register, same-hardware replace, and unregister.
- New `TestOnConnClosedSkipsTeardownForSupersededReconnect` reproduces the race and asserts no orphaned grace timer is left and the call is not ended. Verified it fails without the guard (`an orphaned grace timer was started for a reconnected device`) and passes with it.
- New `TestOnConnClosedHoldsCallForGenuineDisconnect` guards against over-suppression: a real last-device disconnect still starts the grace timer.
- `go vet ./internal/signaling/... ./internal/web/...` clean; full server build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_