### PR TITLE
fix(digitsd): close pipeline output channel on stop to stop goroutine leak

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -1728,16 +1728,12 @@ func main() {
 			}
 		}
 		pip.Stop()
-		// Drain any frames buffered between deadline and Stop
-		for {
-			select {
-			case frame := <-pip.OutFrames():
-				recorded = append(recorded, frame...)
-			default:
-				goto drained
-			}
+		// Drain any frames buffered before Stop closed the channel. Ranging
+		// over the now-closed OutFrames yields the remaining buffered frames
+		// and then returns.
+		for frame := range pip.OutFrames() {
+			recorded = append(recorded, frame...)
 		}
-	drained:
 
 		var maxAmp int32
 		for _, s := range recorded {

--- a/pi/digitsd/internal/audio/pipeline.go
+++ b/pi/digitsd/internal/audio/pipeline.go
@@ -233,6 +233,12 @@ func (p *Pipeline) Stop() {
 	close(p.stop)
 	p.wg.Wait()
 
+	// Safe to close now: captureLoop is the sole sender on outPCM and it has
+	// returned (it is registered in p.wg, and p.wg.Wait above blocks until it
+	// exits). Closing unblocks consumers that range over OutFrames so they do
+	// not leak a goroutine per completed call.
+	close(p.outPCM)
+
 	if p.capture != nil {
 		p.capture.Close()
 		p.capture = nil

--- a/pi/digitsd/internal/audio/pipeline_test.go
+++ b/pi/digitsd/internal/audio/pipeline_test.go
@@ -1,6 +1,40 @@
 package audio
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+// TestPipeline_StopClosesOutFrames locks in the contract that Stop closes the
+// output channel so a `for range OutFrames()` consumer drains buffered frames
+// and then exits, instead of blocking forever and leaking its goroutine.
+func TestPipeline_StopClosesOutFrames(t *testing.T) {
+	p := NewPipeline(PipelineConfig{})
+
+	// Frames a consumer would still see buffered when a call ends.
+	p.outPCM <- []int16{1, 2, 3}
+	p.outPCM <- []int16{4, 5, 6}
+
+	p.Stop()
+
+	done := make(chan int, 1)
+	go func() {
+		n := 0
+		for range p.OutFrames() {
+			n++
+		}
+		done <- n
+	}()
+
+	select {
+	case n := <-done:
+		if n != 2 {
+			t.Fatalf("drained %d buffered frames, want 2", n)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("range over OutFrames did not terminate: Stop left the channel open")
+	}
+}
 
 func TestMaybeMute_ZerosWhenMuted(t *testing.T) {
 	frame := []int16{1, 2, 3, 4, 5}


### PR DESCRIPTION
## What

Closes the audio pipeline's output channel in `Pipeline.Stop()` so the per-call encode/record goroutines exit instead of leaking.

## Why

`Pipeline.Stop()` did `close(p.stop); p.wg.Wait()` and closed the ALSA capture and denoiser, but never closed `p.outPCM`. Consumers iterate with `for frame := range OutFrames()` (the WebRTC encode loop in `webrtc.go` and the voicemail greeting recorder in `voicemail.go`). Because the channel was never closed, those ranges blocked forever after each call ended, leaking one goroutine and one retained `*Pipeline` per completed call. On a Pi Zero 2 W with long uptime and many calls this is unbounded goroutine and heap growth.

`captureLoop` is the only sender on `outPCM` and is registered in `p.wg`, so `p.wg.Wait()` guarantees it has returned before the close: no send-on-closed-channel risk. `Stop()` cannot be called twice on the same instance (both hangup and greeting-finalize snapshot-and-nil `d.pipeline` under `d.mu`, so only one caller ever owns a given `*Pipeline`), so no double-close guard is needed.

This also fixes the audio self-test drain loop in `main.go`, which used `select { case <-OutFrames(): ...; default: goto drained }`. Once the channel is closed, a receive is always ready, so `default` would never fire and the loop would busy-spin. It now uses `for range` to drain buffered frames and exit on close.

## Test plan

- `go build ./...` and `go vet ./...` clean for the digitsd module.
- `go test ./internal/audio/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_