### PR TITLE
fix(digitsd): set write deadline on signaling websocket sends

### DIFF
--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -15,6 +15,12 @@ const (
 	// before considering the connection dead. Must be greater than the
 	// server's ping interval (30s).
 	pingTimeout = 45 * time.Second
+
+	// writeTimeout bounds how long any write to the connection may block.
+	// Without it, a half-open TCP connection (WiFi drop / AP restart) with a
+	// full send buffer would block WriteMessage until the kernel TCP
+	// retransmit timeout (minutes), freezing the daemon's main select loop.
+	writeTimeout = 10 * time.Second
 )
 
 // Client connects to a signald WebSocket server and manages message I/O.
@@ -67,7 +73,9 @@ func (c *Client) Connect() error {
 		return fmt.Errorf("signal: marshal register: %w", err)
 	}
 	c.mu.Lock()
-	err = conn.WriteMessage(websocket.TextMessage, data)
+	if err = conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err == nil {
+		err = conn.WriteMessage(websocket.TextMessage, data)
+	}
 	c.mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("signal: send register: %w", err)
@@ -82,7 +90,7 @@ func (c *Client) Connect() error {
 		if err := c.conn.SetReadDeadline(time.Now().Add(pingTimeout)); err != nil {
 			slog.Warn("signal: set read deadline on ping", "error", err)
 		}
-		return c.conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(10*time.Second))
+		return c.conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(writeTimeout))
 	})
 
 	go c.readPump()
@@ -125,6 +133,9 @@ func (c *Client) Send(msg *Message) error {
 	defer c.mu.Unlock()
 	if c.conn == nil {
 		return fmt.Errorf("signal: not connected")
+	}
+	if err := c.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return fmt.Errorf("signal: set write deadline: %w", err)
 	}
 	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
 		return fmt.Errorf("signal: write: %w", err)

--- a/pi/digitsd/internal/signal/client.go
+++ b/pi/digitsd/internal/signal/client.go
@@ -160,8 +160,11 @@ func (c *Client) Close() error {
 	if c.conn == nil {
 		return nil
 	}
-	// Send a clean close frame
-	_ = c.conn.WriteMessage(websocket.CloseMessage,
-		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	// Send a clean close frame. WriteControl carries its own deadline, so a
+	// half-open connection cannot block this write (and the main loop, which
+	// calls Close inline) until the kernel TCP retransmit timeout.
+	_ = c.conn.WriteControl(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		time.Now().Add(writeTimeout))
 	return c.conn.Close()
 }


### PR DESCRIPTION
## What

Adds a write deadline to signaling websocket sends so a half-open TCP connection can no longer freeze the daemon.

## Why

Signaling reads are bounded (45s read deadline via the ping handler) and the pong control write uses a 10s deadline, but ordinary application sends (`Send` and the initial register write) never called `SetWriteDeadline`. On a half-open TCP connection (Wi-Fi drop, AP restart), once the socket send buffer fills, `WriteMessage` blocks until the kernel TCP retransmit timeout, which is many minutes. The sole consumer `handleSignal` runs inline on the daemon's main select loop, so a stuck write freezes hook and keypad processing: the phone cannot dial or even hang up until TCP gives up.

Each application write now sets a `writeTimeout` (10s) deadline first, reusing the constant the pong write already used. All writes are serialized behind the existing `c.mu`, and each new `SetWriteDeadline` is placed inside the same locked region as its paired write, so no data race is introduced. `WriteControl` (pong) is unchanged: gorilla documents it as safe alongside other writers and it carries its own per-call deadline.

## Test plan

- `go test ./internal/signal/...` passes.
- `go vet ./internal/signal/...` and full digitsd module build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_