### PR TITLE
refactor(digitsd): collapse publishVoicemailState wrappers to a force param

### DIFF
--- a/pi/digitsd/cmd/digitsd/main.go
+++ b/pi/digitsd/cmd/digitsd/main.go
@@ -509,11 +509,16 @@ func publishVoicemailStateOnce(sender sigSender, store *voicemail.Store, last *i
 	return true
 }
 
-// publishVoicemailState is the change-driven wrapper used by mutation triggers
-// (recording finalize, MarkHeard, delete). Snapshots the current store,
-// serializes against concurrent callers via publishVMMu, and dedups against
-// publishVMLast so a no-op mutation does not produce a redundant wire message.
-func (d *daemonCallbacks) publishVoicemailState() {
+// publishVoicemailState snapshots the current store, serializes against
+// concurrent callers via publishVMMu, and publishes the unheard count.
+//
+// force=false is the change-driven path used by mutation triggers (recording
+// finalize, MarkHeard, delete): it dedups against publishVMLast so a no-op
+// mutation does not produce a redundant wire message. force=true is the
+// (re)connect path: it sends the current count unconditionally so the server
+// can seed its per-phone cache on every fresh WS session, even when the local
+// count has not changed since the previous publish.
+func (d *daemonCallbacks) publishVoicemailState(force bool) {
 	d.mu.Lock()
 	store := d.voicemailStore
 	sig := d.sig
@@ -521,22 +526,7 @@ func (d *daemonCallbacks) publishVoicemailState() {
 
 	d.publishVMMu.Lock()
 	defer d.publishVMMu.Unlock()
-	publishVoicemailStateOnce(sig, store, &d.publishVMLast, false)
-}
-
-// publishVoicemailStateInitial is the (re)connect wrapper. It sends the
-// current unheard count unconditionally so the server can seed its per-phone
-// cache on every fresh WS session, even when the local count has not changed
-// since the previous publish.
-func (d *daemonCallbacks) publishVoicemailStateInitial() {
-	d.mu.Lock()
-	store := d.voicemailStore
-	sig := d.sig
-	d.mu.Unlock()
-
-	d.publishVMMu.Lock()
-	defer d.publishVMMu.Unlock()
-	publishVoicemailStateOnce(sig, store, &d.publishVMLast, true)
+	publishVoicemailStateOnce(sig, store, &d.publishVMLast, force)
 }
 
 // setVoicemailConfig replaces the local voicemail config under d.mu and
@@ -2058,7 +2048,7 @@ func main() {
 		slog.Warn("signald connect failed, will retry", "error", err)
 	} else {
 		sendDeviceInfo(sig, fwVersion, fwCommit)
-		cb.publishVoicemailStateInitial()
+		cb.publishVoicemailState(true)
 		requestICEServers(sig)
 	}
 
@@ -2355,7 +2345,7 @@ func main() {
 				slog.Info("firmware capability", "version", fwVersion, "flash_capable", hookFlash)
 				sp.SetFlashEnabled(hookFlash)
 				sendDeviceInfo(sig, fwVersion, fwCommit)
-				cb.publishVoicemailStateInitial()
+				cb.publishVoicemailState(true)
 			} else {
 				slog.Info("pico: firmware version unchanged", "version", fwVersion, "commit", fwCommit)
 			}
@@ -2454,7 +2444,7 @@ func reconnectLoop(
 		}
 
 		sendDeviceInfo(sig, fwVersion, fwCommit)
-		cb.publishVoicemailState()
+		cb.publishVoicemailState(false)
 		requestICEServers(sig)
 		done <- sig
 		return

--- a/pi/digitsd/cmd/digitsd/voicemail.go
+++ b/pi/digitsd/cmd/digitsd/voicemail.go
@@ -171,7 +171,7 @@ func (d *daemonCallbacks) VoicemailPickup() {
 	// Fired off the main goroutine so it can take d.mu inside
 	// publishVoicemailState once this function's defer Unlock runs.
 	if savedPartial {
-		go d.publishVoicemailState()
+		go d.publishVoicemailState(false)
 	}
 
 	if d.callPeer == "" {
@@ -506,7 +506,7 @@ func (d *daemonCallbacks) VoicemailRecordEnded() {
 	// At-cap finalize already ran in the OnTrack loop before VoicemailRecordEnded
 	// was scheduled, so HangupCall's finalizedVoicemail branch did not fire and
 	// did not publish. Publish here so the server learns about the new message.
-	d.publishVoicemailState()
+	d.publishVoicemailState(false)
 }
 
 func (d *daemonCallbacks) VoicemailEnabled() (bool, time.Duration) {
@@ -1025,7 +1025,7 @@ func (d *daemonCallbacks) VoicemailKey(digit string) {
 	// not hold the playback mutex. Dedup inside publishVoicemailState makes
 	// this a no-op when the unheard count did not actually change.
 	if mutated {
-		d.publishVoicemailState()
+		d.publishVoicemailState(false)
 	}
 
 	if openErr != nil {
@@ -1405,7 +1405,7 @@ func (d *daemonCallbacks) voicemailAdvanceFromEOF(sess *voicemailPlaybackSession
 	}
 	// Publish after voicemailMu release; dedup makes redundant calls cheap.
 	if mutated {
-		d.publishVoicemailState()
+		d.publishVoicemailState(false)
 	}
 	if openErr != nil {
 		slog.Error("voicemail: open next after EOF failed", "from_id", sess.id, "error", openErr)

--- a/pi/digitsd/cmd/digitsd/webrtc.go
+++ b/pi/digitsd/cmd/digitsd/webrtc.go
@@ -384,7 +384,7 @@ func (d *daemonCallbacks) HangupCall() {
 		d.evaluateLED()
 		// Same finalize pushes a fresh count to the server so the
 		// owner-side web UI badge updates without polling.
-		d.publishVoicemailState()
+		d.publishVoicemailState(false)
 	}
 
 	if d.pendingAutoUpdate.CompareAndSwap(true, false) && d.autoUpdateAllowed() {


### PR DESCRIPTION
## What

Replace the twin methods `publishVoicemailState()` and `publishVoicemailStateInitial()` with a single `publishVoicemailState(force bool)`, and pass the bool at each call site.

## Why

The two methods had byte-for-byte identical bodies: snapshot `voicemailStore` and `sig` under `d.mu`, take `publishVMMu`, then call `publishVoicemailStateOnce(sig, store, &d.publishVMLast, ...)`. They diverged only in the final argument: `false` for the change-driven mutation path (dedups against `publishVMLast`), `true` for the (re)connect path (publishes unconditionally to seed the server's per-phone cache on a fresh WS session).

Two method names for one operation, with the lock/snapshot boilerplate duplicated purely to hide a boolean. Folding them into one `force`-parameterized method removes the duplication and keeps a single serialization/snapshot path. The former `Initial` callers (connect / reconnect) pass `true`; every mutation trigger passes `false`. No behavior change.

## Test plan

- `go build ./...` clean.
- `go test ./...` passes.
- `golangci-lint run ./...`: 0 issues.