### PR TITLE
perf(server): index calls table on caller and callee

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -493,6 +493,12 @@ END $$;`,
 		// that no code ever read or wrote. Its CREATE is gone from v1 above
 		// so fresh databases never get it; this drop covers existing ones.
 		`DROP TABLE IF EXISTS settings`,
+		// v31: index the append-only calls table on caller and callee. Call
+		// history and *69 lookups filter on these columns and sort by
+		// started_at DESC; without indexes they degrade to full sequential
+		// scans as the table grows.
+		`CREATE INDEX IF NOT EXISTS idx_calls_caller ON calls(caller, started_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_calls_callee ON calls(callee, started_at DESC)`,
 	}
 	for _, m := range migrations {
 		if _, err := d.DB.Exec(m); err != nil {


### PR DESCRIPTION
## What

Adds two indexes on the append-only `calls` table: `idx_calls_caller` on `calls(caller, started_at DESC)` and `idx_calls_callee` on `calls(callee, started_at DESC)`.

## Why

The `calls` table had only a `SERIAL PRIMARY KEY`, but every call query filters and sorts on `caller`/`callee` with `started_at DESC`: call history pages, `RecentForPhones`, the `*69` `LastInboundCaller` lookup, and the `OnCallAnswered`/`OnCallEnded` subqueries. `calls` is append-only and grows for the life of a deployment, so those queries were sequential scans that degrade linearly as call volume grows, with the most-hit paths (`OnCallEnded`, history render, `*69`) getting slower over time. The composite `(col, started_at DESC)` shape matches both the filter and the ordering.

Added as a new idempotent migration (`CREATE INDEX IF NOT EXISTS`) matching the existing index idiom in `db.go` (`idx_call_link_health_*`, `idx_devices_*`).

## Test plan

- `go build ./...` and `go vet ./internal/db/... ./internal/calls/...` clean.
- `go test ./internal/calls/...` passes (`internal/db` has no test files).
- Indexes are `IF NOT EXISTS`, so the migration is safe to re-run and on existing databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_