### PR TITLE
refactor(server): dedupe the end-call SET clause into a const

### DIFF
--- a/server/internal/calls/tracker.go
+++ b/server/internal/calls/tracker.go
@@ -238,8 +238,7 @@ func (t *Tracker) OnCallEnded(ctx context.Context, caller, callee string) error 
 	}
 
 	_, err := t.db.ExecContext(ctx,
-		`UPDATE calls SET status = 'ended', ended_at = CURRENT_TIMESTAMP,
-		 duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT
+		`UPDATE calls SET `+endCallSetClause+`
 		 WHERE id = (
 		   SELECT id FROM calls
 		   WHERE ((caller = $1 AND callee = $2) OR (caller = $3 AND callee = $4))
@@ -296,8 +295,7 @@ func (t *Tracker) ClearByNumber(ctx context.Context, number string) {
 	// End any open calls in the database
 	if t.db != nil {
 		if _, err := t.db.ExecContext(ctx,
-			`UPDATE calls SET status = 'ended', ended_at = CURRENT_TIMESTAMP,
-		 duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT
+			`UPDATE calls SET `+endCallSetClause+`
 		 WHERE (caller = $1 OR callee = $1)
 		 AND status IN ('initiated', 'ringing', 'connected')`,
 			number,
@@ -486,6 +484,13 @@ func (t *Tracker) Active(ctx context.Context) []ActiveCall {
 // scanCallRows. Keep the order in sync with the scan there.
 const callColumns = `id, caller, callee, status, started_at, answered_at, ended_at, duration_s,
 	end_reason, originating_conference_id, force_ended_by`
+
+// endCallSetClause is the UPDATE SET list that marks a call ended and stamps
+// its duration from the answer time (or the start time, for a call that rang
+// but never answered). Shared by the normal-hangup and disconnect-sweep
+// teardown paths so the duration expression cannot drift between them.
+const endCallSetClause = `status = 'ended', ended_at = CURRENT_TIMESTAMP,
+	duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT`
 
 func scanCallRows(rows *sql.Rows) ([]Call, error) {
 	var calls []Call


### PR DESCRIPTION
## What

Extract the shared "mark a call ended" UPDATE SET clause in `internal/calls/tracker.go` into an `endCallSetClause` const and interpolate it into the two teardown queries (`OnCallEnded`, `ClearByNumber`).

## Why

Both statements carried the identical SET clause verbatim:

```
status = 'ended', ended_at = CURRENT_TIMESTAMP,
duration_s = EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(answered_at, started_at)))::INT
```

differing only in their `WHERE`. The `EXTRACT(EPOCH FROM ... COALESCE(answered_at, started_at))::INT` duration expression is easy to get subtly wrong and must stay identical between the normal-hangup path (`OnCallEnded`) and the disconnect-sweep path (`ClearByNumber`); keeping two copies invites silent drift on a future edit to the duration semantics.

Hoisting it into a const follows the same pattern the file already uses for `callColumns` and `conferenceSummaryColumns`. The separate ended-write in `CreateConferencePersistent` (the conference-merge case) is intentionally left as-is: it sets a different `end_reason` and computes no duration, so it is not the same clause. No SQL semantics change; the only difference is whitespace, which Postgres ignores.

## Test plan

- `go build ./...` and `go build -tags integration ./...` clean.
- `go test ./...` passes; `go vet ./internal/calls/...` clean.
- `golangci-lint run ./...`: 0 issues.