### PR TITLE
refactor(digitsd): shrink voicemail store's exported API to real usage

### DIFF
--- a/pi/digitsd/internal/voicemail/greeting_test.go
+++ b/pi/digitsd/internal/voicemail/greeting_test.go
@@ -5,10 +5,18 @@ import (
 	"testing"
 )
 
-func TestHasGreeting_NoFile(t *testing.T) {
+// hasGreeting reports whether a greeting file exists on disk. Production code
+// never asks this directly (it relies on OpenGreeting's os.ErrNotExist), so
+// the check lives here as a white-box test helper rather than on the Store.
+func hasGreeting(s *Store) bool {
+	_, err := os.Stat(s.greetingPath())
+	return err == nil
+}
+
+func TestGreetingAbsentInitially(t *testing.T) {
 	s := newTestStore(t, Options{})
-	if s.HasGreeting() {
-		t.Error("HasGreeting should be false with no greeting file")
+	if hasGreeting(s) {
+		t.Error("greeting should not exist with no greeting file")
 	}
 }
 
@@ -29,11 +37,11 @@ func TestGreetingRecordAndCheck(t *testing.T) {
 		t.Fatalf("Finalize: %v", err)
 	}
 
-	if !s.HasGreeting() {
-		t.Error("HasGreeting should be true after recording")
+	if !hasGreeting(s) {
+		t.Error("greeting should exist after recording")
 	}
 
-	path := s.GreetingPath()
+	path := s.greetingPath()
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("greeting file should exist at %s: %v", path, err)
 	}
@@ -69,8 +77,8 @@ func TestGreetingRecordOverwritesPrevious(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !s.HasGreeting() {
-		t.Error("HasGreeting should be true")
+	if !hasGreeting(s) {
+		t.Error("greeting should exist")
 	}
 
 	// Only one greeting file should exist.
@@ -103,15 +111,15 @@ func TestDeleteGreeting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !s.HasGreeting() {
+	if !hasGreeting(s) {
 		t.Fatal("greeting should exist before delete")
 	}
 
 	if err := s.DeleteGreeting(); err != nil {
 		t.Fatalf("DeleteGreeting: %v", err)
 	}
-	if s.HasGreeting() {
-		t.Error("HasGreeting should be false after delete")
+	if hasGreeting(s) {
+		t.Error("greeting should not exist after delete")
 	}
 }
 

--- a/pi/digitsd/internal/voicemail/store.go
+++ b/pi/digitsd/internal/voicemail/store.go
@@ -255,13 +255,6 @@ func (r *Recorder) AppendFrame(payload []byte) (atCap bool, err error) {
 	return false, nil
 }
 
-// Frames returns the number of frames written so far. For tests and cap checks.
-func (r *Recorder) Frames() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.frames
-}
-
 // Finalize closes the temp file, fsyncs, renames to the canonical path,
 // writes the metadata file, and applies retention. If no frames were written,
 // the temp file is discarded instead and (0, nil) returned.
@@ -396,17 +389,6 @@ func (p *Player) Close() error {
 // greetingPath returns the absolute path to the greeting frames file.
 func (s *Store) greetingPath() string {
 	return filepath.Join(s.dir, greetingFile)
-}
-
-// HasGreeting reports whether a custom greeting has been recorded.
-func (s *Store) HasGreeting() bool {
-	_, err := os.Stat(s.greetingPath())
-	return err == nil
-}
-
-// GreetingPath returns the absolute path where the greeting is (or would be) stored.
-func (s *Store) GreetingPath() string {
-	return s.greetingPath()
 }
 
 // OpenGreeting returns a Player for the recorded greeting. Returns an


### PR DESCRIPTION
## What

Delete three exported methods on the `voicemail` package that had no production callers: `Recorder.Frames()`, `Store.HasGreeting()`, and `Store.GreetingPath()`.

## Why

An exported method signals "supported API." These three did not carry their weight:

- **`Recorder.Frames()`** had zero callers anywhere in the module (verified by a module-wide grep). Its doc comment claimed it was "for tests and cap checks," but the cap check is done through `AppendFrame`'s `atCap` return value, and no test ever called `Frames()`. Pure dead code.
- **`Store.HasGreeting()`** was called only from the in-package `greeting_test.go`. Production never asks "does a greeting exist?" through it: the one real consumer opens the greeting and relies on the `os.ErrNotExist`-wrapped error from `OpenGreeting()`. So `HasGreeting` was a second, redundant way to ask a question production already answers differently.
- **`Store.GreetingPath()`** was a public wrapper over the unexported `greetingPath()`, existing only so a test could stat the file. The test is white-box (`package voicemail`), so it can call `greetingPath()` directly.

The greeting tests keep the existence assertions they legitimately need, but via a local `hasGreeting` white-box helper and the unexported `greetingPath()` instead of exported Store methods. The result: the Store's public surface reflects what production actually calls, and the test-only convenience lives in the test file.

This is the right scope: it is one idea (drop exported symbols with no production callers) and the three are a cluster in the same file, not a lone removal.

## Test plan

From `pi/digitsd/`, all clean on the voicemail package:

- `go build ./internal/voicemail/...`
- `go vet ./internal/voicemail/...`
- `go test ./internal/voicemail/...` (green)
- `golangci-lint run ./internal/voicemail/...` (0 issues)

A module-wide grep confirms no `.Frames()` / `.HasGreeting()` / `.GreetingPath()` call sites remain anywhere, including the opus-gated packages not built in this environment.