### PR TITLE
refactor(digitsd): make the contacts cache a number set, not a map with dead names

### DIFF
--- a/pi/digitsd/internal/contacts/cache.go
+++ b/pi/digitsd/internal/contacts/cache.go
@@ -14,18 +14,20 @@ type Entry struct {
 	Name   string `json:"name"`
 }
 
-// Cache is a thread-safe in-memory contact list loaded from a JSON file.
+// Cache is a thread-safe in-memory safelist of contact numbers loaded from a
+// JSON file. Only the set of numbers is retained; the display names in the
+// file are for humans reading contacts.json and are not used in memory.
 type Cache struct {
-	mu       sync.RWMutex
-	contacts map[string]string // number → name
-	path     string            // file path to load from (empty = always empty cache)
+	mu      sync.RWMutex
+	numbers map[string]struct{} // set of allowed numbers
+	path    string              // file path to load from (empty = always empty cache)
 }
 
 // NewCache creates a new Cache. If path is non-empty, Load will read that file.
 func NewCache(path string) *Cache {
 	return &Cache{
-		contacts: make(map[string]string),
-		path:     path,
+		numbers: make(map[string]struct{}),
+		path:    path,
 	}
 }
 
@@ -33,7 +35,7 @@ func NewCache(path string) *Cache {
 func (c *Cache) IsContact(number string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	_, ok := c.contacts[number]
+	_, ok := c.numbers[number]
 	return ok
 }
 
@@ -41,7 +43,7 @@ func (c *Cache) IsContact(number string) bool {
 func (c *Cache) Count() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return len(c.contacts)
+	return len(c.numbers)
 }
 
 // Load reads the contact list from the configured file path.
@@ -61,12 +63,12 @@ func (c *Cache) Load() error {
 	if err := json.Unmarshal(data, &entries); err != nil {
 		return err
 	}
-	contacts := make(map[string]string, len(entries))
+	numbers := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
-		contacts[e.Number] = e.Name
+		numbers[e.Number] = struct{}{}
 	}
 	c.mu.Lock()
-	c.contacts = contacts
+	c.numbers = numbers
 	c.mu.Unlock()
 	return nil
 }


### PR DESCRIPTION
## What

Change the contacts `Cache`'s in-memory store from `map[string]string` (number to name) to `map[string]struct{}` (a set of numbers).

## Why

The cache loaded and stored a display name for every number, but that name value is never read:

- `IsContact` does a `_, ok := c.contacts[number]` membership test.
- `Count` returns `len`.
- There is no name getter anywhere on the type.
- The only production consumer (`cmd/digitsd/main.go`) wires `IsContact` in as a dial safelist predicate via `SetContactChecker` and reads `Count`.

So the map was a set carrying a dead payload: a reader trying to understand the type sees `map[string]string` and reasonably asks "where is the name used?", then finds it never is. Modeling it as `map[string]struct{}` makes the type state what it actually is, a number safelist.

The `Entry` struct keeps its `Name` field: it documents the human-readable name column present in `contacts.json`. The name simply isn't retained in memory once the file is parsed.

Small but a genuine clarity fix, not a lone dead-symbol removal: it corrects what the data structure claims to hold, and confirming it was safe required verifying module-wide that nothing reads the name.

## Test plan

From `pi/digitsd/`, all clean on the contacts package:

- `go build ./internal/contacts/...`
- `go vet ./internal/contacts/...`
- `go test ./internal/contacts/...` (existing cache tests green; they exercise `IsContact`/`Count`/`Load`, all unchanged in behavior)
- `golangci-lint run ./internal/contacts/...` (0 issues)
- `gofmt` applied