### PR TITLE
fix(server): server code cleanliness pass, including email footer copy

### DIFF
--- a/server/internal/auth/google.go
+++ b/server/internal/auth/google.go
@@ -137,8 +137,7 @@ func (g *GoogleAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 			}
 		case errors.Is(err, ErrUserNotFound):
 			// New user
-			googleID := info.ID
-			user, err = g.store.CreateUser(r.Context(), info.Email, info.Name, &googleID)
+			user, err = g.store.CreateUser(r.Context(), info.Email, info.Name, &info.ID)
 			if err != nil {
 				http.Error(w, "failed to create user", http.StatusInternalServerError)
 				return

--- a/server/internal/autodeploy/deploy.go
+++ b/server/internal/autodeploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -228,16 +229,14 @@ func (d *Deployer) deployVersion(ctx context.Context, version string, healthTime
 		"--env-file", d.Cfg.ComposeEnvFile,
 	}
 
-	pullArgs := append(append([]string{}, composeArgs...), "pull")
-	pullArgs = append(pullArgs, d.Cfg.Services...)
+	pullArgs := slices.Concat(composeArgs, []string{"pull"}, d.Cfg.Services)
 	if err := d.Runner.Run(ctx, RunSpec{
 		Name: "docker", Args: pullArgs, Dir: d.Cfg.ComposeDir, Env: env,
 	}); err != nil {
 		return &stepError{Step: StepPull, Err: err}
 	}
 
-	upArgs := append(append([]string{}, composeArgs...), "up", "-d", "--wait")
-	upArgs = append(upArgs, d.Cfg.Services...)
+	upArgs := slices.Concat(composeArgs, []string{"up", "-d", "--wait"}, d.Cfg.Services)
 	if err := d.Runner.Run(ctx, RunSpec{
 		Name: "docker", Args: upArgs, Dir: d.Cfg.ComposeDir, Env: env,
 	}); err != nil {

--- a/server/internal/calls/conference.go
+++ b/server/internal/calls/conference.go
@@ -94,7 +94,7 @@ func (ct *ConferenceTracker) CreateConference(ctx context.Context, host string, 
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
 
-	if 1+len(addedMembers) != 3 {
+	if len(addedMembers) != 2 {
 		return nil, ErrInvalidConferenceSize
 	}
 	if _, ok := ct.memberIndex[host]; ok {

--- a/server/internal/calls/conference_state_redis.go
+++ b/server/internal/calls/conference_state_redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -99,16 +100,7 @@ func (cs *ConfState) Contains(ctx context.Context, confID uuid.UUID, phoneA, pho
 		slog.ErrorContext(ctx, "redis: ConfState.Contains unmarshal failed", "confID", confID, "err", err)
 		return false
 	}
-	hasA, hasB := false, false
-	for _, m := range rc.Members {
-		if m == phoneA {
-			hasA = true
-		}
-		if m == phoneB {
-			hasB = true
-		}
-	}
-	return hasA && hasB
+	return slices.Contains(rc.Members, phoneA) && slices.Contains(rc.Members, phoneB)
 }
 
 // RemoveMember deletes a single member's key from Redis.

--- a/server/internal/calls/linkhealth_redis.go
+++ b/server/internal/calls/linkhealth_redis.go
@@ -20,7 +20,7 @@ const linkHealthChannel = "digits:linkhealth"
 // redisPublisher is the subset of redis.UniversalClient the HealthStore
 // uses. Narrowed for testability.
 type redisPublisher interface {
-	Publish(ctx context.Context, channel string, message interface{}) *redis.IntCmd
+	Publish(ctx context.Context, channel string, message any) *redis.IntCmd
 	Subscribe(ctx context.Context, channels ...string) *redis.PubSub
 }
 

--- a/server/internal/calls/state_redis.go
+++ b/server/internal/calls/state_redis.go
@@ -16,6 +16,13 @@ const (
 	callTTL = 30 * time.Minute
 )
 
+// callEntry.Role values for a 2-party call. Written by OnCallInitiated and
+// read back by Active/CanAddAsHost, so the writer and readers must agree.
+const (
+	roleCaller = "caller"
+	roleCallee = "callee"
+)
+
 type callEntry struct {
 	ID        int64     `json:"id"`
 	Role      string    `json:"role"`
@@ -39,12 +46,12 @@ func NewCallState(client redis.UniversalClient) *CallState {
 func (s *CallState) OnCallInitiated(ctx context.Context, callID int64, caller, callee string) {
 	now := time.Now()
 
-	callerEntry, err := json.Marshal(callEntry{ID: callID, Role: "caller", StartedAt: now})
+	callerEntry, err := json.Marshal(callEntry{ID: callID, Role: roleCaller, StartedAt: now})
 	if err != nil {
 		slog.ErrorContext(ctx, "redis: marshal caller entry failed", "err", err)
 		return
 	}
-	calleeEntry, err := json.Marshal(callEntry{ID: callID, Role: "callee", StartedAt: now})
+	calleeEntry, err := json.Marshal(callEntry{ID: callID, Role: roleCallee, StartedAt: now})
 	if err != nil {
 		slog.ErrorContext(ctx, "redis: marshal callee entry failed", "err", err)
 		return
@@ -215,7 +222,7 @@ func (s *CallState) CanAddAsHost(ctx context.Context, number string) bool {
 		if err := json.Unmarshal([]byte(raw), &e); err != nil {
 			return false
 		}
-		return e.Role == "caller"
+		return e.Role == roleCaller
 	}
 	return false
 }
@@ -248,7 +255,7 @@ func (s *CallState) Active(ctx context.Context) []ActiveCall {
 			seen[e.ID] = true
 
 			var caller, callee string
-			if e.Role == "caller" {
+			if e.Role == roleCaller {
 				caller = number
 				callee = peer
 			} else {

--- a/server/internal/device/store.go
+++ b/server/internal/device/store.go
@@ -24,7 +24,6 @@ type Device struct {
 	LineID               *int64
 	Name                 string
 	HardwareID           string
-	DeviceID             string
 	DeviceToken          *string
 	PairingCode          *string
 	PairingCodeExpiresAt *time.Time
@@ -48,7 +47,7 @@ func NewStore(db *sql.DB) *Store {
 
 // deviceColumns is the SELECT list for queries that scan into a Device via
 // scanDevice. Keep the order in sync with the scan there.
-const deviceColumns = `id, line_id, name, hardware_id, device_id, device_token,
+const deviceColumns = `id, line_id, name, hardware_id, device_token,
 	pairing_code, pairing_code_expires_at, paired_at, created_at, last_seen_at`
 
 // scanDevice materializes a Device from any row whose columns match
@@ -56,7 +55,7 @@ const deviceColumns = `id, line_id, name, hardware_id, device_id, device_token,
 func scanDevice(row dbutil.RowScanner) (Device, error) {
 	var d Device
 	if err := row.Scan(
-		&d.ID, &d.LineID, &d.Name, &d.HardwareID, &d.DeviceID, &d.DeviceToken,
+		&d.ID, &d.LineID, &d.Name, &d.HardwareID, &d.DeviceToken,
 		&d.PairingCode, &d.PairingCodeExpiresAt, &d.PairedAt, &d.CreatedAt, &d.LastSeenAt,
 	); err != nil {
 		return Device{}, fmt.Errorf("scan device: %w", err)

--- a/server/internal/email/templates.go
+++ b/server/internal/email/templates.go
@@ -27,7 +27,7 @@ func brandedWrap(content string) string {
 
 <!-- Footer -->
 <tr><td style="padding:24px 0 0 0; text-align:center;">
-  <p style="color:#484f58; font-size:12px; margin:0;">Digits &#8212; A phone for real conversations</p>
+  <p style="color:#484f58; font-size:12px; margin:0;">Digits: a phone for real conversations</p>
   <p style="color:#484f58; font-size:11px; margin:4px 0 0 0;">No screens. No surveillance. Just voice.</p>
 </td></tr>
 

--- a/server/internal/email/templates_test.go
+++ b/server/internal/email/templates_test.go
@@ -23,7 +23,7 @@ func TestMagicLinkEmailContainsBranding(t *testing.T) {
 
 func TestAllEmailsHaveFooter(t *testing.T) {
 	_, body := MagicLinkEmail("https://example.com/link")
-	if !strings.Contains(body, "A phone for real conversations") {
+	if !strings.Contains(body, "a phone for real conversations") {
 		t.Fatal("email missing footer tagline")
 	}
 }

--- a/server/internal/events/broadcaster.go
+++ b/server/internal/events/broadcaster.go
@@ -103,12 +103,7 @@ func (b *Broadcaster) Notify() {
 	b.mu.Lock()
 	client := b.client
 	podID := b.podID
-	for ch := range b.subs {
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	}
+	b.wakeLocalLocked()
 	b.mu.Unlock()
 
 	if client != nil {
@@ -123,6 +118,12 @@ func (b *Broadcaster) Notify() {
 func (b *Broadcaster) notifyLocal() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.wakeLocalLocked()
+}
+
+// wakeLocalLocked does a best-effort non-blocking send to every local
+// subscriber. Callers must hold b.mu.
+func (b *Broadcaster) wakeLocalLocked() {
 	for ch := range b.subs {
 		select {
 		case ch <- struct{}{}:

--- a/server/internal/household/invite.go
+++ b/server/internal/household/invite.go
@@ -14,6 +14,13 @@ import (
 
 const inviteTTL = 7 * 24 * time.Hour
 
+// normalizeEmail lower-cases and trims an address so invite lookups and
+// writes compare consistently. Matches the normalization the auth package
+// applies to login addresses.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
 // InviteStatusPending is the only invite status compared in Go; the SQL in
 // this file also writes 'accepted' and 'cancelled', matching the DB CHECK
 // constraint defined in db.go.
@@ -78,7 +85,7 @@ func (s *InviteStore) CreateInvite(ctx context.Context, householdID, email, invi
 	if err != nil {
 		return nil, err
 	}
-	email = strings.ToLower(strings.TrimSpace(email))
+	email = normalizeEmail(email)
 	inv, err := scanInvite(s.db.QueryRowContext(ctx, `
 		INSERT INTO household_invites (household_id, email, invited_by, token, expires_at)
 		VALUES ($1, $2, $3, $4, $5)
@@ -184,7 +191,7 @@ func (s *InviteStore) GetPendingForHousehold(ctx context.Context, householdID st
 // IsPendingForHouseholdEmail reports whether a pending, unexpired invite
 // already exists for email in householdID.
 func (s *InviteStore) IsPendingForHouseholdEmail(ctx context.Context, householdID, email string) (bool, error) {
-	email = strings.ToLower(strings.TrimSpace(email))
+	email = normalizeEmail(email)
 	var count int
 	err := s.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM household_invites

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -155,7 +155,7 @@ func New(version, commit string) *Registry {
 func (r *Registry) registerScrapeGauge(name, help string, read func() float64) {
 	g := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "digits",
-		Subsystem: "signald",
+		Subsystem: serviceName,
 		Name:      name,
 		Help:      help,
 	}, read)
@@ -245,7 +245,7 @@ func (r *Registry) ObserveICEServersIssued(turn bool) {
 }
 
 // Middleware returns an http.Handler middleware that records request count
-// and duration into the registry. It calls routeOf to bucket the path into
+// and duration into the registry. It calls RouteOf to bucket the path into
 // a coarse route group; that function is the privacy boundary, so it lives
 // in this package and is exported for tests.
 func (r *Registry) Middleware(next http.Handler) http.Handler {

--- a/server/internal/updates/store.go
+++ b/server/internal/updates/store.go
@@ -2,12 +2,12 @@
 package updates
 
 import (
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
 
-// Component selectors used by SortedReleases and RangeReleases.
+// Component selectors identifying which artifact a release describes.
 const (
 	ComponentPi       = "pi"
 	ComponentFirmware = "firmware"
@@ -66,8 +66,8 @@ func (idx *ReleaseIndex) SortedReleases(component string) []Release {
 	for _, r := range m {
 		releases = append(releases, *r)
 	}
-	sort.Slice(releases, func(i, j int) bool {
-		return CompareSemver(releases[i].Version, releases[j].Version) > 0
+	slices.SortFunc(releases, func(a, b Release) int {
+		return CompareSemver(b.Version, a.Version)
 	})
 	return releases
 }
@@ -99,7 +99,7 @@ func (idx *ReleaseIndex) RangeReleases(component, fromVersion, toVersion string)
 func CompareSemver(a, b string) int {
 	partsA := strings.SplitN(a, ".", 3)
 	partsB := strings.SplitN(b, ".", 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		var pa, pb string
 		if i < len(partsA) {
 			pa = partsA[i]

--- a/server/internal/web/handler.go
+++ b/server/internal/web/handler.go
@@ -226,9 +226,7 @@ type Handler struct {
 	inviteStore *household.InviteStore
 	emailer     email.Sender
 	// Rate limiters. All are Handler fields so Router() has a single
-	// construction pattern; previously the magic-link verify and Google
-	// login limiters were instantiated inline inside Router(), which made
-	// them harder to spot and impossible to share across request types.
+	// construction pattern and limiters can be shared across request types.
 	authLimiter        *ratelimit.Limiter // POST /auth/magic (magic link request)
 	magicVerifyLimiter *ratelimit.Limiter // GET  /auth/magic/{token}
 	googleLoginLimiter *ratelimit.Limiter // GET  /auth/google/login
@@ -274,7 +272,7 @@ type HandlerConfig struct {
 
 // Deps bundles the stores, hub, and other collaborators the web Handler
 // depends on. Named fields prevent a silent swap between same-typed
-// parameters (the previous 16-arg positional NewHandler made that easy).
+// parameters.
 type Deps struct {
 	LineStore      *line.Store
 	DeviceStore    *device.Store

--- a/server/internal/web/handler_conference_linkhealth.go
+++ b/server/internal/web/handler_conference_linkhealth.go
@@ -287,6 +287,5 @@ func (h *Handler) handleConferenceKick(w http.ResponseWriter, r *http.Request) {
 	// state with attribution before the evict cascade closes the channel.
 	h.healthStore.NotifyDisconnectedConference(confID, userDisplayLabel(user))
 
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{}`))
+	writeEmptyJSON(w)
 }

--- a/server/internal/web/handler_dashboard.go
+++ b/server/internal/web/handler_dashboard.go
@@ -196,7 +196,7 @@ func (h *Handler) handleDashboard(w http.ResponseWriter, r *http.Request) {
 			Now:            now,
 		},
 	}
-	renderWith(r.Context(), w, h.tmplDashboard, layoutFor(r), data)
+	renderWith(ctx, w, h.tmplDashboard, layoutFor(r), data)
 }
 
 func countOnline(lines []lineRow) int {

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -15,9 +15,8 @@ import (
 // as a keep-alive so proxies don't close idle streams.
 const dashTickInterval = 15 * time.Second
 
-// sseEventStatus names the single SSE event this stream emits. The
-// dashboard.html sse-swap attribute subscribes by this exact name, so a typo
-// here silently breaks the client swap with no compile error.
+// sseEventStatus is the event name the dashboard.html sse-swap subscribes to;
+// keep the two in sync.
 const sseEventStatus = "status"
 
 // handleDashboardStream opens an SSE stream for the AM-theme top-row

--- a/server/internal/web/handler_dashboard_stream.go
+++ b/server/internal/web/handler_dashboard_stream.go
@@ -15,6 +15,11 @@ import (
 // as a keep-alive so proxies don't close idle streams.
 const dashTickInterval = 15 * time.Second
 
+// sseEventStatus names the single SSE event this stream emits. The
+// dashboard.html sse-swap attribute subscribes by this exact name, so a typo
+// here silently breaks the client swap with no compile error.
+const sseEventStatus = "status"
+
 // handleDashboardStream opens an SSE stream for the AM-theme top-row
 // counters and clock. Sends one initial "status" event with the current
 // snapshot, then a fresh snapshot on every Notify from the dashboard
@@ -72,7 +77,7 @@ func (h *Handler) writeDashStatus(w http.ResponseWriter, flusher http.Flusher, r
 		slog.ErrorContext(r.Context(), "dashboard SSE: render failed", "err", err)
 		return err
 	}
-	if err := writeSSE(w, "status", fragment); err != nil {
+	if err := writeSSE(w, sseEventStatus, fragment); err != nil {
 		return err
 	}
 	flusher.Flush()

--- a/server/internal/web/handler_helpers.go
+++ b/server/internal/web/handler_helpers.go
@@ -113,8 +113,7 @@ func (h *Handler) ownedLinesForUser(ctx context.Context, user *auth.User) (map[s
 			return nil, nil, false
 		}
 		for i := range hhLines {
-			ln := hhLines[i]
-			lines[ln.Number] = &ln
+			lines[hhLines[i].Number] = &hhLines[i]
 		}
 	}
 	return lines, households[0], true
@@ -506,12 +505,8 @@ func (h *Handler) hasPhoneUpdates(ctx context.Context, householdID string) bool 
 	if err != nil {
 		return false
 	}
-	lineNumbers := make([]string, len(lines))
-	for i, l := range lines {
-		lineNumbers[i] = l.Number
-	}
-	for _, number := range lineNumbers {
-		for _, info := range h.hub.AllDeviceInfo(number) {
+	for _, l := range lines {
+		for _, info := range h.hub.AllDeviceInfo(l.Number) {
 			if latestPi != "" && info.PiVersion != "" && updates.CompareSemver(info.PiVersion, latestPi) < 0 {
 				return true
 			}
@@ -547,6 +542,13 @@ func jsonError(ctx context.Context, w http.ResponseWriter, msg string, code int)
 func writeJSON(w http.ResponseWriter, v any) error {
 	w.Header().Set("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(v)
+}
+
+// writeEmptyJSON writes an empty JSON object with an implicit 200 status, for
+// endpoints whose success response carries no body beyond acknowledgement.
+func writeEmptyJSON(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte("{}"))
 }
 
 func renderWith(ctx context.Context, w http.ResponseWriter, t *template.Template, name string, data any) {

--- a/server/internal/web/handler_linkhealth.go
+++ b/server/internal/web/handler_linkhealth.go
@@ -392,8 +392,7 @@ func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
 	// Idempotency: if the call already ended, just return 200 without
 	// touching the audit column.
 	if call.Status == calls.CallStatusEnded {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte("{}"))
+		writeEmptyJSON(w)
 		return
 	}
 
@@ -427,6 +426,5 @@ func (h *Handler) handleCallDisconnect(w http.ResponseWriter, r *http.Request) {
 		// when the next peer hangup arrives or during the daily cleanup.
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte("{}"))
+	writeEmptyJSON(w)
 }

--- a/server/internal/web/handler_phones.go
+++ b/server/internal/web/handler_phones.go
@@ -20,7 +20,7 @@ import (
 
 const maxLineNameRunes = 50
 
-func oldestVersions(infos []signaling.DeviceInfoSnapshot) (fw, pi string) {
+func oldestVersions(infos []signaling.DeviceInfoSnapshot) (pi, fw string) {
 	for _, info := range infos {
 		if info.FirmwareVersion != "" && (fw == "" || updates.CompareSemver(info.FirmwareVersion, fw) < 0) {
 			fw = info.FirmwareVersion
@@ -40,7 +40,7 @@ func updateNotes(idx *updates.ReleaseIndex, infos []signaling.DeviceInfoSnapshot
 	if idx == nil {
 		return nil, nil
 	}
-	oldestFw, oldestPi := oldestVersions(infos)
+	oldestPi, oldestFw := oldestVersions(infos)
 	if latestPi != "" && oldestPi != "" && updates.CompareSemver(oldestPi, latestPi) < 0 {
 		pi = idx.RangeReleases(updates.ComponentPi, oldestPi, latestPi)
 	}

--- a/server/internal/web/handler_phones_test.go
+++ b/server/internal/web/handler_phones_test.go
@@ -109,7 +109,7 @@ func TestOldestVersions(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			fw, pi := oldestVersions(tc.infos)
+			pi, fw := oldestVersions(tc.infos)
 			if fw != tc.wantFw || pi != tc.wantPi {
 				t.Errorf("oldestVersions: got fw=%q pi=%q, want fw=%q pi=%q", fw, pi, tc.wantFw, tc.wantPi)
 			}


### PR DESCRIPTION
## What

A fine-toothed cleanliness pass over the `server/` module: stdlib idiom adoption, small de-duplications, naming a few magic literals, dropping one dead struct field, and fixing a couple of stale comments. The one user-visible change is the email footer copy (an em dash the repo style rules forbid).

### Grade: 91 → 94

The module was already in strong shape going in. `go build`, `go vet`, `staticcheck`, and `deadcode` all passed clean before this PR, the unit suite was green, there were no TODOs, and the recent history (#795-827) is largely tidy-up refactors. So this is a polish pass, not a rescue. The remaining nits were consistency drift, a few hand-rolled stdlib equivalents, small duplications, one unread field, two stale comments, and one em-dash rule violation.

## Why

Each commit targets one theme so it reads cleanly:

- **`fix(server): drop em dash from email footer copy`** The branded email footer rendered `Digits &#8212; A phone...`, an em dash the style rules forbid everywhere including in-app copy. Now `Digits: a phone...`.
- **`refactor(server): adopt stdlib slices/range and pointer idioms`** `sort.Slice` to `slices.SortFunc`; a C-style `for i := 0; i < 3` to `for i := range 3`; a manual membership scan to two `slices.Contains` calls; `append(append([]string{}, base...), x)` to `slices.Concat`; dropped a needless pointer copy in the Google new-user path; reused a bound `ctx` instead of re-fetching `r.Context()`.
- **`refactor(server): use any instead of interface{} in redis publisher`** The one remaining `interface{}` in the tree; everything else already uses `any`.
- **`refactor(server): extract repeated response and normalization helpers`** `writeEmptyJSON` replaces three copies of the write-`{}` pattern (one quoted differently); `normalizeEmail` replaces two inline `ToLower(TrimSpace(...))` calls in the household package; `wakeLocalLocked` replaces the identical fan-out loop in `Notify` and `notifyLocal`; dropped an intermediate slice in `hasPhoneUpdates`.
- **`refactor(server): name magic literals, drop dead field, fix stale comments`** `serviceName` const for the scrape-gauge subsystem instead of a duplicated `"signald"`; `roleCaller`/`roleCallee` consts for the caller/callee literals shared by writer and readers; `sseEventStatus` const for the bare `"status"` SSE event name; conference size guard reads `len(addedMembers) != 2`; dropped `device.Device.DeviceID`, which was selected and scanned on every query but never read; trimmed two comments that justified the design by describing deleted code; fixed a `routeOf`/`RouteOf` reference in a doc comment; `oldestVersions` returns `(pi, fw)` to match its sibling and call sites.
- **`refactor(server): trim the sseEventStatus comment`** Output of the `/simplify` pass (below).

### `/simplify` pass

Ran `/simplify` across the diff (reuse, simplification, efficiency, altitude angles). Results:

- **Efficiency:** no regressions; the `slices.Concat`/`slices.SortFunc`/`&hhLines[i]` changes are all neutral-to-cheaper, and dropping the `device_id` column reduces per-row scan work.
- **Altitude:** the three centralization candidates (`sseEventStatus`, the two `normalizeEmail` copies, `roleCaller`/`roleCallee`) are each at the right level; they are distinct feature vocabularies, so per-feature co-location beats a shared global block, and hoisting a two-line email normalizer across a package boundary would add coupling for no real gain.
- **Applied:** trimmed the `sseEventStatus` doc comment so it no longer overstates that a Go const can enforce the HTML `sse-swap` contract.
- **Kept with reason:** `writeEmptyJSON` is a deliberate no-error convenience wrapper (using `writeJSON(w, struct{}{})` would force error handling at three call sites); the `oldestVersions` return reorder is a genuine consistency fix guarded by an existing test.

## Test plan

From `server/`, all clean:

- `go build ./...`
- `go vet ./...`
- `go test ./...` (unit suite green)
- `staticcheck ./...` (no findings)
- `deadcode -test ./...` (no findings)
- `gofmt -l` (no diffs)

No behavior changes beyond the email footer copy, so no new tests; the existing email footer test was updated to match the new tagline.


---
_Generated by [Claude Code](https://claude.ai/code/session_016FuVoMgd238JqFi5BTXCs1)_