### PR TITLE
fix(digitsd): stop routing the DIAL:RESET:OK ack to onDial

### DIFF
--- a/pi/digitsd/internal/phone/serial.go
+++ b/pi/digitsd/internal/phone/serial.go
@@ -287,6 +287,12 @@ func isUnsolicitedEvent(line string) bool {
 		return true
 	case strings.HasPrefix(line, "KEY:"):
 		return true
+	case line == "DIAL:RESET:OK":
+		// Ack for the fire-and-forget DIAL:RESET command, not a dialed
+		// number. It shares the DIAL: prefix but must not be forwarded as an
+		// unsolicited event, or it reaches onDial as if the user dialed
+		// "RESET:OK". Handled as a fire-and-forget ack below instead.
+		return false
 	case strings.HasPrefix(line, "DIAL:"):
 		return true
 	case strings.HasPrefix(line, "FSM:"):
@@ -297,10 +303,10 @@ func isUnsolicitedEvent(line string) bool {
 }
 
 // isFireAndForgetAck returns true for protocol acks the Pico emits in
-// response to fire-and-forget commands (HOOK:FLASH:ON/OFF, CALL:CONNECTED).
-// These have no waiting consumer on the Pi side. Without this filter they
-// fall through to the events channel and trigger spurious "unhandled event"
-// warnings for every call.
+// response to fire-and-forget commands (HOOK:FLASH:ON/OFF, CALL:CONNECTED,
+// DIAL:RESET). These have no waiting consumer on the Pi side. Without this
+// filter they fall through to the events channel and trigger spurious
+// "unhandled event" warnings for every call.
 func isFireAndForgetAck(line string) bool {
 	switch line {
 	case "HOOK:FLASH:ON", "HOOK:FLASH:OFF":
@@ -308,6 +314,8 @@ func isFireAndForgetAck(line string) bool {
 	case "CALL:CONNECTED:ACK", "CALL:CONNECTED:IGNORED":
 		return true
 	case "STATE:SET:OK":
+		return true
+	case "DIAL:RESET:OK":
 		return true
 	default:
 		return false
@@ -322,7 +330,7 @@ func isKnownResponsePrefix(line string) bool {
 	switch {
 	case line == "PONG":
 		return true
-	case line == "RST:OK", line == "REBOOT:OK", line == "DIAL:RESET:OK":
+	case line == "RST:OK", line == "REBOOT:OK":
 		return true
 	case line == "RING:ACK", line == "RING:TEST:ACK", line == "RING:DONE":
 		return true

--- a/pi/digitsd/internal/phone/serial_test.go
+++ b/pi/digitsd/internal/phone/serial_test.go
@@ -44,6 +44,9 @@ func TestIsUnsolicitedEvent(t *testing.T) {
 		"RST:OK",
 		"STATE:IDLE",
 		"MODE:KEYTEST", "MODE:NORMAL",
+		// Ack for the fire-and-forget DIAL:RESET command. Shares the DIAL:
+		// prefix but must not be classified as an unsolicited dialed number.
+		"DIAL:RESET:OK",
 	}
 	for _, msg := range commandResponses {
 		if isUnsolicitedEvent(msg) {
@@ -56,6 +59,9 @@ func TestIsFireAndForgetAck(t *testing.T) {
 	acks := []string{
 		"HOOK:FLASH:ON", "HOOK:FLASH:OFF",
 		"CALL:CONNECTED:ACK", "CALL:CONNECTED:IGNORED",
+		// DIAL:RESET is sent fire-and-forget, so its ack has no waiting
+		// consumer and must be dropped here rather than routed as an event.
+		"DIAL:RESET:OK",
 	}
 	for _, msg := range acks {
 		if !isFireAndForgetAck(msg) {


### PR DESCRIPTION
## What

Classifies the firmware's `DIAL:RESET:OK` ack as a fire-and-forget ack so it is no longer forwarded to the controller as a dialed number.

## Why

`DIAL:RESET:OK` is the ack the Pico sends in reply to the fire-and-forget `DIAL:RESET` command. But `isUnsolicitedEvent` returns true for any `DIAL:` prefix, and that check runs before the command-response and known-response paths, so the ack was delivered to the events channel. Downstream, `main.go` routes any `DIAL:` event to `onDial`, so the ack arrived as if the user had dialed the number `RESET:OK`, which runs the contact-filter/reject path or attempts a bogus call. The firmware only ever emits two `DIAL:` lines: `DIAL:RESET:OK` (this ack) and `DIAL:<digits>` (a real dialed number), so the fix is unambiguous.

`DIAL:RESET` is always sent via `SendFire` (no waiting consumer), so its ack should simply be dropped. The change excludes `DIAL:RESET:OK` from `isUnsolicitedEvent`, adds it to `isFireAndForgetAck` (dropped when no command is pending), and removes it from `isKnownResponsePrefix` so there is a single source of truth. A synchronous `DIAL:RESET` would still work: the pending-command path delivers any line to a waiter before the ack classifier runs.

## Test plan

- `go test ./internal/phone/...` passes.
- Extended `TestIsUnsolicitedEvent` to assert `DIAL:RESET:OK` is a command response, not unsolicited.
- Extended `TestIsFireAndForgetAck` to assert `DIAL:RESET:OK` is a fire-and-forget ack. Both assertions fail against the old classifier and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_