### PR TITLE
refactor(server): drop dead household return from requireLineOwnershipAdmin

### DIFF
--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -32,16 +32,16 @@ func (h *Handler) requireLineOwnership(w http.ResponseWriter, r *http.Request, n
 // requireLineOwnershipAdmin is requireLineOwnership with an additional admin
 // role check. Used for destructive phone endpoints (delete, factory reset,
 // restart, update, pair, add line).
-func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Request, number string) (*line.Line, *household.Household) {
+func (h *Handler) requireLineOwnershipAdmin(w http.ResponseWriter, r *http.Request, number string) *line.Line {
 	ln, hh := h.requireLineOwnershipWithHousehold(w, r, number)
 	if ln == nil {
-		return nil, nil
+		return nil
 	}
 	if !h.isHouseholdAdmin(r, hh.ID) {
 		http.Error(w, "forbidden", http.StatusForbidden)
-		return nil, nil
+		return nil
 	}
-	return ln, hh
+	return ln
 }
 
 // isHouseholdAdmin reports whether the request's user is an admin of the given

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -558,7 +558,7 @@ func (h *Handler) handlePhoneNamePost(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneNumberPost(w http.ResponseWriter, r *http.Request) {
 	oldNumber := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, oldNumber)
+	ln := h.requireLineOwnershipAdmin(w, r, oldNumber)
 	if ln == nil {
 		return
 	}
@@ -831,7 +831,7 @@ func (h *Handler) pushLineSettings(number string, settings line.Settings) error 
 
 func (h *Handler) handlePhoneUpdate(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	ln := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -901,7 +901,7 @@ func (h *Handler) handlePhoneRingTest(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	ln := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -922,7 +922,7 @@ func (h *Handler) handlePhoneFactoryReset(w http.ResponseWriter, r *http.Request
 
 func (h *Handler) handlePhoneRestart(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	ln := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -981,7 +981,7 @@ func validateDevModePassword(pw string) error {
 // signaling channel.
 func (h *Handler) handlePhoneDevMode(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	ln := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -1129,7 +1129,7 @@ func (h *Handler) respondPhoneCommandResult(w http.ResponseWriter, r *http.Reque
 
 func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	ln, _ := h.requireLineOwnershipAdmin(w, r, number)
+	ln := h.requireLineOwnershipAdmin(w, r, number)
 	if ln == nil {
 		return
 	}
@@ -1143,7 +1143,7 @@ func (h *Handler) handlePhoneDelete(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) handlePhoneConvert(w http.ResponseWriter, r *http.Request) {
 	number := r.PathValue("number")
-	srcLn, _ := h.requireLineOwnershipAdmin(w, r, number)
+	srcLn := h.requireLineOwnershipAdmin(w, r, number)
 	if srcLn == nil {
 		return
 	}


### PR DESCRIPTION
## What

Change `requireLineOwnershipAdmin` to return `*line.Line` instead of `(*line.Line, *household.Household)`.

## Why

The second return value was dead. All 7 call sites in `handler_phones.go` discarded it with `ln, _ := h.requireLineOwnershipAdmin(...)`. The household is only used internally for the admin-role check, so returning it just implied to a reader that callers care about the household when none do.

`requireLineOwnershipWithHousehold` still returns the household for the two handlers that genuinely use it, so nothing loses access.

## Test plan

- `go build ./...`
- `go test ./...`
- `go vet ./internal/web/`
- `golangci-lint run ./internal/web/...` (0 issues)