### PR TITLE
refactor(server): merge relay's two observer interfaces into one

### DIFF
--- a/server/cmd/signald/main.go
+++ b/server/cmd/signald/main.go
@@ -184,7 +184,6 @@ func run(ctx context.Context) error {
 	// Relay and TURN
 	relay := signaling.NewRelay(hub, tracker, line.NewAuthorizer(database), signaling.NewLineStoreAdapter(lineStore))
 	relay.HealthStore = healthStore
-	relay.Errors = mreg
 	relay.Metrics = mreg
 	tracker.SetCallEndObserver(relay)
 	hub.SetReconnectHook(relay.HandleRemoteReconnect)

--- a/server/internal/signaling/relay.go
+++ b/server/internal/signaling/relay.go
@@ -64,24 +64,18 @@ type HealthRecorder interface {
 	RecordEdge(confID uuid.UUID, from, peer string, sample calls.Sample)
 }
 
-// ErrorObserver counts signaling errors by category. Implemented
-// by *metrics.Registry; the interface lives here so internal/signaling does
-// not import internal/metrics directly. Categories are defined as untyped
-// strings on this surface so the relay package stays independent; the
-// metrics package validates them by exposing only a fixed set of constants.
-type ErrorObserver interface {
+// MetricsObserver counts the events the relay can see as it routes signaling:
+// categorized signaling errors, and media-negotiation events (which ICE
+// candidate types and transports flow between peers, and whether ICE-server
+// responses include TURN). Implemented by *metrics.Registry; the interface
+// lives here so internal/signaling does not import internal/metrics directly.
+// Categories and label values are untyped strings on this surface so the relay
+// package stays independent; the metrics package validates them by exposing
+// only a fixed set of constants, so a malformed value can never widen the
+// label space. Media arguments are derived from the parsed candidate, never
+// from raw user input, so no peer identity reaches a label.
+type MetricsObserver interface {
 	ObserveSignalingError(category string)
-}
-
-// MediaObserver counts media-negotiation events the relay can see as it relays
-// signaling: which ICE candidate types and transports flow between peers, and
-// whether ICE-server responses include TURN. Implemented by *metrics.Registry.
-// Like ErrorObserver, the interface lives here so internal/signaling does not
-// import internal/metrics; the metrics package validates the label values
-// against a fixed set so a malformed candidate can never widen the label space.
-// All arguments are derived from the parsed candidate, never from raw user
-// input, so no peer identity reaches a label.
-type MediaObserver interface {
 	ObserveICECandidate(candType, transport string)
 	ObserveICEServersIssued(turn bool)
 }
@@ -115,16 +109,12 @@ type Relay struct {
 	CallAuthorizer CallAuthorizer
 	LineStore      LineStore
 	HealthStore    HealthRecorder
-	// Errors is optional. When set, signaling-error counters are emitted
-	// for the cases the relay can categorize cleanly (auth failed, peer
-	// unreachable, etc). nil disables instrumentation; production wires it
-	// in cmd/signald/main.go.
-	Errors ErrorObserver
-
-	// Metrics is optional. When set, media-negotiation counters (ICE
-	// candidate types/transports relayed, ICE-server issuance) are emitted.
-	// nil disables them; production wires it in cmd/signald/main.go.
-	Metrics MediaObserver
+	// Metrics is optional. When set, the relay emits signaling-error counters
+	// for the cases it can categorize cleanly (auth failed, peer unreachable,
+	// etc) and media-negotiation counters (ICE candidate types/transports
+	// relayed, ICE-server issuance). nil disables instrumentation; production
+	// wires it in cmd/signald/main.go.
+	Metrics MetricsObserver
 
 	// GraceWindow is how long a 2-party call is held open after the last
 	// device on a line disconnects, before teardown. Defaults to
@@ -155,12 +145,12 @@ func graceKey(number, hardwareID string) string {
 	return number + "\x00" + hardwareID
 }
 
-// observeError is a nil-safe pass-through to the ErrorObserver.
+// observeError is a nil-safe pass-through to the MetricsObserver.
 // Centralizing it here means a missing observer never panics, and there is
 // only one place to look when reviewing what categories the relay emits.
 func (r *Relay) observeError(category string) {
-	if r.Errors != nil {
-		r.Errors.ObserveSignalingError(category)
+	if r.Metrics != nil {
+		r.Metrics.ObserveSignalingError(category)
 	}
 }
 

--- a/server/internal/signaling/relay_test.go
+++ b/server/internal/signaling/relay_test.go
@@ -1150,23 +1150,36 @@ func TestHandleLinkHealth_2WayPath_UnchangedBehavior(t *testing.T) {
 	}
 }
 
-// fakeErrorObserver records every category passed to ObserveSignalingError.
-// Tests assert against the slice rather than a counter so the order of
+// fakeMetricsObserver records every event passed to the MetricsObserver.
+// Error categories are kept as a slice rather than a counter so the order of
 // observations is also verifiable; ordering matters when we want to confirm
-// the relay's first error wins instead of doubling up.
-type fakeErrorObserver struct {
-	seen []string
+// the relay's first error wins instead of doubling up. Candidate and
+// ICE-server events are recorded so tests can assert the relay reports
+// media-negotiation telemetry derived from the parsed candidate, never from
+// raw user input.
+type fakeMetricsObserver struct {
+	seen       []string    // signaling-error categories
+	candidates [][2]string // (cand_type, transport) pairs
+	turnIssued []bool
 }
 
-func (f *fakeErrorObserver) ObserveSignalingError(category string) {
+func (f *fakeMetricsObserver) ObserveSignalingError(category string) {
 	f.seen = append(f.seen, category)
+}
+
+func (f *fakeMetricsObserver) ObserveICECandidate(candType, transport string) {
+	f.candidates = append(f.candidates, [2]string{candType, transport})
+}
+
+func (f *fakeMetricsObserver) ObserveICEServersIssued(turn bool) {
+	f.turnIssued = append(f.turnIssued, turn)
 }
 
 func TestRelayDoesNotErrorOnOfflineCall(t *testing.T) {
 	hub := NewHub()
-	obs := &fakeErrorObserver{}
+	obs := &fakeMetricsObserver{}
 	relay := NewRelay(hub, nil, nil, nil)
-	relay.Errors = obs
+	relay.Metrics = obs
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	_ = hub.Register("3140001", conn1)
@@ -1193,10 +1206,10 @@ func TestRelayDoesNotErrorOnOfflineCall(t *testing.T) {
 
 func TestRelayObservesAuthFailedWhenAuthorizerDenies(t *testing.T) {
 	hub := NewHub()
-	obs := &fakeErrorObserver{}
+	obs := &fakeMetricsObserver{}
 	authorizer := &mockCallAuthorizer{allowed: map[[2]string]bool{}}
 	relay := NewRelay(hub, newMockTracker(), authorizer, nil)
-	relay.Errors = obs
+	relay.Metrics = obs
 
 	conn1 := &Conn{Send: make(chan []byte, 10)}
 	conn2 := &Conn{Send: make(chan []byte, 10)}
@@ -1226,9 +1239,9 @@ func TestRelayDoesNotErrorOnSignalingWithoutCall(t *testing.T) {
 		{&Message{Type: TypeICE, To: "3140002", Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"}, ""},
 	} {
 		hub := NewHub()
-		obs := &fakeErrorObserver{}
+		obs := &fakeMetricsObserver{}
 		relay := NewRelay(hub, newMockTracker(), nil, nil)
-		relay.Errors = obs
+		relay.Metrics = obs
 
 		conn1 := &Conn{Send: make(chan []byte, 10)}
 		_ = hub.Register("3140001", conn1)
@@ -1270,9 +1283,9 @@ func TestRelayObservesInvalidMessageOnEmptyDestination(t *testing.T) {
 		{Type: TypeICE, Candidate: "candidate:1 1 udp 1 1.2.3.4 5 typ host"},
 	} {
 		hub := NewHub()
-		obs := &fakeErrorObserver{}
+		obs := &fakeMetricsObserver{}
 		relay := NewRelay(hub, newMockTracker(), nil, nil)
-		relay.Errors = obs
+		relay.Metrics = obs
 
 		conn1 := &Conn{Send: make(chan []byte, 10)}
 		_ = hub.Register("3140001", conn1)
@@ -1586,26 +1599,10 @@ func TestHandleCallOfflineAndIdleReturnsNotConnected(t *testing.T) {
 	}
 }
 
-// fakeMediaObserver records ICE candidate and ICE-server issuance events so
-// tests can assert the relay reports media-negotiation telemetry derived from
-// the parsed candidate, never from raw user input.
-type fakeMediaObserver struct {
-	candidates [][2]string // (cand_type, transport) pairs
-	turnIssued []bool
-}
-
-func (f *fakeMediaObserver) ObserveICECandidate(candType, transport string) {
-	f.candidates = append(f.candidates, [2]string{candType, transport})
-}
-
-func (f *fakeMediaObserver) ObserveICEServersIssued(turn bool) {
-	f.turnIssued = append(f.turnIssued, turn)
-}
-
 func TestRelayObservesICECandidateOnForward(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	obs := &fakeMediaObserver{}
+	obs := &fakeMetricsObserver{}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.Metrics = obs
 
@@ -1645,7 +1642,7 @@ func TestRelayObservesICECandidateOnForward(t *testing.T) {
 func TestRelayDoesNotObserveUnparseableCandidate(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	obs := &fakeMediaObserver{}
+	obs := &fakeMetricsObserver{}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.Metrics = obs
 
@@ -1671,7 +1668,7 @@ func TestRelayDoesNotObserveUnparseableCandidate(t *testing.T) {
 func TestRelayObservesMalformedCandidateAsOther(t *testing.T) {
 	hub := NewHub()
 	tracker := newMockTracker()
-	obs := &fakeMediaObserver{}
+	obs := &fakeMetricsObserver{}
 	relay := NewRelay(hub, tracker, nil, nil)
 	relay.Metrics = obs
 
@@ -1702,7 +1699,7 @@ func TestRelayObservesMalformedCandidateAsOther(t *testing.T) {
 
 func TestRelayObservesICEServersIssued(t *testing.T) {
 	hub := NewHub()
-	obs := &fakeMediaObserver{}
+	obs := &fakeMetricsObserver{}
 	relay := NewRelay(hub, newMockTracker(), nil, nil)
 	relay.Metrics = obs
 


### PR DESCRIPTION
## What

Collapse the relay's `ErrorObserver` and `MediaObserver` interfaces into a single `MetricsObserver` interface with one `Metrics` field on `Relay`.

## Why

The two interfaces were separate optional dependencies, each with its own `Relay` field and nil-check:

- `Errors ErrorObserver` (one method: `ObserveSignalingError`)
- `Metrics MediaObserver` (two methods: `ObserveICECandidate`, `ObserveICEServersIssued`)

But in every configuration they are the same object. `cmd/signald/main.go` wires both to the single `*metrics.Registry`, always together, and there is no path that sets one without the other. The split modeled a flexibility (instrument signaling errors independently from media negotiation) that no call site uses: premature interface segregation.

Merging them keeps the package decoupled from `internal/metrics` exactly as before (the interface still lives in `signaling` with untyped-string categories that the metrics package validates against a fixed constant set), while removing one field, one nil-check path, and one interface type. The two test fakes (`fakeErrorObserver`, `fakeMediaObserver`) fold into one `fakeMetricsObserver`.

This is the right scope: it is one coherent idea (one observer, not two) and touches only the three files that referenced the split. Nothing about the emitted metrics or their labels changes.

## Test plan

From `server/`, all clean:

- `go build ./...`
- `go vet ./...`
- `go test ./...` (full unit suite green, including the signaling package's observer tests)
- `golangci-lint run ./...` (0 issues)

No behavior change: the same three metrics fire from the same call sites; only the interface shape consolidates.