### PR TITLE
refactor(server): drop always-true ended from DropMember

### DIFF
--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -186,19 +186,19 @@ func (ct *ConferenceTracker) ConferenceContains(ctx context.Context, confID uuid
 	return false
 }
 
-// DropMember removes a single member. Returns the remaining member list and
-// whether the conference ended as a result. In v1, any drop ends the conference
-// (we cap at exactly 3, so dropping to 2 terminates).
-func (ct *ConferenceTracker) DropMember(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, ended bool, err error) {
+// DropMember removes a single member and returns the remaining member list.
+// In v1, any drop ends the conference (we cap at exactly 3, so dropping to 2
+// terminates), so the caller can treat every successful drop as terminal.
+func (ct *ConferenceTracker) DropMember(ctx context.Context, confID uuid.UUID, phone, reason string) (remaining []string, err error) {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
 	conf, ok := ct.active[confID]
 	if !ok {
-		return nil, false, ErrConferenceNotFound
+		return nil, ErrConferenceNotFound
 	}
 	m, ok := conf.Members[phone]
 	if !ok {
-		return nil, false, fmt.Errorf("phone %s not in conference", phone)
+		return nil, fmt.Errorf("phone %s not in conference", phone)
 	}
 	now := time.Now()
 	m.LeftAt = &now
@@ -224,7 +224,7 @@ func (ct *ConferenceTracker) DropMember(ctx context.Context, confID uuid.UUID, p
 		ct.state.End(ctx, confID, remaining)
 	}
 
-	return remaining, true, nil
+	return remaining, nil
 }
 
 // Snapshot returns a copy of the active conference with the given ID, or nil

--- a/server/internal/calls/conference_test.go
+++ b/server/internal/calls/conference_test.go
@@ -53,12 +53,9 @@ func TestConferenceTracker_DropMemberEndsConference(t *testing.T) {
 	ct := NewConferenceTracker()
 	conf, _ := ct.CreateConference(context.Background(), "5550001", 42, []string{"5550002", "5550003"})
 
-	remaining, ended, err := ct.DropMember(context.Background(), conf.ID, "5550002", "hangup")
+	remaining, err := ct.DropMember(context.Background(), conf.ID, "5550002", "hangup")
 	if err != nil {
 		t.Fatalf("drop: %v", err)
-	}
-	if !ended {
-		t.Fatalf("expected conference to end after a drop (v1 caps at 3)")
 	}
 	if len(remaining) != 2 {
 		t.Fatalf("expected 2 remaining members, got %d", len(remaining))

--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -722,9 +722,8 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 		return nil, fmt.Errorf("phone %s is not in any active conference", phone)
 	}
 
-	// v1: any drop ends the conference, so ended is always true here. It gates
-	// the health eviction below but is not surfaced to callers.
-	remaining, ended, err := t.conferences.DropMember(ctx, confID, phone, reason)
+	// v1: any drop ends the conference (see DropMember).
+	remaining, err = t.conferences.DropMember(ctx, confID, phone, reason)
 	if err != nil {
 		return nil, err
 	}
@@ -789,10 +788,10 @@ func (t *Tracker) DropMemberPersistent(ctx context.Context, confID uuid.UUID, ph
 	if s != nil && len(remaining) == 2 {
 		s.OnCallInitiated(ctx, continuationCallID, pairA, pairB)
 	}
-	if h != nil && ended {
+	if h != nil {
 		h.EvictConference(confID)
 	}
-	slog.InfoContext(ctx, "conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining, "ended", ended)
+	slog.InfoContext(ctx, "conference: drop persisted", "conf_id", confID.String(), "dropped", phone, "reason", reason, "remaining", remaining)
 	return remaining, nil
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -178,7 +178,7 @@ func (m *mockTracker) EndConferencePersistent(ctx context.Context, id uuid.UUID,
 }
 
 func (m *mockTracker) DropMemberPersistent(ctx context.Context, id uuid.UUID, phone, reason string) ([]string, error) {
-	remaining, _, err := m.conferences.DropMember(ctx, id, phone, reason)
+	remaining, err := m.conferences.DropMember(ctx, id, phone, reason)
 	return remaining, err
 }
 


### PR DESCRIPTION
## What

Change `ConferenceTracker.DropMember` from `(remaining []string, ended bool, err error)` to `(remaining []string, err error)`, and drop the `ended` handling in its caller `Tracker.DropMemberPersistent`.

## Why

`ended` was a constant `true` on every success path. In v1 a conference caps at exactly 3 members, so any drop takes it to 2 and terminates it: the success return was literally `return remaining, true, nil`. `DropMemberPersistent` even carried a comment saying "ended is always true here" and used the value only to gate an eviction that should always run (`if h != nil && ended`) plus a redundant log field.

This is the same always-true-return pattern removed elsewhere in this package (see #818, #820). The `&& ended` guard read as if a drop could leave the conference alive; it can't. `EvictConference` now runs unconditionally (its behavior is unchanged), and the `ended` log field is dropped.

The `DropMemberEndsConference` test keeps full coverage: its existing `IsBusy` assertions already prove the conference ended and was removed from the active set, so the removed `ended` assertion was redundant.

## Test plan

- `go build ./...` clean.
- `go test ./...` passes (calls, signaling, web, cmd/signald all rebuild and pass).
- `golangci-lint run ./...`: 0 issues.