### PR TITLE
refactor(server): drop always-true ended return from DropMemberPersistent

### DIFF
--- a/server/internal/calls/conference_integration_test.go
+++ b/server/internal/calls/conference_integration_test.go
@@ -117,12 +117,9 @@ func TestDropMemberCreatesContinuationCall_Integration(t *testing.T) {
 	_, _ = tr.OnCallInitiated(context.Background(), "5550100", "5550102")
 	conf, _ := tr.CreateConferencePersistent(context.Background(), "5550100", callID, []string{"5550101", "5550102"})
 
-	remaining, ended, err := tr.DropMemberPersistent(context.Background(), conf.ID, "5550101", "hangup")
+	remaining, err := tr.DropMemberPersistent(context.Background(), conf.ID, "5550101", "hangup")
 	if err != nil {
 		t.Fatalf("DropMemberPersistent: %v", err)
-	}
-	if !ended {
-		t.Fatalf("expected conference ended")
 	}
 	if len(remaining) != 2 {
 		t.Fatalf("expected 2 remaining, got %d", len(remaining))
@@ -234,14 +231,13 @@ func TestDropMemberFiresEvictConference(t *testing.T) {
 		t.Fatalf("CreateConferencePersistent: %v", err)
 	}
 
-	_, ended, err := tr.DropMemberPersistent(ctx, conf.ID, m3, "kick")
+	_, err = tr.DropMemberPersistent(ctx, conf.ID, m3, "kick")
 	if err != nil {
 		t.Fatalf("DropMemberPersistent: %v", err)
 	}
-	if !ended {
-		t.Fatal("v1 DropMember should end the conference (3 -> 2 terminates)")
-	}
 
+	// v1 ends the conference on any drop (3 -> 2 terminates), which evicts it
+	// from the health tracker.
 	if len(h.confEvicts) != 1 || h.confEvicts[0] != conf.ID {
 		t.Fatalf("EvictConference from DropMember: got %v want [%s]", h.confEvicts, conf.ID)
 	}

--- a/server/internal/calls/history_integration_test.go
+++ b/server/internal/calls/history_integration_test.go
@@ -125,12 +125,9 @@ func TestRecentHistoryForPhones_MemberLeave(t *testing.T) {
 		t.Fatalf("CreateConferencePersistent: %v", err)
 	}
 
-	remaining, ended, err := tr.DropMemberPersistent(context.Background(), conf.ID, "7772003", "hangup")
+	remaining, err := tr.DropMemberPersistent(context.Background(), conf.ID, "7772003", "hangup")
 	if err != nil {
 		t.Fatalf("DropMemberPersistent: %v", err)
-	}
-	if !ended {
-		t.Fatal("expected conference ended after drop")
 	}
 	if len(remaining) != 2 {
 		t.Fatalf("expected 2 remaining, got %d", len(remaining))

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -716,15 +716,17 @@ func (t *Tracker) GetConferenceByID(ctx context.Context, confID uuid.UUID) (*Con
 // and (for the 2 surviving members) inserts a fresh calls row stamped with
 // originating_conference_id so Busy() and call history stay consistent after the
 // conference ends but the surviving pair's PC continues as a regular 2-party call.
-func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, ended bool, err error) {
+func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, err error) {
 	// Bail early with a useful error if the phone has no active conference.
 	if t.conferences.ConferenceByPhone(ctx, phone) == nil {
-		return nil, false, fmt.Errorf("phone %s is not in any active conference", phone)
+		return nil, fmt.Errorf("phone %s is not in any active conference", phone)
 	}
 
-	remaining, ended, err = t.conferences.DropMember(ctx, confID, phone, reason)
+	// v1: any drop ends the conference, so ended is always true here. It gates
+	// the health eviction below but is not surfaced to callers.
+	remaining, ended, err := t.conferences.DropMember(ctx, confID, phone, reason)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	// Compute the sorted pair once. All three use sites (DB insert, active map,
@@ -770,7 +772,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 		}
 		return nil
 	}); txErr != nil {
-		return nil, false, txErr
+		return nil, txErr
 	}
 
 	// Register the surviving pair in the 2-party active map so Busy() and
@@ -791,7 +793,7 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 		h.EvictConference(confID)
 	}
 	slog.InfoContext(ctx, "conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining, "ended", ended)
-	return remaining, ended, nil
+	return remaining, nil
 }
 
 // GetCall returns the call row by id. Returns zero-value Call and nil error

--- a/server/internal/signaling/conference.go
+++ b/server/internal/signaling/conference.go
@@ -128,7 +128,7 @@ func (r *Relay) dropMemberFromConference(ctx context.Context, confID uuid.UUID, 
 			others = append(others, p)
 		}
 	}
-	remaining, _, err := r.Tracker.DropMemberPersistent(ctx, confID, phone, reason)
+	remaining, err := r.Tracker.DropMemberPersistent(ctx, confID, phone, reason)
 	if err != nil {
 		slog.ErrorContext(ctx, "drop member", "err", err)
 		return

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -49,7 +49,7 @@ type CallTracker interface {
 	CallIDForPair(ctx context.Context, a, b string) int64
 	CallIDFor(ctx context.Context, number string) (int64, bool)
 	EndConferencePersistent(ctx context.Context, confID uuid.UUID, reason string) error
-	DropMemberPersistent(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, ended bool, err error)
+	DropMemberPersistent(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, err error)
 	LastInboundCaller(ctx context.Context, number string) (string, error)
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -177,8 +177,9 @@ func (m *mockTracker) EndConferencePersistent(ctx context.Context, id uuid.UUID,
 	return err
 }
 
-func (m *mockTracker) DropMemberPersistent(ctx context.Context, id uuid.UUID, phone, reason string) ([]string, bool, error) {
-	return m.conferences.DropMember(ctx, id, phone, reason)
+func (m *mockTracker) DropMemberPersistent(ctx context.Context, id uuid.UUID, phone, reason string) ([]string, error) {
+	remaining, _, err := m.conferences.DropMember(ctx, id, phone, reason)
+	return remaining, err
 }
 
 func (m *mockTracker) LastInboundCaller(ctx context.Context, number string) (string, error) {


### PR DESCRIPTION
## What

Change `Tracker.DropMemberPersistent` to return `(remaining []string, err error)` instead of `(remaining []string, ended bool, err error)`, and update the `CallTracker` interface, the relay mock, and the callers.

## Why

Under v1 conference semantics, any drop ends the conference, so `ended` was always true. The sole production caller (`dropMemberFromConference`) discarded it with `remaining, _, err := ...`; only integration tests read it, and only to assert it was true. It was speculative return surface for a v2 where drops do not end the conference, semantics that do not exist yet, and it made a core signaling contract advertise a variable outcome that never varies.

The internal `ended` value is kept as a local because it still gates the health eviction (`h.EvictConference`). The kick integration test already asserts the eviction happened (`h.confEvicts`), which is the observable effect of the conference ending, so dropping the trivially-true `if !ended` assertions loses no coverage.

## Test plan

- `go build ./...`
- `go test ./...`
- `go vet -tags integration ./internal/calls/ ./internal/signaling/` (compile-checks the integration tests; they require Postgres to run and are covered by server-integration CI)
- `golangci-lint run ./...` and `golangci-lint run --build-tags=integration ./internal/calls/... ./internal/signaling/...` (0 issues)