### PR TITLE
ci: run pi-ci on rootfs-overlay, tones, and mixer-state changes

### DIFF
--- a/.github/workflows/pi-ci.yml
+++ b/.github/workflows/pi-ci.yml
@@ -5,10 +5,16 @@ on:
     branches: [main]
     paths:
       - 'pi/digitsd/**'
+      - 'pi/image/rootfs-overlay/**'
+      - 'pi/tones/**'
+      - 'pi/mixer-state/**'
       - '.github/workflows/pi-ci.yml'
   pull_request:
     paths:
       - 'pi/digitsd/**'
+      - 'pi/image/rootfs-overlay/**'
+      - 'pi/tones/**'
+      - 'pi/mixer-state/**'
       - '.github/workflows/pi-ci.yml'
 
 permissions:


### PR DESCRIPTION
## What

Adds `pi/image/rootfs-overlay/**`, `pi/tones/**`, and `pi/mixer-state/**` to the `pi-ci` workflow's push and pull_request path filters.

## Why

The digitsd `embed` Makefile target bundles those three trees into the binary, and `internal/assets` tests assert against the embedded rootfs tree. But `pi-ci` only triggered on `pi/digitsd/**`, so a PR touching only the overlay, tones, or mixer state ran no CI, even though the content ships inside the binary. Meanwhile `pi-release.yml` already fires on `pi/**`, so an untested overlay change could be embedded and released. This closes that gap so overlay/tone/mixer changes exercise the build and the embed/asset tests before release.

## Test plan

- YAML validated with `yaml.safe_load`.
- Both the push and pull_request `paths:` lists updated, mirroring existing structure; the workflow self-reference is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iD5aTGsaxsnVBqqGACovA)_