### PR TITLE
docs: correct profiling doc after mutex/block knob removal

### DIFF
--- a/server/docs/tracing.md
+++ b/server/docs/tracing.md
@@ -102,8 +102,7 @@ Applied to every span as part of the OTel resource:
 
 Pushed by the Pyroscope Go SDK to `PYROSCOPE_SERVER_ADDRESS`. Profile
 types: CPU, alloc objects, alloc space, inuse objects, inuse space,
-goroutines. Mutex / block profiling is off by default and gated behind
-explicit non-zero `MutexProfileFraction` / `BlockProfileRate` config.
+goroutines. Mutex and block profiling are not collected.
 
 Label set is closed:
 


### PR DESCRIPTION
## What

Update `server/docs/tracing.md` so the "Continuous profiles" section no longer describes mutex/block profiling as a configurable capability. It now states plainly that mutex and block profiling are not collected.

## Why

This is a cross-PR doc-drift fix caught in daily holistic review, not a single-PR nit.

PR #824 (`refactor(server): drop dead Pyroscope mutex/block profiling knobs`) removed `Config.MutexProfileFraction` and `Config.BlockProfileRate` from `internal/profiling`, along with the runtime-enable branches they gated. It updated the package doc in `profiling.go` to list the effective profile set (CPU, alloc objects/space, inuse objects/space, goroutines) but left `server/docs/tracing.md` describing the removed knobs:

> Mutex / block profiling is off by default and gated behind explicit non-zero `MutexProfileFraction` / `BlockProfileRate` config.

After #824 there is no such config and no code path to enable those profiles, so the doc pointed at symbols that no longer exist. The replacement matches the effective profile set documented in `internal/profiling/profiling.go`.

## Test plan

Docs-only change; no code touched. Verified the removed identifiers no longer appear anywhere in the tree and that `profiling.go`'s collected-profiles list matches the corrected wording.